### PR TITLE
Emit the cascade epilogues and branch sites as single lines

### DIFF
--- a/crates/dewasm-backend-ruby/src/lib.rs
+++ b/crates/dewasm-backend-ruby/src/lib.rs
@@ -569,19 +569,17 @@ impl<'a> Gen<'a> {
     /// and reaches this decision): if the pending `__br` names this frame,
     /// clear it and fall through (the wasm branch lands past the block);
     /// otherwise a still-pending `__br` targets an ancestor, so `break` again
-    /// to relay it outward.
+    /// to relay it outward. Emitted as a single line: epilogues sit at every
+    /// crossed frame, often deeply indented, so each extra line costs its full
+    /// indent in output bytes.
     fn emit_land_or_relay(&self, w: &mut CodeWriter, label_id: u32) {
-        w.line(format!("if __br == {label_id}"));
-        w.indent();
-        w.line("__br = nil");
-        w.dedent();
         if self.has_enclosing_frame() {
-            w.line("elsif __br");
-            w.indent();
-            w.line("break");
-            w.dedent();
+            w.line(format!(
+                "if __br == {label_id} then __br = nil elsif __br then break end"
+            ));
+        } else {
+            w.line(format!("__br = nil if __br == {label_id}"));
         }
-        w.line("end");
     }
 
     /// An access expression for global `idx`, whichever representation it
@@ -1034,13 +1032,10 @@ impl<'a> Gen<'a> {
                     // fallthrough leaves `__br` nil and exits the loop.
                     w.block("while true", "end", |w| {
                         w.block("begin", "end while false", |w| self.stmts(w, body));
-                        w.line(format!("if __br == {}", label.id));
-                        w.indent();
-                        w.line("__br = nil");
-                        w.line("next");
-                        w.dedent();
-                        w.line("end");
-                        w.line("break");
+                        w.line(format!(
+                            "if __br == {} then __br = nil; next else break end",
+                            label.id
+                        ));
                     });
                 } else {
                     // No `br` reaches this loop from a nested frame: a back-edge
@@ -1056,7 +1051,7 @@ impl<'a> Gen<'a> {
                 // A `br` that passes through this loop toward an ancestor left
                 // `__br` set and `break`ed the `while`; relay it outward.
                 if crossed && self.has_enclosing_frame() {
-                    w.block("if __br", "end", |w| w.line("break"));
+                    w.line("break if __br");
                 }
                 self.frame_stack.borrow_mut().pop();
             }
@@ -1277,8 +1272,7 @@ impl<'a> Gen<'a> {
                 let innermost = self.frame_stack.borrow().last() == Some(label);
                 let via_var = !innermost || (*is_loop && self.is_wrapped(*label));
                 if via_var {
-                    w.line(format!("__br = {label}"));
-                    w.line("break");
+                    w.line(format!("__br = {label}; break"));
                 } else {
                     w.line(if *is_loop { "next" } else { "break" });
                 }

--- a/docs/adr/42-ruby-label-variable-cascade.md
+++ b/docs/adr/42-ruby-label-variable-cascade.md
@@ -81,7 +81,10 @@ the per-block dispatch loop ADR-4 feared is unnecessary.
 - Negative: a *wrapped* loop's back-edge takes a `__br` assignment and a
   compare instead of a plain `next`; the common loop+block idiom stays
   unwrapped and keeps `next`. A multi-level `br` emits one small epilogue
-  per crossed frame.
+  per crossed frame — an output-size cost (epilogues sit at deep indents,
+  so they are emitted as single lines; measured on `sqlite3-shell`, the
+  multi-line first cut grew the output by 37%, mostly leading
+  whitespace).
 - The spec harness (ADR-3) binds correctness: it is green for the Ruby
   backend under this lowering, including `br_table`, `unwind`, and
   `labels`.


### PR DESCRIPTION
Closes #1.

## What

The ADR-42 label-variable cascade emits explicit control code at every crossed frame, and those lines sit at deep nesting (up to ~90 levels ≈ 180 bytes of indent each), so the multi-line forms were expensive purely in output bytes — 81% of the cascade's size growth on sqlite3-shell was leading whitespace. This PR folds each form onto a single line with identical semantics:

| form | before | after |
| --- | --- | --- |
| Block/If land-or-relay | 5 lines | `if __br == N then __br = nil elsif __br then break end` |
| ...outermost frame | 3 lines | `__br = nil if __br == N` |
| wrapped-loop decision | 6 lines | `if __br == N then __br = nil; next else break end` |
| post-loop relay | 3 lines | `break if __br` |
| branch site | 2 lines | `__br = N; break` |

Also records the measured size consequence in ADR-42's Consequences section.

## Measured effect

| output | pre-cascade | cascade (main) | this PR |
| --- | --- | --- | --- |
| sqlite3-shell.rb | 15.5 MB | 21.3 MB | **17.6 MB (−17%)** |
| ruby.wasm → .rb | 167 MB | 202 MB | **175.7 MB (−13%)** |

Recovers ~64% of the cascade's growth; the remainder is the genuinely new control code.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`: clean
- `cargo test`: 1053 passed / 0 failed; ruby spec sweep `--include-ignored`: 257 / 0
- bench.sql output byte-identical to main's; runtime unchanged (6.78s user, same as main)
- One-line forms parse-checked and behavior-checked standalone before wiring into the emitter

🤖 Generated with [Claude Code](https://claude.com/claude-code)