### PR TITLE
Reject SYMLINK_FOLLOW in the Go path_link unit

### DIFF
--- a/runtime/go/units/wasi/path_link.go
+++ b/runtime/go/units/wasi/path_link.go
@@ -1,11 +1,13 @@
 // requires: memory/read_string, wasi/resolve_path, wasi/errno_fs
-// Create a hard link new = old, both endpoints contained. The source is
-// followed only under LOOKUPFLAGS_SYMLINK_FOLLOW; the destination is resolved
-// NOFOLLOW (ADR-40).
+// Create a hard link new = old, both endpoints contained. Both endpoints are
+// resolved NOFOLLOW and LOOKUPFLAGS_SYMLINK_FOLLOW is rejected as EINVAL like
+// the other backends (ADR-40).
 func (w *WASI) wasi_path_link(oldDirfd, oldFlags, oldPathPtr, oldPathLen, newDirfd, newPathPtr, newPathLen uint32) uint32 {
-    oldFollow := oldFlags&0x1 != 0 // lookupflags::SYMLINK_FOLLOW
+    if oldFlags&0x1 != 0 { // lookupflags::SYMLINK_FOLLOW
+        return wasiInval
+    }
     oldRel := string(w.memory.read_string(uint64(oldPathPtr), uint64(oldPathLen)))
-    oldHost, err := w.resolve_path(oldDirfd, oldRel, oldFollow)
+    oldHost, err := w.resolve_path(oldDirfd, oldRel, false)
     if err != wasiOk {
         return err
     }
@@ -23,14 +25,12 @@ func (w *WASI) wasi_path_link(oldDirfd, oldFlags, oldPathPtr, oldPathLen, newDir
         // AT_SYMLINK_NOFOLLOW linkat the suite expects), and std exposes no
         // portable linkat. Emulate a NOFOLLOW hard-link-to-a-symlink by
         // recreating the symlink at the destination (ADR-40).
-        if !oldFollow {
-            if fi, le := os.Lstat(oldHost); le == nil && fi.Mode()&os.ModeSymlink != 0 {
-                if target, re := os.Readlink(oldHost); re == nil {
-                    if se := os.Symlink(target, newHost); se != nil {
-                        return w.fs_errno(se)
-                    }
-                    return wasiOk
+        if fi, le := os.Lstat(oldHost); le == nil && fi.Mode()&os.ModeSymlink != 0 {
+            if target, re := os.Readlink(oldHost); re == nil {
+                if se := os.Symlink(target, newHost); se != nil {
+                    return w.fs_errno(se)
                 }
+                return wasiOk
             }
         }
         return w.fs_errno(e)


### PR DESCRIPTION
Closes #5

The first CI run on ubuntu-latest (PR #4) caught this: the Go backend's `path_link` unit resolved the source with the follow flag and left the outcome to the host `link(2)`, which follows symlinks on macOS but not on Linux. The wasi-testsuite requires `path_link` with `LOOKUPFLAGS_SYMLINK_FOLLOW` to fail, so the suite passed on macOS and failed on Linux.

The fix rejects the flag up front with `EINVAL` and resolves both endpoints NOFOLLOW — matching the other four backends' first-check convention and the NOFOLLOW shape ADR-40 already specifies. The macOS recreate-the-symlink fallback stays as the now-unconditional NOFOLLOW path. One file changed: `runtime/go/units/wasi/path_link.go`.

## Verification

- `cargo test -p dewasm-backend-go --test wasi_testsuite path_link` passes
- `cargo test -p dewasm-backend-go` fully green
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` clean
- Full workspace `cargo test` green (all five backends, macOS)

Linux verification: this branch has no CI workflow yet (it lands in PR #4). Once this PR merges, re-running PR #4's checks will exercise the fix on ubuntu-latest via the PR merge ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)