### PR TITLE
Guard Ruby f64.sub against hosts that skip sNaN quieting

### DIFF
--- a/crates/dewasm-backend-ruby/src/lib.rs
+++ b/crates/dewasm-backend-ruby/src/lib.rs
@@ -1446,7 +1446,13 @@ impl<'a> Gen<'a> {
             F32Mul => format!("{}({a} * {b})", self.rt("f32")),
             F32Div => format!("{}({a} / {b})", self.rt("f32")),
             F64Add => format!("({a} + {b})"),
-            F64Sub => format!("({a} - {b})"),
+            // MRI's `Float#-` leaves a signaling NaN unquieted when the RHS
+            // is +0.0 (observed on every x86_64-linux build 3.4.5..4.1dev;
+            // macOS is unaffected), so the host FPU cannot be trusted to
+            // return an arithmetic NaN. Quiet any NaN result explicitly; the
+            // `== r` self-compare is false only for NaN, keeping the common
+            // finite path allocation- and call-free. See ADR-2 / issue #11.
+            F64Sub => format!("((r = {a} - {b}) == r ? r : {}(r))", self.rt("quiet_nan")),
             F64Mul => format!("({a} * {b})"),
             F64Div => format!("({a} / {b})"),
             F32Min | F64Min => format!("{}({a}, {b})", self.rt("fmin")),

--- a/docs/adr/47-ruby-f64-sub-quiet-guard.md
+++ b/docs/adr/47-ruby-f64-sub-quiet-guard.md
@@ -1,0 +1,60 @@
+# ADR-47 — Inline Quiet-NaN Guard for Ruby f64.sub
+
+Status: **Accepted, 2026-07-29.** Implemented in the Ruby backend's binop
+lowering (`crates/dewasm-backend-ruby/src/lib.rs`, `F64Sub`), reusing the
+existing `rt/quiet_nan` unit.
+
+## Context
+
+Wasm requires float arithmetic to return *arithmetic* (quiet-bit-set) NaNs.
+The Ruby lowering emitted plain `(a - b)` for `f64.sub` ([ADR-4](4-ruby-backend-lowering.md)),
+implicitly assuming the host FPU executes the subtraction and quietens a
+signaling-NaN operand. Linux builds of MRI break that assumption: `a - b`
+with `b == +0.0` returns the LHS bits unquieted (a fresh Float, same bits) on
+every version probed (3.4.5, 3.4.10, 4.0.6, head), on every call shape.
+`x - (+0.0) → x` is the one sub identity that is IEEE-valid *except* for sNaN
+quieting, which is exactly the shape a compiler building the interpreter may
+fold; macOS/arm64 builds execute the real subtraction. Caught by the first
+Linux CI runs (issue #11): f64.wast:742,746 and float_exprs.wast:76,2409.
+
+## Decision
+
+Lower `f64.sub` to an inline self-compare guard:
+
+```ruby
+((r = a - b) == r ? r : Rt.quiet_nan(r))
+```
+
+`r == r` is false only for NaN, so the common path adds one C-level compare —
+no method call, no allocation — matching the Ruby perf posture
+(ADR-32/33/42–44); the NaN path routes through the existing `rt/quiet_nan`
+(sign and payload preserved, hence still an arithmetic NaN).
+
+The criterion for guarding an op: **an op gets a quiet guard only when a real
+host was observed returning a signaling NaN from it.** Today that is `f64.sub`
+alone — `f32.sub` is already safe because the `Rt.f32` re-round's `pack("e")`
+narrowing quietens on every probed host, and add/mul/div quietened everywhere.
+The same criterion applies to other backends if they exhibit the class.
+
+## Rejected alternatives
+
+- **Guard every float binop defensively.** Pays the guard cost on ops no host
+  has been observed to break; the spec harness runs on both dev (macOS) and CI
+  (Linux) hosts, so a newly broken op surfaces as a red spec trial and gets
+  its guard then, with evidence.
+- **Pin the CI/dev Ruby to an unaffected build.** No unaffected Linux MRI
+  exists (all probed versions fold), and generated code must be correct on
+  whatever host ruby a user runs.
+- **An `Rt.fsub` helper unit.** A method call per subtraction on the hot
+  path; the inline guard is both faster and no less clear.
+
+## Consequences
+
+- `f64.sub` output grows a temp-and-ternary wrapper; correctness outranks
+  generated-code readability ([ADR-1](1-ir-design.md)).
+- The `r` temp is written then immediately read within one expression, so
+  nested subs re-assign it only after the inner value is consumed; it cannot
+  collide with the generated `l*`/`s*` locals.
+- The quiet guard's absence elsewhere is a deliberate, evidence-driven gap:
+  a future host that folds another identity (e.g. `x + (-0.0)`) will fail the
+  spec harness loudly, not silently.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -68,6 +68,7 @@ the consequences.
 | ADR-44 | [Ruby Backend: Fixed-Arity `call_indirect` Dispatch](44-ruby-call-indirect-arity.md) | Accepted |
 | ADR-45 | [Rails Demo via a sqlite3-Gem Shim over Converted libsqlite3](45-rails-sqlite3-shim-example.md) | Accepted |
 | ADR-46 | [Host-OS-Scoped Expected-Failure Ledgers for the WASI Testsuite Harness](46-host-scoped-wasi-ledgers.md) | Accepted |
+| ADR-47 | [Inline Quiet-NaN Guard for Ruby f64.sub](47-ruby-f64-sub-quiet-guard.md) | Accepted |
 
 ## Adding a new ADR
 


### PR DESCRIPTION
Closes #11

Stacked on #10 (retargets automatically as the stack merges). The last red job in the CI stack: the Ruby backend failed 4 spec assertions on ubuntu-latest because Linux MRI builds return the minuend's bits **unquieted** from `a - b` when `b == +0.0` — probed on 3.4.5 / 3.4.10 / 4.0.6 / head via a throwaway workflow, all identical, every call shape; macOS builds quieten correctly. `x - (+0.0) → x` is the one sub identity that is IEEE-valid except for sNaN quieting, so a compiler building the interpreter may fold it; the plain `(a - b)` lowering silently depended on the FPU actually running.

The fix lowers `f64.sub` to `((r = a - b) == r ? r : Rt.quiet_nan(r))` — `r == r` is false only for NaN, so the common path costs one C-level compare with no method call (ADR-32/33/42–44 perf posture); NaN results route through the existing `rt/quiet_nan` unit. Only `f64.sub` is guarded: `f32.sub` is already quietened by the `Rt.f32` re-round (`pack("e")` narrowing quietens on all probed hosts) and add/mul/div quietened everywhere. **ADR-47** records the evidence-driven criterion (guard an op only when a real host was observed returning a signaling NaN from it) and the rejected alternatives.

## Verification

- macOS: full gate green (`cargo fmt --check`, clippy `-D warnings`, full `cargo test`; the four assertions pass).
- Linux: the fixed generated code was pushed to the probe branch and `f64_sub(sNaN, +0.0)` now yields `7ffc000000000000` (quiet) on all four Ruby versions; this PR's own CI run is the end-to-end spec confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)