### PR TITLE
Write the Go e2e build source to a per-attempt path

### DIFF
--- a/crates/dewasm-backend-go/tests/e2e.rs
+++ b/crates/dewasm-backend-go/tests/e2e.rs
@@ -174,15 +174,19 @@ fn build_go(source: &str) -> Result<PathBuf, Output> {
     let bin = cache.join(format!("prog-{hash:016x}"));
 
     if !bin.exists() {
-        let src = cache.join(format!("src-{hash:016x}.go"));
-        std::fs::write(&src, source).unwrap();
-        // Build to a unique path, then rename onto the cache key so concurrent
-        // test threads never hand out a half-written binary.
-        let tmp_bin = cache.join(format!(
-            "prog-{hash:016x}.{}.{}",
+        // Both the source and the binary get per-attempt unique names: two
+        // threads with the same hash (cowsay's args and stdin cases) may build
+        // concurrently, and a shared source path would let one truncate the
+        // file mid-read of the other's `go build` (issue #19). Only the final
+        // rename onto the cache key is shared, and that is atomic.
+        let unique = format!(
+            "{hash:016x}.{}.{}",
             std::process::id(),
             COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-        ));
+        );
+        let src = cache.join(format!("src-{unique}.go"));
+        std::fs::write(&src, source).unwrap();
+        let tmp_bin = cache.join(format!("prog-{unique}"));
         let build = Command::new(&go)
             .arg("build")
             .arg("-o")
@@ -194,6 +198,7 @@ fn build_go(source: &str) -> Result<PathBuf, Output> {
             return Err(build);
         }
         let _ = std::fs::rename(&tmp_bin, &bin);
+        let _ = std::fs::remove_file(&src);
     }
 
     Ok(bin)


### PR DESCRIPTION
Closes #19

Dependabot PR #15's `test (go)` failure (`cowsay_args` with empty stdout, green on rerun) was a race in the e2e harness, not anything to do with the checkout bump: `build_go` protects the cached **binary** with a unique-path build + atomic rename, but wrote the **source** to the shared `src-{hash}.go` with `std::fs::write` (truncate + write). cowsay's args/stdin cases share one source hash and run on parallel libtest threads; with a cold cache one thread can truncate the source mid-read of the other's `go build`, and the failed build's `Output` (empty stdout) becomes the run result.

The source now gets the same per-attempt unique naming as the binary (mirroring the Java harness, which already compiles inside its unique temp dir) and is removed after a successful build; only the atomic rename onto the cache key is shared.

Verified: 10 consecutive cold-cache runs of `cargo test -p dewasm-backend-go --test e2e cowsay` (both cases in parallel each time) all green; fmt/clippy clean; go e2e suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)