### PR TITLE
Split slow tests into slow_test and ultra_slow_test tiers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       matrix:
         backend: [ruby, bash, python, go, java]
     runs-on: ubuntu-latest
-    # The --include-ignored sweep (full spec suites + heavy apps) has
+    # The slow-tier sweep (full spec suites + slow apps, ADR-48) has
     # unmeasured wall time; give it generous headroom and tighten later.
     timeout-minutes: ${{ github.event_name == 'pull_request' && 60 || 300 }}
     steps:
@@ -87,6 +87,12 @@ jobs:
         with:
           distribution: temurin
           java-version: '21'
+      # ubuntu-24.04's system python 3.12.3 hits the static-block limit that
+      # breaks qjs-scale generated code, so pin >= 3.12.4 (#21).
+      - if: matrix.backend == 'python'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: test-${{ matrix.backend }}
@@ -101,14 +107,18 @@ jobs:
       - name: Test
         if: github.event_name == 'pull_request'
         run: cargo test -p dewasm-backend-${{ matrix.backend }} --no-fail-fast
-      - name: Test (including heavy cases)
+      # Tiers (ADR-48): the `slow_test` feature runs the full spec sweep plus the
+      # slow per-case app cases (CI's main sweep). It deliberately excludes the
+      # `ultra_slow_test` cases — the ~1 min+ pty / giant-`go build` cases that
+      # timed out (#22) or exhausted runner memory (#23) — which run only locally.
+      - name: Test (slow tier)
         if: github.event_name != 'pull_request'
-        run: cargo test -p dewasm-backend-${{ matrix.backend }} --no-fail-fast -- --include-ignored
+        run: cargo test -p dewasm-backend-${{ matrix.backend }} --no-fail-fast --features dewasm-backend-${{ matrix.backend }}/slow_test
 
   core:
     needs: apps-cache
     runs-on: ubuntu-latest
-    # The --include-ignored sweep (full spec suites + heavy apps) has
+    # The slow-tier sweep (full spec suites + slow apps, ADR-48) has
     # unmeasured wall time; give it generous headroom and tighten later.
     timeout-minutes: ${{ github.event_name == 'pull_request' && 60 || 300 }}
     steps:
@@ -116,7 +126,8 @@ jobs:
         with:
           submodules: true
       # dewasm-cli holds the cross-backend tests, so this job needs every
-      # backend toolchain (bash and python ship with the runner).
+      # backend toolchain (bash ships with the runner; python is pinned below
+      # because ubuntu-24.04's 3.12.3 breaks qjs-scale generated code, #21).
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.4'
@@ -128,6 +139,9 @@ jobs:
         with:
           distribution: temurin
           java-version: '21'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: core
@@ -139,8 +153,11 @@ jobs:
           path: examples/apps/cache
           key: ${{ needs.apps-cache.outputs.key }}
           fail-on-cache-miss: true
-      # `--include-ignored` un-ignores the apps_wasmtime golden-freshness
-      # suite, which execs `wasmtime run` and fails loudly without it (ADR-15).
+      # Tiers (ADR-48): the slow tier feature-gates what `--include-ignored`
+      # used to un-ignore. `dewasm-test-helper/wasmtime_test` runs the
+      # apps_wasmtime golden-freshness suite (execs `wasmtime run`, installed
+      # below, ADR-15); `dewasm-cli/slow_test` runs the slow cross-backend
+      # `--data-file` real-app cases.
       - uses: bytecodealliance/actions/wasmtime/setup@v1
         if: github.event_name != 'pull_request'
         with:
@@ -148,6 +165,6 @@ jobs:
       - name: Test
         if: github.event_name == 'pull_request'
         run: cargo test -p dewasm-core -p dewasm-backend -p dewasm-cli -p dewasm-test-helper -p xtask --no-fail-fast
-      - name: Test (including heavy cases)
+      - name: Test (slow tier)
         if: github.event_name != 'pull_request'
-        run: cargo test -p dewasm-core -p dewasm-backend -p dewasm-cli -p dewasm-test-helper -p xtask --no-fail-fast -- --include-ignored
+        run: cargo test -p dewasm-core -p dewasm-backend -p dewasm-cli -p dewasm-test-helper -p xtask --no-fail-fast --features dewasm-cli/slow_test,dewasm-test-helper/wasmtime_test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,10 +36,14 @@ instruction instead of skipping.
 ## Verification
 
 After any non-trivial change, run `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`,
-and `cargo test`. `cargo test` alone leaves each backend's heavy app cases (QuickJS, SQLite, the
-filesystem/C-API apps, the interactive-REPL pty case) `#[ignore]`d — gated by that backend's
-`heavy_test` cargo feature rather than an environment variable; run the full suite, heavy cases
-included, with one command: `cargo test -- --include-ignored`. Spec-harness failures mean a
+and `cargo test`. Tests run in tiers ([ADR-48](docs/adr/48-slow-test-tiers.md)): `cargo test` is the
+fast gate. `--features slow_test` adds each backend's slow app cases (QuickJS, SQLite, the
+filesystem/C-API apps, the interactive-REPL pty case) plus the full spec-testsuite sweep — this is
+CI's main sweep, gated by that backend's `slow_test` cargo feature rather than an environment
+variable. `--features ultra_slow_test` (or the everything-included `cargo test -- --include-ignored`)
+additionally runs the ultra tier — the cases measured at ~1 minute or more on a CI runner (the bash
+interactive-REPL pty case, go's giant generated-program builds), which are deliberately kept out of
+CI and run only in local pre-release verification. Spec-harness failures mean a
 semantics bug: fix the cause. Adding to a per-backend `EXPECTED_FAILURES` ledger in
 `crates/dewasm-backend-<lang>/tests/spec.rs` is a last resort and requires an attribution tag plus a
 reason ([ADR-8](docs/adr/8-latest-testsuite-support-matrix.md)). When support declarations or WASI

--- a/README.md
+++ b/README.md
@@ -152,9 +152,9 @@ against `wasmtime` is a checked-in test gate ([docs/apps-audit.md](docs/apps-aud
   Converting a runtime and running it back on Ruby is the **"Ruby on Ruby"**
   north-star, achieved.
 
-Honest caveats: the heavy apps (QuickJS, SQLite, CPython, CRuby) are `#[ignore]`d
-by default in the test suite — gated behind each backend crate's `heavy_test`
-cargo feature — because they are slow and large — CRuby is a ~335 MB Ruby
+Honest caveats: the slow apps (QuickJS, SQLite, CPython, CRuby) are `#[ignore]`d
+by default in the test suite — gated behind each backend crate's `slow_test`
+cargo feature ([ADR-48](docs/adr/48-slow-test-tiers.md)) — because they are slow and large — CRuby is a ~335 MB Ruby
 source file that runs in ~60 s — and Bash skips them by default because its
 softfloat makes float-heavy programs slow. These are deliberate performance
 opt-outs, not correctness gaps ([ADR-15](docs/adr/15-tests-fail-not-skip.md)).

--- a/crates/dewasm-backend-bash/Cargo.toml
+++ b/crates/dewasm-backend-bash/Cargo.toml
@@ -11,10 +11,14 @@ repository.workspace = true
 workspace = true
 
 [features]
-# Opt-in: expands the heavy per-case macros (dewasm-test-helper, ADR-27
-# revision) as active `#[test]`s instead of `#[ignore]`d ones. See
-# docs/testing.md.
-heavy_test = []
+# Opt-in test tiers (see docs/testing.md). `slow_test` expands the slow
+# per-case macros (dewasm-test-helper, ADR-27 revision) as active `#[test]`s
+# instead of `#[ignore]`d ones and runs the full spec testsuite sweep — CI's
+# main sweep tier. `ultra_slow_test` additionally un-ignores the cases measured
+# at ~1 min+ on a CI runner (the interactive qjs REPL pty case), which are kept
+# out of CI and run only in local pre-release verification.
+slow_test = []
+ultra_slow_test = ["slow_test"]
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/dewasm-backend-bash/tests/e2e.rs
+++ b/crates/dewasm-backend-bash/tests/e2e.rs
@@ -206,34 +206,35 @@ standalone_dir_e2e!(Bash);
 
 cowsay_args_e2e!(Bash);
 cowsay_stdin_e2e!(Bash);
-// qjs_eval_e2e! / sqlite3_shell_e2e!: invoked, but heavy — Bash's softfloat
+// qjs_eval_e2e! / sqlite3_shell_e2e!: invoked, but slow — Bash's softfloat
 // makes QuickJS/SQLite take tens of seconds, so the generated tests are
-// `#[ignore]`d by default; `--features heavy_test` or `-- --include-ignored` runs
+// `#[ignore]`d by default; `--features slow_test` or `-- --include-ignored` runs
 // them anyway (same as every other backend, ADR-27 revision).
 qjs_eval_e2e!(Bash);
 sqlite3_shell_e2e!(Bash);
 // minigzip is integer-only (no softfloat), so it runs under Bash by default,
-// unlike the heavy floating-point apps (QuickJS/SQLite).
+// unlike the slow floating-point apps (QuickJS/SQLite).
 gzip_e2e!(Bash);
 
 // Filesystem app cases (ADR-34): Bash's WASI filesystem now covers preopens,
 // path_open, and positioned I/O, so the three small-fixture fs apps are
-// wired (all heavy, softfloat-bound QuickJS/SQLite — see qjs_eval_e2e! above).
+// wired (all slow, softfloat-bound QuickJS/SQLite — see qjs_eval_e2e! above).
 qjs_file_io_e2e!(Bash, BASH_QJS_FILE_IO_GLUE);
 qjs_repl_e2e!(Bash, BASH_QJS_REPL_GLUE);
 sqlite3_shell_dbfile_e2e!(Bash, BASH_SQLITE3_SHELL_DBFILE_GLUE);
 // qjs_repl_pty is not a filesystem case (no preopens) but is wired here
-// alongside them: it shares their standalone-mode QuickJS conversion and is
-// gated the same way. It is markedly slower than the other heavy cases —
-// every keystroke of the scripted session re-enters QuickJS's interactive
-// line editor (redraw/completion), and each successive evaluation measured
-// slower than the last (first prompt ~135s, then +~65s, then +~330s for
-// `[3,1,2].sort()`) — so it will exceed the shared 180s per-prompt
-// `PTY_TIMEOUT` (`crates/dewasm-test-helper/src/qjs_repl.rs`) under
-// `--features heavy_test`/`--include-ignored`. Left wired rather than
-// unwired per ADR-15 (fail loud, not silently skip): a timeout is still an
-// honest signal, and the case is excluded from `cargo test`'s default run.
-qjs_repl_pty_e2e!(Bash);
+// alongside them: it shares their standalone-mode QuickJS conversion. It is
+// markedly slower than every other case — every keystroke of the scripted
+// session re-enters QuickJS's interactive line editor (redraw/completion), and
+// each successive evaluation measured slower than the last (first prompt ~135s,
+// then +~65s, then +~330s for `[3,1,2].sort()`), so it exceeds the shared 180s
+// per-prompt `PTY_TIMEOUT` (`crates/dewasm-test-helper/src/qjs_repl.rs`) and
+// timed out on CI (#22). It is therefore pinned to the `ultra` tier (ADR-48):
+// kept out of CI's `slow_test` sweep and run only under
+// `--features ultra_slow_test` or `-- --include-ignored`, in local pre-release
+// verification. Left wired rather than unwired per ADR-15 (fail loud, not
+// silently skip): a timeout is still an honest signal.
+qjs_repl_pty_e2e!(Bash, ultra);
 // rg_search_e2e! / cpython_hello_e2e! / cruby_hello_e2e!: not invoked — these
 // wasm binaries are tens of MB; the Bash backend's per-instruction lowering
 // (ADR-11) would generate a hundreds-of-MB script, well beyond what bash's

--- a/crates/dewasm-backend-go/Cargo.toml
+++ b/crates/dewasm-backend-go/Cargo.toml
@@ -11,10 +11,14 @@ repository.workspace = true
 workspace = true
 
 [features]
-# Opt-in: expands the heavy per-case macros (dewasm-test-helper, ADR-27
-# revision) as active `#[test]`s instead of `#[ignore]`d ones. See
-# docs/testing.md.
-heavy_test = []
+# Opt-in test tiers (see docs/testing.md). `slow_test` expands the slow
+# per-case macros (dewasm-test-helper, ADR-27 revision) as active `#[test]`s
+# instead of `#[ignore]`d ones and runs the full spec testsuite sweep — CI's
+# main sweep tier. `ultra_slow_test` additionally un-ignores the cases measured
+# at ~1 min+ on a CI runner (the giant-generated-program `go build` cases),
+# which are kept out of CI and run only in local pre-release verification.
+slow_test = []
+ultra_slow_test = ["slow_test"]
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/dewasm-backend-go/tests/e2e.rs
+++ b/crates/dewasm-backend-go/tests/e2e.rs
@@ -672,23 +672,29 @@ standalone_dir_e2e!(Go);
 
 cowsay_args_e2e!(Go);
 cowsay_stdin_e2e!(Go);
-qjs_eval_e2e!(Go);
-sqlite3_shell_e2e!(Go);
+// The `ultra`-tier cases (ADR-48) are the giant-generated-program `go build`s
+// that individually ran ~1 min+ and collectively exhausted a 4-core CI runner's
+// memory (SIGTERM, #23): kept out of CI's `slow_test` sweep, run only under
+// `--features ultra_slow_test` or `-- --include-ignored`. The other giant builds
+// (`qjs_repl`, `qjs_repl_pty`, `sqlite3_shell_dbfile`, `pcap_compile`,
+// `treesitter_parse`) stayed under the ~1-min bar and remain at the `slow` tier.
+qjs_eval_e2e!(Go, ultra);
+sqlite3_shell_e2e!(Go, ultra);
 gzip_e2e!(Go);
 
-qjs_file_io_e2e!(Go, GO_QJS_FILE_IO_GLUE);
+qjs_file_io_e2e!(Go, GO_QJS_FILE_IO_GLUE, ultra);
 qjs_repl_e2e!(Go, GO_QJS_REPL_GLUE);
 sqlite3_shell_dbfile_e2e!(Go, GO_SQLITE3_SHELL_GLUE);
-rg_search_e2e!(Go, GO_RG_SEARCH_GLUE);
-cpython_hello_e2e!(Go, GO_CPYTHON_GLUE);
+rg_search_e2e!(Go, GO_RG_SEARCH_GLUE, ultra);
+cpython_hello_e2e!(Go, GO_CPYTHON_GLUE, ultra);
 // cruby_hello_e2e!: not invoked — the ~35 MB CRuby wasm's ~242 MB Go source
 // exceeds the ADR-24 ~5-minute practicality bar under `go build` (measured
 // >6 min); see docs/apps-audit.md.
 qjs_repl_pty_e2e!(Go);
 
-libsqlite3_c_api_e2e!(Go, GO_LIBSQLITE3_MEM);
-sqlite3_file_c_api_e2e!(Go, GO_LIBSQLITE3_FILE);
-sqlite3_callback_binding_e2e!(Go, GO_SQLITE3_CALLBACK);
+libsqlite3_c_api_e2e!(Go, GO_LIBSQLITE3_MEM, ultra);
+sqlite3_file_c_api_e2e!(Go, GO_LIBSQLITE3_FILE, ultra);
+sqlite3_callback_binding_e2e!(Go, GO_SQLITE3_CALLBACK, ultra);
 pcap_compile_e2e!(Go, GO_PCAP_COMPILE);
 treesitter_parse_e2e!(Go, GO_TREESITTER_PARSE);
 

--- a/crates/dewasm-backend-java/Cargo.toml
+++ b/crates/dewasm-backend-java/Cargo.toml
@@ -11,10 +11,10 @@ repository.workspace = true
 workspace = true
 
 [features]
-# Opt-in: expands the heavy per-case macros (dewasm-test-helper, ADR-27
-# revision) as active `#[test]`s instead of `#[ignore]`d ones. See
-# docs/testing.md.
-heavy_test = []
+# Opt-in: expands the slow per-case macros (dewasm-test-helper, ADR-27
+# revision) as active `#[test]`s instead of `#[ignore]`d ones, and runs the
+# full spec testsuite sweep — CI's main sweep tier. See docs/testing.md.
+slow_test = []
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/dewasm-backend-python/Cargo.toml
+++ b/crates/dewasm-backend-python/Cargo.toml
@@ -11,10 +11,10 @@ repository.workspace = true
 workspace = true
 
 [features]
-# Opt-in: expands the heavy per-case macros (dewasm-test-helper, ADR-27
-# revision) as active `#[test]`s instead of `#[ignore]`d ones. See
-# docs/testing.md.
-heavy_test = []
+# Opt-in: expands the slow per-case macros (dewasm-test-helper, ADR-27
+# revision) as active `#[test]`s instead of `#[ignore]`d ones, and runs the
+# full spec testsuite sweep — CI's main sweep tier. See docs/testing.md.
+slow_test = []
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/dewasm-backend-python/tests/e2e.rs
+++ b/crates/dewasm-backend-python/tests/e2e.rs
@@ -2,7 +2,7 @@
 //! wired up for the Python backend. Per the ADR-27 revision this file holds ONLY
 //! the [`BackendUnderTest`] impl, named glue string constants, and per-case
 //! macro invocations. Python covers full WASI preview 1 incl. the filesystem
-//! (ADR-28), so it wires every WASI kind, the heavy `apps`/`fs_apps`/`capi`
+//! (ADR-28), so it wires every WASI kind, the slow-tier `apps`/`fs_apps`/`capi`
 //! suites, and the shared-table multi-module case.
 
 use std::path::PathBuf;

--- a/crates/dewasm-backend-ruby/Cargo.toml
+++ b/crates/dewasm-backend-ruby/Cargo.toml
@@ -11,10 +11,10 @@ repository.workspace = true
 workspace = true
 
 [features]
-# Opt-in: expands the heavy per-case macros (dewasm-test-helper, ADR-27
-# revision) as active `#[test]`s instead of `#[ignore]`d ones. See
-# docs/testing.md.
-heavy_test = []
+# Opt-in: expands the slow per-case macros (dewasm-test-helper, ADR-27
+# revision) as active `#[test]`s instead of `#[ignore]`d ones, and runs the
+# full spec testsuite sweep — CI's main sweep tier. See docs/testing.md.
+slow_test = []
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/dewasm-cli/Cargo.toml
+++ b/crates/dewasm-cli/Cargo.toml
@@ -10,6 +10,13 @@ repository.workspace = true
 [lints]
 workspace = true
 
+[features]
+# Opt-in: expands the slow cross-backend `--data-file` real-app cases
+# (tests/data_file.rs — convert + run/build the cached qjs.wasm) as active
+# `#[test]`s instead of `#[ignore]`d ones. CI's main sweep tier; see
+# docs/testing.md.
+slow_test = []
+
 [lib]
 name = "dewasm_cli"
 path = "src/lib.rs"

--- a/crates/dewasm-cli/tests/data_file.rs
+++ b/crates/dewasm-cli/tests/data_file.rs
@@ -6,9 +6,10 @@
 //!
 //! The inline fixture carries an active segment, a passive segment initialized
 //! via `memory.init` + `data.drop`, and a bulky third segment so the sidecar
-//! form provably shrinks the source. The heavy real-app cases (`qjs.wasm`) are
-//! `#[ignore]`d, matching the project's convention for cases that pay a
-//! multi-second `go build` / interpreter startup (run with `--include-ignored`).
+//! form provably shrinks the source. The slow real-app cases (`qjs.wasm`) are
+//! `#[ignore]`d unless the `slow_test` feature is on, matching the project's
+//! tier convention (ADR-48) for cases that pay a multi-second `go build` /
+//! interpreter startup (run with `--features slow_test` or `--include-ignored`).
 
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
@@ -487,7 +488,8 @@ fn rejects_unsupported_targets_and_stdout() {
 }
 
 // --------------------------------------------------------------------------
-// Real-app parity (heavy: `#[ignore]`d; run with --include-ignored).
+// Real-app parity (slow: `#[ignore]`d unless `--features slow_test`; also run
+// with --include-ignored).
 
 fn qjs_wasm() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("../../examples/apps/cache/qjs.wasm")
@@ -498,7 +500,10 @@ const QJS_ARGS: &[&str] = &["-e", "console.log(6 * 7)"];
 const QJS_STDOUT: &str = "42\n";
 
 #[test]
-#[ignore = "heavy: converts and runs the cached qjs.wasm (multi-second)"]
+#[cfg_attr(
+    not(feature = "slow_test"),
+    ignore = "slow: converts and runs the cached qjs.wasm (multi-second): --features slow_test or -- --include-ignored"
+)]
 fn ruby_qjs_data_file_matches_embedded() {
     let wasm = qjs_wasm();
     assert!(
@@ -551,7 +556,10 @@ fn ruby_qjs_data_file_matches_embedded() {
 }
 
 #[test]
-#[ignore = "heavy: go build of the cached qjs.wasm source (multi-second)"]
+#[cfg_attr(
+    not(feature = "slow_test"),
+    ignore = "slow: go build of the cached qjs.wasm source (multi-second): --features slow_test or -- --include-ignored"
+)]
 fn go_qjs_data_file_matches_embedded() {
     let wasm = qjs_wasm();
     assert!(
@@ -608,7 +616,10 @@ fn go_qjs_data_file_matches_embedded() {
 }
 
 #[test]
-#[ignore = "heavy: converts and runs the cached qjs.wasm (multi-second)"]
+#[cfg_attr(
+    not(feature = "slow_test"),
+    ignore = "slow: converts and runs the cached qjs.wasm (multi-second): --features slow_test or -- --include-ignored"
+)]
 fn python_qjs_data_file_matches_embedded() {
     let wasm = qjs_wasm();
     assert!(
@@ -661,7 +672,10 @@ fn python_qjs_data_file_matches_embedded() {
 }
 
 #[test]
-#[ignore = "heavy: javac of the cached qjs.wasm source (multi-second)"]
+#[cfg_attr(
+    not(feature = "slow_test"),
+    ignore = "slow: javac of the cached qjs.wasm source (multi-second): --features slow_test or -- --include-ignored"
+)]
 fn java_qjs_data_file_matches_embedded() {
     let wasm = qjs_wasm();
     assert!(

--- a/crates/dewasm-test-helper/src/apps.rs
+++ b/crates/dewasm-test-helper/src/apps.rs
@@ -9,10 +9,10 @@
 //! is a `pub const` [`AppCase`] driven by its own per-case macro
 //! (`cowsay_args_e2e!`, `cowsay_stdin_e2e!`, `qjs_eval_e2e!`,
 //! `sqlite3_shell_e2e!`, ADR-27 revision). `qjs_eval_e2e!`/`sqlite3_shell_e2e!`
-//! are heavy — softfloat makes QuickJS/SQLite take tens of seconds under
+//! are slow — softfloat makes QuickJS/SQLite take tens of seconds under
 //! Bash — so the macro expands their generated `#[test]` as `#[ignore]`d
-//! unless the expanding backend crate's `heavy_test` feature is enabled; see
-//! [`run_heavy_app_case`], which just runs the case unconditionally now that
+//! unless the expanding backend crate's `slow_test` feature is enabled; see
+//! [`run_slow_app_case`], which just runs the case unconditionally now that
 //! the gating lives at the macro/feature level.
 
 use dewasm_backend::Mode;
@@ -48,8 +48,8 @@ pub const COWSAY_STDIN: AppCase = AppCase {
     expect_code: 0,
 };
 
-/// QuickJS `-e` one-liner eval (heavy: softfloat-bound interpreters skip by
-/// default, see [`run_heavy_app_case`]).
+/// QuickJS `-e` one-liner eval (slow tier: softfloat-bound interpreters skip by
+/// default, see [`run_slow_app_case`]).
 pub const QJS_EVAL: AppCase = AppCase {
     name: "qjs",
     args: &[
@@ -61,8 +61,8 @@ pub const QJS_EVAL: AppCase = AppCase {
     expect_code: 0,
 };
 
-/// sqlite3 shell against an in-memory database (heavy: softfloat-bound
-/// interpreters skip by default, see [`run_heavy_app_case`]).
+/// sqlite3 shell against an in-memory database (slow tier: softfloat-bound
+/// interpreters skip by default, see [`run_slow_app_case`]).
 pub const SQLITE3_SHELL: AppCase = AppCase {
     name: "sqlite3-shell",
     args: &[],
@@ -110,18 +110,18 @@ fn run_app_case_inner(lang: &dyn BackendUnderTest, case: &AppCase) {
     );
 }
 
-/// Run a non-heavy [`AppCase`] (`COWSAY_ARGS`/`COWSAY_STDIN`) for `lang`
+/// Run a fast [`AppCase`] (`COWSAY_ARGS`/`COWSAY_STDIN`) for `lang`
 /// unconditionally.
 pub fn run_app_case(lang: &dyn BackendUnderTest, case: &AppCase) {
     run_app_case_inner(lang, case);
 }
 
-/// Run a heavy [`AppCase`] (`QJS_EVAL`/`SQLITE3_SHELL`) for `lang`
+/// Run a slow-tier [`AppCase`] (`QJS_EVAL`/`SQLITE3_SHELL`) for `lang`
 /// unconditionally. The perf opt-out now lives at the macro/feature level
 /// (`qjs_eval_e2e!`/`sqlite3_shell_e2e!` expand their `#[test]` as
-/// `#[ignore]`d unless the `heavy_test` feature is on), so this runner — also used
+/// `#[ignore]`d unless the `slow_test` feature is on), so this runner — also used
 /// directly by the wasmtime suite — never needs to gate itself.
-pub fn run_heavy_app_case(lang: &dyn BackendUnderTest, case: &AppCase) {
+pub fn run_slow_app_case(lang: &dyn BackendUnderTest, case: &AppCase) {
     run_app_case_inner(lang, case);
 }
 

--- a/crates/dewasm-test-helper/src/apps_capi.rs
+++ b/crates/dewasm-test-helper/src/apps_capi.rs
@@ -17,7 +17,7 @@
 //! — it has no WASI filesystem and no host-language object model to plumb a C
 //! API through (ADR-12). These cases reconvert the ~5 MB sqlite3 artifacts, so
 //! each per-case macro expands its generated `#[test]` as `#[ignore]`d unless
-//! the expanding backend crate's `heavy_test` feature is enabled; [`run_capi_case`]
+//! the expanding backend crate's `slow_test` feature is enabled; [`run_capi_case`]
 //! itself just runs the case unconditionally.
 
 use std::path::{Path, PathBuf};

--- a/crates/dewasm-test-helper/src/apps_fs.rs
+++ b/crates/dewasm-test-helper/src/apps_fs.rs
@@ -16,10 +16,10 @@
 //! preopens directly, so the same case consts feed both the backend macros and
 //! the wasmtime suite (via [`run_fs_app_case`], called directly).
 //!
-//! These cases are heavy (they reconvert qjs/sqlite and stage ripgrep's 22 MB
+//! These cases are slow (they reconvert qjs/sqlite and stage ripgrep's 22 MB
 //! binary), so the perf opt-out lives at the macro/feature level: each
 //! per-case macro (`qjs_file_io_e2e!`, ...) expands its generated `#[test]` as
-//! `#[ignore]`d unless the expanding backend crate's `heavy_test` feature is
+//! `#[ignore]`d unless the expanding backend crate's `slow_test` feature is
 //! enabled. [`run_fs_app_case`] itself just runs the case unconditionally.
 
 use std::path::{Path, PathBuf};

--- a/crates/dewasm-test-helper/src/lib.rs
+++ b/crates/dewasm-test-helper/src/lib.rs
@@ -21,7 +21,7 @@ mod wasi_testsuite;
 mod wasmtime_backend;
 
 pub use apps::{
-    run_app_case, run_gzip_cases, run_heavy_app_case, AppCase, COWSAY_ARGS, COWSAY_STDIN, QJS_EVAL,
+    run_app_case, run_gzip_cases, run_slow_app_case, AppCase, COWSAY_ARGS, COWSAY_STDIN, QJS_EVAL,
     SQLITE3_SHELL,
 };
 pub use apps_capi::{
@@ -68,7 +68,7 @@ pub use wasmtime_backend::Wasmtime;
 macro_rules! spec_suite {
     ($lang:expr) => {
         fn main() {
-            $crate::spec_main(&$lang);
+            $crate::spec_main(&$lang, cfg!(feature = "slow_test"));
         }
     };
 }
@@ -85,6 +85,34 @@ macro_rules! wasi_testsuite_suite {
         fn main() {
             $crate::wasi_testsuite_main(&$lang);
         }
+    };
+}
+
+/// Internal: attach a two-tier `#[ignore]` gate to a generated `#[test]` item
+/// (ADR-48). The per-case app macros below delegate here so a callsite can pick
+/// the tier without duplicating the gate:
+///
+/// * `slow` — gated on the backend crate's `slow_test` feature (CI's main sweep
+///   tier). This is the default for every slow-case macro.
+/// * `ultra` — gated on `ultra_slow_test` (which implies `slow_test`), for a
+///   case measured at roughly a minute or more on a CI runner. These are kept
+///   out of CI and run only under `--features ultra_slow_test` or
+///   `-- --include-ignored`, in local pre-release verification.
+#[macro_export]
+macro_rules! slow_tier_test {
+    (slow, $item:item) => {
+        #[cfg_attr(
+            not(feature = "slow_test"),
+            ignore = "slow app case: --features slow_test or -- --include-ignored"
+        )]
+        $item
+    };
+    (ultra, $item:item) => {
+        #[cfg_attr(
+            not(feature = "ultra_slow_test"),
+            ignore = "ultra-slow app case (~1min+ on a CI runner, ADR-48): --features ultra_slow_test or -- --include-ignored"
+        )]
+        $item
     };
 }
 
@@ -223,9 +251,10 @@ macro_rules! wasi_root_containment_e2e {
 /// [`BackendUnderTest`]). No glue argument — these are standalone-mode
 /// stdin/args cases, so no host-language glue is needed. `cowsay_args_e2e!`
 /// and `cowsay_stdin_e2e!` always run; `qjs_eval_e2e!` and `sqlite3_shell_e2e!`
-/// are heavy — their generated `#[test]` is `#[ignore]`d unless the expanding
-/// backend crate's `heavy_test` feature is enabled (run with `--features heavy_test` or
-/// `cargo test -- --include-ignored`).
+/// are slow — their generated `#[test]` is `#[ignore]`d unless the expanding
+/// backend crate's `slow_test` feature is enabled (run with `--features slow_test`
+/// or `cargo test -- --include-ignored`). A callsite may pass a trailing tier
+/// token (`slow`, the default, or `ultra`); see [`slow_tier_test!`] (ADR-48).
 ///
 /// [`AppCase`]: crate::AppCase
 #[macro_export]
@@ -249,36 +278,40 @@ macro_rules! cowsay_stdin_e2e {
     };
 }
 
-/// See [`cowsay_args_e2e!`]. Runs the heavy [`QJS_EVAL`](crate::QJS_EVAL) case.
-/// Heavy: the generated `#[test]` is `#[ignore]`d unless the expanding
-/// backend crate's `heavy_test` feature is enabled (ADR-27 revision) — run it with
-/// `--features heavy_test` or `cargo test -- --include-ignored`.
+/// See [`cowsay_args_e2e!`]. Runs the slow [`QJS_EVAL`](crate::QJS_EVAL) case.
+/// Slow: the generated `#[test]` is `#[ignore]`d unless the expanding
+/// backend crate's `slow_test` feature is enabled (ADR-27 revision) — run it with
+/// `--features slow_test` or `cargo test -- --include-ignored`. Pass a trailing
+/// `ultra` to promote it to the ultra tier ([`slow_tier_test!`], ADR-48).
 #[macro_export]
 macro_rules! qjs_eval_e2e {
     ($lang:expr) => {
-        #[cfg_attr(
-            not(feature = "heavy_test"),
-            ignore = "heavy app case: --features heavy_test or -- --include-ignored"
-        )]
-        #[test]
-        fn qjs_eval() {
-            $crate::run_heavy_app_case(&$lang, &$crate::QJS_EVAL);
+        $crate::qjs_eval_e2e!($lang, slow);
+    };
+    ($lang:expr, $tier:tt) => {
+        $crate::slow_tier_test! { $tier,
+            #[test]
+            fn qjs_eval() {
+                $crate::run_slow_app_case(&$lang, &$crate::QJS_EVAL);
+            }
         }
     };
 }
 
-/// See [`cowsay_args_e2e!`]. Runs the heavy [`SQLITE3_SHELL`](crate::SQLITE3_SHELL)
-/// case. Heavy: see [`qjs_eval_e2e!`] for the `#[ignore]`/`heavy_test` feature gate.
+/// See [`cowsay_args_e2e!`]. Runs the slow [`SQLITE3_SHELL`](crate::SQLITE3_SHELL)
+/// case. Slow: see [`qjs_eval_e2e!`] for the `#[ignore]`/`slow_test` feature gate
+/// and the trailing tier token.
 #[macro_export]
 macro_rules! sqlite3_shell_e2e {
     ($lang:expr) => {
-        #[cfg_attr(
-            not(feature = "heavy_test"),
-            ignore = "heavy app case: --features heavy_test or -- --include-ignored"
-        )]
-        #[test]
-        fn sqlite3_shell() {
-            $crate::run_heavy_app_case(&$lang, &$crate::SQLITE3_SHELL);
+        $crate::sqlite3_shell_e2e!($lang, slow);
+    };
+    ($lang:expr, $tier:tt) => {
+        $crate::slow_tier_test! { $tier,
+            #[test]
+            fn sqlite3_shell() {
+                $crate::run_slow_app_case(&$lang, &$crate::SQLITE3_SHELL);
+            }
         }
     };
 }
@@ -299,17 +332,19 @@ macro_rules! gzip_e2e {
 
 /// One `#[test]` driving the bare QuickJS interactive REPL under a real pty for
 /// `$lang` and comparing the transcript byte-for-byte to the wasmtime golden
-/// (Fix 4). Heavy: see [`qjs_eval_e2e!`] for the `#[ignore]`/`heavy_test` feature gate.
+/// (Fix 4). Slow: see [`qjs_eval_e2e!`] for the `#[ignore]`/`slow_test` feature
+/// gate and the trailing tier token.
 #[macro_export]
 macro_rules! qjs_repl_pty_e2e {
     ($lang:expr) => {
-        #[cfg_attr(
-            not(feature = "heavy_test"),
-            ignore = "heavy app case: --features heavy_test or -- --include-ignored"
-        )]
-        #[test]
-        fn qjs_repl_pty() {
-            $crate::run_qjs_repl_pty(&$lang);
+        $crate::qjs_repl_pty_e2e!($lang, slow);
+    };
+    ($lang:expr, $tier:tt) => {
+        $crate::slow_tier_test! { $tier,
+            #[test]
+            fn qjs_repl_pty() {
+                $crate::run_qjs_repl_pty(&$lang);
+            }
         }
     };
 }
@@ -319,20 +354,22 @@ macro_rules! qjs_repl_pty_e2e {
 /// `$glue` (a named `&str` const in the backend crate whose `{scratch}`/`{cache}`
 /// placeholders the runner fills). A backend declares participation by invoking
 /// the macro and drops it (with a REASON comment) for a case it cannot run.
-/// Heavy: the generated `#[test]` is `#[ignore]`d unless the expanding backend
-/// crate's `heavy_test` feature is enabled (see [`qjs_eval_e2e!`]).
+/// Slow: the generated `#[test]` is `#[ignore]`d unless the expanding backend
+/// crate's `slow_test` feature is enabled (see [`qjs_eval_e2e!`]); a trailing
+/// tier token after `$glue` promotes a case to the ultra tier ([`slow_tier_test!`]).
 ///
 /// [`FsAppCase`]: crate::FsAppCase
 #[macro_export]
 macro_rules! qjs_file_io_e2e {
     ($lang:expr, $glue:expr) => {
-        #[cfg_attr(
-            not(feature = "heavy_test"),
-            ignore = "heavy app case: --features heavy_test or -- --include-ignored"
-        )]
-        #[test]
-        fn qjs_file_io() {
-            $crate::run_fs_app_case(&$lang, &$crate::QJS_FILE_IO, $glue);
+        $crate::qjs_file_io_e2e!($lang, $glue, slow);
+    };
+    ($lang:expr, $glue:expr, $tier:tt) => {
+        $crate::slow_tier_test! { $tier,
+            #[test]
+            fn qjs_file_io() {
+                $crate::run_fs_app_case(&$lang, &$crate::QJS_FILE_IO, $glue);
+            }
         }
     };
 }
@@ -341,13 +378,14 @@ macro_rules! qjs_file_io_e2e {
 #[macro_export]
 macro_rules! qjs_repl_e2e {
     ($lang:expr, $glue:expr) => {
-        #[cfg_attr(
-            not(feature = "heavy_test"),
-            ignore = "heavy app case: --features heavy_test or -- --include-ignored"
-        )]
-        #[test]
-        fn qjs_repl() {
-            $crate::run_fs_app_case(&$lang, &$crate::QJS_REPL, $glue);
+        $crate::qjs_repl_e2e!($lang, $glue, slow);
+    };
+    ($lang:expr, $glue:expr, $tier:tt) => {
+        $crate::slow_tier_test! { $tier,
+            #[test]
+            fn qjs_repl() {
+                $crate::run_fs_app_case(&$lang, &$crate::QJS_REPL, $glue);
+            }
         }
     };
 }
@@ -356,13 +394,14 @@ macro_rules! qjs_repl_e2e {
 #[macro_export]
 macro_rules! sqlite3_shell_dbfile_e2e {
     ($lang:expr, $glue:expr) => {
-        #[cfg_attr(
-            not(feature = "heavy_test"),
-            ignore = "heavy app case: --features heavy_test or -- --include-ignored"
-        )]
-        #[test]
-        fn sqlite3_shell_dbfile() {
-            $crate::run_fs_app_case(&$lang, &$crate::SQLITE3_SHELL_DBFILE, $glue);
+        $crate::sqlite3_shell_dbfile_e2e!($lang, $glue, slow);
+    };
+    ($lang:expr, $glue:expr, $tier:tt) => {
+        $crate::slow_tier_test! { $tier,
+            #[test]
+            fn sqlite3_shell_dbfile() {
+                $crate::run_fs_app_case(&$lang, &$crate::SQLITE3_SHELL_DBFILE, $glue);
+            }
         }
     };
 }
@@ -371,13 +410,14 @@ macro_rules! sqlite3_shell_dbfile_e2e {
 #[macro_export]
 macro_rules! rg_search_e2e {
     ($lang:expr, $glue:expr) => {
-        #[cfg_attr(
-            not(feature = "heavy_test"),
-            ignore = "heavy app case: --features heavy_test or -- --include-ignored"
-        )]
-        #[test]
-        fn rg_search() {
-            $crate::run_fs_app_case(&$lang, &$crate::RG_SEARCH, $glue);
+        $crate::rg_search_e2e!($lang, $glue, slow);
+    };
+    ($lang:expr, $glue:expr, $tier:tt) => {
+        $crate::slow_tier_test! { $tier,
+            #[test]
+            fn rg_search() {
+                $crate::run_fs_app_case(&$lang, &$crate::RG_SEARCH, $glue);
+            }
         }
     };
 }
@@ -386,13 +426,14 @@ macro_rules! rg_search_e2e {
 #[macro_export]
 macro_rules! cpython_hello_e2e {
     ($lang:expr, $glue:expr) => {
-        #[cfg_attr(
-            not(feature = "heavy_test"),
-            ignore = "heavy app case: --features heavy_test or -- --include-ignored"
-        )]
-        #[test]
-        fn cpython_hello() {
-            $crate::run_fs_app_case(&$lang, &$crate::CPYTHON_HELLO, $glue);
+        $crate::cpython_hello_e2e!($lang, $glue, slow);
+    };
+    ($lang:expr, $glue:expr, $tier:tt) => {
+        $crate::slow_tier_test! { $tier,
+            #[test]
+            fn cpython_hello() {
+                $crate::run_fs_app_case(&$lang, &$crate::CPYTHON_HELLO, $glue);
+            }
         }
     };
 }
@@ -401,13 +442,14 @@ macro_rules! cpython_hello_e2e {
 #[macro_export]
 macro_rules! cruby_hello_e2e {
     ($lang:expr, $glue:expr) => {
-        #[cfg_attr(
-            not(feature = "heavy_test"),
-            ignore = "heavy app case: --features heavy_test or -- --include-ignored"
-        )]
-        #[test]
-        fn cruby_hello() {
-            $crate::run_fs_app_case(&$lang, &$crate::CRUBY_HELLO, $glue);
+        $crate::cruby_hello_e2e!($lang, $glue, slow);
+    };
+    ($lang:expr, $glue:expr, $tier:tt) => {
+        $crate::slow_tier_test! { $tier,
+            #[test]
+            fn cruby_hello() {
+                $crate::run_fs_app_case(&$lang, &$crate::CRUBY_HELLO, $glue);
+            }
         }
     };
 }
@@ -417,21 +459,22 @@ macro_rules! cruby_hello_e2e {
 /// `$glue` (a named `&str` const in the backend crate; the file-backed case's
 /// `{scratch}` placeholder is filled by the runner). Which backends invoke
 /// these is the capability declaration (ADR-27): Ruby/Python/Go/Java, not Bash
-/// (ADR-12). Heavy: the generated `#[test]` is `#[ignore]`d unless the
-/// expanding backend crate's `heavy_test` feature is enabled (see
+/// (ADR-12). Slow: the generated `#[test]` is `#[ignore]`d unless the
+/// expanding backend crate's `slow_test` feature is enabled (see
 /// [`qjs_eval_e2e!`]).
 ///
 /// [`CApiCase`]: crate::CApiCase
 #[macro_export]
 macro_rules! libsqlite3_c_api_e2e {
     ($lang:expr, $glue:expr) => {
-        #[cfg_attr(
-            not(feature = "heavy_test"),
-            ignore = "heavy app case: --features heavy_test or -- --include-ignored"
-        )]
-        #[test]
-        fn libsqlite3_c_api() {
-            $crate::run_capi_case(&$lang, &$crate::LIBSQLITE3_C_API, $glue);
+        $crate::libsqlite3_c_api_e2e!($lang, $glue, slow);
+    };
+    ($lang:expr, $glue:expr, $tier:tt) => {
+        $crate::slow_tier_test! { $tier,
+            #[test]
+            fn libsqlite3_c_api() {
+                $crate::run_capi_case(&$lang, &$crate::LIBSQLITE3_C_API, $glue);
+            }
         }
     };
 }
@@ -440,51 +483,54 @@ macro_rules! libsqlite3_c_api_e2e {
 #[macro_export]
 macro_rules! sqlite3_file_c_api_e2e {
     ($lang:expr, $glue:expr) => {
-        #[cfg_attr(
-            not(feature = "heavy_test"),
-            ignore = "heavy app case: --features heavy_test or -- --include-ignored"
-        )]
-        #[test]
-        fn sqlite3_file_c_api() {
-            $crate::run_capi_case(&$lang, &$crate::SQLITE3_FILE_C_API, $glue);
+        $crate::sqlite3_file_c_api_e2e!($lang, $glue, slow);
+    };
+    ($lang:expr, $glue:expr, $tier:tt) => {
+        $crate::slow_tier_test! { $tier,
+            #[test]
+            fn sqlite3_file_c_api() {
+                $crate::run_capi_case(&$lang, &$crate::SQLITE3_FILE_C_API, $glue);
+            }
         }
     };
 }
 
 /// See [`libsqlite3_c_api_e2e!`]. Runs the libpcap BPF-compile case
 /// [`PCAP_COMPILE`](crate::PCAP_COMPILE): drives `compile_filter` on
-/// "tcp port 80" and prints the serialized BPF program. Heavy (a ~2 MB
+/// "tcp port 80" and prints the serialized BPF program. Slow (a ~2 MB
 /// reactor artifact reconverted per run), so gated like the sqlite C-API
 /// cases.
 #[macro_export]
 macro_rules! pcap_compile_e2e {
     ($lang:expr, $glue:expr) => {
-        #[cfg_attr(
-            not(feature = "heavy_test"),
-            ignore = "heavy app case: --features heavy_test or -- --include-ignored"
-        )]
-        #[test]
-        fn pcap_compile() {
-            $crate::run_capi_case(&$lang, &$crate::PCAP_COMPILE, $glue);
+        $crate::pcap_compile_e2e!($lang, $glue, slow);
+    };
+    ($lang:expr, $glue:expr, $tier:tt) => {
+        $crate::slow_tier_test! { $tier,
+            #[test]
+            fn pcap_compile() {
+                $crate::run_capi_case(&$lang, &$crate::PCAP_COMPILE, $glue);
+            }
         }
     };
 }
 
 /// See [`libsqlite3_c_api_e2e!`]. Runs the tree-sitter JSON-parse case
 /// [`TREESITTER_PARSE`](crate::TREESITTER_PARSE): drives `parse_source` on a
-/// fixed JSON snippet and prints the parse tree's S-expression. Heavy (a
+/// fixed JSON snippet and prints the parse tree's S-expression. Slow (a
 /// ~1.5 MB reactor artifact reconverted per run), so gated like the sqlite
 /// C-API cases.
 #[macro_export]
 macro_rules! treesitter_parse_e2e {
     ($lang:expr, $glue:expr) => {
-        #[cfg_attr(
-            not(feature = "heavy_test"),
-            ignore = "heavy app case: --features heavy_test or -- --include-ignored"
-        )]
-        #[test]
-        fn treesitter_parse() {
-            $crate::run_capi_case(&$lang, &$crate::TREESITTER_PARSE, $glue);
+        $crate::treesitter_parse_e2e!($lang, $glue, slow);
+    };
+    ($lang:expr, $glue:expr, $tier:tt) => {
+        $crate::slow_tier_test! { $tier,
+            #[test]
+            fn treesitter_parse() {
+                $crate::run_capi_case(&$lang, &$crate::TREESITTER_PARSE, $glue);
+            }
         }
     };
 }
@@ -493,13 +539,14 @@ macro_rules! treesitter_parse_e2e {
 #[macro_export]
 macro_rules! sqlite3_callback_binding_e2e {
     ($lang:expr, $glue:expr) => {
-        #[cfg_attr(
-            not(feature = "heavy_test"),
-            ignore = "heavy app case: --features heavy_test or -- --include-ignored"
-        )]
-        #[test]
-        fn sqlite3_callback_binding() {
-            $crate::run_capi_case(&$lang, &$crate::SQLITE3_CALLBACK_BINDING, $glue);
+        $crate::sqlite3_callback_binding_e2e!($lang, $glue, slow);
+    };
+    ($lang:expr, $glue:expr, $tier:tt) => {
+        $crate::slow_tier_test! { $tier,
+            #[test]
+            fn sqlite3_callback_binding() {
+                $crate::run_capi_case(&$lang, &$crate::SQLITE3_CALLBACK_BINDING, $glue);
+            }
         }
     };
 }

--- a/crates/dewasm-test-helper/src/qjs_repl.rs
+++ b/crates/dewasm-test-helper/src/qjs_repl.rs
@@ -37,7 +37,7 @@ pub const QJS_REPL_SESSION: &[u8] = b"1+2\r[3,1,2].sort()\rMath.max(4,9)\r\\q\r"
 const QJS_PROMPT: &[u8] = b"qjs > ";
 
 /// Hard cap on the pty session (fail loud, ADR-15). Generous: the interactive
-/// loop is I/O-bound line editing, not the heavy batch qjs cases, but the
+/// loop is I/O-bound line editing, not the slow batch qjs cases, but the
 /// compiled backends may pay a one-time build inside `pty_command` first.
 const PTY_TIMEOUT: Duration = Duration::from_secs(180);
 
@@ -74,7 +74,7 @@ pub fn capture_qjs_repl_golden(lang: &dyn BackendUnderTest) -> Vec<u8> {
 /// drive its REPL under a pty, and require the transcript to be
 /// byte-identical to the wasmtime golden. The perf opt-out lives at the
 /// macro/feature level (`qjs_repl_pty_e2e!` expands its `#[test]` as
-/// `#[ignore]`d unless the `heavy_test` feature is on), so this runner runs
+/// `#[ignore]`d unless the `slow_test` feature is on), so this runner runs
 /// unconditionally.
 pub fn run_qjs_repl_pty(lang: &dyn BackendUnderTest) {
     let golden = std::fs::read(qjs_repl_golden_path()).unwrap_or_else(|e| {

--- a/crates/dewasm-test-helper/src/spec.rs
+++ b/crates/dewasm-test-helper/src/spec.rs
@@ -139,7 +139,11 @@ fn spec_dir() -> std::path::PathBuf {
 /// trials, so a plain `cargo test` runs the curated set and `--include-ignored`
 /// (or `--ignored`) sweeps the whole testsuite. Trials run on libtest-mimic's
 /// thread pool; each owns its per-file state, so the sweep parallelizes.
-pub fn spec_trials(lang: &'static dyn SpecBackend) -> Vec<Trial> {
+///
+/// `slow_tier` is the backend crate's `slow_test` feature (CI's main sweep tier,
+/// ADR-48): when on, nothing is marked ignored — the whole testsuite runs, the
+/// same set the old `--include-ignored` sweep covered.
+pub fn spec_trials(lang: &'static dyn SpecBackend, slow_tier: bool) -> Vec<Trial> {
     let dir = spec_dir();
     assert!(
         dir.exists(),
@@ -159,8 +163,13 @@ pub fn spec_trials(lang: &'static dyn SpecBackend) -> Vec<Trial> {
         .collect();
     names.sort();
 
-    let curated: Option<BTreeSet<&'static str>> =
-        lang.curated_files().map(|c| c.iter().copied().collect());
+    // The slow tier runs the whole testsuite (nothing curated => nothing
+    // ignored below), matching the old `--include-ignored` main sweep.
+    let curated: Option<BTreeSet<&'static str>> = if slow_tier {
+        None
+    } else {
+        lang.curated_files().map(|c| c.iter().copied().collect())
+    };
 
     names
         .into_iter()
@@ -179,9 +188,9 @@ pub fn spec_trials(lang: &'static dyn SpecBackend) -> Vec<Trial> {
 
 /// harness=false entry point: parse cargo's test arguments (name filter,
 /// `--ignored`/`--include-ignored`, thread count, ...) and run the trials.
-pub fn spec_main(lang: &'static dyn SpecBackend) {
+pub fn spec_main(lang: &'static dyn SpecBackend, slow_tier: bool) {
     let args = libtest_mimic::Arguments::from_args();
-    libtest_mimic::run(&args, spec_trials(lang)).exit();
+    libtest_mimic::run(&args, spec_trials(lang, slow_tier)).exit();
 }
 
 /// Run one `.wast` file and apply the per-file gates that the old aggregate

--- a/crates/dewasm-test-helper/tests/apps_wasmtime.rs
+++ b/crates/dewasm-test-helper/tests/apps_wasmtime.rs
@@ -22,7 +22,7 @@
 
 use dewasm_test_helper::{
     assert_transcript_eq, capture_qjs_repl_transcript, qjs_repl_golden_path, run_app_case,
-    run_fs_app_case, run_gzip_cases, run_heavy_app_case, run_standalone_dir, Wasmtime, COWSAY_ARGS,
+    run_fs_app_case, run_gzip_cases, run_slow_app_case, run_standalone_dir, Wasmtime, COWSAY_ARGS,
     COWSAY_STDIN, CPYTHON_HELLO, CRUBY_HELLO, QJS_EVAL, QJS_FILE_IO, QJS_REPL, RG_SEARCH,
     SQLITE3_SHELL, SQLITE3_SHELL_DBFILE,
 };
@@ -38,7 +38,7 @@ use dewasm_test_helper::{
 // expr fragment). Calling the shared runners directly is the simplest honest
 // way to attach the `wasmtime_test` ignore gate while still routing through
 // the exact same runners the real backends use. The runners themselves are
-// ungated (the heavy per-case macros carry their own `heavy_test`-feature
+// ungated (the slow per-case macros carry their own `slow_test`-feature
 // `#[ignore]` instead, ADR-27 revision), so `wasmtime_test` alone gates every
 // test in this file.
 
@@ -57,13 +57,13 @@ fn cowsay_stdin() {
 #[cfg_attr(not(feature = "wasmtime_test"), ignore)]
 #[test]
 fn qjs_eval() {
-    run_heavy_app_case(&Wasmtime, &QJS_EVAL);
+    run_slow_app_case(&Wasmtime, &QJS_EVAL);
 }
 
 #[cfg_attr(not(feature = "wasmtime_test"), ignore)]
 #[test]
 fn sqlite3_shell() {
-    run_heavy_app_case(&Wasmtime, &SQLITE3_SHELL);
+    run_slow_app_case(&Wasmtime, &SQLITE3_SHELL);
 }
 
 #[cfg_attr(not(feature = "wasmtime_test"), ignore)]

--- a/docs/adr/48-slow-test-tiers.md
+++ b/docs/adr/48-slow-test-tiers.md
@@ -1,0 +1,67 @@
+# ADR-48 — Two-Tier Slow-Test Gating (slow_test / ultra_slow_test)
+
+Status: **Accepted, 2026-07-29.** Implemented across the backend crates'
+cargo features, the `dewasm-test-helper` case macros (`slow_tier_test!`), the
+spec harness's sweep gating, and the CI workflow's main-branch legs.
+
+## Context
+
+The former single `heavy_test` feature marked every non-fast case, and CI's
+main-branch sweep ran them all via `cargo test -- --include-ignored`. The
+first such run (issues #22, #23) showed the tier conflates two classes: cases
+that are slow but CI-affordable (the java/ruby app legs passed in minutes),
+and cases that individually exceed about a minute on a 4-core runner — the
+bash QuickJS REPL pty case (no prompt within 180 s) and go's
+giant-generated-program builds, whose parallel `go build`s exhausted runner
+memory and got the job killed. Verifying those on every push costs more than
+it returns, but the fail-loud policy ([ADR-15](15-tests-fail-not-skip.md))
+rules out anything that silently skips. "Heavy" was also the wrong word: the
+gate has always been about wall time.
+
+## Decision
+
+Two explicit tiers, named for what they gate:
+
+- `slow_test` (renamed from `heavy_test`): cases CI verifies on every push to
+  main. The feature also un-ignores the spec harness's non-curated sweep, so
+  the CI switch from `--include-ignored` to `--features slow_test` drops
+  nothing unintended.
+- `ultra_slow_test = ["slow_test"]`: cases CI deliberately does not run.
+  **Criterion: roughly one minute per test on a CI runner** (observed, not
+  estimated — a case is promoted on evidence from a real run). The tier is
+  chosen per callsite in each backend's `tests/e2e.rs`, so the same case can
+  be ultra for go (compiling a CPython-sized program) and slow for java.
+
+Local tiers: `cargo test` (fast gate) → `--features slow_test` (what CI's
+main sweep runs) → `--features ultra_slow_test` (everything);
+`-- --include-ignored` remains the feature-independent sledgehammer. The
+ultra tier is thereby *locally* verified — run it before declaring support or
+tagging a release — never silently skipped: the cases stay compiled (clippy
+runs `--all-features`) and visibly `ignored` in default output.
+
+## Rejected alternatives
+
+- **Keep `--include-ignored` and buy bigger runners.** Pays continuously for
+  cases that change rarely; the go memory exhaustion would need the largest
+  runners for a handful of tests.
+- **Runtime time-budget skipping** (skip when a case exceeds N seconds).
+  Nondeterministic pass/skip is exactly what ADR-15 forbids; a tier flip in
+  a reviewed diff is auditable, a runtime skip is not.
+- **A single tier with per-case CI excludes in the workflow.** Scatters the
+  test-selection policy into YAML `--skip` lists that nothing type-checks;
+  the feature keeps the policy next to the case and greppable.
+- **Keeping the `heavy` name.** The gate has never measured memory or size —
+  only time. Historical ADRs keep the old name; living docs and code use
+  `slow`.
+
+## Consequences
+
+- CI main legs run `--features <backend>/slow_test` (the core job:
+  `dewasm-cli/slow_test,dewasm-test-helper/wasmtime_test`); #22 and #23 are
+  resolved by reclassification rather than tuning timeouts and thread counts.
+- The ultra tier's coverage now depends on the local pre-release habit the
+  criterion implies; the tier list is small (bash: 1 pty case, go: 8 builds)
+  and each entry cites the evidence that promoted it.
+- A future case is promoted (or demoted) by editing one callsite and citing a
+  CI run, mirroring the evidence-driven criterion of
+  [ADR-47](47-ruby-f64-sub-quiet-guard.md).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -69,6 +69,7 @@ the consequences.
 | ADR-45 | [Rails Demo via a sqlite3-Gem Shim over Converted libsqlite3](45-rails-sqlite3-shim-example.md) | Accepted |
 | ADR-46 | [Host-OS-Scoped Expected-Failure Ledgers for the WASI Testsuite Harness](46-host-scoped-wasi-ledgers.md) | Accepted |
 | ADR-47 | [Inline Quiet-NaN Guard for Ruby f64.sub](47-ruby-f64-sub-quiet-guard.md) | Accepted |
+| ADR-48 | [Two-Tier Slow-Test Gating (slow_test / ultra_slow_test)](48-slow-test-tiers.md) | Accepted |
 
 ## Adding a new ADR
 

--- a/docs/apps-audit.md
+++ b/docs/apps-audit.md
@@ -50,8 +50,8 @@ Python (`qjs_file_io_python`, `qjs_repl_python`, ADR-28), Go
 (`qjs_file_io_go`, `qjs_repl_go`, ADR-29's third milestone), and Java
 (`qjs_file_io_java`, `qjs_repl_java`, ADR-30's third milestone, all adopting
 ADR-14's fs model) now mirror both against the same fixtures and goldens,
-gated behind the `heavy_test` cargo feature in each crate (`#[ignore]`d
-otherwise; run with `--features heavy_test` or `-- --include-ignored`):
+gated behind the `slow_test` cargo feature in each crate (`#[ignore]`d
+otherwise; run with `--features slow_test` or `-- --include-ignored`):
 
 - *File I/O* (`qjs_file_io_ruby`): the `qjs:std` module writes a file,
   reads it back, and prints it; the test asserts the guest stdout golden
@@ -80,7 +80,7 @@ otherwise; run with `--features heavy_test` or `-- --include-ignored`):
   it does under wasmtime). The interactive REPL is now verified
   **byte-identical to wasmtime under a real pty** on all four
   poll_oneoff backends (Ruby, Python, Go, Java): the `qjs_repl_pty` case
-  (`qjs_repl_pty_e2e!`, gated on the `heavy_test` feature) converts bare qjs to a
+  (`qjs_repl_pty_e2e!`, gated on the `slow_test` feature) converts bare qjs to a
   standalone program, drives the scripted session
   `1+2⏎[3,1,2].sort()⏎Math.max(4,9)⏎\q⏎` under an 80x24 pty
   (`crates/dewasm-test-helper/src/pty.rs`, `portable-pty`), and compares the
@@ -98,7 +98,7 @@ artifacts (ADR-22); the DB-*file* lifecycle and a guest→host callback are
 now covered on the existing ADR-14 syscall set (no new WASI unit). The
 shell DB-file case is also mirrored under Python (`sqlite3_shell_dbfile_python`),
 Go (`sqlite3_shell_dbfile_go`), and Java (`sqlite3_shell_dbfile_java`), same
-fixture/golden, `heavy_test`-feature-gated;
+fixture/golden, `slow_test`-feature-gated;
 the C-API/callback cases stay Ruby-only (they exercise Ruby's provider/guest-
 memory idioms, not new WASI fs):
 
@@ -158,8 +158,8 @@ Where included, each is comfortably under the ADR-24 ~5-minute bar, so it
 genuinely executes rather than being a conversion-only smoke. Because the
 heavy source and RSS on *every* `cargo test` is too costly for the default
 gate, both cases (like all filesystem-app cases) are gated behind the
-`heavy_test` cargo feature —
-the same deliberate perf opt-out the heavy `apps` cases use (ADR-15's
+`slow_test` cargo feature —
+the same deliberate perf opt-out the slow `apps` cases use (ADR-15's
 documented scope: a perf gate, not a missing-environment skip). CRuby on Ruby
 is the "Ruby on Ruby" north-star demo.
 
@@ -175,7 +175,7 @@ run-to-run). ripgrep imports `poll_oneoff`/`path_readlink` but does not call
 them on this path, so no new WASI unit was needed. Ruby (`rg_search_ruby`):
 convert ~1.4 s, run ~1.7 s. Python (`rg_search_python`), Go
 (`rg_search_go`, ADR-29), and Java (`rg_search_java`, ADR-30) now mirror it
-against the same fixture/golden, `heavy_test`-feature-gated: Python ~10 s
+against the same fixture/golden, `slow_test`-feature-gated: Python ~10 s
 convert+run for the 22 MB wasm; Go convert+`go build`+run cold likewise
 dominated by the compile. Java is the class-split stress case: rg's ~7300
 functions and ~4900-entry function table overflow a single class's 65535-entry
@@ -196,7 +196,7 @@ byte-stdio path is exact through compiled output too, ADR-29/ADR-30). Two cases:
 `examples/apps/golden/minigzip_compress.gz`) and *round trip* (compress then
 `-d` decompress → original, self-checking). zlib's gz stream is deterministic
 here — mtime 0, OS byte 3 — so wasmtime and every backend agree byte-for-byte.
-Not marked heavy: no softfloat, so Bash runs it too (compress ~0.9 s + round
+Not marked slow: no softfloat, so Bash runs it too (compress ~0.9 s + round
 trip ~0.3 s under Bash). The binary stdin/golden cannot travel through the
 `&str`/`include_str!` `APP_CASES` path, so these live in a dedicated
 `run_gzip_cases` (bytes-capable `run_bytes`/`run_command_bytes` helpers) that
@@ -215,7 +215,7 @@ guest memory; the C-API case (`pcap_compile`, `pcap_compile_e2e!`) drives
 `compile_filter("tcp port 80", DLT_EN10MB, 65535)` on Ruby, Python, and Go and
 pins the canonical tcp-port-80 program (deterministic — BPF holds
 offsets/constants only). Like the other reactor-library C-API cases it is
-`heavy_test`-gated (a ~2 MB artifact reconverted per run). Bash does not
+`slow_test`-gated (a ~2 MB artifact reconverted per run). Bash does not
 participate: no host-language C API to plumb a pointer-returning binding
 through (ADR-12). *Shim caveat:* wasip1 has no `./configure` host, no
 `socket()`, and no baseline `setjmp`/`longjmp`, so a first-party
@@ -247,7 +247,7 @@ malloc'd C string) into guest memory. The C-API case (`treesitter_parse`,
 Ruby, Python, and Go and pins the S-expression `(document (object (pair key:
 (string (string_content)) value: (array (number) (true) (null)))))`
 (deterministic — tree-sitter's node naming is fixed by the pinned grammar).
-`heavy_test`-gated like the other reactor-library C-API cases; Bash does not
+`slow_test`-gated like the other reactor-library C-API cases; Bash does not
 participate (ADR-12).
 
 ¹¹ **ADR-39 `wasm-opt` preprocessing.** The three modules `fetch.sh` builds

--- a/docs/backends/bash.md
+++ b/docs/backends/bash.md
@@ -56,9 +56,11 @@ WASI. The e2e override glue
 ## Caveats
 
 - **Speed.** Bash arithmetic is signed-64 only, and every float operation is
-  softfloat integer arithmetic, so float-heavy programs are slow — the heavy
+  softfloat integer arithmetic, so float-heavy programs are slow — the slow
   apps (QuickJS, SQLite) are `#[ignore]`d for Bash by default and run only
-  under the `heavy_test` cargo feature (or `cargo test -- --include-ignored`).
+  under the `slow_test` cargo feature (or `cargo test -- --include-ignored`);
+  the interactive qjs REPL pty case is slower still and sits at the
+  `ultra_slow_test` tier ([ADR-48](../adr/48-slow-test-tiers.md), kept out of CI).
   Integer-only programs (cowsay, minigzip) run fine.
 - Every generated function ends with an explicit `return 0`; a trailing
   arithmetic statement would otherwise leak status 1 (the units lint enforces

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -31,7 +31,9 @@ message below is something this document explains how to fix.
 - **`python3` >= 3.9 on `PATH` (or `$DEWASM_PYTHON`)**: needed by the
   Python backend's spec/e2e tests. Like Bash, the Python spec harness runs
   a curated `.wast` subset by default; add `-- --include-ignored` to run
-  every file.
+  every file. Note: the slow qjs-scale generated modules (deep loop nesting)
+  need **python >= 3.12.4** — 3.12.0–3.12.3 hit a static-block limit that
+  breaks that generated code (issue #21), so CI pins 3.13.
 - **`bash` >= 5 on `PATH`, `$DEWASM_BASH`, or a common Homebrew
   install path**: needed by the Bash backend's spec/e2e/softfloat tests.
   macOS's system `/bin/bash` is 3.2 and does not qualify (no associative
@@ -169,11 +171,13 @@ on `dewasm-core` + `dewasm-backend` (never on a concrete backend).
   `shared_table_e2e!`/`embedded_coexist_e2e!`, `wasi_root_containment_e2e!`) take
   no glue (the apps macros) or one named glue-string constant as their only
   glue argument; the WASI-filesystem template `wasi_suite!(Fs, …)` likewise
-  takes one glue constant. `qjs_eval_e2e!`/`sqlite3_shell_e2e!` are heavy —
+  takes one glue constant. `qjs_eval_e2e!`/`sqlite3_shell_e2e!` are slow —
   the macro expands their generated `#[test]` as `#[ignore]`d unless the
-  expanding backend crate's `heavy_test` feature is enabled (run it with
-  `--features heavy_test`, or run everything including ignored tests with a
-  single `cargo test -- --include-ignored`). Per the ADR-27 revision this file
+  expanding backend crate's `slow_test` feature is enabled (run it with
+  `--features slow_test`, or run everything including the ultra tier with a
+  single `cargo test -- --include-ignored`); a callsite may pass a trailing
+  `ultra` tier token ([ADR-48](adr/48-slow-test-tiers.md)). Per the ADR-27
+  revision this file
   contains **only** the `BackendUnderTest` impl, named glue string constants
   (library glue, the WASI-filesystem template, the filesystem-app instantiation
   glue, the C-API driver glue, the multi-module driver glue, and the
@@ -191,10 +195,12 @@ on `dewasm-core` + `dewasm-backend` (never on a concrete backend).
   when `fd_fdstat_get` on stdin reports a character device; a pipe does not.
   The scripted session is *prompt-driven*: each line is sent only after the
   `qjs > ` prompt reappears, so the transcript is stable regardless of how long
-  a backend takes to start (Ruby parses a ~200 MB source first). Heavy: like
-  the other heavy per-case macros, `qjs_repl_pty_e2e!`'s generated `#[test]`
-  is `#[ignore]`d unless the expanding backend crate's `heavy_test` feature is
-  enabled (perf opt-out, ADR-15); the golden lives at
+  a backend takes to start (Ruby parses a ~200 MB source first). Slow: like
+  the other slow per-case macros, `qjs_repl_pty_e2e!`'s generated `#[test]`
+  is `#[ignore]`d unless the expanding backend crate's `slow_test` feature is
+  enabled (perf opt-out, ADR-15). For bash it is promoted to the ultra tier
+  (`ultra_slow_test`) because it timed out on CI
+  ([ADR-48](adr/48-slow-test-tiers.md), #22); the golden lives at
   `examples/apps/golden/qjs_repl_interactive.transcript`.
 - The units lint (`declared_requires_cover_references`, `all_units_bundle`, and
   the go/java whole-bundle compile checks) lives as `#[cfg(test)] mod units`
@@ -255,7 +261,9 @@ variables with cargo's own test UX:
   curated list are `#[ignore]`d trials, so a plain `cargo test` runs the curated
   set (Ruby is fast enough to curate nothing — it runs all files), and
   `-- --include-ignored` (or `-- --ignored` for only the non-curated ones)
-  sweeps the whole testsuite.
+  sweeps the whole testsuite. The `slow_test` feature also runs the full sweep
+  (nothing is marked ignored), so CI's main leg — `--features slow_test` — covers
+  every `.wast` file ([ADR-48](adr/48-slow-test-tiers.md)).
 - **Trials run in parallel** on libtest-mimic's thread pool; each trial owns its
   per-file state, so the sweeps parallelize across cores (control the thread
   count with `-- --test-threads=N`).
@@ -266,16 +274,25 @@ summary plus the failing assertion lines. The former aggregate cross-backend
 Per-file failure counts are still gated against each backend's
 `EXPECTED_FAILURES` ledger (ADR-8) inside the trial.
 
-The heavy app cases (QuickJS, SQLite, the filesystem apps, the C-API cases,
-the interactive-REPL pty case) are gated by the `heavy_test` cargo feature
-instead of an environment variable: each backend crate declares it, and the
-per-case macros expand their generated `#[test]` as `#[ignore]`d unless it is
-enabled. Run them for one backend with `--features heavy_test` (e.g.
-`cargo test -p dewasm-backend-bash --features heavy_test --test e2e`), or run
-everything across the whole workspace — including every backend's heavy
-cases — with a single `cargo test -- --include-ignored` (this is a
-deliberate perf-based opt-out, not a missing-environment one — see ADR-15's
-scope).
+The slow app cases (QuickJS, SQLite, the filesystem apps, the C-API cases,
+the interactive-REPL pty case) run in two tiers gated by cargo features rather
+than an environment variable ([ADR-48](adr/48-slow-test-tiers.md)):
+
+- **`slow_test`** — CI's main sweep. Each backend crate declares it; the
+  per-case macros expand their generated `#[test]` as `#[ignore]`d unless it is
+  enabled, and it also runs the full spec-testsuite sweep. Run one backend's
+  slow tier with `--features slow_test` (e.g.
+  `cargo test -p dewasm-backend-bash --features slow_test --test e2e`).
+- **`ultra_slow_test`** (implies `slow_test`) — the cases measured at roughly a
+  minute or more on a CI runner: the interactive qjs REPL pty case (bash timed
+  out >180s, #22) and go's giant-generated-program `go build`s (which
+  collectively exhausted a 4-core runner's memory, #23). These are pinned per
+  callsite and **deliberately kept out of CI** — run them only in local
+  pre-release verification with `--features ultra_slow_test` or the
+  everything-included `cargo test -- --include-ignored`.
+
+This is a deliberate perf-based opt-out, not a missing-environment one — see
+ADR-15's scope; the ultra tier is not CI-verified.
 
 See `AGENTS.md`'s Common commands table for the exact invocations.
 


### PR DESCRIPTION
Closes #24, closes #22, closes #23; refs #21.

Implements the two-tier proposal: rename `heavy_test` → `slow_test` (the gate has always been about wall time), and add a per-callsite `ultra_slow_test` tier for cases observed at roughly a minute or more per test on CI runners — those run only locally (`--features ultra_slow_test` or `-- --include-ignored`), stay compiled (clippy `--all-features`) and visibly `ignored`, so nothing silently skips (ADR-15). Recorded as **ADR-48** with the criterion and rejected alternatives.

- **Tier assignments (evidence-cited)**: bash `qjs_repl_pty` (>180 s, #22); go's eight 60 s+ giant builds (`qjs_eval`, `qjs_file_io`, `cpython_hello`, `rg_search`, `libsqlite3_c_api`, `sqlite3_shell`, `sqlite3_file_c_api`, `sqlite3_callback_binding`) whose parallel `go build`s killed the job (#23). Everything else stays slow tier.
- **Mechanism**: the shared `*_e2e!` case macros take an optional tier token (`qjs_eval_e2e!(Go, ultra)`), backed by a `slow_tier_test!` helper; per-backend `ultra_slow_test = ["slow_test"]`.
- **CI**: main legs switch from `-- --include-ignored` to `--features <backend>/slow_test` (core: `dewasm-cli/slow_test,dewasm-test-helper/wasmtime_test`). The `slow_test` feature now also un-ignores the spec harness's non-curated sweep, so the switch drops nothing the old command ran; dewasm-cli's `data_file` slow cases get the same feature gate instead of bare `#[ignore]`.
- **#21 (CI part)**: the python leg and core job pin CPython 3.13 via `actions/setup-python` — ubuntu-24.04's system 3.12.3 has the pre-3.12.4 static-block accounting that qjs-scale generated code trips. The lowering-side fix stays open in #21.
- Docs: AGENTS.md / docs/testing.md tier story updated (fast gate → slow_test = CI's main sweep → ultra = local pre-release verification); `run_heavy_app_case` and related comments renamed to match.

## Verification

- `cargo test` (fast gate) fully green; ruby slow tier runs under the renamed feature; go slow tier runs with exactly the 8 ultra cases ignored; one ultra case runs under `ultra_slow_test`; go spec ignored trials 178 → 0 under `slow_test` (sweep preserved).
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `actionlint` all clean; `grep heavy_test` empty outside docs/adr.
- After merge: `gh workflow run ci.yml` should now give a green heavy sweep — the remaining red from the first sweep was exactly #21 (fixed here via setup-python) plus the reclassified #22/#23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)