### PR TITLE
True up README, apps README, and ADR-26 after the org move

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ Build from source with the pinned Rust toolchain (picked up automatically
 from `rust-toolchain.toml`):
 
 ```console
-$ cargo install --git https://github.com/makenowjust-sandbox/dewasm dewasm-cli
+$ cargo install --git https://github.com/dewasm/dewasm dewasm-cli
 ```
 
 or clone and build locally:
 
 ```console
-$ git clone https://github.com/makenowjust-sandbox/dewasm
+$ git clone https://github.com/dewasm/dewasm
 $ cd dewasm
 $ cargo build --release        # binary at target/release/dewasm
 ```
@@ -159,9 +159,13 @@ source file that runs in ~60 s — and Bash skips them by default because its
 softfloat makes float-heavy programs slow. These are deliberate performance
 opt-outs, not correctness gaps ([ADR-15](docs/adr/15-tests-fail-not-skip.md)).
 
-The north-star demos we steer toward: a library-mode SQLite as a pure-Ruby
-`sqlite3` driver (Ruby on Rails on a dewasmified SQLite), and C/Rust tools
-running under plain Bash.
+The other north-star demo — a library-mode SQLite as a pure-Ruby `sqlite3`
+driver, real enough to run Ruby on Rails against a dewasm-converted SQLite —
+has shipped as `examples/rails`
+([ADR-45](docs/adr/45-rails-sqlite3-shim-example.md)): an unmodified Rails 8
+app served over HTTP with `libsqlite3.wasm` converted to Ruby as its only
+database engine. C/Rust tools running under plain Bash are demonstrated
+above by `cowsay` and `minigzip`.
 
 ## Scope
 
@@ -204,7 +208,8 @@ rejected at conversion time with a clear error, never a runtime surprise
 
 ## Toward 0.1
 
-The backends and the app gate are in place. Remaining before tagging 0.1:
+The backends and the app gate are in place, and the GitHub repository has
+been renamed and moved to `dewasm` ([ADR-26](docs/adr/26-rename-dewasm.md)).
+Remaining before tagging 0.1:
 
-1. Rename the GitHub repository to `dewasm` ([ADR-26](docs/adr/26-rename-dewasm.md)).
-2. Cut and tag the 0.1 release.
+1. Cut and tag the 0.1 release.

--- a/docs/adr/26-rename-dewasm.md
+++ b/docs/adr/26-rename-dewasm.md
@@ -1,9 +1,10 @@
 # ADR-26 — Rename the Project: dewasmify → dewasm
 
-Status: **Accepted, 2026-07-25.** Landed 2026-07-26: crates are
-`dewasm-*`, the binary is `dewasm`, env vars are `DEWASM_*`, and docs
-are swept (superseded ADR bodies keep the historical name). The GitHub
-repository rename remains a manual step. Amends the naming note in
+Status: **Accepted, 2026-07-25; fully landed 2026-07-28.** Landed
+2026-07-26: crates are `dewasm-*`, the binary is `dewasm`, env vars are
+`DEWASM_*`, and docs are swept (superseded ADR bodies keep the
+historical name). The GitHub repository itself now lives at
+`github.com/dewasm/dewasm` (commit ae2b430). Amends the naming note in
 [ADR-0](0-foundation.md).
 
 ## Context

--- a/examples/apps/README.md
+++ b/examples/apps/README.md
@@ -6,22 +6,25 @@ upstream, for demos and end-to-end tests.
 **No third-party artifact is committed to this repository** (ADR-9).
 `./fetch.sh` downloads version-pinned, sha256-verified files into
 `cache/` (gitignored); licensing of the binaries stays entirely with
-their upstream distribution. The `apps` cases of the `e2e` test
-(`crates/dewasm-cli/tests/e2e/apps.rs`) convert each cached app and
-compare its output against the golden files in `golden/` (captured once
-from wasmtime; re-validated via `--features wasmtime_test`). A missing
-cache or `ruby` fails the test loudly rather than skipping (ADR-15) —
-run `./fetch.sh` first.
+their upstream distribution. The `apps` cases
+(`crates/dewasm-test-helper/src/apps.rs`, plus `apps_capi.rs` and
+`apps_fs.rs` for the C-API and filesystem shapes) convert each cached app
+and compare its output against the golden files in `golden/` (captured
+once from wasmtime; re-validated via `--features wasmtime_test`), run per
+backend as that backend's `e2e` test, e.g.
+`cargo test -p dewasm-backend-ruby --test e2e apps`. A missing cache or
+`ruby` fails the test loudly rather than skipping (ADR-15) — run
+`./fetch.sh` first.
 
 | App | Source | What it demonstrates |
 | --- | --- | --- |
 | cowsay | [syrusakbary/cowsay@0.3.0](https://wasmer.io/syrusakbary/cowsay) (Wasmer registry) | args + stdout, the classic demo |
 | qjs | [quickjs-ng v0.15.1](https://github.com/quickjs-ng/quickjs/releases/tag/v0.15.1) `qjs-wasi.wasm` (official WASI CLI release asset) | a complete JavaScript engine (1.5 MB wasm) running on plain Ruby; deepened with file-I/O and REPL fixtures (Phase 5a) |
 | sqlite3 | [sqlite 3.53.3 amalgamation](https://sqlite.org/2026/sqlite-amalgamation-3530300.zip), built from source with `zig` (ADR-22) | the full SQLite engine in three shapes: the CLI shell, the C-API library, and a guest→host callback binding |
-| minigzip | [zlib 1.3.1](https://github.com/madler/zlib/releases/tag/v1.3.1), built from source with `zig` | binary-stdio (de)compression — the byte-exact gzip stress that runs under **both** Ruby and Bash (Phase 5b) |
-| rg (ripgrep) | [ripgrep 14.1.1](https://github.com/BurntSushi/ripgrep/releases/tag/14.1.1), built with `cargo build --target wasm32-wasip1` | recursive directory search over a preopened fixture tree, byte-identical to `wasmtime --dir` (Ruby-only, Phase 5b) |
-| cpython | [CPython 3.14.6 wasi build](https://github.com/brettcannon/cpython-wasi-build/releases/tag/v3.14.6) (official prebuilt) | a whole Python interpreter converted and **executed** on Ruby, reading its stdlib from a preopen (Ruby-only, heavy; Phase 5b) |
-| ruby (CRuby) | [ruby.wasm 2.9.4](https://github.com/ruby/ruby.wasm/releases/tag/2.9.4) full build (official prebuilt) | CRuby 3.4 executed on the Ruby backend — the "Ruby on Ruby" north-star demo (Ruby-only, heavy; Phase 5b) |
+| minigzip | [zlib 1.3.1](https://github.com/madler/zlib/releases/tag/v1.3.1), built from source with `zig` | binary-stdio (de)compression — the byte-exact gzip stress that runs under **all five backends** (Phase 5b) |
+| rg (ripgrep) | [ripgrep 14.1.1](https://github.com/BurntSushi/ripgrep/releases/tag/14.1.1), built with `cargo build --target wasm32-wasip1` | recursive directory search over a preopened fixture tree, byte-identical to `wasmtime --dir` (Ruby + Python + Go + Java, Phase 5b) |
+| cpython | [CPython 3.14.6 wasi build](https://github.com/brettcannon/cpython-wasi-build/releases/tag/v3.14.6) (official prebuilt) | a whole Python interpreter converted and **executed**, reading its stdlib from a preopen (Ruby + Python + Go, heavy; Phase 5b) |
+| ruby (CRuby) | [ruby.wasm 2.9.4](https://github.com/ruby/ruby.wasm/releases/tag/2.9.4) full build (official prebuilt) | CRuby 3.4 executed on the Ruby backend — the "Ruby on Ruby" north-star demo (Ruby + Python, heavy; Phase 5b) |
 | libpcap | [libpcap 1.10.6](https://www.tcpdump.org/release/libpcap-1.10.6.tar.gz), built from source with `zig` (reactor) | libpcap's BPF filter compiler as a C-API library: `compile_filter("tcp port 80")` returns a serialized BPF program from guest memory, driven on Ruby + Python + Go (heavy) |
 | treesitter | [tree-sitter 0.26.11](https://github.com/tree-sitter/tree-sitter/releases/tag/v0.26.11) + [tree-sitter-json 0.24.8](https://github.com/tree-sitter/tree-sitter-json/releases/tag/v0.24.8), built from source with `zig` (reactor) | the tree-sitter parsing runtime as a C-API library: `parse_source("{...}")` returns the JSON parse tree's S-expression, driven on Ruby + Python + Go (heavy) |
 


### PR DESCRIPTION
## Summary

Fixes the staleness confirmed in #32:

- `README.md` — install/clone commands now point at `github.com/dewasm/dewasm` instead of the old `makenowjust-sandbox` org.
- `README.md` "Toward 0.1" — dropped the "rename the GitHub repository" item (done) and folded it into the intro sentence with a link to ADR-26; only "cut and tag the 0.1 release" remains. (Checked whether other items had quietly landed too — the MIT license / repo-metadata commit `ae2b430` isn't a checklist item here, and there's no `v0.1.0` tag yet, so nothing else to true up.)
- `README.md` "north-star demos" — rewrote the SQLite/Rails paragraph in past tense: it shipped as `examples/rails` (ADR-45), an unmodified Rails 8 app on `libsqlite3.wasm` converted to Ruby.
- `examples/apps/README.md` — fixed the e2e pointer (the old `crates/dewasm-cli/tests/e2e/apps.rs` doesn't exist; the real home is `crates/dewasm-test-helper/src/apps.rs` + `apps_capi.rs`/`apps_fs.rs`, run per backend via `cargo test -p dewasm-backend-<lang> --test e2e apps`), and corrected the ripgrep/CPython/CRuby/minigzip backend columns against `docs/apps-audit.md` (ripgrep: Ruby+Python+Go+Java; CPython: Ruby/Python/Go; CRuby: Ruby/Python; minigzip: all five).
- `docs/adr/26-rename-dewasm.md` — status now records the GitHub repository rename/move as landed (`github.com/dewasm/dewasm`, commit `ae2b430`), matching the wording style of other trued-up ADR statuses (e.g. ADR-34).

## Verification

- `git grep -n makenowjust-sandbox` — empty.
- `git grep -rn dewasmify -- ':!tests/spec'` — only historical mentions inside superseded ADR bodies (and the ADR-26 title/index entry), per ADR-26's own note.

## Test plan

- [x] Docs-only change; no code touched, no `cargo test` needed.
- [x] Confirmed `examples/rails` and ADR-45 exist and describe the shipped Rails demo.
- [x] Confirmed `crates/dewasm-test-helper/src/{apps,apps_capi,apps_fs}.rs` exist.
- [x] Cross-checked the apps table against `docs/apps-audit.md`'s verdicts/footnotes.
- [x] Confirmed no `v0.1.0` tag exists yet, so "cut and tag the 0.1 release" correctly remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)