### PR TITLE
Compare the wasmtime REPL golden modulo trailing CRLFs

### DIFF
--- a/crates/dewasm-test-helper/tests/apps_wasmtime.rs
+++ b/crates/dewasm-test-helper/tests/apps_wasmtime.rs
@@ -116,9 +116,27 @@ fn qjs_repl_interactive_golden() {
         )
     });
     let got = capture_qjs_repl_transcript(&Wasmtime);
-    assert_transcript_eq(&got, &golden, "wasmtime");
+    // Linux wasmtime emits one extra trailing CRLF on pty teardown that
+    // macOS wasmtime (which captured the golden) does not; the converted
+    // backends match the golden byte-for-byte on both hosts, so the
+    // difference is wasmtime's own exit behavior, outside the transcript's
+    // meaningful content (it ends at the `\q` echo). Compare modulo trailing
+    // CRLFs here only — the per-backend comparison stays exact (issue #33).
+    assert_transcript_eq(
+        trim_trailing_crlfs(&got),
+        trim_trailing_crlfs(&golden),
+        "wasmtime",
+    );
     println!(
         "qjs interactive REPL under wasmtime: matches the golden ({} bytes)",
         got.len()
     );
+}
+
+/// Strip any trailing `\r\n` pairs (see `qjs_repl_interactive_golden`).
+fn trim_trailing_crlfs(mut t: &[u8]) -> &[u8] {
+    while let Some(rest) = t.strip_suffix(b"\r\n") {
+        t = rest;
+    }
+    t
 }


### PR DESCRIPTION
Closes #33

The merged main's first slow-tier sweep was green except `core`, which failed only on `qjs_repl_interactive_golden`: live wasmtime (47.0.2, same as the golden's) emits **one extra trailing `\r\n` on Linux pty teardown** (got 2091 bytes vs want 2089, first diff at byte 2089 = end of golden). The golden itself is correct — the converted backends match it byte-for-byte on both macOS and Linux (go's `qjs_repl_pty` passed in the same run) — so this is wasmtime's own exit behavior, past the transcript's meaningful content (it ends at the `\q` echo).

The freshness test now compares after stripping trailing CRLF pairs from both sides; the per-backend transcript comparison stays exact. Verified on macOS with a live wasmtime (test passes; fmt/clippy clean). This PR's CI exercises lint + fast tests; the freshness test itself runs in the core job's slow leg on main after merge — that run should then be the first fully green sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)