### PR TITLE
Bail data-segment merging when any offset is non-constant

### DIFF
--- a/crates/dewasm-core/src/data_merge.rs
+++ b/crates/dewasm-core/src/data_merge.rs
@@ -7,27 +7,35 @@
 //! semantics-preserving win that composes with every downstream backend for
 //! free. This pass runs unconditionally at the end of module building.
 //!
-//! Three guards make the rewrite sound; failing any of them bails the whole
+//! Four guards make the rewrite sound; failing any of them bails the whole
 //! pass (leaving `module.datas` untouched):
 //!
 //! 1. **No bulk-memory segment references.** `memory.init` / `data.drop`
 //!    address segments *by index*; merging renumbers and drops indices, so a
 //!    single such op anywhere makes the pass unsafe.
-//! 2. **Declaration order is never reordered among barriers.** Only runs of
-//!    segments already consecutive in `module.datas` are merged; active
-//!    segments initialize in order and later writes win, so preserving order
-//!    preserves the final memory image.
+//! 2. **Declaration order is never reordered.** Only runs of segments already
+//!    consecutive in `module.datas` are merged; active segments initialize in
+//!    order and later writes win, so preserving order preserves the final
+//!    memory image.
 //! 3. **Active `i32.const` segments are globally ascending and
 //!    non-overlapping.** This proves no other constant-offset segment occupies
 //!    a gap between two merged segments, so zero-filling that gap cannot erase
-//!    a byte some other segment wrote.
+//!    a byte some other constant-offset segment wrote.
+//! 4. **Every active segment has an `i32.const` offset.** A `global.get`
+//!    offset writes to a runtime-unknown address that guard 3 cannot exclude
+//!    from the gaps: if it lands inside one and a merged blob is emitted after
+//!    it, the gap's zero fill silently clobbers its bytes (issue #28 — with
+//!    `[(global.get base) "XX", (i32.const 0) "ab", (i32.const 8) "cd"]` and
+//!    `base = 4`, the merged blob's zeros at 2..8 erase "XX" at 4..6). One
+//!    such segment anywhere therefore bails the whole pass, keeping guard 3's
+//!    "no segment occupies a gap" claim true for *every* segment. This forgoes
+//!    merging in mixed modules, but real toolchain output is all-const
+//!    (non-PIC) or all-`global.get __memory_base` (PIC, nothing to merge
+//!    either way), so nothing of value is lost.
 //!
 //! Passive segments (`offset: None`) carry no standalone memory effect once
 //! guard 1 has ruled out `memory.init`, so they pass straight through without
-//! closing an open run. A `global.get`-offset active segment writes to a
-//! runtime-unknown address and so acts as an opaque barrier: it flushes the
-//! current run, keeping its relative order against the constant-offset
-//! segments intact.
+//! closing an open run.
 
 use crate::ir::{DataSegment, Expr, Module, Stmt};
 
@@ -50,6 +58,17 @@ pub(crate) fn merge_adjacent_data_segments(module: &mut Module) {
     // Guard 3: the active i32.const segments must be globally ascending and
     // non-overlapping.
     if !active_const_segments_ascending(&module.datas) {
+        return;
+    }
+
+    // Guard 4: no active segment may have a non-constant (global.get) offset —
+    // its runtime-unknown target could sit inside a gap a merged blob
+    // zero-fills.
+    if module
+        .datas
+        .iter()
+        .any(|seg| !matches!(seg.offset, None | Some(Expr::I32Const(_))))
+    {
         return;
     }
 
@@ -81,7 +100,9 @@ pub(crate) fn merge_adjacent_data_segments(module: &mut Module) {
             }
             // Passive: no standalone memory effect, keep the run open.
             None => out.push(DataSegment { offset: None, data }),
-            // global.get (or any non-constant offset): opaque barrier.
+            // Non-constant offset: unreachable under guard 4; kept as an
+            // order-preserving pass-through so a future guard change cannot
+            // silently reorder writes.
             Some(other) => {
                 if let Some((run_start, acc)) = run.take() {
                     out.push(active_segment(run_start, acc));

--- a/crates/dewasm-core/tests/data_merge.rs
+++ b/crates/dewasm-core/tests/data_merge.rs
@@ -1,7 +1,7 @@
 //! The adjacent active-data-segment merging pass (ADR-41): assert the
 //! `module.datas` shape the pass produces from small wat inputs — merged runs,
-//! zero-filled gaps, the gap threshold, the `global.get` barrier, and every
-//! bail condition (bulk-memory ops, overlapping/descending offsets).
+//! zero-filled gaps, the gap threshold, and every bail condition (bulk-memory
+//! ops, overlapping/descending offsets, `global.get` offsets).
 
 use dewasm_core::build_module;
 use dewasm_core::ir::{DataSegment, Expr, Module};
@@ -64,9 +64,10 @@ fn gap_at_or_above_threshold_keeps_segments_separate() {
 }
 
 #[test]
-fn global_get_offset_is_a_barrier_that_flushes_the_run() {
-    // A `global.get` offset is opaque, so it neither merges nor lets the
-    // segments on either side merge across it.
+fn global_get_offset_bails_the_whole_pass() {
+    // A `global.get` offset writes to a runtime-unknown address, so its
+    // presence anywhere bails the pass: nothing merges, everything passes
+    // through unchanged.
     let m = module(
         r#"(module
             (import "env" "base" (global $base i32))
@@ -75,17 +76,53 @@ fn global_get_offset_is_a_barrier_that_flushes_the_run() {
             (data (global.get $base) "cd")
             (data (i32.const 4) "ef"))"#,
     );
-    assert_eq!(m.datas.len(), 3, "the barrier keeps all three separate");
+    assert_eq!(
+        m.datas.len(),
+        3,
+        "a global.get offset keeps all three apart"
+    );
     assert_eq!(const_offset(&m.datas[0]), Some(0));
     assert_eq!(m.datas[0].data, b"ab");
     assert!(
         matches!(m.datas[1].offset, Some(Expr::GlobalGet(_))),
-        "the barrier passes through unchanged: {:?}",
+        "the global.get segment passes through unchanged: {:?}",
         m.datas[1].offset
     );
     assert_eq!(m.datas[1].data, b"cd");
     assert_eq!(const_offset(&m.datas[2]), Some(4));
     assert_eq!(m.datas[2].data, b"ef");
+}
+
+#[test]
+fn global_get_before_mergeable_consts_bails_the_whole_pass() {
+    // Issue #28 regression. With `base = 4` at instantiation, "XX" lands at
+    // 4..6 — inside the 2..8 gap that merging the two const segments would
+    // zero-fill. The merged blob is emitted *after* the global.get segment,
+    // so its zeros would clobber "XX". The pass must therefore leave every
+    // segment untouched, keeping the final memory image identical.
+    let m = module(
+        r#"(module
+            (import "env" "base" (global $base i32))
+            (memory 1)
+            (data (global.get $base) "XX")
+            (data (i32.const 0) "ab")
+            (data (i32.const 8) "cd"))"#,
+    );
+    assert_eq!(
+        m.datas.len(),
+        3,
+        "no merge with a global.get segment present"
+    );
+    assert!(
+        matches!(m.datas[0].offset, Some(Expr::GlobalGet(_))),
+        "the global.get segment passes through unchanged: {:?}",
+        m.datas[0].offset
+    );
+    assert_eq!(m.datas[0].data, b"XX");
+    assert_eq!(const_offset(&m.datas[1]), Some(0));
+    assert_eq!(m.datas[1].data, b"ab", "no zero fill appended");
+    assert_eq!(const_offset(&m.datas[2]), Some(8));
+    assert_eq!(m.datas[2].data, b"cd");
 }
 
 #[test]


### PR DESCRIPTION
Fixes #28.

## The bug

`data_merge.rs` merges runs of adjacent `i32.const` active segments, zero-filling the gap between them. Guard 3 (globally ascending, non-overlapping const offsets) only proved that no other **const-offset** segment occupies a gap; a `global.get`-offset segment was treated as a mere run barrier, so its runtime-unknown target address was never excluded. If it lands inside a merged gap, the merged blob — emitted after it — overwrites its bytes with zeros at instantiation.

Reproduced end-to-end on the Ruby backend with the issue's shape (`[(global.get base) "XX", (i32.const 0) "ab", (i32.const 8) "cd"]`, imported `base = 4`), reading memory 0..10 after instantiation:

- before the fix: `ab\0\0\0\0\0\0cd` — "XX" clobbered
- after the fix: `ab\0\0XX\0\0cd` — identical to the unmerged image

## The rule chosen

The conservative one: a new guard 4 bails the whole pass when any active segment has a non-constant offset. It fits the pass's existing all-or-nothing guard structure and restores guard 3's "no segment occupies a gap" claim for *every* segment. A partial rule (e.g. merge only runs preceding the first `global.get`) buys nothing in practice: real toolchain output is either all-const (non-PIC) or all-`global.get __memory_base` (PIC — nothing mergeable either way). The soundness comment now covers the `global.get` case explicitly.

Regression tests: the issue-#28 shape plus the reworked mixed-offset case in `crates/dewasm-core/tests/data_merge.rs`. No checked-in goldens embed merged segments for imported-global modules (the app goldens are behavioral stdout), so nothing to regenerate.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test -p dewasm-core` — 6/6 suites ok (9 data_merge tests incl. the two new/updated)
- `cargo test -p dewasm-backend-ruby --test spec data -- --include-ignored` — 6 passed, 0 failed
- `cargo test -p dewasm-backend-go --test spec data -- --include-ignored` — 6 passed, 0 failed

The full gate (`cargo test` across all backends) runs on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)