### PR TITLE
Reject --data-file paths that collide with generated outputs

### DIFF
--- a/crates/dewasm-cli/src/main.rs
+++ b/crates/dewasm-cli/src/main.rs
@@ -98,6 +98,19 @@ fn main() -> Result<()> {
                      must be written to a real path next to the generated program"
                 );
             }
+            // The sidecar and the primary source are written independently
+            // (the loop below); a --data-file that resolves to the same file
+            // as -o would clobber the freshly written source with the data
+            // blob. Fail before anything is written (ADR-0).
+            if resolve_for_collision(path) == resolve_for_collision(&cli.output) {
+                bail!(
+                    "--data-file {} resolves to the same file as the output path {}: \
+                     the data sidecar would overwrite the generated source \
+                     (choose a different --data-file path)",
+                    path.display(),
+                    cli.output.display()
+                );
+            }
             let sidecar_name = path
                 .file_name()
                 .map(|s| s.to_string_lossy().into_owned())
@@ -147,6 +160,23 @@ fn main() -> Result<()> {
     // `sidecar_name`) goes to `--data-file`'s path, the primary source to
     // `-o` (ADR-37).
     let sidecar_name = opts.data_file.as_ref().map(|c| c.sidecar_name.as_str());
+    // Only the sidecar itself may carry `sidecar_name`: a generated source
+    // file sharing that name (e.g. the java backend's fixed `Main.java`)
+    // would be misrouted to the sidecar path and clobbered by the blob.
+    // Two shapes: with data segments the source *and* the sidecar match
+    // (`matching > 1`); without, the backend emits no sidecar and the lone
+    // matching file is the source (`matching == files.len()`). Fail before
+    // anything is written (ADR-0).
+    if let Some(name) = sidecar_name {
+        let matching = files.iter().filter(|f| f.name == name).count();
+        if matching > 1 || matching == files.len() {
+            bail!(
+                "--data-file name {name:?} collides with a generated output file \
+                 of the {} backend; choose a different sidecar filename",
+                backend.name()
+            );
+        }
+    }
     for file in files {
         if Some(file.name.as_str()) == sidecar_name {
             let path = cli
@@ -166,4 +196,26 @@ fn main() -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// Resolve `path` for the --data-file/-o collision check: canonicalize as far
+/// as the filesystem allows — the file itself when it exists, otherwise its
+/// parent directory (the write target's location) joined with the final
+/// component — so differently spelled paths (`out.py` vs `./out.py`, `..`
+/// hops, symlinked directories) compare equal. Falls back to the
+/// cwd-anchored absolute form when nothing exists yet.
+fn resolve_for_collision(path: &Path) -> PathBuf {
+    if let Ok(resolved) = path.canonicalize() {
+        return resolved;
+    }
+    if let Some(name) = path.file_name() {
+        let parent = match path.parent() {
+            Some(p) if !p.as_os_str().is_empty() => p,
+            _ => Path::new("."),
+        };
+        if let Ok(parent) = parent.canonicalize() {
+            return parent.join(name);
+        }
+    }
+    std::path::absolute(path).unwrap_or_else(|_| path.to_path_buf())
 }

--- a/crates/dewasm-cli/tests/data_file.rs
+++ b/crates/dewasm-cli/tests/data_file.rs
@@ -486,6 +486,118 @@ fn rejects_unsupported_targets_and_stdout() {
     );
 }
 
+/// A `--data-file` resolving to the same file as `-o` is rejected before
+/// anything is written: the blob would otherwise clobber the freshly written
+/// source (#30). Covers both the identical spelling and a `..`-hop alias of
+/// the same path.
+#[test]
+fn rejects_data_file_colliding_with_output_path() {
+    let dir = tempdir("collide-output");
+    let wat = dir.join("mod.wat");
+    write(&wat, &fixture_wat());
+    let watp = wat.to_str().unwrap();
+
+    let out = dir.join("out.py");
+    // Pre-existing content must survive the rejected conversion untouched.
+    write(&out, "sentinel");
+
+    let r = run_dewasm(&[
+        watp,
+        "-t",
+        "python",
+        "-m",
+        "standalone",
+        "-o",
+        out.to_str().unwrap(),
+        "--data-file",
+        out.to_str().unwrap(),
+    ]);
+    assert!(!r.status.success(), "expected same-path rejection");
+    assert!(
+        String::from_utf8_lossy(&r.stderr).contains("same file"),
+        "error should say the paths are the same file, got: {}",
+        String::from_utf8_lossy(&r.stderr)
+    );
+    assert_eq!(std::fs::read_to_string(&out).unwrap(), "sentinel");
+
+    // A differently spelled alias of the same file ("dir/../dir/out.py") must
+    // be caught too: the check compares resolved paths, not strings.
+    let alias = dir.join("..").join(dir.file_name().unwrap()).join("out.py");
+    let r = run_dewasm(&[
+        watp,
+        "-t",
+        "python",
+        "-m",
+        "standalone",
+        "-o",
+        out.to_str().unwrap(),
+        "--data-file",
+        alias.to_str().unwrap(),
+    ]);
+    assert!(!r.status.success(), "expected aliased-path rejection");
+    assert_eq!(std::fs::read_to_string(&out).unwrap(), "sentinel");
+}
+
+/// A `--data-file` whose filename collides with a generated output file's
+/// name is rejected: routing is by name, so the java backend's fixed
+/// `Main.java` source would be misrouted to the sidecar path and clobbered by
+/// the blob (#30). Covered with data segments (source and sidecar share the
+/// name) and without (the lone source itself matches the sidecar name).
+#[test]
+fn rejects_data_file_colliding_with_generated_name() {
+    let dir = tempdir("collide-name");
+    let wat = dir.join("mod.wat");
+    write(&wat, &fixture_wat());
+
+    let out = dir.join("out").join("Main.java");
+    std::fs::create_dir_all(out.parent().unwrap()).unwrap();
+    let sidecar = dir.join("sidecar").join("Main.java");
+    std::fs::create_dir_all(sidecar.parent().unwrap()).unwrap();
+
+    let r = run_dewasm(&[
+        wat.to_str().unwrap(),
+        "-t",
+        "java",
+        "-m",
+        "standalone",
+        "-o",
+        out.to_str().unwrap(),
+        "--data-file",
+        sidecar.to_str().unwrap(),
+    ]);
+    assert!(!r.status.success(), "expected name-collision rejection");
+    assert!(
+        String::from_utf8_lossy(&r.stderr).contains("collides"),
+        "error should name the collision, got: {}",
+        String::from_utf8_lossy(&r.stderr)
+    );
+    assert!(!out.exists(), "no source may be written on rejection");
+    assert!(!sidecar.exists(), "no sidecar may be written on rejection");
+
+    // Same collision with a data-less module: the backend emits no sidecar,
+    // so the lone `Main.java` source itself matches the sidecar name and
+    // would be misrouted; it must be rejected identically.
+    let nodata = dir.join("nodata.wat");
+    write(&nodata, "(module (func (export \"_start\")))\n");
+    let r = run_dewasm(&[
+        nodata.to_str().unwrap(),
+        "-t",
+        "java",
+        "-m",
+        "standalone",
+        "-o",
+        out.to_str().unwrap(),
+        "--data-file",
+        sidecar.to_str().unwrap(),
+    ]);
+    assert!(
+        !r.status.success(),
+        "expected name-collision rejection (no data segments)"
+    );
+    assert!(!out.exists(), "no source may be written on rejection");
+    assert!(!sidecar.exists(), "no sidecar may be written on rejection");
+}
+
 // --------------------------------------------------------------------------
 // Real-app parity (heavy: `#[ignore]`d; run with --include-ignored).
 


### PR DESCRIPTION
Closes #30.

The CLI's write loop routes generated files by name and writes the primary source and the data sidecar independently, so two `--data-file` shapes silently destroyed the generated source:

- `dewasm foo.wasm -t python -o out.py --data-file out.py` — the source was written to `out.py`, then the data blob overwrote it.
- `dewasm foo.wasm -t java --data-file Main.java` — the java backend's primary output name is fixed (`Main.java`), so the source itself was misrouted into the sidecar branch and clobbered.

Per ADR-0 both now fail at conversion time, before anything is written:

- **Same-file check** (pre-generation): the `--data-file` path and the `-o` path are compared after filesystem resolution (`canonicalize` of the file, or of its parent directory joined with the final component when the file does not exist yet), so differently spelled aliases (`./out.py`, `..` hops, symlinked directories) are caught too. `-o -` was already rejected earlier, so stdout mode needs no path comparison.
- **Name-collision check** (post-generation, pre-write): only the sidecar itself may carry `sidecar_name` in the backend's `OutputFile` list. Both shapes are covered: with data segments the source *and* the sidecar match (count > 1); with a data-less module the backend emits no sidecar and the lone matching file is the source itself (count == number of files).

Both checks live in `crates/dewasm-cli/src/main.rs`; backends stay unaware of CLI path routing. Tests follow the existing `tests/data_file.rs` pattern (`std::process::Command` against `CARGO_BIN_EXE_dewasm`), asserting failing exit, a clear message, and that pre-existing/target files are left untouched.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test -p dewasm-cli` — 11 passed (incl. new `rejects_data_file_colliding_with_output_path`, `rejects_data_file_colliding_with_generated_name`), 0 failed, 4 heavy ignored
- Manual: both issue repros now exit 1 with a clear error; a pre-existing `-o` file keeps its contents and no output/sidecar file is created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)