### PR TITLE
Apply the ADR-28 recursion mitigation in emitted Python entrypoints

### DIFF
--- a/crates/dewasm-backend-python/src/lib.rs
+++ b/crates/dewasm-backend-python/src/lib.rs
@@ -239,6 +239,11 @@ impl Backend for PythonBackend {
         w.line("import select");
         w.line("import struct");
         w.line("import sys");
+        if opts.mode == Mode::Standalone {
+            // Backs the ADR-28 big-stack guest thread in the standalone
+            // entrypoint below; library mode never needs it.
+            w.line("import threading");
+        }
         w.line("import time");
         // Externalized data blob (ADR-37): read once at import time from the
         // sidecar next to this module, then sliced by the generated
@@ -310,9 +315,47 @@ impl Backend for PythonBackend {
             } else {
                 w.line(format!("_inst = {class_name}()"));
             }
+            // Deep-but-valid guest recursion needs far more than CPython's
+            // default ~1000-frame limit, and raising the limit alone risks a
+            // C-stack overflow, so the guest runs on a big-stack thread with a
+            // raised recursion limit — the same values the spec harness uses
+            // (ADR-28). The thread carries any exception back so proc_exit and
+            // traps still resolve to ADR-31's exit codes via `sys.exit` on the
+            // main thread. A daemon thread lets a KeyboardInterrupt delivered
+            // to the main thread (blocked in `join`) exit the process without
+            // waiting for the guest, as when the guest ran on the main thread.
+            w.line("_err = []");
+            w.line("");
+            w.line("def _run():");
+            w.indent();
             w.line("try:");
             w.indent();
             w.line("_inst.invoke(\"_start\")");
+            w.dedent();
+            w.line("except BaseException as _e:");
+            w.indent();
+            w.line("_err.append(_e)");
+            w.dedent();
+            w.dedent();
+            w.line("");
+            w.line("sys.setrecursionlimit(1000000)");
+            w.line("try:");
+            w.indent();
+            w.line("threading.stack_size(512 * 1024 * 1024)");
+            w.dedent();
+            w.line("except (ValueError, OverflowError, RuntimeError):");
+            w.indent();
+            w.line("pass");
+            w.dedent();
+            w.line("_t = threading.Thread(target=_run, daemon=True)");
+            w.line("_t.start()");
+            w.line("_t.join()");
+            w.line("try:");
+            w.indent();
+            w.line("if _err:");
+            w.indent();
+            w.line("raise _err[0]");
+            w.dedent();
             w.line("sys.exit(0)");
             w.dedent();
             w.line("except Rt.Exit as _e:");

--- a/crates/dewasm-backend-python/tests/e2e.rs
+++ b/crates/dewasm-backend-python/tests/e2e.rs
@@ -11,9 +11,9 @@ use dewasm_backend::{Backend, Mode, RuntimeLinkage};
 use dewasm_backend_python::{find_python, PythonBackend};
 use dewasm_test_helper::{
     convert, cowsay_args_e2e, cowsay_stdin_e2e, cpython_hello_e2e, cruby_hello_e2e,
-    custom_wasi_provider_e2e, examples_dir, gzip_e2e, library_add_e2e, libsqlite3_c_api_e2e,
-    partial_override_e2e, pcap_compile_e2e, qjs_eval_e2e, qjs_file_io_e2e, qjs_repl_e2e,
-    qjs_repl_pty_e2e, rg_search_e2e, shared_table_e2e, sqlite3_callback_binding_e2e,
+    custom_wasi_provider_e2e, deep_recursion_e2e, examples_dir, gzip_e2e, library_add_e2e,
+    libsqlite3_c_api_e2e, partial_override_e2e, pcap_compile_e2e, qjs_eval_e2e, qjs_file_io_e2e,
+    qjs_repl_e2e, qjs_repl_pty_e2e, rg_search_e2e, shared_table_e2e, sqlite3_callback_binding_e2e,
     sqlite3_file_c_api_e2e, sqlite3_shell_dbfile_e2e, sqlite3_shell_e2e, standalone_dir_e2e,
     stdio_capture_e2e, treesitter_parse_e2e, wasi_import_override_e2e, wasi_root_containment_e2e,
     wasi_suite, BackendUnderTest,
@@ -491,6 +491,8 @@ wasi_suite!(Python, Poll);
 wasi_suite!(Python, Fs, PYTHON_FS_GLUE);
 wasi_root_containment_e2e!(Python, PYTHON_CONTAINMENT_GLUE);
 standalone_dir_e2e!(Python);
+// The standalone entrypoint's ADR-28 recursion mitigation (issue #31).
+deep_recursion_e2e!(Python);
 
 cowsay_args_e2e!(Python);
 cowsay_stdin_e2e!(Python);

--- a/crates/dewasm-test-helper/src/lib.rs
+++ b/crates/dewasm-test-helper/src/lib.rs
@@ -52,8 +52,8 @@ pub use qjs_repl::{
 };
 pub use spec::{spec_main, spec_trials, Converted, SpecBackend};
 pub use wasi::{
-    run_standalone_dir, run_wasi_containment, run_wasi_fs, run_wasi_standalone, WasiCase,
-    WasiCheck, WasiKind, WASI_CASES,
+    run_deep_recursion, run_standalone_dir, run_wasi_containment, run_wasi_fs, run_wasi_standalone,
+    WasiCase, WasiCheck, WasiKind, WASI_CASES,
 };
 pub use wasi_testsuite::{wasi_testsuite_main, wasi_testsuite_trials, WasiTestsuiteBackend};
 pub use wasmtime_backend::Wasmtime;
@@ -200,6 +200,24 @@ macro_rules! standalone_dir_e2e {
         #[test]
         fn standalone_dir() {
             $crate::run_standalone_dir(&$lang);
+        }
+    };
+}
+
+/// One `#[test]` requiring the standalone entrypoint to survive deep-but-valid
+/// guest recursion for `$lang`: convert `deep_recursion.wat` (5000-frame
+/// recursion) standalone, run it, and require the guest's `proc_exit(42)` as
+/// the exit code — see [`run_deep_recursion`](crate::run_deep_recursion). No
+/// glue — this exercises the emitted entrypoint itself. Wired by Python, whose
+/// entrypoint applies ADR-28's mitigation (issue #31); each other backend's
+/// host recursion depth is its own concern — it invokes this once its
+/// entrypoint needs (and has) such a mitigation.
+#[macro_export]
+macro_rules! deep_recursion_e2e {
+    ($lang:expr) => {
+        #[test]
+        fn deep_recursion() {
+            $crate::run_deep_recursion(&$lang);
         }
     };
 }

--- a/crates/dewasm-test-helper/src/wasi.rs
+++ b/crates/dewasm-test-helper/src/wasi.rs
@@ -368,6 +368,37 @@ pub fn run_standalone_dir(lang: &dyn BackendUnderTest) {
     );
 }
 
+/// Run the deep-recursion standalone case (`deep_recursion_e2e!`): convert
+/// `deep_recursion.wat` — whose `_start` recurses 5000 wasm frames, far past
+/// e.g. CPython's default ~1000-frame recursion limit — in *standalone* mode
+/// and run it with no arguments. The generated entrypoint must survive the
+/// recursion (Python: ADR-28's raised recursion limit plus a big-stack guest
+/// thread) and still surface the guest's `proc_exit(42)` as the process exit
+/// code (ADR-31). Like `run_standalone_dir`, this exercises the emitted
+/// entrypoint itself, so no glue.
+pub fn run_deep_recursion(lang: &dyn BackendUnderTest) {
+    let src = convert(
+        lang.backend(),
+        &examples_dir().join("deep_recursion.wat"),
+        Mode::Standalone,
+        "deep_recursion",
+    );
+    let output = lang.run(&src, &[], "");
+    assert_eq!(
+        output.status.code(),
+        Some(42),
+        "deep_recursion under {}: exit code\n{}",
+        lang.name(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "",
+        "deep_recursion under {}: stdout",
+        lang.name()
+    );
+}
+
 /// Run the root-preopen containment probe (`wasi_root_containment_e2e!`): a
 /// preopen whose realpath is the filesystem root must not reject every path
 /// (the containment check would otherwise build the prefix "//" and never

--- a/docs/adr/28-python-backend-lowering.md
+++ b/docs/adr/28-python-backend-lowering.md
@@ -23,6 +23,10 @@ uses `os.listdir`, and the errno map keys on `OSError.errno` (the `errno`
 module) rather than exception classes. With this, `has_wasi_p1` reports the
 same surface as Ruby, and the shared WASI `Fs` suite plus the gzip byte-stdio
 and heavy filesystem app cases (QuickJS, SQLite, ripgrep) run under Python.
+**Revision, 2026-07-29 (issue #31):** the recursion/exhaustion mitigation below
+is no longer harness-only — the emitted standalone entrypoint applies the same
+raised recursion limit and big-stack guest thread itself, carrying the guest's
+exit/trap back to the main thread so ADR-31's exit codes are unchanged.
 
 ## Context
 

--- a/examples/wat/deep_recursion.wat
+++ b/examples/wat/deep_recursion.wat
@@ -1,0 +1,15 @@
+;; _start recurses 5000 wasm frames — far past e.g. CPython's default
+;; ~1000-frame recursion limit — then reports the depth check via proc_exit
+;; (42 on success), so a standalone entrypoint without a deep-recursion
+;; mitigation fails loudly instead of exiting 42.
+(module
+  (import "wasi_snapshot_preview1" "proc_exit" (func $proc_exit (param i32)))
+  ;; f(n) = n, computed through n recursive frames.
+  (func $f (param $n i32) (result i32)
+    (if (i32.eqz (local.get $n))
+      (then (return (i32.const 0))))
+    (i32.add (i32.const 1) (call $f (i32.sub (local.get $n) (i32.const 1)))))
+  (func (export "_start")
+    (if (i32.eq (call $f (i32.const 5000)) (i32.const 5000))
+      (then (call $proc_exit (i32.const 42))))
+    (call $proc_exit (i32.const 1))))


### PR DESCRIPTION
Closes #31.

The Python standalone entrypoint called `_inst.invoke("_start")` directly on the main thread, so a converted program recursing past CPython's default ~1000-frame limit died with a raw `RecursionError` under `python3 out.py` — ADR-28's mitigation (raised `sys.setrecursionlimit` + a big-stack thread) existed only in the spec-harness glue.

## What changed

- **Emitter** (`crates/dewasm-backend-python/src/lib.rs`): the `__main__` block now sets `sys.setrecursionlimit(1000000)` and runs the guest on a `threading.Thread` with `threading.stack_size(512 * 1024 * 1024)` — the exact values the spec harness uses, so there is one convention. The guest thread captures any `BaseException`; after `join` the main thread re-raises it into the unchanged `except Rt.Exit / Rt.Trap` handlers, so `proc_exit(N)` still reaches `sys.exit(N)` from the main thread, traps still print `trap: <msg>` and exit 134, and `_start` returning still exits 0 (the ADR-31 surface is byte-for-byte the same). The thread is a daemon so a `KeyboardInterrupt` delivered to the main thread during `join` still exits promptly. Library/embedded mode is untouched (`import threading` is emitted for standalone only).
- **Regression e2e**: new fixture `examples/wat/deep_recursion.wat` (`_start` recurses 5000 wasm frames, then `proc_exit(42)` on a depth check), run via a shared `deep_recursion_e2e!` case in `crates/dewasm-test-helper` — wired for Python only in this PR; other backends' recursion depths are their own concern (noted per the non-invocation comment policy).
- **ADR-28** status trued up: the emitter now applies the mitigation itself.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test -p dewasm-backend-python` — all green (units 2, e2e 16 passed / 14 heavy-ignored, spec 78, wasi-testsuite 72)
- Manual: converted `deep_recursion.wat` exits 42 with the fix; the old entrypoint shape reproduces the raw `RecursionError`. Trap fixture exits 134 with `trap: unreachable` on stderr; empty `_start` exits 0; a module with no WASI imports takes the no-kwargs instantiation branch and works identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)