### PR TITLE
Guard Java memory sizing and fd_readdir cookies against overflow

### DIFF
--- a/crates/dewasm-backend-java/tests/memory_grow.rs
+++ b/crates/dewasm-backend-java/tests/memory_grow.rs
@@ -1,0 +1,117 @@
+//! Regression tests for issue #27's memory-size overflow: Java's linear
+//! memory is a single `byte[]`, capped at `Integer.MAX_VALUE` bytes, so a
+//! spec-legal size of 32768+ pages (2 GiB+) cannot be represented.
+//! `memory.grow` must answer -1 (never `NegativeArraySizeException` from the
+//! overflowing int multiply), and instantiating a module whose *initial* size
+//! already exceeds the cap must fail with a clear trap, not the raw exception.
+//!
+//! These cases are Java-only (the cap is a JVM artifact — the other backends
+//! can grow to 32768 pages for real, which a shared case must not force), so
+//! they live here with their own minimal `javac`-and-run plumbing, mirroring
+//! the e2e suite's compile-and-execute recipe (ADR-30). A missing
+//! `javac`/`java` fails loud (ADR-15).
+
+use std::process::{Command, Output};
+
+use dewasm_backend::Mode;
+use dewasm_backend_java::{find_java, find_javac, JavaBackend};
+use dewasm_test_helper::convert_bytes;
+
+/// Convert `wat` in library mode, append `glue` (a `public class Main`),
+/// compile the single compilation unit into a fresh scratch dir keyed by
+/// `name`, and run `java -cp <dir> Main`.
+fn convert_and_run(wat: &str, glue: &str, name: &str) -> Output {
+    let javac =
+        find_javac().expect("javac not found on PATH (or $DEWASM_JAVAC) — see docs/testing.md");
+    let java = find_java().expect("java not found on PATH (or $DEWASM_JAVA) — see docs/testing.md");
+
+    let bytes = wat::parse_str(wat).expect("parse wat");
+    let source = format!(
+        "{}\n{glue}",
+        convert_bytes(&JavaBackend, &bytes, Mode::Library, "prog")
+    );
+
+    let dir = std::env::temp_dir().join(format!("dewasm-java-{name}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let src = dir.join("Main.java");
+    std::fs::write(&src, source).unwrap();
+    let build = Command::new(&javac)
+        .arg("-d")
+        .arg(&dir)
+        .arg(&src)
+        .output()
+        .expect("spawn javac");
+    assert!(
+        build.status.success(),
+        "javac failed:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    Command::new(&java)
+        .arg("-cp")
+        .arg(&dir)
+        .arg("Main")
+        .output()
+        .expect("spawn java")
+}
+
+/// `memory.grow` to 32768 pages (2^31 bytes, one past the `byte[]` cap) must
+/// return -1 and leave the memory intact and still growable — with no
+/// declared max, `maxPages` defaults to 65536, so only the byte-size guard
+/// stands between the request and the overflowing allocation.
+#[test]
+fn grow_beyond_byte_array_cap_returns_minus_one() {
+    let wat = r#"(module
+      (memory 1)
+      (func (export "grow") (param i32) (result i32) (memory.grow (local.get 0)))
+      (func (export "size") (result i32) (memory.size)))"#;
+    let glue = r#"public class Main {
+    public static void main(String[] a) {
+        Prog p = new Prog(null, null, null, null);
+        System.out.println((int)(Integer)((Rt.Fn) p.Exports.get("grow")).invoke(new Object[]{32768}));
+        System.out.println((int)(Integer)((Rt.Fn) p.Exports.get("grow")).invoke(new Object[]{1}));
+        System.out.println((int)(Integer)((Rt.Fn) p.Exports.get("size")).invoke(new Object[]{}));
+    }
+}
+"#;
+    let out = convert_and_run(wat, glue, "grow-cap");
+    assert!(
+        out.status.success(),
+        "run failed: {}\n{}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&out.stdout), "-1\n1\n2\n");
+}
+
+/// A module declaring an *initial* memory past the `byte[]` cap cannot be
+/// instantiated on the JVM; that failure must be a clear `Rt.Trap` naming the
+/// page count, not a `NegativeArraySizeException` (which would escape `Main`
+/// and fail the run's exit status here).
+#[test]
+fn initial_memory_beyond_byte_array_cap_traps_clearly() {
+    let wat = r#"(module (memory 32768) (func (export "f")))"#;
+    let glue = r#"public class Main {
+    public static void main(String[] a) {
+        try {
+            new Prog(null, null, null, null);
+            System.out.println("instantiated");
+        } catch (Rt.Trap e) {
+            System.out.println("trap: " + e.getMessage());
+        }
+    }
+}
+"#;
+    let out = convert_and_run(wat, glue, "grow-initial-cap");
+    assert!(
+        out.status.success(),
+        "run failed: {}\n{}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.starts_with("trap: ") && stdout.contains("32768 pages"),
+        "expected a clear instantiation trap, got: {stdout:?}"
+    );
+}

--- a/crates/dewasm-test-helper/src/wasi.rs
+++ b/crates/dewasm-test-helper/src/wasi.rs
@@ -167,6 +167,24 @@ pub const WASI_CASES: &[WasiCase] = &[
             unix_only: false,
         },
     },
+    // fd_readdir with a dircookie whose high bit is set (u64 2^63): the
+    // cookie is an unsigned position past any snapshot's end, so the call
+    // succeeds with bufused 0 (matching wasmtime). Runtimes holding the
+    // cookie in a signed type must not index negatively (issue #27).
+    WasiCase {
+        name: "fs_readdir_high_cookie",
+        wat: "wasi_readdir_high_cookie.wat",
+        kind: WasiKind::Fs,
+        args: &[],
+        stdin: "",
+        check: WasiCheck::Fs {
+            preopen_subdir: None,
+            setup: |dir| std::fs::write(dir.join("entry.txt"), "x").unwrap(),
+            check_stdout: |out| assert_eq!(out, "past-end ok\n"),
+            assert_host: |_dir| {},
+            unix_only: false,
+        },
+    },
     // path_open with oflags::DIRECTORY on a missing path is ENOENT (44), not
     // ENOTDIR (54) — guests (e.g. wasi-libc's opendir) branch on the
     // difference. The fixture exits with the errno.

--- a/examples/wat/wasi_readdir_high_cookie.wat
+++ b/examples/wat/wasi_readdir_high_cookie.wat
@@ -1,0 +1,32 @@
+;; fd_readdir with a dircookie whose high bit is set: the u64 cookie is an
+;; unsigned position far past any snapshot's end, so each call must succeed
+;; with zero dirent bytes (matching wasmtime) — never crash in a runtime that
+;; holds the cookie in a signed type, and never return entries. Two shapes:
+;; 0x8000000000000000 truncates to index 0 (the silently-wrong-entries shape)
+;; and 0x8000000000000063's low bits land past the snapshot end (the
+;; out-of-bounds shape). A nonzero errno becomes the exit code; a nonzero
+;; bufused exits 200/201.
+(module
+  (import "wasi_snapshot_preview1" "fd_readdir"
+    (func $fd_readdir (param i32 i32 i32 i64 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "fd_write"
+    (func $fd_write (param i32 i32 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "proc_exit" (func $proc_exit (param i32)))
+  (memory (export "memory") 1)
+  (data (i32.const 0) "past-end ok\n")
+  (func $check (param $cookie i64) (param $failcode i32)
+    (local $e i32)
+    (local.set $e (call $fd_readdir
+      (i32.const 3)   ;; dirfd: the first preopen
+      (i32.const 300) ;; buf ptr
+      (i32.const 256) ;; buf len
+      (local.get $cookie)
+      (i32.const 260)))
+    (if (local.get $e) (then (call $proc_exit (local.get $e))))
+    (if (i32.load (i32.const 260)) (then (call $proc_exit (local.get $failcode)))))
+  (func (export "_start")
+    (call $check (i64.const 0x8000000000000000) (i32.const 200))
+    (call $check (i64.const 0x8000000000000063) (i32.const 201))
+    (i32.store (i32.const 104) (i32.const 0))
+    (i32.store (i32.const 108) (i32.const 12))
+    (drop (call $fd_write (i32.const 1) (i32.const 104) (i32.const 1) (i32.const 116)))))

--- a/runtime/bash/units/wasi/fd_readdir.sh
+++ b/runtime/bash/units/wasi/fd_readdir.sh
@@ -63,6 +63,11 @@ wasi_fd_readdir() {
   local -n __m=${__p}mem
   local LC_ALL=C
   local __out=() __outlen=0 __ri=$__cookie __name __nlen __next __ck __b
+  # The u64 cookie arrives as bash's signed-64 bit pattern (ADR-11): a
+  # negative value is a huge unsigned position past any snapshot's end, so
+  # report end-of-directory (an empty result, matching wasmtime) instead of
+  # letting the loop read negative subscripts.
+  if (( __ri < 0 )); then __ri=$__total; fi
   while (( __ri < __total && __outlen < __buf_len )); do
     __name=${__names[__ri]}
     __nlen=${#__name}

--- a/runtime/java/units/memory/_class.java
+++ b/runtime/java/units/memory/_class.java
@@ -8,7 +8,14 @@ java.nio.ByteBuffer bb;
 int maxPages;
 
 Memory(int minPages, int maxPages) {
-    this.d = new byte[minPages * 65536];
+    // A spec-legal minimum of 32768+ pages (2 GiB+) exceeds what a Java
+    // byte[] can hold; fail instantiation with a clear trap instead of the
+    // NegativeArraySizeException the overflowing int multiply would throw.
+    long bytes = (long) minPages * 65536;
+    if (bytes > Integer.MAX_VALUE) {
+        Rt.trap("cannot allocate " + minPages + " pages of linear memory (exceeds Java's byte[] limit)");
+    }
+    this.d = new byte[(int) bytes];
     this.maxPages = maxPages;
     rewrap();
 }

--- a/runtime/java/units/memory/grow.java
+++ b/runtime/java/units/memory/grow.java
@@ -1,12 +1,21 @@
 // memory.grow: extend by `delta` pages (delta read unsigned); returns the old
-// size in pages, or -1 (i32 0xFFFFFFFF) if the page cap would be exceeded.
+// size in pages, or -1 (i32 0xFFFFFFFF) if the request cannot be satisfied.
+// The byte size is computed in long and checked against the byte[] cap before
+// the int cast (32768 pages is already 2^31 bytes, one past what a Java array
+// can hold), and an allocation failure is likewise reported as -1 — wasm lets
+// grow fail, never crash.
 int grow(int delta) {
     int old = d.length / 65536;
     long want = (long) old + (delta & 0xFFFFFFFFL);
-    if (want > maxPages) {
+    if (want > maxPages || want * 65536 > Integer.MAX_VALUE) {
         return -1;
     }
-    byte[] nd = new byte[(int) (want * 65536)];
+    byte[] nd;
+    try {
+        nd = new byte[(int) (want * 65536)];
+    } catch (OutOfMemoryError e) {
+        return -1;
+    }
     System.arraycopy(d, 0, nd, 0, d.length);
     d = nd;
     rewrap();

--- a/runtime/java/units/wasi/fd_readdir.java
+++ b/runtime/java/units/wasi/fd_readdir.java
@@ -17,8 +17,11 @@ int wasi_fd_readdir(int fd, int bufPtr, int bufLen, long cookie, int bufusedPtr)
     }
     long lim = Integer.toUnsignedLong(bufLen);
     java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+    // The u64 cookie lives in a signed long: compare unsigned so a high-bit
+    // cookie reads as a huge position past any snapshot's end (an empty
+    // result, matching wasmtime) instead of a negative subscript.
     long i = cookie;
-    while (i < dir.entries.size() && out.size() < lim) {
+    while (Long.compareUnsigned(i, dir.entries.size()) < 0 && out.size() < lim) {
         Dirent ent = dir.entries.get((int) i);
         // dirent: d_next (u64, resume cookie) + d_ino (u64) + d_namlen (u32) +
         // d_type (u8) + 3 pad, followed by the (unpadded) name.


### PR DESCRIPTION
Closes #27.

Two uncaught-exception crashes in the Java runtime on spec-legal input, plus a cross-backend audit of the same cookie bug.

## Fixes

- **`runtime/java/units/memory/grow.java`** — the new byte size is computed in `long` and checked against the `byte[]` cap *before* the `int` cast (32768 pages = 2^31 bytes, one past `Integer.MAX_VALUE`), so `memory.grow` answers -1 instead of throwing `NegativeArraySizeException`; an `OutOfMemoryError` from the allocation is likewise reported as -1 (wasm permits failing with -1, never crashing).
- **`runtime/java/units/memory/_class.java`** — the initial-allocation path had the same overflowing multiply: a module declaring `(memory 32768)` now fails instantiation with a clear `Rt.trap` naming the page count instead of a raw `NegativeArraySizeException`.
- **`runtime/java/units/wasi/fd_readdir.java`** — the u64 dircookie lives in a signed `long`; the walk now uses `Long.compareUnsigned`, so a high-bit cookie reads as a position past the snapshot's end and yields an empty result (bufused 0, matching wasmtime) instead of `IndexOutOfBoundsException` / wrong entries from the truncated `(int)` subscript.

## Cross-backend fd_readdir audit

| Backend | Verdict |
| --- | --- |
| Java | **Affected** — crash (`IndexOutOfBoundsException`) or silently wrong entries, fixed above |
| Bash | **Affected** — i64 is the signed-64 bit pattern (ADR-11), so a negative cookie walked negative array subscripts (`bad array subscript` noise + garbage dirents); now reports end-of-directory |
| Go | Not affected — the cookie parameter is `uint64`, the guard already compares unsigned |
| Python | Not affected — integers are stored masked-unsigned (ADR-2), so the cookie arrives as a large positive and `i < len(entries)` ends the walk |
| Ruby | Not affected — same masked-unsigned convention as Python |

## Tests

- `examples/wat/wasi_readdir_high_cookie.wat` + a shared `WasiCheck::Fs` case (`fs_readdir_high_cookie`) run by **all five backends**: two cookie shapes — `0x8000000000000000` (truncates to index 0: the silently-wrong-entries shape) and `0x8000000000000063` (low bits past the snapshot end: the crashing shape). Verified load-bearing: with the runtime fixes reverted, Java reproduces the issue's exact `IndexOutOfBoundsException: Index 3 out of bounds for length 3` and Bash fails the stdout assertion.
- `crates/dewasm-backend-java/tests/memory_grow.rs` (Java-only — the other backends can satisfy a 2 GiB grow for real): `memory.grow(32768)` returns -1 and leaves the memory intact/growable, and `(memory 32768)` instantiation traps with a clear message.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test -p dewasm-backend-java` — lib 3, e2e 13, memory_grow 2, spec 79, wasi_testsuite 72 passed; 0 failed
- `cargo test -p dewasm-backend-bash` — lib 3, e2e 12, softfloat 5, spec 86, wasi_testsuite 72 passed; 0 failed
- `cargo test -p dewasm-backend-go -p dewasm-backend-python -p dewasm-backend-ruby --test e2e` — 12/15/16 passed; 0 failed (includes the new shared readdir case)
- `cargo test -p dewasm-test-helper`, `cargo test -p dewasm-cli --test support_docs` — ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)