### PR TITLE
Enforce fd rights on pread/pwrite and close two path_open gates

### DIFF
--- a/crates/dewasm-test-helper/src/wasi.rs
+++ b/crates/dewasm-test-helper/src/wasi.rs
@@ -238,6 +238,32 @@ pub const WASI_CASES: &[WasiCase] = &[
             unix_only: false,
         },
     },
+    // Per-fd rights enforcement (ADR-40). A fd narrowed by
+    // fd_fdstat_set_rights must refuse fd_pread/fd_pwrite (NOTCAPABLE, like
+    // fd_read/fd_write); a dirfd stripped of PATH_FILESTAT_SET_SIZE must
+    // refuse an O_TRUNC open without touching the file; and one stripped of
+    // PATH_OPEN must refuse any open. The fixture prints "<tag><errno>" per
+    // probe (76 = NOTCAPABLE), so the expected stdout pins every gate.
+    WasiCase {
+        name: "fs_rights_notcapable",
+        wat: "wasi_rights_notcapable.wat",
+        kind: WasiKind::Fs,
+        args: &[],
+        stdin: "",
+        check: WasiCheck::Fs {
+            preopen_subdir: None,
+            setup: |dir| std::fs::write(dir.join("data.txt"), "keep me").unwrap(),
+            check_stdout: |out| assert_eq!(out, "a00\nb00\np76\nw76\nc00\nt76\nd00\no76\n"),
+            assert_host: |dir| {
+                assert_eq!(
+                    std::fs::read_to_string(dir.join("data.txt")).unwrap(),
+                    "keep me",
+                    "O_TRUNC without PATH_FILESTAT_SET_SIZE must not truncate"
+                )
+            },
+            unix_only: false,
+        },
+    },
 ];
 
 /// Run the `WasiCheck::Standalone` cases of `kind` (stdio, args/env,

--- a/examples/wat/wasi_rights_notcapable.wat
+++ b/examples/wat/wasi_rights_notcapable.wat
@@ -1,0 +1,69 @@
+;; Per-fd rights enforcement (ADR-40): every probe prints "<tag><errno as two
+;; decimal digits>\n" so the expected stdout pins each errno exactly.
+;;   a/b/c/d — setup steps that must succeed (00),
+;;   p/w     — fd_pread/fd_pwrite on a fd narrowed to no rights (76 NOTCAPABLE),
+;;   t       — O_TRUNC open under a dirfd without PATH_FILESTAT_SET_SIZE (76,
+;;             and the host file must stay untruncated),
+;;   o       — any open under a dirfd without PATH_OPEN (76).
+(module
+  (import "wasi_snapshot_preview1" "path_open"
+    (func $path_open (param i32 i32 i32 i32 i32 i64 i64 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "fd_fdstat_set_rights"
+    (func $set_rights (param i32 i64 i64) (result i32)))
+  (import "wasi_snapshot_preview1" "fd_pread"
+    (func $fd_pread (param i32 i32 i32 i64 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "fd_pwrite"
+    (func $fd_pwrite (param i32 i32 i32 i64 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "fd_write"
+    (func $fd_write (param i32 i32 i32 i32) (result i32)))
+  (memory (export "memory") 1)
+  (data (i32.const 0) "data.txt")
+  ;; 16: opened-fd cell, 24: pread/pwrite iovec, 32: 4-byte data buffer,
+  ;; 40: nread/nwritten cell, 48: 4-byte message, 56: message iovec,
+  ;; 64: message nwritten cell.
+  (func $report (param $tag i32) (param $errno i32)
+    (i32.store8 (i32.const 48) (local.get $tag))
+    (i32.store8 (i32.const 49)
+      (i32.add (i32.const 48) (i32.div_u (local.get $errno) (i32.const 10))))
+    (i32.store8 (i32.const 50)
+      (i32.add (i32.const 48) (i32.rem_u (local.get $errno) (i32.const 10))))
+    (i32.store8 (i32.const 51) (i32.const 10))
+    (i32.store (i32.const 56) (i32.const 48))
+    (i32.store (i32.const 60) (i32.const 4))
+    (drop (call $fd_write (i32.const 1) (i32.const 56) (i32.const 1) (i32.const 64))))
+  (func (export "_start")
+    (local $fd i32)
+    ;; The pread/pwrite iovec: 4 bytes at 32.
+    (i32.store (i32.const 24) (i32.const 32))
+    (i32.store (i32.const 28) (i32.const 4))
+    ;; a: open data.txt with rights FD_READ|FD_WRITE (0x42).
+    (call $report (i32.const 97)
+      (call $path_open (i32.const 3) (i32.const 0) (i32.const 0) (i32.const 8)
+        (i32.const 0) (i64.const 0x42) (i64.const 0) (i32.const 0) (i32.const 16)))
+    (local.set $fd (i32.load (i32.const 16)))
+    ;; b: narrow the fd to no rights at all (fd_fdstat_set_rights narrows only).
+    (call $report (i32.const 98)
+      (call $set_rights (local.get $fd) (i64.const 0) (i64.const 0)))
+    ;; p: fd_pread without FD_READ is NOTCAPABLE.
+    (call $report (i32.const 112)
+      (call $fd_pread (local.get $fd) (i32.const 24) (i32.const 1)
+        (i64.const 0) (i32.const 40)))
+    ;; w: fd_pwrite without FD_WRITE is NOTCAPABLE.
+    (call $report (i32.const 119)
+      (call $fd_pwrite (local.get $fd) (i32.const 24) (i32.const 1)
+        (i64.const 0) (i32.const 40)))
+    ;; c: narrow the preopen dirfd to PATH_OPEN only (0x2000), inheriting rw.
+    (call $report (i32.const 99)
+      (call $set_rights (i32.const 3) (i64.const 0x2000) (i64.const 0x42)))
+    ;; t: O_TRUNC (oflags 0x8) without PATH_FILESTAT_SET_SIZE is NOTCAPABLE —
+    ;; and must not truncate the host file.
+    (call $report (i32.const 116)
+      (call $path_open (i32.const 3) (i32.const 0) (i32.const 0) (i32.const 8)
+        (i32.const 0x8) (i64.const 0x40) (i64.const 0) (i32.const 0) (i32.const 16)))
+    ;; d: drop PATH_OPEN too.
+    (call $report (i32.const 100)
+      (call $set_rights (i32.const 3) (i64.const 0) (i64.const 0)))
+    ;; o: any open through the narrowed dirfd is NOTCAPABLE.
+    (call $report (i32.const 111)
+      (call $path_open (i32.const 3) (i32.const 0) (i32.const 0) (i32.const 8)
+        (i32.const 0) (i64.const 0x2) (i64.const 0) (i32.const 0) (i32.const 16)))))

--- a/runtime/go/units/wasi/_class.go
+++ b/runtime/go/units/wasi/_class.go
@@ -59,8 +59,8 @@ const (
         rightPathLinkSource | rightPathLinkTarget | rightPathOpen |
         rightFdReaddir | rightPathReadlink | rightPathRenameSource |
         rightPathRenameTarget | rightPathSymlink | rightPathRemoveDirectory |
-        rightPathUnlinkFile | rightPathFilestatGet | rightPathFilestatSetTimes |
-        rightFdFilestatGet | rightFdFilestatSetTimes
+        rightPathUnlinkFile | rightPathFilestatGet | rightPathFilestatSetSize |
+        rightPathFilestatSetTimes | rightFdFilestatGet | rightFdFilestatSetTimes
     dirRightsInheriting uint64 = dirRightsBase | rightFdDatasync | rightFdRead |
         rightFdSeek | rightFdFdstatSetFlags | rightFdSync | rightFdTell |
         rightFdWrite | rightFdAdvise | rightFdAllocate | rightFdFilestatSetSize |

--- a/runtime/go/units/wasi/fd_pread.go
+++ b/runtime/go/units/wasi/fd_pread.go
@@ -7,6 +7,9 @@ func (w *WASI) wasi_fd_pread(fd, iovsPtr, iovsLen uint32, offset uint64, nreadPt
     if w.isStdio(f) {
         return wasiSpipe
     }
+    if e := w.checkRight(fd, rightFdRead); e != wasiOk { // ADR-40
+        return e
+    }
     nread := uint32(0)
     for i := uint32(0); i < iovsLen; i++ {
         ptr := w.memory.i32_load(uint64(iovsPtr) + uint64(i)*8)

--- a/runtime/go/units/wasi/fd_pwrite.go
+++ b/runtime/go/units/wasi/fd_pwrite.go
@@ -7,6 +7,9 @@ func (w *WASI) wasi_fd_pwrite(fd, iovsPtr, iovsLen uint32, offset uint64, nwritt
     if w.isStdio(f) {
         return wasiSpipe
     }
+    if e := w.checkRight(fd, rightFdWrite); e != wasiOk { // ADR-40
+        return e
+    }
     written := uint32(0)
     for i := uint32(0); i < iovsLen; i++ {
         ptr := w.memory.i32_load(uint64(iovsPtr) + uint64(i)*8)

--- a/runtime/go/units/wasi/path_open.go
+++ b/runtime/go/units/wasi/path_open.go
@@ -11,6 +11,14 @@ func (w *WASI) wasi_path_open(dirfd, dirflags, pathPtr, pathLen, oflags uint32, 
     if e := w.checkRight(dirfd, rightPathOpen); e != wasiOk {
         return e
     }
+    // OFLAGS_TRUNC truncates on open; that spends the directory's
+    // PATH_FILESTAT_SET_SIZE right (ADR-40), checked before the OS open can
+    // touch the file.
+    if oflags&0x8 != 0 { // oflags::TRUNC
+        if e := w.checkRight(dirfd, rightPathFilestatSetSize); e != wasiOk {
+            return e
+        }
+    }
     // Opening a directory read/write is ISDIR; the suite requires it for
     // O_DIRECTORY with FD_WRITE requested, before the directory is even stat'd.
     if oflags&0x2 != 0 && fsRightsBase&rightFdWrite != 0 {

--- a/runtime/java/units/wasi/fd_pread.java
+++ b/runtime/java/units/wasi/fd_pread.java
@@ -9,6 +9,9 @@ int wasi_fd_pread(int fd, int iovsPtr, int iovsLen, long offset, int nreadPtr) {
     if (!(e instanceof Handle)) {
         return WASI_BADF;
     }
+    if (lacksRight(fd, R_FD_READ)) {
+        return WASI_NOTCAPABLE;
+    }
     java.nio.channels.FileChannel ch = ((Handle) e).ch;
     int nread = 0;
     try {

--- a/runtime/java/units/wasi/fd_pwrite.java
+++ b/runtime/java/units/wasi/fd_pwrite.java
@@ -9,6 +9,9 @@ int wasi_fd_pwrite(int fd, int iovsPtr, int iovsLen, long offset, int nwrittenPt
     if (!(e instanceof Handle)) {
         return WASI_BADF;
     }
+    if (lacksRight(fd, R_FD_WRITE)) {
+        return WASI_NOTCAPABLE;
+    }
     java.nio.channels.FileChannel ch = ((Handle) e).ch;
     int written = 0;
     try {

--- a/runtime/python/units/wasi/fd_pread.py
+++ b/runtime/python/units/wasi/fd_pread.py
@@ -5,6 +5,8 @@ def wasi_fd_pread(self, fd, iovs_ptr, iovs_len, offset, nread_ptr):
         return self.ERRNO_BADF
     if io in self.std_ios:
         return self.ERRNO_SPIPE
+    if not (self.fd_meta[fd][0] & self.RIGHTS_FD_READ):
+        return self.ERRNO_NOTCAPABLE
     nread = 0
     try:
         for i in range(iovs_len):

--- a/runtime/python/units/wasi/fd_pwrite.py
+++ b/runtime/python/units/wasi/fd_pwrite.py
@@ -5,6 +5,8 @@ def wasi_fd_pwrite(self, fd, iovs_ptr, iovs_len, offset, nwritten_ptr):
         return self.ERRNO_BADF
     if io in self.std_ios:
         return self.ERRNO_SPIPE
+    if not (self.fd_meta[fd][0] & self.RIGHTS_FD_WRITE):
+        return self.ERRNO_NOTCAPABLE
     written = 0
     try:
         for i in range(iovs_len):

--- a/runtime/python/units/wasi/path_open.py
+++ b/runtime/python/units/wasi/path_open.py
@@ -6,6 +6,10 @@ def wasi_path_open(self, dirfd, dirflags, path_ptr, path_len, oflags, fs_rights_
     host_path, err = self.resolve_path(dirfd, rel, symlink_follow)
     if err is not None:
         return err
+    # The dirfd must itself carry PATH_OPEN (ADR-40); a rights-narrowed dir fd
+    # that dropped it can no longer open beneath itself.
+    if not (self.fd_meta[dirfd][0] & self.RIGHTS_PATH_OPEN):
+        return self.ERRNO_NOTCAPABLE
     # OFLAGS_TRUNC needs the PATH_FILESTAT_SET_SIZE right on the dirfd (ADR-40).
     if oflags & 0x8 != 0 and not (self.fd_meta[dirfd][0] & self.RIGHTS_PATH_FILESTAT_SET_SIZE):
         return self.ERRNO_NOTCAPABLE

--- a/runtime/ruby/units/wasi/fd_pread.rb
+++ b/runtime/ruby/units/wasi/fd_pread.rb
@@ -1,8 +1,9 @@
-# requires: memory/i32_load, memory/i32_store, memory/init
+# requires: memory/i32_load, memory/i32_store, memory/init, wasi/rights
 def wasi_fd_pread(fd, iovs_ptr, iovs_len, offset, nread_ptr)
   io = @fds[fd]
   return ERRNO_BADF if io.nil? || io.is_a?(WasiDir)
   return ERRNO_SPIPE if @std_ios.include?(io)
+  return ERRNO_NOTCAPABLE unless fd_has_right?(fd, RIGHT_FD_READ)
   nread = 0
   iovs_len.times do |i|
     ptr = @memory.i32_load(iovs_ptr + i * 8)

--- a/runtime/ruby/units/wasi/fd_pwrite.rb
+++ b/runtime/ruby/units/wasi/fd_pwrite.rb
@@ -1,8 +1,9 @@
-# requires: memory/i32_load, memory/i32_store, memory/read_string
+# requires: memory/i32_load, memory/i32_store, memory/read_string, wasi/rights
 def wasi_fd_pwrite(fd, iovs_ptr, iovs_len, offset, nwritten_ptr)
   io = @fds[fd]
   return ERRNO_BADF if io.nil? || io.is_a?(WasiDir)
   return ERRNO_SPIPE if @std_ios.include?(io)
+  return ERRNO_NOTCAPABLE unless fd_has_right?(fd, RIGHT_FD_WRITE)
   written = 0
   iovs_len.times do |i|
     ptr = @memory.i32_load(iovs_ptr + i * 8)


### PR DESCRIPTION
Closes #26.

## What

The ADR-40 per-fd rights model had three enforcement gaps:

1. **fd_pread / fd_pwrite skipped the rights check** their fd_read / fd_write siblings perform, on Ruby, Go, Java and Python (only Bash gated them). Each backend now gates on `FD_READ` / `FD_WRITE` respectively, mirroring its own fd_read/fd_write idiom exactly (Ruby `fd_has_right?`, Go `checkRight`, Java `lacksRight`, Python inline `fd_meta` mask — read/write right only, Bash's existing baseline). Ruby's units gained `wasi/rights` in their `# requires:` headers; the other backends' helpers live in `_class`.
2. **Python `path_open` never checked the dirfd carries `PATH_OPEN`** — added first, right after path resolution, mirroring Ruby/Go/Java.
3. **Go `path_open` applied `OFLAGS_TRUNC` without `PATH_FILESTAT_SET_SIZE`** — now returns `NOTCAPABLE`, mirroring the other four backends.

Surprise found along the way: Go's `dirRightsBase` was missing `rightPathFilestatSetSize`, which the other four backends and wasmtime's directory mask carry. That is *why* the upstream wasi-testsuite `truncation_rights` trial never caught the missing TRUNC gate on Go — it self-skips ("implementation doesn't support setting file sizes") when the dir base lacks the bit. The bit is added, so the trial now runs in full on Go and exercises the new gate (Go wasi_testsuite: 72 passed, no ledger change).

## Regression coverage

New cross-backend fixture `fs_rights_notcapable` (`examples/wat/wasi_rights_notcapable.wat` + a `WasiCase` in `crates/dewasm-test-helper/src/wasi.rs`), run by **all five** backends' `wasi_fs` e2e suites. It pins every gate by exact errno (`<tag><errno>` lines, expected stdout `a00 b00 p76 w76 c00 t76 d00 o76`): NOTCAPABLE from pread/pwrite on a fd narrowed via `fd_fdstat_set_rights`, from an `O_TRUNC` open under a dirfd stripped of `PATH_FILESTAT_SET_SIZE` (also asserting the host file stays untruncated — the exact Go regression), and from any open once the dirfd drops `PATH_OPEN`. Before the fix it failed on all four affected backends and passed on Bash.

## Verification (local, macOS)

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test -p dewasm-backend-ruby -p dewasm-backend-go -p dewasm-backend-java -p dewasm-backend-python` — all green (per crate: unit + e2e + spec + wasi_testsuite; e.g. Ruby spec 257 passed, each backend's wasi_testsuite 72 passed, 0 failed)
- `cargo test -p dewasm-backend-bash --test e2e wasi_fs` — green (Bash baseline runs the new fixture too)
- `cargo xtask update-support-docs` — no changes (no support declarations changed)

The full cross-backend gate (incl. `dewasm-cli`) runs on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)