### PR TITLE
Fix four Bash WASI filesystem error paths

### DIFF
--- a/crates/dewasm-backend-bash/tests/wasi_fs_regressions.rs
+++ b/crates/dewasm-backend-bash/tests/wasi_fs_regressions.rs
@@ -1,0 +1,320 @@
+//! Bash-only WASI filesystem regression pins (the issue-29 fixes): drive a
+//! converted library-mode module plus its bundled units directly under bash,
+//! the same direct-drive shape as `softfloat.rs`. These cases do not join the
+//! shared `WASI_CASES` conformance table because the other backends inherit
+//! the probed errnos from the host OS — which differs between Linux and macOS
+//! on some of them — while the bash units implement each choice
+//! deterministically; the exact codes pinned here are bash's own contract
+//! (`runtime/bash/units/wasi/path_rename.sh` / `fd_close.sh` /
+//! `fd_allocate.sh`).
+//!
+//! The permission-based cases (a read-only parent to fail `rmdir`, a
+//! read-only file to fail the close-time flush) assume a non-root test user:
+//! root ignores permission bits and would see the operations succeed.
+#![cfg(unix)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use dewasm_backend::Mode;
+use dewasm_backend_bash::{find_bash5, BashBackend};
+use dewasm_test_helper::convert_bytes;
+
+/// A fresh, empty scratch directory keyed by `name`, so cases running in
+/// parallel never share host state (the `wasi.rs` helper's shape).
+fn scratch_dir(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("dewasm-bash-wasi-reg-{name}"));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// Convert `wat_src` in library mode (module name `prog`, embedded runtime,
+/// bundled WASI), append `glue`, run the script under bash >= 5, and return
+/// its stdout. The script itself must exit 0 (the glue ends in `exit 0`).
+fn run_module(name: &str, wat_src: &str, glue: &str) -> String {
+    let bash = find_bash5().expect("bash >= 5 not found — see docs/testing.md");
+    let bytes = wat::parse_str(wat_src).expect("parse wat");
+    let src = convert_bytes(&BashBackend, &bytes, Mode::Library, "prog");
+    let script_path = std::env::temp_dir().join(format!(
+        "dewasm-bash-wasi-reg-{name}-{}.sh",
+        std::process::id()
+    ));
+    std::fs::write(&script_path, format!("{src}\n{glue}")).unwrap();
+    let output = Command::new(&bash)
+        .arg(&script_path)
+        .output()
+        .expect("run bash");
+    assert!(
+        output.status.success(),
+        "{name}: bash failed: {}\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+/// The standard `_start` glue (`e2e.rs`'s `BASH_FS_GLUE` with the preopen
+/// inlined): preopen `host` at guest `/`, run `_start`, surface a `proc_exit`
+/// code — `invoke` returns status 133 with the code in `$EXIT_CODE` (ADR-12)
+/// — as a trailing decimal line.
+fn start_glue(host: &Path) -> String {
+    format!(
+        r#"WASI_DIRS=('{}::/')
+prog_init || {{ echo "init failed" >&2; exit 1; }}
+prog_invoke '_start'
+status=$?
+if [[ $status -eq 133 ]]; then
+  echo "$EXIT_CODE"
+fi
+exit 0
+"#,
+        host.display()
+    )
+}
+
+/// A module whose `_start` calls `path_rename(3, old, 3, new)` against the
+/// first preopen and exits with the errno.
+fn rename_wat(old: &str, new: &str) -> String {
+    format!(
+        r#"(module
+  (import "wasi_snapshot_preview1" "path_rename"
+    (func $path_rename (param i32 i32 i32 i32 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "proc_exit" (func $proc_exit (param i32)))
+  (memory (export "memory") 1)
+  (data (i32.const 0) "{old}")
+  (data (i32.const 128) "{new}")
+  (func (export "_start")
+    (call $proc_exit
+      (call $path_rename
+        (i32.const 3) (i32.const 0) (i32.const {old_len})
+        (i32.const 3) (i32.const 128) (i32.const {new_len})))))"#,
+        old_len = old.len(),
+        new_len = new.len(),
+    )
+}
+
+/// A module whose `_start` opens (CREAT) the file `f` with
+/// FD_READ|FD_WRITE|FD_ALLOCATE rights, calls `fd_allocate(fd, offset, len)`,
+/// and exits with the errno.
+fn allocate_wat(offset: i64, len: i64) -> String {
+    format!(
+        r#"(module
+  (import "wasi_snapshot_preview1" "path_open"
+    (func $path_open (param i32 i32 i32 i32 i32 i64 i64 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "fd_allocate"
+    (func $fd_allocate (param i32 i64 i64) (result i32)))
+  (import "wasi_snapshot_preview1" "proc_exit" (func $proc_exit (param i32)))
+  (memory (export "memory") 1)
+  (data (i32.const 0) "f")
+  (func (export "_start")
+    (local $err i32)
+    (local.set $err
+      (call $path_open
+        (i32.const 3)   ;; dirfd: the first preopen
+        (i32.const 0)   ;; dirflags
+        (i32.const 0)   ;; path ptr
+        (i32.const 1)   ;; path len
+        (i32.const 0x1) ;; oflags: CREAT
+        (i64.const 0x142) ;; rights: FD_READ|FD_WRITE|FD_ALLOCATE
+        (i64.const 0)   ;; rights inheriting
+        (i32.const 0)   ;; fdflags
+        (i32.const 64)))
+    (if (local.get $err) (then (call $proc_exit (local.get $err))))
+    (call $proc_exit
+      (call $fd_allocate
+        (i32.load (i32.const 64))
+        (i64.const {offset})
+        (i64.const {len})))))"#
+    )
+}
+
+/// A trailing slash on a source that resolves to a regular file is ENOTDIR
+/// (54), and nothing moves — before the fix the slash was silently stripped
+/// and the rename succeeded.
+#[test]
+fn rename_trailing_slash_on_file_source_is_enotdir() {
+    let dir = scratch_dir("slash-src-file");
+    std::fs::write(dir.join("file"), "x").unwrap();
+    let out = run_module(
+        "slash-src-file",
+        &rename_wat("file/", "renamed"),
+        &start_glue(&dir),
+    );
+    assert_eq!(out, "54\n");
+    assert!(dir.join("file").exists(), "source must survive");
+    assert!(!dir.join("renamed").exists(), "nothing may be created");
+}
+
+/// A trailing slash on a nonexistent source is the ordinary missing-source
+/// ENOENT (44) — POSIX: rename("nonexistent/", "x") fails pathname
+/// resolution, not ENOTDIR.
+#[test]
+fn rename_trailing_slash_missing_source_is_enoent() {
+    let dir = scratch_dir("slash-src-missing");
+    let out = run_module(
+        "slash-src-missing",
+        &rename_wat("nosuch/", "x"),
+        &start_glue(&dir),
+    );
+    assert_eq!(out, "44\n");
+}
+
+/// A trailing slash on a destination that resolves to an existing regular
+/// file is ENOTDIR (54) — without the slash this would be a legal replace.
+#[test]
+fn rename_trailing_slash_on_file_destination_is_enotdir() {
+    let dir = scratch_dir("slash-dst-file");
+    std::fs::write(dir.join("src"), "s").unwrap();
+    std::fs::write(dir.join("dst"), "d").unwrap();
+    let out = run_module(
+        "slash-dst-file",
+        &rename_wat("src", "dst/"),
+        &start_glue(&dir),
+    );
+    assert_eq!(out, "54\n");
+    assert_eq!(std::fs::read_to_string(dir.join("src")).unwrap(), "s");
+    assert_eq!(std::fs::read_to_string(dir.join("dst")).unwrap(), "d");
+}
+
+/// A trailing slash on a *nonexistent* destination names a directory to be
+/// created, which a regular-file source cannot satisfy: ENOENT (44) per POSIX
+/// pathname resolution (macOS agrees; Linux reports ENOTDIR — the bash unit
+/// follows POSIX, documented in the unit header).
+#[test]
+fn rename_trailing_slash_missing_destination_file_source_is_enoent() {
+    let dir = scratch_dir("slash-dst-missing");
+    std::fs::write(dir.join("src"), "s").unwrap();
+    let out = run_module(
+        "slash-dst-missing",
+        &rename_wat("src", "newdir/"),
+        &start_glue(&dir),
+    );
+    assert_eq!(out, "44\n");
+    assert!(dir.join("src").exists(), "source must survive");
+    assert!(!dir.join("newdir").exists(), "nothing may be created");
+}
+
+/// Trailing slashes on directories keep working: rename("d1/", "d2/") with a
+/// directory source and a nonexistent destination succeeds.
+#[test]
+fn rename_trailing_slash_on_directories_still_renames() {
+    let dir = scratch_dir("slash-dirs-ok");
+    std::fs::create_dir(dir.join("d1")).unwrap();
+    let out = run_module(
+        "slash-dirs-ok",
+        &rename_wat("d1/", "d2/"),
+        &start_glue(&dir),
+    );
+    assert_eq!(out, "0\n");
+    assert!(!dir.join("d1").exists(), "source must be gone");
+    assert!(dir.join("d2").is_dir(), "destination must be the directory");
+}
+
+/// When the `rmdir` clearing an empty destination directory fails (here: its
+/// parent is read-only), path_rename must report the failure — before the fix
+/// the unchecked `rmdir` was followed by an unconditional `mv`, which nested
+/// the source *inside* the surviving destination and reported success. The
+/// destination is still empty afterwards, so the errno is the unit's default
+/// EIO (29); a destination that gained entries would be ENOTEMPTY (55), but
+/// that race cannot be staged deterministically here.
+#[test]
+fn rename_rmdir_failure_is_reported_and_moves_nothing() {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = scratch_dir("rmdir-failure");
+    std::fs::create_dir(dir.join("src")).unwrap();
+    std::fs::create_dir_all(dir.join("ro/dst")).unwrap();
+    std::fs::set_permissions(dir.join("ro"), std::fs::Permissions::from_mode(0o555)).unwrap();
+    let out = run_module(
+        "rmdir-failure",
+        &rename_wat("src", "ro/dst"),
+        &start_glue(&dir),
+    );
+    // Restore before asserting so a later scratch cleanup can delete the tree.
+    std::fs::set_permissions(dir.join("ro"), std::fs::Permissions::from_mode(0o755)).unwrap();
+    assert_eq!(out, "29\n");
+    assert!(dir.join("src").is_dir(), "source must survive");
+    assert!(dir.join("ro/dst").is_dir(), "destination must survive");
+    assert!(
+        !dir.join("ro/dst/src").exists(),
+        "the source must not be nested inside the surviving destination"
+    );
+}
+
+/// offset+len past i64::MAX must not wrap bash's signed-64 arithmetic into a
+/// silent no-op success: it is EIO (29), the code Ruby/Python surface when the
+/// host refuses an unsatisfiable size (their unmapped EFBIG falls through to
+/// ERRNO_IO).
+#[test]
+fn fd_allocate_overflowing_size_is_eio() {
+    let dir = scratch_dir("alloc-overflow");
+    let out = run_module(
+        "alloc-overflow",
+        &allocate_wat(0x4000_0000_0000_0000, 0x4000_0000_0000_0000),
+        &start_glue(&dir),
+    );
+    assert_eq!(out, "29\n");
+}
+
+/// A negative (u64 >= 2^63) len keeps its existing EINVAL (28) — the overflow
+/// guard must not shadow the sign check.
+#[test]
+fn fd_allocate_negative_len_is_einval() {
+    let dir = scratch_dir("alloc-negative");
+    let out = run_module("alloc-negative", &allocate_wat(0, -1), &start_glue(&dir));
+    assert_eq!(out, "28\n");
+}
+
+/// A flush failure at close (the buffered file was made unwritable between
+/// the write and the close) must surface its errno — before the fix fd_close
+/// unconditionally reported 0 and the guest never learned its writes were
+/// lost. The fd state must still be released: a second close is EBADF (8).
+#[test]
+fn fd_close_flush_failure_propagates_errno_and_releases_fd() {
+    let dir = scratch_dir("close-flush-failure");
+    let wat = r#"(module
+  (import "wasi_snapshot_preview1" "path_open"
+    (func $path_open (param i32 i32 i32 i32 i32 i64 i64 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "fd_write"
+    (func $fd_write (param i32 i32 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "fd_close"
+    (func $fd_close (param i32) (result i32)))
+  (memory (export "memory") 1)
+  (data (i32.const 0) "f")
+  (data (i32.const 8) "hi")
+  ;; Open (CREAT) /f for writing, buffer two bytes (marking it dirty), and
+  ;; return the fd. The file itself is created eagerly at open time.
+  (func (export "openwrite") (result i32)
+    (local $fd i32)
+    (drop (call $path_open
+      (i32.const 3) (i32.const 0) (i32.const 0) (i32.const 1)
+      (i32.const 0x1)  ;; oflags: CREAT
+      (i64.const 0x42) ;; rights: FD_READ|FD_WRITE
+      (i64.const 0) (i32.const 0) (i32.const 64)))
+    (local.set $fd (i32.load (i32.const 64)))
+    (i32.store (i32.const 32) (i32.const 8)) ;; iovec: ptr
+    (i32.store (i32.const 36) (i32.const 2)) ;; iovec: len
+    (drop (call $fd_write (local.get $fd) (i32.const 32) (i32.const 1) (i32.const 40)))
+    (local.get $fd))
+  (func (export "closefd") (param i32) (result i32)
+    (call $fd_close (local.get 0))))"#;
+    // Glue: open+write, then make the file unwritable *behind the buffer* so
+    // the close-time flush fails (file_flush's truncate-open reports EIO, 29),
+    // then close twice — the second close must see a released fd (EBADF, 8).
+    let glue = format!(
+        r#"WASI_DIRS=('{host}::/')
+prog_init || {{ echo "init failed" >&2; exit 1; }}
+prog_invoke openwrite
+fd=$R0
+command chmod 444 '{host}/f'
+prog_invoke closefd "$fd"
+echo "$R0"
+prog_invoke closefd "$fd"
+echo "$R0"
+exit 0
+"#,
+        host = dir.display()
+    );
+    let out = run_module("close-flush-failure", wat, &glue);
+    assert_eq!(out, "29\n8\n");
+}

--- a/runtime/bash/units/wasi/fd_allocate.sh
+++ b/runtime/bash/units/wasi/fd_allocate.sh
@@ -15,6 +15,13 @@ wasi_fd_allocate() {
     R0=28 # EINVAL
     return 0
   fi
+  if (( __len > 0x7fffffffffffffff - __offset )); then
+    # offset+len would wrap bash's signed-64 arithmetic; no file can be that
+    # large. EIO matches Ruby/Python, whose OS-level EFBIG falls through their
+    # generic errno mapping as ERRNO_IO.
+    R0=29 # EIO
+    return 0
+  fi
   local __want=$(( __offset + __len ))
   local -n __wbuf=${__p}wbuf${__fd}
   local -n __wdirty=${__p}wdirty

--- a/runtime/bash/units/wasi/fd_close.sh
+++ b/runtime/bash/units/wasi/fd_close.sh
@@ -1,7 +1,10 @@
 # requires: wasi/fd_flush
 # Closing a file fd (kind 2) flushes a dirty buffer to disk, then drops the
 # buffer and its parallel fd-table entries (ADR-34). fds are never reused. A
-# directory or stdio fd just leaves the table.
+# directory or stdio fd just leaves the table. A flush failure's errno (R0,
+# the only channel wasi_fd_flush reports through) is propagated so the guest
+# learns its writes were lost — but the fd state is released either way: the
+# fd is gone after close, success or not.
 wasi_fd_close() {
   local __p=$1 __fd=$2
   local -n __fds=${__p}wfds
@@ -10,8 +13,10 @@ wasi_fd_close() {
     R0=8 # EBADF
     return 0
   fi
+  local __errno=0
   if [[ $__kind == 2 ]]; then
     wasi_fd_flush "$__p" "$__fd" || return $?
+    __errno=$R0
     unset "${__p}wbuf${__fd}"
     local -n __wpath=${__p}wpath
     local -n __wrbase=${__p}wrbase
@@ -24,6 +29,6 @@ wasi_fd_close() {
       "__wfdflags[$__fd]" "__wapp[$__fd]" "__wdirty[$__fd]" "__tell[$__fd]"
   fi
   unset "__fds[$__fd]"
-  R0=0
+  R0=$__errno
   return 0
 }

--- a/runtime/bash/units/wasi/path_rename.sh
+++ b/runtime/bash/units/wasi/path_rename.sh
@@ -24,8 +24,14 @@
 #   - destination exists, both sides are non-directories: falls through to
 #     `mv`, which replaces the destination like rename(2) does.
 # Trailing slashes on either name are stripped before resolution so a
-# `mv`/`rmdir` on the clean physical path behaves (the directories the
-# trailing-slash conformance case renames all exist as directories).
+# `mv`/`rmdir` on the clean physical path behaves, but the slash is
+# remembered: POSIX pathname resolution only lets "name/" resolve to an
+# existing directory (or a directory about to be created), so a
+# slash-bearing name that resolves to an existing non-directory is ENOTDIR
+# on either side, a nonexistent slash-bearing source is ENOENT (the
+# ordinary missing-source check), and a nonexistent slash-bearing
+# destination is only acceptable when the source is a directory — ENOENT
+# otherwise (POSIX/macOS; Linux reports ENOTDIR for that last case).
 # Anything else `mv` still manages to fail on (e.g. a permission error)
 # defaults to EIO.
 wasi_path_rename() {
@@ -33,14 +39,16 @@ wasi_path_rename() {
   local __new_dirfd=$5 __new_path_ptr=$6 __new_path_len=$7
   wasi_read_path "$__p" "$__old_path_ptr" "$__old_path_len" || return $?
   if (( R0 != 0 )); then return 0; fi
-  local __old_rel=$R1
+  local __old_rel=$R1 __old_slash=0
+  [[ $__old_rel == */ ]] && __old_slash=1
   while [[ $__old_rel == */ ]]; do __old_rel=${__old_rel%/}; done
   wasi_resolve_path "$__p" "$__old_dirfd" "$__old_rel" 0 || return $?
   if (( R0 != 0 )); then return 0; fi
   local __old_host=$R1
   wasi_read_path "$__p" "$__new_path_ptr" "$__new_path_len" || return $?
   if (( R0 != 0 )); then return 0; fi
-  local __new_rel=$R1
+  local __new_rel=$R1 __new_slash=0
+  [[ $__new_rel == */ ]] && __new_slash=1
   while [[ $__new_rel == */ ]]; do __new_rel=${__new_rel%/}; done
   wasi_resolve_path "$__p" "$__new_dirfd" "$__new_rel" 0 || return $?
   if (( R0 != 0 )); then return 0; fi
@@ -51,8 +59,16 @@ wasi_path_rename() {
   fi
   local __old_is_dir=0 __new_is_dir=0
   [[ -d $__old_host ]] && __old_is_dir=1
+  if (( __old_slash && ! __old_is_dir )); then
+    R0=54 # ENOTDIR: trailing slash on a non-directory source
+    return 0
+  fi
   if [[ -e $__new_host || -h $__new_host ]]; then
     [[ -d $__new_host ]] && __new_is_dir=1
+    if (( __new_slash && ! __new_is_dir )); then
+      R0=54 # ENOTDIR: trailing slash on a non-directory destination
+      return 0
+    fi
     if (( __old_is_dir && ! __new_is_dir )); then
       R0=54 # ENOTDIR: renaming a directory onto a non-directory
       return 0
@@ -73,8 +89,30 @@ wasi_path_rename() {
         R0=55 # ENOTEMPTY
         return 0
       fi
-      command rmdir -- "$__new_host" 2>/dev/null
+      if ! command rmdir -- "$__new_host" 2>/dev/null; then
+        # The destination survived, so the `mv` below would nest the source
+        # inside it instead of replacing it — report the failure instead.
+        # Re-probe emptiness: an entry that appeared since the check above is
+        # rename(2)'s ENOTEMPTY; anything else (e.g. a permission error on the
+        # parent) is the unit's default EIO.
+        __save=$(shopt -p dotglob nullglob)
+        shopt -s dotglob nullglob
+        __entries=("$__new_host"/*)
+        eval "$__save"
+        if (( ${#__entries[@]} > 0 )); then
+          R0=55 # ENOTEMPTY
+        else
+          R0=29 # EIO
+        fi
+        return 0
+      fi
     fi
+  elif (( __new_slash && ! __old_is_dir )); then
+    # A nonexistent destination with a trailing slash names a directory to be
+    # created, which only a directory source can satisfy (POSIX pathname
+    # resolution; macOS reports ENOENT here, Linux ENOTDIR — we follow POSIX).
+    R0=44 # ENOENT
+    return 0
   fi
   if command mv -- "$__old_host" "$__new_host" 2>/dev/null; then
     R0=0


### PR DESCRIPTION
Closes #29.

Four error paths in `runtime/bash/units/wasi/` silently reported success where rename(2)/close(2)/fallocate semantics demand an errno:

- **`path_rename.sh` — unchecked `rmdir`**: the empty-destination `rmdir` was not exit-status-checked and the `mv` ran unconditionally, so an rmdir failure nested the source *inside* the surviving destination and reported success. The rmdir is now checked: a destination that gained entries since the emptiness probe is **ENOTEMPTY (55)**; anything else (e.g. a read-only parent) is the unit's default **EIO (29)**; `mv` never runs against a surviving destination.
- **`path_rename.sh` — trailing slashes**: slashes were stripped with no directory check, so `rename("file/", "new")` on a regular file succeeded. The slash is now remembered across resolution: a slash-bearing name resolving to an existing non-directory is **ENOTDIR (54)** on either side; a nonexistent slash-bearing source stays **ENOENT (44)** (POSIX: `rename("nonexistent/", "x")` → ENOENT); a nonexistent slash-bearing destination is **ENOENT (44)** unless the source is a directory (POSIX pathname resolution, matches macOS; Linux reports ENOTDIR there — documented in the unit header). Trailing slashes on directories keep renaming (the upstream `rust/path_rename_dir_trailing_slashes` trial stays green).
- **`fd_close.sh` — clobbered flush errno**: the unconditional `R0=0` overwrote the errno `wasi_fd_flush` reports via R0, so a failed flush at close looked like success. The flush errno now propagates while the fd state is still released either way (a second close is EBADF), matching how `fd_sync.sh` already leaves R0 alone.
- **`fd_allocate.sh` — offset+len overflow**: the sum wraps negative in bash signed-64 arithmetic, turning huge requests into silent no-op successes. An overflowing sum is now guarded before the arithmetic and returns **EIO (29)** — the code Ruby and Python surface for an unsatisfiable size (the OS's EFBIG is unmapped in both `runtime/ruby/units/wasi/errno_fs.rb` and `runtime/python/units/wasi/errno_fs.py`, falling through to `ERRNO_IO`).

## Tests

New `crates/dewasm-backend-bash/tests/wasi_fs_regressions.rs` (9 cases) drives the converted module directly under bash, `softfloat.rs`-style. These are deliberately **not** shared `WASI_CASES`: the other backends inherit these errnos from the host OS, which differs between Linux and macOS on some of them (and Ruby/Python's `dirname`/`basename` recomposition in `resolve_path` drops the trailing slash, so they would not pass the slash cases), while the bash units implement each choice deterministically.

- trailing slash on file source / file destination → 54; missing slash-bearing source → 44; missing slash-bearing destination with file source → 44; directory-to-directory with slashes still renames
- rmdir-failure branch exercised via a read-only parent (rename reports 29, nothing moves, no nesting); the concurrent-entry ENOTEMPTY race itself cannot be staged deterministically and is covered only up to its errno branch
- fd_close flush failure staged by `chmod 444` on the buffered file between write and close → returns 29, second close → 8 (fd released)
- fd_allocate `2^62 + 2^62` → 29; negative len still 28 (guard must not shadow the sign check)

The permission-based cases assume a non-root test user (noted in the file header).

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test -p dewasm-backend-bash` — all green: units lint 3/3, e2e 12 passed (6 heavy ignored), spec harness, softfloat oracle, wasi-testsuite 72 passed / 0 failed (incl. `rust/path_rename`, `rust/path_rename_dir_trailing_slashes`), new `wasi_fs_regressions` 9/9
- `cargo test -p dewasm-cli --test support_docs` — docs/support.md not stale (no function-coverage change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)