### PR TITLE
Preserve trailing-slash semantics in WASI paths, following wasmtime (ADR-49)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,10 @@ units change, regenerate the matrix: `cargo xtask update-support-docs` (`cargo t
 
 ## Implementation guidelines
 
+- Where the WASI spec is silent (trailing-slash paths, errno flavors), behavior follows
+  wasmtime as measured on both CI hosts — never POSIX or invented semantics — and the
+  wasi-testsuite harness runs the Rust suite under host-pinned strict errno modes
+  ([ADR-49](docs/adr/49-spec-silent-follow-wasmtime.md)).
 - **The spec testsuite binds; an ADR says why** ([ADR-3](docs/adr/3-testing-strategy.md)).
   Correctness of generated code outranks its readability ([ADR-1](docs/adr/1-ir-design.md));
   readability improvements go into optional passes, never into semantics-relevant lowering.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,10 +52,9 @@ units change, regenerate the matrix: `cargo xtask update-support-docs` (`cargo t
 
 ## Implementation guidelines
 
-- Where the WASI spec is silent (trailing-slash paths, errno flavors), behavior follows
-  wasmtime as measured on both CI hosts — never POSIX or invented semantics — and the
-  wasi-testsuite harness runs the Rust suite under host-pinned strict errno modes
-  ([ADR-49](docs/adr/49-spec-silent-follow-wasmtime.md)).
+- Where the WASI spec is silent (trailing-slash paths, errno flavors), behavior copies
+  wasmtime as measured on both CI hosts, and the wasi-testsuite Rust suite runs under
+  host-pinned strict errno modes ([ADR-49](docs/adr/49-spec-silent-follow-wasmtime.md)).
 - **The spec testsuite binds; an ADR says why** ([ADR-3](docs/adr/3-testing-strategy.md)).
   Correctness of generated code outranks its readability ([ADR-1](docs/adr/1-ir-design.md));
   readability improvements go into optional passes, never into semantics-relevant lowering.

--- a/crates/dewasm-backend-bash/tests/wasi_fs_regressions.rs
+++ b/crates/dewasm-backend-bash/tests/wasi_fs_regressions.rs
@@ -178,11 +178,8 @@ fn rename_trailing_slash_on_file_destination_is_enotdir() {
 }
 
 /// A trailing slash on a *nonexistent* destination is stripped and the
-/// rename proceeds, creating a plain file at the bare name — wasmtime 47's
-/// cap-std behavior on both hosts, which ADR-49 adopts over the POSIX
-/// reading (ENOENT) this pin used to assert. The raw hosts diverge here
-/// (macOS rename(2) ENOENT, Linux ENOTDIR), which is why the unit implements
-/// the stripped rename explicitly rather than passing the slash through.
+/// rename proceeds onto the bare name — wasmtime's behavior (ADR-49). The
+/// raw hosts diverge here (macOS ENOENT / Linux ENOTDIR), hence the pin.
 #[test]
 fn rename_trailing_slash_missing_destination_strips_and_renames() {
     let dir = scratch_dir("slash-dst-missing");

--- a/crates/dewasm-backend-bash/tests/wasi_fs_regressions.rs
+++ b/crates/dewasm-backend-bash/tests/wasi_fs_regressions.rs
@@ -177,12 +177,14 @@ fn rename_trailing_slash_on_file_destination_is_enotdir() {
     assert_eq!(std::fs::read_to_string(dir.join("dst")).unwrap(), "d");
 }
 
-/// A trailing slash on a *nonexistent* destination names a directory to be
-/// created, which a regular-file source cannot satisfy: ENOENT (44) per POSIX
-/// pathname resolution (macOS agrees; Linux reports ENOTDIR — the bash unit
-/// follows POSIX, documented in the unit header).
+/// A trailing slash on a *nonexistent* destination is stripped and the
+/// rename proceeds, creating a plain file at the bare name — wasmtime 47's
+/// cap-std behavior on both hosts, which ADR-49 adopts over the POSIX
+/// reading (ENOENT) this pin used to assert. The raw hosts diverge here
+/// (macOS rename(2) ENOENT, Linux ENOTDIR), which is why the unit implements
+/// the stripped rename explicitly rather than passing the slash through.
 #[test]
-fn rename_trailing_slash_missing_destination_file_source_is_enoent() {
+fn rename_trailing_slash_missing_destination_strips_and_renames() {
     let dir = scratch_dir("slash-dst-missing");
     std::fs::write(dir.join("src"), "s").unwrap();
     let out = run_module(
@@ -190,9 +192,13 @@ fn rename_trailing_slash_missing_destination_file_source_is_enoent() {
         &rename_wat("src", "newdir/"),
         &start_glue(&dir),
     );
-    assert_eq!(out, "44\n");
-    assert!(dir.join("src").exists(), "source must survive");
-    assert!(!dir.join("newdir").exists(), "nothing may be created");
+    assert_eq!(out, "0\n");
+    assert!(!dir.join("src").exists(), "source must move");
+    assert_eq!(
+        std::fs::read_to_string(dir.join("newdir")).unwrap(),
+        "s",
+        "the bare name receives the file"
+    );
 }
 
 /// Trailing slashes on directories keep working: rename("d1/", "d2/") with a

--- a/crates/dewasm-backend-go/src/lib.rs
+++ b/crates/dewasm-backend-go/src/lib.rs
@@ -308,6 +308,7 @@ fn scan_imports(bundle: &str, standalone: bool) -> Vec<String> {
         ("math.", "math"),
         ("rand.", "crypto/rand"),
         ("reflect.", "reflect"),
+        ("runtime.", "runtime"),
         ("os.", "os"),
         ("sort.", "sort"),
         ("strings.", "strings"),
@@ -323,9 +324,27 @@ fn scan_imports(bundle: &str, standalone: bool) -> Vec<String> {
         })
         .collect::<Vec<_>>()
         .join("\n");
+    // A selector only counts at an identifier boundary: `runtime.GOOS` must
+    // not register a use of `time.`.
+    fn selector_used(code: &str, sel: &str) -> bool {
+        let bytes = code.as_bytes();
+        let mut start = 0;
+        while let Some(i) = code[start..].find(sel) {
+            let idx = start + i;
+            if idx == 0 {
+                return true;
+            }
+            let prev = bytes[idx - 1];
+            if !(prev.is_ascii_alphanumeric() || prev == b'_' || prev == b'.') {
+                return true;
+            }
+            start = idx + 1;
+        }
+        false
+    }
     let mut set: BTreeSet<&'static str> = BTreeSet::new();
     for (sel, path) in candidates {
-        if code.contains(sel) {
+        if selector_used(&code, sel) {
             set.insert(path);
         }
     }

--- a/crates/dewasm-test-helper/src/wasi.rs
+++ b/crates/dewasm-test-helper/src/wasi.rs
@@ -256,6 +256,85 @@ pub const WASI_CASES: &[WasiCase] = &[
             unix_only: false,
         },
     },
+    // Trailing-slash pathname resolution (issue #42): "name/" may only resolve
+    // to a directory, a signal the runtimes' path plumbing used to drop before
+    // the host syscall could enforce it. The fixture's probes cover the whole
+    // path_* family; the fixture header documents which shapes are normalized
+    // (nonexistent slash-suffixed rename destination / O_CREAT target, mkdir
+    // of "file/") because Linux and macOS disagree at the host level, and
+    // which symlink-through-slash shapes stay untested as accepted host
+    // splits. The bash-only Linux/macOS-divergence pins from PR #41 live in
+    // crates/dewasm-backend-bash/tests/wasi_fs_regressions.rs.
+    WasiCase {
+        name: "fs_trailing_slash",
+        wat: "wasi_trailing_slash.wat",
+        kind: WasiKind::Fs,
+        args: &[],
+        stdin: "",
+        check: WasiCheck::Fs {
+            preopen_subdir: None,
+            setup: |dir| {
+                std::fs::write(dir.join("file"), "keep me").unwrap();
+                std::fs::write(dir.join("file2"), "also kept").unwrap();
+                std::fs::create_dir(dir.join("dir")).unwrap();
+            },
+            check_stdout: |out| {
+                assert_eq!(
+                    out,
+                    "a54\nb54\nc54\nd44\ne54\nf54\ng54\nh54\ni54\nj44\nk44\nl44\nm20\nn00\no00\n"
+                )
+            },
+            assert_host: |dir| {
+                // Every failing probe must have left the filesystem alone; the
+                // two succeeding ones (n, o) must have taken effect.
+                assert_eq!(
+                    std::fs::read_to_string(dir.join("file")).unwrap(),
+                    "keep me"
+                );
+                assert_eq!(
+                    std::fs::read_to_string(dir.join("file2")).unwrap(),
+                    "also kept"
+                );
+                assert!(!dir.join("renamed").exists(), "a must not rename");
+                assert!(!dir.join("lnk").exists(), "i must not link");
+                assert!(!dir.join("newd").exists(), "k must not create a file");
+                assert!(!dir.join("newf").exists(), "l must not create a file");
+                assert!(dir.join("newdir").is_dir(), "n must create newdir/");
+                assert!(!dir.join("dir").exists(), "o must remove dir/");
+            },
+            unix_only: false,
+        },
+    },
+    // The symlink side of the trailing-slash rule: the slash forces the final
+    // symlink to be followed even for the nofollow-shaped syscalls, so a
+    // slash-suffixed symlink-to-a-file is ENOTDIR (never the link itself).
+    WasiCase {
+        name: "fs_trailing_slash_symlink",
+        wat: "wasi_trailing_slash_symlink.wat",
+        kind: WasiKind::Fs,
+        args: &[],
+        stdin: "",
+        check: WasiCheck::Fs {
+            preopen_subdir: None,
+            setup: |dir| {
+                #[cfg(unix)]
+                {
+                    std::fs::write(dir.join("file"), "x").unwrap();
+                    std::os::unix::fs::symlink("file", dir.join("linkfile")).unwrap();
+                }
+                #[cfg(not(unix))]
+                let _ = dir;
+            },
+            check_stdout: |out| assert_eq!(out, "s54\nt54\n"),
+            assert_host: |dir| {
+                assert!(
+                    dir.join("linkfile").symlink_metadata().is_ok(),
+                    "the probes must not remove the link"
+                )
+            },
+            unix_only: true,
+        },
+    },
     // Per-fd rights enforcement (ADR-40). A fd narrowed by
     // fd_fdstat_set_rights must refuse fd_pread/fd_pwrite (NOTCAPABLE, like
     // fd_read/fd_write); a dirfd stripped of PATH_FILESTAT_SET_SIZE must

--- a/crates/dewasm-test-helper/src/wasi.rs
+++ b/crates/dewasm-test-helper/src/wasi.rs
@@ -256,14 +256,14 @@ pub const WASI_CASES: &[WasiCase] = &[
             unix_only: false,
         },
     },
-    // Trailing-slash pathname resolution (issue #42): "name/" may only resolve
-    // to a directory, a signal the runtimes' path plumbing used to drop before
-    // the host syscall could enforce it. The fixture's probes cover the whole
-    // path_* family; the fixture header documents which shapes are normalized
-    // (nonexistent slash-suffixed rename destination / O_CREAT target, mkdir
-    // of "file/") because Linux and macOS disagree at the host level, and
-    // which symlink-through-slash shapes stay untested as accepted host
-    // splits. The bash-only Linux/macOS-divergence pins from PR #41 live in
+    // Trailing-slash pathname resolution (issue #42, ADR-49): the WASI spec is
+    // silent here, so the expectations are wasmtime 47's measured behavior on
+    // both hosts — a signal the runtimes' path plumbing used to drop before
+    // the host syscall could enforce anything. The fixture's probes cover the
+    // whole path_* family; its header documents the one host-split probe (k,
+    // O_CREAT through a slash: EINVAL on macOS, EISDIR on Linux — wasmtime's
+    // own split, asserted per-host below) and the shapes deliberately left
+    // untested. The bash-only pins from PR #41 live in
     // crates/dewasm-backend-bash/tests/wasi_fs_regressions.rs.
     WasiCase {
         name: "fs_trailing_slash",
@@ -279,35 +279,45 @@ pub const WASI_CASES: &[WasiCase] = &[
                 std::fs::create_dir(dir.join("dir")).unwrap();
             },
             check_stdout: |out| {
+                let k = if cfg!(target_os = "macos") {
+                    "k28"
+                } else {
+                    "k31"
+                };
                 assert_eq!(
                     out,
-                    "a54\nb54\nc54\nd44\ne54\nf54\ng54\nh54\ni54\nj44\nk44\nl44\nm20\nn00\no00\n"
+                    format!(
+                        "a54\nb54\nc54\nd44\ne54\nf54\ng54\nh54\ni44\nj00\n{k}\nl20\nm00\nn44\no28\np00\n"
+                    )
                 )
             },
             assert_host: |dir| {
-                // Every failing probe must have left the filesystem alone; the
-                // two succeeding ones (n, o) must have taken effect.
+                // The failing probes must have left the filesystem alone; the
+                // succeeding ones (j, m, p) must have taken effect.
                 assert_eq!(
                     std::fs::read_to_string(dir.join("file")).unwrap(),
                     "keep me"
                 );
                 assert_eq!(
-                    std::fs::read_to_string(dir.join("file2")).unwrap(),
-                    "also kept"
+                    std::fs::read_to_string(dir.join("newd")).unwrap(),
+                    "also kept",
+                    "j must rename file2 to a plain file newd (wasmtime strips the slash)"
                 );
+                assert!(!dir.join("file2").exists(), "j must move file2 away");
                 assert!(!dir.join("renamed").exists(), "a must not rename");
-                assert!(!dir.join("lnk").exists(), "i must not link");
-                assert!(!dir.join("newd").exists(), "k must not create a file");
-                assert!(!dir.join("newf").exists(), "l must not create a file");
-                assert!(dir.join("newdir").is_dir(), "n must create newdir/");
-                assert!(!dir.join("dir").exists(), "o must remove dir/");
+                assert!(!dir.join("lnk").exists(), "h must not link");
+                assert!(!dir.join("newf").exists(), "k must not create a file");
+                assert!(dir.join("newdir").is_dir(), "m must create newdir/");
+                assert!(!dir.join("dir").exists(), "o must keep dir, p removes it");
             },
             unix_only: false,
         },
     },
-    // The symlink side of the trailing-slash rule: the slash forces the final
-    // symlink to be followed even for the nofollow-shaped syscalls, so a
-    // slash-suffixed symlink-to-a-file is ENOTDIR (never the link itself).
+    // The symlink side of the trailing-slash rule (ADR-49): readlink through
+    // a slash follows to the target (ENOTDIR on a file), and a slash-suffixed
+    // symlink *destination* is EEXIST/ENOTDIR/ENOENT by what sits behind the
+    // slash — wasmtime's resolution order on both hosts, where a raw Linux
+    // symlinkat(2) would report EEXIST even over a plain file.
     WasiCase {
         name: "fs_trailing_slash_symlink",
         wat: "wasi_trailing_slash_symlink.wat",
@@ -321,16 +331,21 @@ pub const WASI_CASES: &[WasiCase] = &[
                 {
                     std::fs::write(dir.join("file"), "x").unwrap();
                     std::os::unix::fs::symlink("file", dir.join("linkfile")).unwrap();
+                    std::fs::create_dir(dir.join("sd1")).unwrap();
                 }
                 #[cfg(not(unix))]
                 let _ = dir;
             },
-            check_stdout: |out| assert_eq!(out, "s54\nt54\n"),
+            check_stdout: |out| assert_eq!(out, "t54\nu20\nv54\nw44\n"),
             assert_host: |dir| {
                 assert!(
                     dir.join("linkfile").symlink_metadata().is_ok(),
                     "the probes must not remove the link"
-                )
+                );
+                assert!(
+                    dir.join("dang").symlink_metadata().is_err(),
+                    "w must not create a symlink"
+                );
             },
             unix_only: true,
         },

--- a/crates/dewasm-test-helper/src/wasi.rs
+++ b/crates/dewasm-test-helper/src/wasi.rs
@@ -256,15 +256,10 @@ pub const WASI_CASES: &[WasiCase] = &[
             unix_only: false,
         },
     },
-    // Trailing-slash pathname resolution (issue #42, ADR-49): the WASI spec is
-    // silent here, so the expectations are wasmtime 47's measured behavior on
-    // both hosts — a signal the runtimes' path plumbing used to drop before
-    // the host syscall could enforce anything. The fixture's probes cover the
-    // whole path_* family; its header documents the one host-split probe (k,
-    // O_CREAT through a slash: EINVAL on macOS, EISDIR on Linux — wasmtime's
-    // own split, asserted per-host below) and the shapes deliberately left
-    // untested. The bash-only pins from PR #41 live in
-    // crates/dewasm-backend-bash/tests/wasi_fs_regressions.rs.
+    // Trailing-slash shapes (issue #42): pinned to wasmtime 47 on both hosts
+    // (ADR-49). Probe k is wasmtime's own host split, asserted per host; the
+    // fixture header lists the unpinned shapes. The bash-only PR #41 pins
+    // live in crates/dewasm-backend-bash/tests/wasi_fs_regressions.rs.
     WasiCase {
         name: "fs_trailing_slash",
         wat: "wasi_trailing_slash.wat",
@@ -313,11 +308,9 @@ pub const WASI_CASES: &[WasiCase] = &[
             unix_only: false,
         },
     },
-    // The symlink side of the trailing-slash rule (ADR-49): readlink through
-    // a slash follows to the target (ENOTDIR on a file), and a slash-suffixed
-    // symlink *destination* is EEXIST/ENOTDIR/ENOENT by what sits behind the
-    // slash — wasmtime's resolution order on both hosts, where a raw Linux
-    // symlinkat(2) would report EEXIST even over a plain file.
+    // The symlink side (ADR-49): readlink through a slash follows to the
+    // target; a slash-suffixed symlink destination errs by what sits behind
+    // the slash.
     WasiCase {
         name: "fs_trailing_slash_symlink",
         wat: "wasi_trailing_slash_symlink.wat",

--- a/crates/dewasm-test-helper/src/wasi_testsuite.rs
+++ b/crates/dewasm-test-helper/src/wasi_testsuite.rs
@@ -19,6 +19,11 @@
 //! decides whether it is expected. Every ledger entry names the WASI function
 //! or interface behaviour responsible.
 //!
+//! The Rust suite runs with the host-matched strict errno mode injected into
+//! the guest environment (ADR-49) — see the comment in [`evaluate`] — so its
+//! `assert_errno!` arms pin the host's errno flavor instead of the permissive
+//! union of all flavors.
+//!
 //! A ledger entry may be *host-scoped*: some failures depend on the host libc
 //! or interpreter (e.g. macOS CoreFoundation injecting `__CF_USER_TEXT_ENCODING`,
 //! or a Linux JDK truncating symlink times to microseconds). A backend declares
@@ -253,11 +258,32 @@ fn evaluate(lang: &dyn WasiTestsuiteBackend, case: &Case) -> Outcome {
     };
 
     let args: Vec<&str> = m.args.iter().map(String::as_str).collect();
-    let env: Vec<(&str, &str)> = m
+    let mut env: Vec<(&str, &str)> = m
         .env
         .iter()
         .map(|(k, v)| (k.as_str(), v.as_str()))
         .collect();
+    // Pin the Rust suite's errno assertions to the host's flavor (ADR-49).
+    // Unset, the suite's `TestConfig` is Permissive — every `assert_errno!`
+    // accepts the *union* of its unix/macos/windows arms, which is how
+    // host-divergence bugs slipped through (issue #42). Upstream's intended
+    // strict usage is to set exactly one mode; since dewasm backends surface
+    // the host OS's errnos (like wasmtime), the mode must match the host.
+    // This deliberately deviates from the manifest-only-env rule (commit
+    // 02c5ef5): that rule exists so environ_*-counting trials see exactly the
+    // manifest environment, and no *Rust* trial counts environ entries — the
+    // C/assemblyscript suites, which do, ignore ERRNO_MODE_* anyway and run
+    // untouched.
+    if case.trial_name.starts_with("rust/") {
+        env.push((
+            if std::env::consts::OS == "macos" {
+                "ERRNO_MODE_MACOS"
+            } else {
+                "ERRNO_MODE_UNIX"
+            },
+            "1",
+        ));
+    }
 
     let output = lang.run_standalone_wasi(&program, &dirs, &args, &env, b"");
 

--- a/crates/dewasm-test-helper/src/wasi_testsuite.rs
+++ b/crates/dewasm-test-helper/src/wasi_testsuite.rs
@@ -19,10 +19,8 @@
 //! decides whether it is expected. Every ledger entry names the WASI function
 //! or interface behaviour responsible.
 //!
-//! The Rust suite runs with the host-matched strict errno mode injected into
-//! the guest environment (ADR-49) — see the comment in [`evaluate`] — so its
-//! `assert_errno!` arms pin the host's errno flavor instead of the permissive
-//! union of all flavors.
+//! The Rust suite runs with the host-matched strict errno mode injected
+//! (ADR-49); see [`evaluate`].
 //!
 //! A ledger entry may be *host-scoped*: some failures depend on the host libc
 //! or interpreter (e.g. macOS CoreFoundation injecting `__CF_USER_TEXT_ENCODING`,
@@ -263,17 +261,11 @@ fn evaluate(lang: &dyn WasiTestsuiteBackend, case: &Case) -> Outcome {
         .iter()
         .map(|(k, v)| (k.as_str(), v.as_str()))
         .collect();
-    // Pin the Rust suite's errno assertions to the host's flavor (ADR-49).
-    // Unset, the suite's `TestConfig` is Permissive — every `assert_errno!`
-    // accepts the *union* of its unix/macos/windows arms, which is how
-    // host-divergence bugs slipped through (issue #42). Upstream's intended
-    // strict usage is to set exactly one mode; since dewasm backends surface
-    // the host OS's errnos (like wasmtime), the mode must match the host.
-    // This deliberately deviates from the manifest-only-env rule (commit
-    // 02c5ef5): that rule exists so environ_*-counting trials see exactly the
-    // manifest environment, and no *Rust* trial counts environ entries — the
-    // C/assemblyscript suites, which do, ignore ERRNO_MODE_* anyway and run
-    // untouched.
+    // Pin the Rust suite's errno assertions to the host flavor (ADR-49):
+    // unset, upstream's TestConfig is Permissive — the union of its per-OS
+    // arms. Deliberate deviation from the manifest-only-env rule (commit
+    // 02c5ef5), scoped to Rust: the C/assemblyscript suites assert exact
+    // environ contents.
     if case.trial_name.starts_with("rust/") {
         env.push((
             if std::env::consts::OS == "macos" {

--- a/docs/adr/49-spec-silent-follow-wasmtime.md
+++ b/docs/adr/49-spec-silent-follow-wasmtime.md
@@ -20,6 +20,26 @@ accepting the union of its `unix`/`macos`/`windows` arms — which is exactly
 how these divergences had gone undetected; its intended strict usage is to set
 one `ERRNO_MODE_*` variable.
 
+### Survey of other implementations (2026-07-29)
+
+The 25-probe matrix was also run (macOS host) under wasmer 7.2.1, WasmEdge
+0.17.1, and Node 24 (`node:wasi`/uvwasi); the full table is in PR #43. On the
+resolution family (slash over an existing non-directory → ENOTDIR, missing →
+ENOENT, the symlink-destination and unlink-of-directory shapes) wasmtime's
+behavior is the consensus. On the contentious shapes it is not uniformly so:
+`rmdir("dir/")` → EINVAL is **wasmtime alone** (WasmEdge and Node both
+succeed, the POSIX reading), and EINVAL for O_CREAT through `"newf/"` on
+macOS is matched by no other runtime (WasmEdge/Node pass the host's ENOENT
+through). Stripping the slash on a nonexistent rename destination is shared
+with WasmEdge (Node reports the host's ENOENT), as is `mkdir("file/")` →
+EEXIST (Node passes the host's ENOTDIR through). WasmEdge itself silently
+renames through a slash-suffixed *source* — the issue-42 bug class — and
+wasmer 7's virtual-fs overlay denies all namespace mutations on mapped
+volumes (EACCES/NOTCAPABLE), leaving only its resolution probes usable. The
+survey did not change the decision: the user chose one reference to copy
+rather than a majority vote per shape, and wasmtime — the runtime the
+upstream testsuite itself encodes — remains it.
+
 ## Decision
 
 **Where the WASI spec is silent, dewasm's WASI behavior follows wasmtime's

--- a/docs/adr/49-spec-silent-follow-wasmtime.md
+++ b/docs/adr/49-spec-silent-follow-wasmtime.md
@@ -1,0 +1,72 @@
+# ADR-49 — Where the WASI Spec Is Silent, Follow wasmtime; Host-Pinned Errno Modes for wasi-testsuite
+
+Status: **Accepted, 2026-07-29.** Implemented in PR #43 (issue #42): the
+trailing-slash behavior of every backend's `path_*` units matches wasmtime 47
+as measured on macOS and Linux, and the wasi-testsuite harness injects the
+host-matched strict errno mode into the Rust suite's trials.
+
+## Context
+
+WASI preview 1 does not define trailing-slash path semantics, and preview 2's
+`path-resolution.md` is equally silent. Issue #42 showed each backend invented
+its own answer (mostly: drop the slash before the host could see it); the
+first fix pinned POSIX pathname-resolution semantics instead, which turned out
+to *contradict* the reference runtime — wasmtime/cap-std strips the slash on a
+nonexistent rename destination and renames anyway, rejects `rmdir("dir/")`
+with EINVAL, and splits `open(O_CREAT, "x/")` per host (EINVAL on macOS from
+its manual resolution, EISDIR on Linux via passthrough). Meanwhile the
+upstream wasi-testsuite's `assert_errno!` runs *Permissive* by default —
+accepting the union of its `unix`/`macos`/`windows` arms — which is exactly
+how these divergences had gone undetected; its intended strict usage is to set
+one `ERRNO_MODE_*` variable.
+
+## Decision
+
+**Where the WASI spec is silent, dewasm's WASI behavior follows wasmtime's
+observed behavior (currently wasmtime 47), not POSIX and not invented
+semantics.** The reusable rule: a spec-silent behavior question is settled by
+measuring wasmtime on both CI hosts — if wasmtime is host-uniform, backends
+implement that value deterministically; if wasmtime inherits a host split
+(e.g. unlink-of-directory: EPERM on macOS, EISDIR on Linux), backends surface
+the same per-host split; if wasmtime's behavior on one host is an internal
+artifact with no portable expectation (its Linux-only slash-strip in
+nofollow `path_filestat_get`), the shape is left unpinned and documented at
+the test site (`examples/wat/wasi_trailing_slash.wat`).
+
+Correspondingly, the wasi-testsuite harness
+(`crates/dewasm-test-helper/src/wasi_testsuite.rs`) injects the host-matched
+strict errno mode — `ERRNO_MODE_MACOS` on macOS, `ERRNO_MODE_UNIX` on Linux —
+into the **Rust suite's** guest environment, closing the errno-union hole.
+This is a deliberate, commented deviation from the manifest-only-environment
+rule (commit 02c5ef5): no Rust trial counts environ entries, and the
+C/assemblyscript suites — which do — are left untouched (they ignore
+`ERRNO_MODE_*` anyway).
+
+## Rejected alternatives
+
+- **Pin POSIX pathname-resolution semantics** (the first revision of PR #43)
+  — self-consistent and standard-backed, but it invents a WASI surface no
+  runtime exhibits: guests are built and tested against wasmtime, and the
+  upstream testsuite's strict modes assert wasmtime's host-split errnos, so a
+  POSIX-pinned backend fails the strict suite on at least one host. Rejected
+  by user decision: no semantics beyond the reference implementation.
+- **Keep the suite Permissive** — hides real divergence (the issue-42 bugs
+  passed Permissive); strictness is the upstream-intended usage.
+- **Inject the errno mode into all three suites** — the C/assemblyscript
+  suites assert exact environ contents in places; scoping to Rust keeps the
+  02c5ef5 isolation intact where it matters.
+
+## Consequences
+
+- Positive: one measurable arbiter for every future spec-silent question;
+  the strict suite now pins per-host errnos on all five backends, on both CI
+  hosts.
+- Negative: some units carry host-OS branches (`RUBY_PLATFORM`,
+  `sys.platform`, `runtime.GOOS`, `os.name`, `$OSTYPE`) to reproduce
+  wasmtime's splits, and wasmtime quirks are copied as-is — e.g. a rename
+  onto `"newd/"` silently creates the plain file `newd`, and
+  `rmdir("dir/")` is EINVAL.
+- Carry-over: expectations are pinned to wasmtime 47's observed behavior; a
+  future wasmtime that changes a spec-silent shape forces a re-measure and a
+  revision here. The PR #41 bash pins remain, re-based on this rule
+  (`crates/dewasm-backend-bash/tests/wasi_fs_regressions.rs`).

--- a/docs/adr/49-spec-silent-follow-wasmtime.md
+++ b/docs/adr/49-spec-silent-follow-wasmtime.md
@@ -1,92 +1,51 @@
 # ADR-49 — Where the WASI Spec Is Silent, Follow wasmtime; Host-Pinned Errno Modes for wasi-testsuite
 
-Status: **Accepted, 2026-07-29.** Implemented in PR #43 (issue #42): the
-trailing-slash behavior of every backend's `path_*` units matches wasmtime 47
-as measured on macOS and Linux, and the wasi-testsuite harness injects the
-host-matched strict errno mode into the Rust suite's trials.
+Status: **Accepted, 2026-07-29.** Implemented in PR #43 (issue #42).
 
 ## Context
 
-WASI preview 1 does not define trailing-slash path semantics, and preview 2's
-`path-resolution.md` is equally silent. Issue #42 showed each backend invented
-its own answer (mostly: drop the slash before the host could see it); the
-first fix pinned POSIX pathname-resolution semantics instead, which turned out
-to *contradict* the reference runtime — wasmtime/cap-std strips the slash on a
-nonexistent rename destination and renames anyway, rejects `rmdir("dir/")`
-with EINVAL, and splits `open(O_CREAT, "x/")` per host (EINVAL on macOS from
-its manual resolution, EISDIR on Linux via passthrough). Meanwhile the
-upstream wasi-testsuite's `assert_errno!` runs *Permissive* by default —
-accepting the union of its `unix`/`macos`/`windows` arms — which is exactly
-how these divergences had gone undetected; its intended strict usage is to set
-one `ERRNO_MODE_*` variable.
+WASI p1 (and p2's `path-resolution.md`) says nothing about trailing-slash
+paths, and the shapes are inconsequential — a real program breaking on one of
+these errnos is astronomically unlikely. Still, each backend needs *some*
+answer; the first fix for issue #42 pinned POSIX, which contradicts wasmtime
+on a few shapes. The upstream wasi-testsuite's `assert_errno!` runs
+Permissive by default (the union of its per-OS arms) — how the divergences
+went unnoticed; setting one `ERRNO_MODE_*` is its intended strict usage.
 
-### Survey of other implementations (2026-07-29)
-
-The 25-probe matrix was also run (macOS host) under wasmer 7.2.1, WasmEdge
-0.17.1, and Node 24 (`node:wasi`/uvwasi); the full table is in PR #43. On the
-resolution family (slash over an existing non-directory → ENOTDIR, missing →
-ENOENT, the symlink-destination and unlink-of-directory shapes) wasmtime's
-behavior is the consensus. On the contentious shapes it is not uniformly so:
-`rmdir("dir/")` → EINVAL is **wasmtime alone** (WasmEdge and Node both
-succeed, the POSIX reading), and EINVAL for O_CREAT through `"newf/"` on
-macOS is matched by no other runtime (WasmEdge/Node pass the host's ENOENT
-through). Stripping the slash on a nonexistent rename destination is shared
-with WasmEdge (Node reports the host's ENOENT), as is `mkdir("file/")` →
-EEXIST (Node passes the host's ENOTDIR through). WasmEdge itself silently
-renames through a slash-suffixed *source* — the issue-42 bug class — and
-wasmer 7's virtual-fs overlay denies all namespace mutations on mapped
-volumes (EACCES/NOTCAPABLE), leaving only its resolution probes usable. The
-survey did not change the decision: the user chose one reference to copy
-rather than a majority vote per shape, and wasmtime — the runtime the
-upstream testsuite itself encodes — remains it.
+Survey (macOS; full table in PR #43): wasmer 7 can't run the mutation probes
+(its VFS denies them); WasmEdge 0.17 and Node 24 agree with wasmtime on the
+ENOTDIR resolution family but not on the quirks — `rmdir("dir/")` EINVAL and
+macOS O_CREAT-through-slash EINVAL are wasmtime alone. Noted for the record;
+it changed nothing.
 
 ## Decision
 
-**Where the WASI spec is silent, dewasm's WASI behavior follows wasmtime's
-observed behavior (currently wasmtime 47), not POSIX and not invented
-semantics.** The reusable rule: a spec-silent behavior question is settled by
-measuring wasmtime on both CI hosts — if wasmtime is host-uniform, backends
-implement that value deterministically; if wasmtime inherits a host split
-(e.g. unlink-of-directory: EPERM on macOS, EISDIR on Linux), backends surface
-the same per-host split; if wasmtime's behavior on one host is an internal
-artifact with no portable expectation (its Linux-only slash-strip in
-nofollow `path_filestat_get`), the shape is left unpinned and documented at
-the test site (`examples/wat/wasi_trailing_slash.wat`).
+**Where the WASI spec is silent, backends copy wasmtime's observed behavior**
+(currently 47), measured on both CI hosts: host-uniform values are
+implemented deterministically, host splits wasmtime inherits (unlink of a
+directory: EPERM/EISDIR) are reproduced per host, and one-host internal
+artifacts (its Linux-only nofollow-stat slash strip) stay unpinned, noted at
+the test site. wasmtime is the pick because the upstream testsuite encodes
+it, not because its behavior is better; where it is an outlier the value is
+arbitrary and not worth debating.
 
-Correspondingly, the wasi-testsuite harness
-(`crates/dewasm-test-helper/src/wasi_testsuite.rs`) injects the host-matched
-strict errno mode — `ERRNO_MODE_MACOS` on macOS, `ERRNO_MODE_UNIX` on Linux —
-into the **Rust suite's** guest environment, closing the errno-union hole.
-This is a deliberate, commented deviation from the manifest-only-environment
-rule (commit 02c5ef5): no Rust trial counts environ entries, and the
-C/assemblyscript suites — which do — are left untouched (they ignore
-`ERRNO_MODE_*` anyway).
+The wasi-testsuite runner injects the host-matched strict errno mode
+(`ERRNO_MODE_MACOS`/`ERRNO_MODE_UNIX`) into the Rust suite's guest
+environment — a deliberate deviation from the manifest-only-env rule (commit
+02c5ef5), scoped to Rust because the C/assemblyscript suites assert exact
+environ contents.
 
 ## Rejected alternatives
 
-- **Pin POSIX pathname-resolution semantics** (the first revision of PR #43)
-  — self-consistent and standard-backed, but it invents a WASI surface no
-  runtime exhibits: guests are built and tested against wasmtime, and the
-  upstream testsuite's strict modes assert wasmtime's host-split errnos, so a
-  POSIX-pinned backend fails the strict suite on at least one host. Rejected
-  by user decision: no semantics beyond the reference implementation.
-- **Keep the suite Permissive** — hides real divergence (the issue-42 bugs
-  passed Permissive); strictness is the upstream-intended usage.
-- **Inject the errno mode into all three suites** — the C/assemblyscript
-  suites assert exact environ contents in places; scoping to Rust keeps the
-  02c5ef5 isolation intact where it matters.
+- **POSIX semantics** (this PR's first revision) — nothing tests against
+  POSIX; fails the strict suite on at least one host.
+- **Permissive errno modes** — hides real divergence.
+- **Majority vote across runtimes** — effort spent on shapes that don't
+  matter, with no canonical electorate.
 
 ## Consequences
 
-- Positive: one measurable arbiter for every future spec-silent question;
-  the strict suite now pins per-host errnos on all five backends, on both CI
-  hosts.
-- Negative: some units carry host-OS branches (`RUBY_PLATFORM`,
-  `sys.platform`, `runtime.GOOS`, `os.name`, `$OSTYPE`) to reproduce
-  wasmtime's splits, and wasmtime quirks are copied as-is — e.g. a rename
-  onto `"newd/"` silently creates the plain file `newd`, and
-  `rmdir("dir/")` is EINVAL.
-- Carry-over: expectations are pinned to wasmtime 47's observed behavior; a
-  future wasmtime that changes a spec-silent shape forces a re-measure and a
-  revision here. The PR #41 bash pins remain, re-based on this rule
-  (`crates/dewasm-backend-bash/tests/wasi_fs_regressions.rs`).
+Some units carry host-OS branches to reproduce wasmtime's splits; its quirks
+are copied as-is. A future wasmtime change to a spec-silent shape forces a
+re-measure. The PR #41 bash pins are re-based on this rule
+(`crates/dewasm-backend-bash/tests/wasi_fs_regressions.rs`).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -70,6 +70,7 @@ the consequences.
 | ADR-46 | [Host-OS-Scoped Expected-Failure Ledgers for the WASI Testsuite Harness](46-host-scoped-wasi-ledgers.md) | Accepted |
 | ADR-47 | [Inline Quiet-NaN Guard for Ruby f64.sub](47-ruby-f64-sub-quiet-guard.md) | Accepted |
 | ADR-48 | [Two-Tier Slow-Test Gating (slow_test / ultra_slow_test)](48-slow-test-tiers.md) | Accepted |
+| ADR-49 | [Where the WASI Spec Is Silent, Follow wasmtime; Host-Pinned Errno Modes for wasi-testsuite](49-spec-silent-follow-wasmtime.md) | Accepted |
 
 ## Adding a new ADR
 

--- a/examples/wat/wasi_trailing_slash.wat
+++ b/examples/wat/wasi_trailing_slash.wat
@@ -1,41 +1,45 @@
-;; Trailing-slash pathname resolution (POSIX; issue #42): "name/" may only
-;; resolve to a directory, and the shared runtimes must enforce that even
-;; where their path plumbing (File.join, filepath.Join, Paths.get.normalize)
-;; would silently drop the slash before the host syscall could see it. Every
-;; probe prints "<tag><errno as two decimal digits>\n" so the expected stdout
-;; pins each errno exactly. Host layout (from the case's setup): a regular
-;; file "file", a second file "file2", a directory "dir".
+;; Trailing-slash pathname resolution (issue #42, ADR-49): the WASI spec is
+;; silent about trailing slashes, so dewasm follows wasmtime 47's observed
+;; behavior — every expected errno below was measured against wasmtime on
+;; both macOS and Linux (they agree except where noted). The runtimes must
+;; enforce these shapes even where their path plumbing (File.join,
+;; filepath.Join, Paths.get.normalize) would silently drop the slash before
+;; the host syscall could see it. Every probe prints "<tag><errno as two
+;; decimal digits>\n" so the expected stdout pins each errno exactly. Host
+;; layout (from the case's setup): a regular file "file", a second file
+;; "file2", a directory "dir".
 ;;   a — path_rename with a slash-suffixed regular-file *source* (54 ENOTDIR),
 ;;   b — path_rename with a slash-suffixed existing-file *destination* (54),
 ;;   c — path_unlink_file of "file/" (54),
 ;;   d — path_unlink_file of "missing/" (44 ENOENT),
-;;   e/f — path_filestat_get of "file/" with/without SYMLINK_FOLLOW (54),
-;;   g — path_open of "file/" read-only (54),
-;;   h — path_remove_directory of "file/" (54),
-;;   i — path_link with a slash-suffixed regular-file source (54),
-;;   j — path_rename with a missing slash-suffixed source (44),
-;;   k — path_rename of a file onto a *nonexistent* slash-suffixed
-;;       destination (44 — normalized: macOS/POSIX ENOENT vs Linux ENOTDIR;
-;;       every backend implements the check deterministically, and must not
-;;       silently create a plain file at the name),
-;;   l — path_open O_CREAT through a nonexistent slash-suffixed name (44 —
-;;       normalized: macOS/POSIX ENOENT vs Linux EISDIR; must not create),
-;;   m — path_create_directory of "file/" (20 EEXIST — normalized: macOS
-;;       mkdir(2) says ENOTDIR, Linux EEXIST; the slash is stripped since
-;;       mkdir names a directory by definition),
-;;   n — path_create_directory of "newdir/" (00: the slash is legal here),
-;;   o — path_remove_directory of "dir/" (00: ditto).
-;; Deliberately untested (host-divergent symlink-through-slash arcana, kept
-;; out per docs/testing.md): unlink/rename onto "symlink-to-dir/" (macOS
-;; EPERM / Linux ENOTDIR — the same accepted split as unlinking a plain
-;; directory) and O_NOFOLLOW opens of slash-suffixed symlinks.
-;; Ground truth: wasmtime 47 agrees on a-j exactly. It diverges on the
-;; normalized shapes — k succeeds by silently renaming through the slash
-;; onto a plain *file* (the very bug class issue #29/#42 removes), l/o are
-;; EINVAL — which is cap-std's slash stripping, not POSIX pathname
-;; resolution (a slash-terminated nonexistent name is ENOENT; rmdir of
-;; "dir/" resolves to the directory and succeeds), so the POSIX shapes are
-;; pinned here, as ADR-40/PR #41 chose for rename.
+;;   e — path_filestat_get of "file/" with SYMLINK_FOLLOW (54),
+;;   f — path_open of "file/" read-only (54),
+;;   g — path_remove_directory of "file/" (54),
+;;   h — path_link with a slash-suffixed regular-file source (54),
+;;   i — path_rename with a missing slash-suffixed source (44),
+;;   j — path_rename of a file onto a *nonexistent* slash-suffixed
+;;       destination (00: wasmtime's cap-std strips the slash and renames —
+;;       "file2" becomes a plain file "newd"),
+;;   k — path_open O_CREAT through a nonexistent slash-suffixed name
+;;       (host-split, as wasmtime: 28 EINVAL on macOS from its manual path
+;;       resolution, 31 EISDIR on Linux via host passthrough; must not
+;;       create),
+;;   l — path_create_directory of "file/" (20 EEXIST: the slash is stripped —
+;;       mkdir names a directory by definition — matching wasmtime),
+;;   m — path_create_directory of "newdir/" (00: the slash is legal here),
+;;   n — path_remove_directory of "missing/" (44),
+;;   o — path_remove_directory of "dir/" (28 EINVAL on both hosts —
+;;       wasmtime/cap-std rejects removing a directory through a slash —
+;;       and "dir" must survive),
+;;   p — path_remove_directory of "dir" (00: the bare name still works).
+;; Deliberately untested, per ADR-49's "copy wasmtime, don't invent" rule:
+;; path_filestat_get of "file/" *without* SYMLINK_FOLLOW — wasmtime-on-Linux
+;; strips the slash internally and succeeds (00) where wasmtime-on-macOS and
+;; even a raw Linux lstat(2) say ENOTDIR, an artifact with no portable
+;; expectation — and the unlink/rename-of-a-directory shapes whose errno
+;; wasmtime inherits from the host split (macOS EPERM / Linux EISDIR),
+;; which the upstream wasi-testsuite already pins per host under the
+;; strict errno modes.
 (module
   (import "wasi_snapshot_preview1" "path_rename"
     (func $path_rename (param i32 i32 i32 i32 i32 i32) (result i32)))
@@ -54,18 +58,18 @@
   (import "wasi_snapshot_preview1" "fd_write"
     (func $fd_write (param i32 i32 i32 i32) (result i32)))
   (memory (export "memory") 1)
+  ;; Prefix reuse: "file/" also serves "file" (len 4), "dir/" serves "dir"
+  ;; (len 3), "file2/" serves "file2" (len 5).
   (data (i32.const 0) "file/")
   (data (i32.const 8) "renamed")
-  (data (i32.const 16) "dir")
-  (data (i32.const 20) "file2/")
+  (data (i32.const 16) "dir/")
+  (data (i32.const 24) "file2/")
   (data (i32.const 32) "missing/")
   (data (i32.const 40) "x")
   (data (i32.const 48) "lnk")
   (data (i32.const 56) "newd/")
   (data (i32.const 64) "newf/")
   (data (i32.const 72) "newdir/")
-  (data (i32.const 80) "dir/")
-  (data (i32.const 88) "file")
   ;; 96: opened-fd cell, 128..191: filestat buffer, 200: 4-byte message,
   ;; 208: message iovec, 216: message nwritten cell.
   (func $report (param $tag i32) (param $errno i32)
@@ -86,7 +90,7 @@
     ;; b: rename("dir", "file2/") — slash-suffixed existing-file destination.
     (call $report (i32.const 98)
       (call $path_rename (i32.const 3) (i32.const 16) (i32.const 3)
-        (i32.const 3) (i32.const 20) (i32.const 6)))
+        (i32.const 3) (i32.const 24) (i32.const 6)))
     ;; c: unlink("file/").
     (call $report (i32.const 99)
       (call $path_unlink_file (i32.const 3) (i32.const 0) (i32.const 5)))
@@ -97,40 +101,43 @@
     (call $report (i32.const 101)
       (call $path_filestat_get (i32.const 3) (i32.const 1)
         (i32.const 0) (i32.const 5) (i32.const 128)))
-    ;; f: filestat_get("file/") without SYMLINK_FOLLOW.
+    ;; f: open("file/") read-only (rights FD_READ).
     (call $report (i32.const 102)
-      (call $path_filestat_get (i32.const 3) (i32.const 0)
-        (i32.const 0) (i32.const 5) (i32.const 128)))
-    ;; g: open("file/") read-only (rights FD_READ).
-    (call $report (i32.const 103)
       (call $path_open (i32.const 3) (i32.const 0) (i32.const 0) (i32.const 5)
         (i32.const 0) (i64.const 0x2) (i64.const 0) (i32.const 0) (i32.const 96)))
-    ;; h: remove_directory("file/").
-    (call $report (i32.const 104)
+    ;; g: remove_directory("file/").
+    (call $report (i32.const 103)
       (call $path_remove_directory (i32.const 3) (i32.const 0) (i32.const 5)))
-    ;; i: link("file/", "lnk") — slash-suffixed hard-link source.
-    (call $report (i32.const 105)
+    ;; h: link("file/", "lnk") — slash-suffixed hard-link source.
+    (call $report (i32.const 104)
       (call $path_link (i32.const 3) (i32.const 0) (i32.const 0) (i32.const 5)
         (i32.const 3) (i32.const 48) (i32.const 3)))
-    ;; j: rename("missing/", "x").
-    (call $report (i32.const 106)
+    ;; i: rename("missing/", "x").
+    (call $report (i32.const 105)
       (call $path_rename (i32.const 3) (i32.const 32) (i32.const 8)
         (i32.const 3) (i32.const 40) (i32.const 1)))
-    ;; k: rename("file", "newd/") — nonexistent slash-suffixed destination,
-    ;; non-directory source (normalized ENOENT).
-    (call $report (i32.const 107)
-      (call $path_rename (i32.const 3) (i32.const 88) (i32.const 4)
+    ;; j: rename("file2", "newd/") — nonexistent slash-suffixed destination:
+    ;; the slash is stripped and the rename proceeds (wasmtime).
+    (call $report (i32.const 106)
+      (call $path_rename (i32.const 3) (i32.const 24) (i32.const 5)
         (i32.const 3) (i32.const 56) (i32.const 5)))
-    ;; l: open("newf/", O_CREAT, rights FD_READ|FD_WRITE) — must not create.
-    (call $report (i32.const 108)
+    ;; k: open("newf/", O_CREAT, rights FD_READ|FD_WRITE) — must not create;
+    ;; EINVAL on macOS, EISDIR on Linux (wasmtime's own split).
+    (call $report (i32.const 107)
       (call $path_open (i32.const 3) (i32.const 0) (i32.const 64) (i32.const 5)
         (i32.const 0x1) (i64.const 0x42) (i64.const 0) (i32.const 0) (i32.const 96)))
-    ;; m: create_directory("file/") — EEXIST, uniformly.
-    (call $report (i32.const 109)
+    ;; l: create_directory("file/") — EEXIST, uniformly.
+    (call $report (i32.const 108)
       (call $path_create_directory (i32.const 3) (i32.const 0) (i32.const 5)))
-    ;; n: create_directory("newdir/") — the slash is legal on mkdir.
-    (call $report (i32.const 110)
+    ;; m: create_directory("newdir/") — the slash is legal on mkdir.
+    (call $report (i32.const 109)
       (call $path_create_directory (i32.const 3) (i32.const 72) (i32.const 7)))
-    ;; o: remove_directory("dir/") — the slash is legal on a directory.
+    ;; n: remove_directory("missing/").
+    (call $report (i32.const 110)
+      (call $path_remove_directory (i32.const 3) (i32.const 32) (i32.const 8)))
+    ;; o: remove_directory("dir/") — EINVAL, and "dir" survives.
     (call $report (i32.const 111)
-      (call $path_remove_directory (i32.const 3) (i32.const 80) (i32.const 4)))))
+      (call $path_remove_directory (i32.const 3) (i32.const 16) (i32.const 4)))
+    ;; p: remove_directory("dir") — the bare name still removes it.
+    (call $report (i32.const 112)
+      (call $path_remove_directory (i32.const 3) (i32.const 16) (i32.const 3)))))

--- a/examples/wat/wasi_trailing_slash.wat
+++ b/examples/wat/wasi_trailing_slash.wat
@@ -1,45 +1,12 @@
-;; Trailing-slash pathname resolution (issue #42, ADR-49): the WASI spec is
-;; silent about trailing slashes, so dewasm follows wasmtime 47's observed
-;; behavior — every expected errno below was measured against wasmtime on
-;; both macOS and Linux (they agree except where noted). The runtimes must
-;; enforce these shapes even where their path plumbing (File.join,
-;; filepath.Join, Paths.get.normalize) would silently drop the slash before
-;; the host syscall could see it. Every probe prints "<tag><errno as two
-;; decimal digits>\n" so the expected stdout pins each errno exactly. Host
-;; layout (from the case's setup): a regular file "file", a second file
-;; "file2", a directory "dir".
-;;   a — path_rename with a slash-suffixed regular-file *source* (54 ENOTDIR),
-;;   b — path_rename with a slash-suffixed existing-file *destination* (54),
-;;   c — path_unlink_file of "file/" (54),
-;;   d — path_unlink_file of "missing/" (44 ENOENT),
-;;   e — path_filestat_get of "file/" with SYMLINK_FOLLOW (54),
-;;   f — path_open of "file/" read-only (54),
-;;   g — path_remove_directory of "file/" (54),
-;;   h — path_link with a slash-suffixed regular-file source (54),
-;;   i — path_rename with a missing slash-suffixed source (44),
-;;   j — path_rename of a file onto a *nonexistent* slash-suffixed
-;;       destination (00: wasmtime's cap-std strips the slash and renames —
-;;       "file2" becomes a plain file "newd"),
-;;   k — path_open O_CREAT through a nonexistent slash-suffixed name
-;;       (host-split, as wasmtime: 28 EINVAL on macOS from its manual path
-;;       resolution, 31 EISDIR on Linux via host passthrough; must not
-;;       create),
-;;   l — path_create_directory of "file/" (20 EEXIST: the slash is stripped —
-;;       mkdir names a directory by definition — matching wasmtime),
-;;   m — path_create_directory of "newdir/" (00: the slash is legal here),
-;;   n — path_remove_directory of "missing/" (44),
-;;   o — path_remove_directory of "dir/" (28 EINVAL on both hosts —
-;;       wasmtime/cap-std rejects removing a directory through a slash —
-;;       and "dir" must survive),
-;;   p — path_remove_directory of "dir" (00: the bare name still works).
-;; Deliberately untested, per ADR-49's "copy wasmtime, don't invent" rule:
-;; path_filestat_get of "file/" *without* SYMLINK_FOLLOW — wasmtime-on-Linux
-;; strips the slash internally and succeeds (00) where wasmtime-on-macOS and
-;; even a raw Linux lstat(2) say ENOTDIR, an artifact with no portable
-;; expectation — and the unlink/rename-of-a-directory shapes whose errno
-;; wasmtime inherits from the host split (macOS EPERM / Linux EISDIR),
-;; which the upstream wasi-testsuite already pins per host under the
-;; strict errno modes.
+;; Trailing-slash shapes across the path_* family (issue #42): unspecified by
+;; WASI, pinned to wasmtime 47 as measured on macOS and Linux (ADR-49). Each
+;; probe prints "<tag><errno as two decimal digits>\n"; per-probe intent is
+;; commented at each call, expectations live in the shared WASI_CASES entry.
+;; Setup provides a file "file", a file "file2", and a directory "dir".
+;; Probe k is wasmtime's own host split: EINVAL on macOS, EISDIR on Linux.
+;; Left unpinned: nofollow filestat of "file/" (wasmtime's two hosts
+;; disagree) and unlink/rename-of-directory errnos (host split, covered per
+;; host by the strict wasi-testsuite).
 (module
   (import "wasi_snapshot_preview1" "path_rename"
     (func $path_rename (param i32 i32 i32 i32 i32 i32) (result i32)))

--- a/examples/wat/wasi_trailing_slash.wat
+++ b/examples/wat/wasi_trailing_slash.wat
@@ -1,0 +1,136 @@
+;; Trailing-slash pathname resolution (POSIX; issue #42): "name/" may only
+;; resolve to a directory, and the shared runtimes must enforce that even
+;; where their path plumbing (File.join, filepath.Join, Paths.get.normalize)
+;; would silently drop the slash before the host syscall could see it. Every
+;; probe prints "<tag><errno as two decimal digits>\n" so the expected stdout
+;; pins each errno exactly. Host layout (from the case's setup): a regular
+;; file "file", a second file "file2", a directory "dir".
+;;   a — path_rename with a slash-suffixed regular-file *source* (54 ENOTDIR),
+;;   b — path_rename with a slash-suffixed existing-file *destination* (54),
+;;   c — path_unlink_file of "file/" (54),
+;;   d — path_unlink_file of "missing/" (44 ENOENT),
+;;   e/f — path_filestat_get of "file/" with/without SYMLINK_FOLLOW (54),
+;;   g — path_open of "file/" read-only (54),
+;;   h — path_remove_directory of "file/" (54),
+;;   i — path_link with a slash-suffixed regular-file source (54),
+;;   j — path_rename with a missing slash-suffixed source (44),
+;;   k — path_rename of a file onto a *nonexistent* slash-suffixed
+;;       destination (44 — normalized: macOS/POSIX ENOENT vs Linux ENOTDIR;
+;;       every backend implements the check deterministically, and must not
+;;       silently create a plain file at the name),
+;;   l — path_open O_CREAT through a nonexistent slash-suffixed name (44 —
+;;       normalized: macOS/POSIX ENOENT vs Linux EISDIR; must not create),
+;;   m — path_create_directory of "file/" (20 EEXIST — normalized: macOS
+;;       mkdir(2) says ENOTDIR, Linux EEXIST; the slash is stripped since
+;;       mkdir names a directory by definition),
+;;   n — path_create_directory of "newdir/" (00: the slash is legal here),
+;;   o — path_remove_directory of "dir/" (00: ditto).
+;; Deliberately untested (host-divergent symlink-through-slash arcana, kept
+;; out per docs/testing.md): unlink/rename onto "symlink-to-dir/" (macOS
+;; EPERM / Linux ENOTDIR — the same accepted split as unlinking a plain
+;; directory) and O_NOFOLLOW opens of slash-suffixed symlinks.
+;; Ground truth: wasmtime 47 agrees on a-j exactly. It diverges on the
+;; normalized shapes — k succeeds by silently renaming through the slash
+;; onto a plain *file* (the very bug class issue #29/#42 removes), l/o are
+;; EINVAL — which is cap-std's slash stripping, not POSIX pathname
+;; resolution (a slash-terminated nonexistent name is ENOENT; rmdir of
+;; "dir/" resolves to the directory and succeeds), so the POSIX shapes are
+;; pinned here, as ADR-40/PR #41 chose for rename.
+(module
+  (import "wasi_snapshot_preview1" "path_rename"
+    (func $path_rename (param i32 i32 i32 i32 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "path_unlink_file"
+    (func $path_unlink_file (param i32 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "path_filestat_get"
+    (func $path_filestat_get (param i32 i32 i32 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "path_open"
+    (func $path_open (param i32 i32 i32 i32 i32 i64 i64 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "path_remove_directory"
+    (func $path_remove_directory (param i32 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "path_link"
+    (func $path_link (param i32 i32 i32 i32 i32 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "path_create_directory"
+    (func $path_create_directory (param i32 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "fd_write"
+    (func $fd_write (param i32 i32 i32 i32) (result i32)))
+  (memory (export "memory") 1)
+  (data (i32.const 0) "file/")
+  (data (i32.const 8) "renamed")
+  (data (i32.const 16) "dir")
+  (data (i32.const 20) "file2/")
+  (data (i32.const 32) "missing/")
+  (data (i32.const 40) "x")
+  (data (i32.const 48) "lnk")
+  (data (i32.const 56) "newd/")
+  (data (i32.const 64) "newf/")
+  (data (i32.const 72) "newdir/")
+  (data (i32.const 80) "dir/")
+  (data (i32.const 88) "file")
+  ;; 96: opened-fd cell, 128..191: filestat buffer, 200: 4-byte message,
+  ;; 208: message iovec, 216: message nwritten cell.
+  (func $report (param $tag i32) (param $errno i32)
+    (i32.store8 (i32.const 200) (local.get $tag))
+    (i32.store8 (i32.const 201)
+      (i32.add (i32.const 48) (i32.div_u (local.get $errno) (i32.const 10))))
+    (i32.store8 (i32.const 202)
+      (i32.add (i32.const 48) (i32.rem_u (local.get $errno) (i32.const 10))))
+    (i32.store8 (i32.const 203) (i32.const 10))
+    (i32.store (i32.const 208) (i32.const 200))
+    (i32.store (i32.const 212) (i32.const 4))
+    (drop (call $fd_write (i32.const 1) (i32.const 208) (i32.const 1) (i32.const 216))))
+  (func (export "_start")
+    ;; a: rename("file/", "renamed") — slash-suffixed non-directory source.
+    (call $report (i32.const 97)
+      (call $path_rename (i32.const 3) (i32.const 0) (i32.const 5)
+        (i32.const 3) (i32.const 8) (i32.const 7)))
+    ;; b: rename("dir", "file2/") — slash-suffixed existing-file destination.
+    (call $report (i32.const 98)
+      (call $path_rename (i32.const 3) (i32.const 16) (i32.const 3)
+        (i32.const 3) (i32.const 20) (i32.const 6)))
+    ;; c: unlink("file/").
+    (call $report (i32.const 99)
+      (call $path_unlink_file (i32.const 3) (i32.const 0) (i32.const 5)))
+    ;; d: unlink("missing/") — missing beats the slash: ENOENT.
+    (call $report (i32.const 100)
+      (call $path_unlink_file (i32.const 3) (i32.const 32) (i32.const 8)))
+    ;; e: filestat_get("file/") with SYMLINK_FOLLOW.
+    (call $report (i32.const 101)
+      (call $path_filestat_get (i32.const 3) (i32.const 1)
+        (i32.const 0) (i32.const 5) (i32.const 128)))
+    ;; f: filestat_get("file/") without SYMLINK_FOLLOW.
+    (call $report (i32.const 102)
+      (call $path_filestat_get (i32.const 3) (i32.const 0)
+        (i32.const 0) (i32.const 5) (i32.const 128)))
+    ;; g: open("file/") read-only (rights FD_READ).
+    (call $report (i32.const 103)
+      (call $path_open (i32.const 3) (i32.const 0) (i32.const 0) (i32.const 5)
+        (i32.const 0) (i64.const 0x2) (i64.const 0) (i32.const 0) (i32.const 96)))
+    ;; h: remove_directory("file/").
+    (call $report (i32.const 104)
+      (call $path_remove_directory (i32.const 3) (i32.const 0) (i32.const 5)))
+    ;; i: link("file/", "lnk") — slash-suffixed hard-link source.
+    (call $report (i32.const 105)
+      (call $path_link (i32.const 3) (i32.const 0) (i32.const 0) (i32.const 5)
+        (i32.const 3) (i32.const 48) (i32.const 3)))
+    ;; j: rename("missing/", "x").
+    (call $report (i32.const 106)
+      (call $path_rename (i32.const 3) (i32.const 32) (i32.const 8)
+        (i32.const 3) (i32.const 40) (i32.const 1)))
+    ;; k: rename("file", "newd/") — nonexistent slash-suffixed destination,
+    ;; non-directory source (normalized ENOENT).
+    (call $report (i32.const 107)
+      (call $path_rename (i32.const 3) (i32.const 88) (i32.const 4)
+        (i32.const 3) (i32.const 56) (i32.const 5)))
+    ;; l: open("newf/", O_CREAT, rights FD_READ|FD_WRITE) — must not create.
+    (call $report (i32.const 108)
+      (call $path_open (i32.const 3) (i32.const 0) (i32.const 64) (i32.const 5)
+        (i32.const 0x1) (i64.const 0x42) (i64.const 0) (i32.const 0) (i32.const 96)))
+    ;; m: create_directory("file/") — EEXIST, uniformly.
+    (call $report (i32.const 109)
+      (call $path_create_directory (i32.const 3) (i32.const 0) (i32.const 5)))
+    ;; n: create_directory("newdir/") — the slash is legal on mkdir.
+    (call $report (i32.const 110)
+      (call $path_create_directory (i32.const 3) (i32.const 72) (i32.const 7)))
+    ;; o: remove_directory("dir/") — the slash is legal on a directory.
+    (call $report (i32.const 111)
+      (call $path_remove_directory (i32.const 3) (i32.const 80) (i32.const 4)))))

--- a/examples/wat/wasi_trailing_slash_symlink.wat
+++ b/examples/wat/wasi_trailing_slash_symlink.wat
@@ -1,26 +1,36 @@
-;; Trailing-slash resolution through a symlink (POSIX; issue #42): the slash
-;; forces the final symlink to be *followed*, even for syscalls that otherwise
-;; operate on the link itself — so a slash-suffixed symlink-to-a-file is
-;; ENOTDIR everywhere the target's non-directory-ness is reached. Host layout
-;; (from the case's setup): a regular file "file" and a symlink
-;; "linkfile" -> "file". Probes print "<tag><errno>\n" like
+;; Trailing slashes on the symlink-flavored syscalls (issue #42, ADR-49:
+;; follow wasmtime — every expected errno measured against wasmtime 47 on
+;; both macOS and Linux, where they agree). Host layout (from the case's
+;; setup): a regular file "file", a symlink "linkfile" -> "file", and a
+;; directory "sd1". Probes print "<tag><errno>\n" like
 ;; wasi_trailing_slash.wat:
-;;   s — path_filestat_get of "linkfile/" *without* SYMLINK_FOLLOW: the slash
-;;       still forces following, and the target is a file (54 ENOTDIR),
-;;   t — path_readlink of "linkfile/": ditto (54), never the link content.
-;; The symlink-to-a-*directory* shapes stay untested: hosts diverge on them
-;; (see wasi_trailing_slash.wat's exclusion note).
+;;   t — path_readlink of "linkfile/": the slash forces following, and the
+;;       target is a file (54 ENOTDIR) — never the link content,
+;;   u — path_symlink onto "sd1/" (existing directory): 20 EEXIST,
+;;   v — path_symlink onto "file/" (existing non-directory): 54 ENOTDIR —
+;;       wasmtime's resolution order, where a raw Linux symlinkat(2) would
+;;       say EEXIST,
+;;   w — path_symlink onto "dang/" (nothing there): 44 ENOENT.
+;; Deliberately untested: path_filestat_get of "linkfile/" without
+;; SYMLINK_FOLLOW — wasmtime-on-Linux strips the slash internally and stats
+;; the link itself (00) where wasmtime-on-macOS (and a raw lstat(2) on
+;; either host) says ENOTDIR, an artifact with no portable expectation
+;; (ADR-49's "copy wasmtime, don't invent" rule).
 (module
-  (import "wasi_snapshot_preview1" "path_filestat_get"
-    (func $path_filestat_get (param i32 i32 i32 i32 i32) (result i32)))
   (import "wasi_snapshot_preview1" "path_readlink"
     (func $path_readlink (param i32 i32 i32 i32 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "path_symlink"
+    (func $path_symlink (param i32 i32 i32 i32 i32) (result i32)))
   (import "wasi_snapshot_preview1" "fd_write"
     (func $fd_write (param i32 i32 i32 i32) (result i32)))
   (memory (export "memory") 1)
   (data (i32.const 0) "linkfile/")
-  ;; 64..95: readlink buffer, 100: bufused cell, 128..191: filestat buffer,
-  ;; 200: 4-byte message, 208: message iovec, 216: message nwritten cell.
+  (data (i32.const 16) "s")
+  (data (i32.const 24) "sd1/")
+  (data (i32.const 32) "file/")
+  (data (i32.const 40) "dang/")
+  ;; 64..95: readlink buffer, 100: bufused cell, 200: 4-byte message,
+  ;; 208: message iovec, 216: message nwritten cell.
   (func $report (param $tag i32) (param $errno i32)
     (i32.store8 (i32.const 200) (local.get $tag))
     (i32.store8 (i32.const 201)
@@ -32,11 +42,19 @@
     (i32.store (i32.const 212) (i32.const 4))
     (drop (call $fd_write (i32.const 1) (i32.const 208) (i32.const 1) (i32.const 216))))
   (func (export "_start")
-    ;; s: filestat_get("linkfile/") without SYMLINK_FOLLOW.
-    (call $report (i32.const 115)
-      (call $path_filestat_get (i32.const 3) (i32.const 0)
-        (i32.const 0) (i32.const 9) (i32.const 128)))
     ;; t: readlink("linkfile/").
     (call $report (i32.const 116)
       (call $path_readlink (i32.const 3) (i32.const 0) (i32.const 9)
-        (i32.const 64) (i32.const 32) (i32.const 100)))))
+        (i32.const 64) (i32.const 32) (i32.const 100)))
+    ;; u: symlink("s", "sd1/") — existing directory behind the slash.
+    (call $report (i32.const 117)
+      (call $path_symlink (i32.const 16) (i32.const 1)
+        (i32.const 3) (i32.const 24) (i32.const 4)))
+    ;; v: symlink("s", "file/") — existing non-directory behind the slash.
+    (call $report (i32.const 118)
+      (call $path_symlink (i32.const 16) (i32.const 1)
+        (i32.const 3) (i32.const 32) (i32.const 5)))
+    ;; w: symlink("s", "dang/") — nothing behind the slash.
+    (call $report (i32.const 119)
+      (call $path_symlink (i32.const 16) (i32.const 1)
+        (i32.const 3) (i32.const 40) (i32.const 5)))))

--- a/examples/wat/wasi_trailing_slash_symlink.wat
+++ b/examples/wat/wasi_trailing_slash_symlink.wat
@@ -1,0 +1,42 @@
+;; Trailing-slash resolution through a symlink (POSIX; issue #42): the slash
+;; forces the final symlink to be *followed*, even for syscalls that otherwise
+;; operate on the link itself — so a slash-suffixed symlink-to-a-file is
+;; ENOTDIR everywhere the target's non-directory-ness is reached. Host layout
+;; (from the case's setup): a regular file "file" and a symlink
+;; "linkfile" -> "file". Probes print "<tag><errno>\n" like
+;; wasi_trailing_slash.wat:
+;;   s — path_filestat_get of "linkfile/" *without* SYMLINK_FOLLOW: the slash
+;;       still forces following, and the target is a file (54 ENOTDIR),
+;;   t — path_readlink of "linkfile/": ditto (54), never the link content.
+;; The symlink-to-a-*directory* shapes stay untested: hosts diverge on them
+;; (see wasi_trailing_slash.wat's exclusion note).
+(module
+  (import "wasi_snapshot_preview1" "path_filestat_get"
+    (func $path_filestat_get (param i32 i32 i32 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "path_readlink"
+    (func $path_readlink (param i32 i32 i32 i32 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "fd_write"
+    (func $fd_write (param i32 i32 i32 i32) (result i32)))
+  (memory (export "memory") 1)
+  (data (i32.const 0) "linkfile/")
+  ;; 64..95: readlink buffer, 100: bufused cell, 128..191: filestat buffer,
+  ;; 200: 4-byte message, 208: message iovec, 216: message nwritten cell.
+  (func $report (param $tag i32) (param $errno i32)
+    (i32.store8 (i32.const 200) (local.get $tag))
+    (i32.store8 (i32.const 201)
+      (i32.add (i32.const 48) (i32.div_u (local.get $errno) (i32.const 10))))
+    (i32.store8 (i32.const 202)
+      (i32.add (i32.const 48) (i32.rem_u (local.get $errno) (i32.const 10))))
+    (i32.store8 (i32.const 203) (i32.const 10))
+    (i32.store (i32.const 208) (i32.const 200))
+    (i32.store (i32.const 212) (i32.const 4))
+    (drop (call $fd_write (i32.const 1) (i32.const 208) (i32.const 1) (i32.const 216))))
+  (func (export "_start")
+    ;; s: filestat_get("linkfile/") without SYMLINK_FOLLOW.
+    (call $report (i32.const 115)
+      (call $path_filestat_get (i32.const 3) (i32.const 0)
+        (i32.const 0) (i32.const 9) (i32.const 128)))
+    ;; t: readlink("linkfile/").
+    (call $report (i32.const 116)
+      (call $path_readlink (i32.const 3) (i32.const 0) (i32.const 9)
+        (i32.const 64) (i32.const 32) (i32.const 100)))))

--- a/examples/wat/wasi_trailing_slash_symlink.wat
+++ b/examples/wat/wasi_trailing_slash_symlink.wat
@@ -1,21 +1,8 @@
-;; Trailing slashes on the symlink-flavored syscalls (issue #42, ADR-49:
-;; follow wasmtime — every expected errno measured against wasmtime 47 on
-;; both macOS and Linux, where they agree). Host layout (from the case's
-;; setup): a regular file "file", a symlink "linkfile" -> "file", and a
-;; directory "sd1". Probes print "<tag><errno>\n" like
-;; wasi_trailing_slash.wat:
-;;   t — path_readlink of "linkfile/": the slash forces following, and the
-;;       target is a file (54 ENOTDIR) — never the link content,
-;;   u — path_symlink onto "sd1/" (existing directory): 20 EEXIST,
-;;   v — path_symlink onto "file/" (existing non-directory): 54 ENOTDIR —
-;;       wasmtime's resolution order, where a raw Linux symlinkat(2) would
-;;       say EEXIST,
-;;   w — path_symlink onto "dang/" (nothing there): 44 ENOENT.
-;; Deliberately untested: path_filestat_get of "linkfile/" without
-;; SYMLINK_FOLLOW — wasmtime-on-Linux strips the slash internally and stats
-;; the link itself (00) where wasmtime-on-macOS (and a raw lstat(2) on
-;; either host) says ENOTDIR, an artifact with no portable expectation
-;; (ADR-49's "copy wasmtime, don't invent" rule).
+;; Trailing slashes through symlinks (issue #42): pinned to wasmtime 47 on
+;; both hosts (ADR-49). Setup: file "file", symlink "linkfile" -> "file",
+;; directory "sd1". Probes print "<tag><errno>\n" and are commented at each
+;; call; expectations live in the shared WASI_CASES entry. Left unpinned:
+;; nofollow filestat of "linkfile/" (wasmtime's two hosts disagree).
 (module
   (import "wasi_snapshot_preview1" "path_readlink"
     (func $path_readlink (param i32 i32 i32 i32 i32 i32) (result i32)))

--- a/runtime/bash/units/wasi/path_create_directory.sh
+++ b/runtime/bash/units/wasi/path_create_directory.sh
@@ -16,11 +16,9 @@ wasi_path_create_directory() {
   wasi_read_path "$__p" "$__path_ptr" "$__path_len" || return $?
   if (( R0 != 0 )); then return 0; fi
   local __rel=$R1
-  # mkdir names a directory by definition, so a trailing slash adds nothing
-  # but divergent errnos (the reference hosts split ENOTDIR/EEXIST on
-  # "file/"): strip it — before resolve_path's directory gate — so the
-  # existing-target probe below reports EEXIST uniformly and "sub/" still
-  # creates (issue #42).
+  # Strip a trailing slash before the resolver's directory gate: mkdir names
+  # a directory anyway, and EEXIST is wasmtime's answer for mkdir("file/")
+  # where the hosts split (ADR-49).
   local __stripped=$__rel
   while [[ $__stripped == */ ]]; do __stripped=${__stripped%/}; done
   [[ -n $__stripped ]] && __rel=$__stripped

--- a/runtime/bash/units/wasi/path_create_directory.sh
+++ b/runtime/bash/units/wasi/path_create_directory.sh
@@ -16,6 +16,14 @@ wasi_path_create_directory() {
   wasi_read_path "$__p" "$__path_ptr" "$__path_len" || return $?
   if (( R0 != 0 )); then return 0; fi
   local __rel=$R1
+  # mkdir names a directory by definition, so a trailing slash adds nothing
+  # but divergent errnos (the reference hosts split ENOTDIR/EEXIST on
+  # "file/"): strip it — before resolve_path's directory gate — so the
+  # existing-target probe below reports EEXIST uniformly and "sub/" still
+  # creates (issue #42).
+  local __stripped=$__rel
+  while [[ $__stripped == */ ]]; do __stripped=${__stripped%/}; done
+  [[ -n $__stripped ]] && __rel=$__stripped
   wasi_resolve_path "$__p" "$__dirfd" "$__rel" 0 || return $?
   if (( R0 != 0 )); then return 0; fi
   local __host=$R1

--- a/runtime/bash/units/wasi/path_open.sh
+++ b/runtime/bash/units/wasi/path_open.sh
@@ -37,12 +37,9 @@ wasi_path_open() {
   if (( (__oflags & 0x8) && (__dir_base & 0x80000) == 0 )); then R0=76; return 0; fi # TRUNC needs PATH_FILESTAT_SET_SIZE
   # A symlink final component that was not followed cannot be opened (D3).
   if (( (__dirflags & 1) == 0 )) && [[ -h $__host ]]; then R0=32; return 0; fi
-  # A slash-suffixed name may only resolve to a directory (issue #42); an
-  # existing non-directory was already ENOTDIR in resolve_path, and the create
-  # branch below must never manufacture a plain *file* through the slash. The
-  # nonexistent case follows wasmtime 47 (ADR-49): with O_CREAT it is EINVAL
-  # on macOS (wasmtime's manual path resolution rejects the shape) and EISDIR
-  # on Linux (host passthrough); a plain open is ENOENT on both.
+  # Slash-suffixed and nonexistent (existing non-directories were ENOTDIR in
+  # resolve_path): O_CREAT must not create through the slash — per wasmtime
+  # (ADR-49) EINVAL on macOS / EISDIR on Linux; a plain open is ENOENT.
   if [[ $__rel == */ && ! -e $__host && ! -h $__host ]]; then
     if (( __oflags & 0x1 )); then
       if [[ $OSTYPE == darwin* ]]; then

--- a/runtime/bash/units/wasi/path_open.sh
+++ b/runtime/bash/units/wasi/path_open.sh
@@ -37,6 +37,15 @@ wasi_path_open() {
   if (( (__oflags & 0x8) && (__dir_base & 0x80000) == 0 )); then R0=76; return 0; fi # TRUNC needs PATH_FILESTAT_SET_SIZE
   # A symlink final component that was not followed cannot be opened (D3).
   if (( (__dirflags & 1) == 0 )) && [[ -h $__host ]]; then R0=32; return 0; fi
+  # A slash-suffixed name may only resolve to a directory (issue #42); an
+  # existing non-directory was already ENOTDIR in resolve_path. A nonexistent
+  # one is ENOENT even with O_CREAT — open(2) cannot create a directory —
+  # normalized here (macOS/POSIX ENOENT, Linux EISDIR), so the create branch
+  # below can never manufacture a plain *file* through the slash.
+  if [[ $__rel == */ && ! -e $__host && ! -h $__host ]]; then
+    R0=44 # ENOENT
+    return 0
+  fi
   local __fd=$__wnext
   if (( __oflags & 0x2 )) || { [[ ! -h $__host ]] && [[ -d $__host ]]; }; then
     if (( __oflags & 0x2 )); then

--- a/runtime/bash/units/wasi/path_open.sh
+++ b/runtime/bash/units/wasi/path_open.sh
@@ -38,12 +38,21 @@ wasi_path_open() {
   # A symlink final component that was not followed cannot be opened (D3).
   if (( (__dirflags & 1) == 0 )) && [[ -h $__host ]]; then R0=32; return 0; fi
   # A slash-suffixed name may only resolve to a directory (issue #42); an
-  # existing non-directory was already ENOTDIR in resolve_path. A nonexistent
-  # one is ENOENT even with O_CREAT — open(2) cannot create a directory —
-  # normalized here (macOS/POSIX ENOENT, Linux EISDIR), so the create branch
-  # below can never manufacture a plain *file* through the slash.
+  # existing non-directory was already ENOTDIR in resolve_path, and the create
+  # branch below must never manufacture a plain *file* through the slash. The
+  # nonexistent case follows wasmtime 47 (ADR-49): with O_CREAT it is EINVAL
+  # on macOS (wasmtime's manual path resolution rejects the shape) and EISDIR
+  # on Linux (host passthrough); a plain open is ENOENT on both.
   if [[ $__rel == */ && ! -e $__host && ! -h $__host ]]; then
-    R0=44 # ENOENT
+    if (( __oflags & 0x1 )); then
+      if [[ $OSTYPE == darwin* ]]; then
+        R0=28 # EINVAL
+      else
+        R0=31 # EISDIR
+      fi
+    else
+      R0=44 # ENOENT
+    fi
     return 0
   fi
   local __fd=$__wnext

--- a/runtime/bash/units/wasi/path_remove_directory.sh
+++ b/runtime/bash/units/wasi/path_remove_directory.sh
@@ -18,6 +18,14 @@ wasi_path_remove_directory() {
   wasi_resolve_path "$__p" "$__dirfd" "$__rel" 0 || return $?
   if (( R0 != 0 )); then return 0; fi
   local __host=$R1
+  # wasmtime 47 (ADR-49) rejects removing an existing directory through a
+  # slash-suffixed name with EINVAL on both hosts (cap-std's final-component
+  # handling); a missing target stays ENOENT and a non-directory was already
+  # ENOTDIR in resolve_path.
+  if [[ $__rel == */ && -d $__host ]]; then
+    R0=28 # EINVAL
+    return 0
+  fi
   if command rmdir -- "$__host" 2>/dev/null; then
     R0=0
     return 0

--- a/runtime/bash/units/wasi/path_remove_directory.sh
+++ b/runtime/bash/units/wasi/path_remove_directory.sh
@@ -18,10 +18,8 @@ wasi_path_remove_directory() {
   wasi_resolve_path "$__p" "$__dirfd" "$__rel" 0 || return $?
   if (( R0 != 0 )); then return 0; fi
   local __host=$R1
-  # wasmtime 47 (ADR-49) rejects removing an existing directory through a
-  # slash-suffixed name with EINVAL on both hosts (cap-std's final-component
-  # handling); a missing target stays ENOENT and a non-directory was already
-  # ENOTDIR in resolve_path.
+  # rmdir through a trailing slash on an existing directory is EINVAL per
+  # wasmtime (ADR-49); other shapes come from resolve_path or the probes.
   if [[ $__rel == */ && -d $__host ]]; then
     R0=28 # EINVAL
     return 0

--- a/runtime/bash/units/wasi/path_rename.sh
+++ b/runtime/bash/units/wasi/path_rename.sh
@@ -25,15 +25,14 @@
 #     `mv`, which replaces the destination like rename(2) does.
 # Trailing slashes on either name are stripped before resolution so a
 # `mv`/`rmdir` on the clean physical path behaves, but the slash is
-# remembered: POSIX pathname resolution only lets "name/" resolve to an
-# existing directory (or a directory about to be created), so a
-# slash-bearing name that resolves to an existing non-directory is ENOTDIR
-# on either side, a nonexistent slash-bearing source is ENOENT (the
-# ordinary missing-source check), and a nonexistent slash-bearing
-# destination is only acceptable when the source is a directory — ENOENT
-# otherwise (POSIX/macOS; Linux reports ENOTDIR for that last case).
-# Anything else `mv` still manages to fail on (e.g. a permission error)
-# defaults to EIO.
+# remembered: a slash-bearing name that resolves to an existing
+# non-directory is ENOTDIR on either side, and a nonexistent slash-bearing
+# source is ENOENT (the ordinary missing-source check). A nonexistent
+# slash-bearing destination simply loses its slash and the rename proceeds
+# — even from a non-directory source — matching wasmtime's cap-std
+# resolution (ADR-49; POSIX would refuse, but where the WASI spec is
+# silent dewasm follows wasmtime). Anything else `mv` still manages to
+# fail on (e.g. a permission error) defaults to EIO.
 wasi_path_rename() {
   local __p=$1 __old_dirfd=$2 __old_path_ptr=$3 __old_path_len=$4
   local __new_dirfd=$5 __new_path_ptr=$6 __new_path_len=$7
@@ -107,12 +106,6 @@ wasi_path_rename() {
         return 0
       fi
     fi
-  elif (( __new_slash && ! __old_is_dir )); then
-    # A nonexistent destination with a trailing slash names a directory to be
-    # created, which only a directory source can satisfy (POSIX pathname
-    # resolution; macOS reports ENOENT here, Linux ENOTDIR — we follow POSIX).
-    R0=44 # ENOENT
-    return 0
   fi
   if command mv -- "$__old_host" "$__new_host" 2>/dev/null; then
     R0=0

--- a/runtime/bash/units/wasi/path_rename.sh
+++ b/runtime/bash/units/wasi/path_rename.sh
@@ -23,16 +23,11 @@
 #     ENOTEMPTY, since it cannot be replaced.
 #   - destination exists, both sides are non-directories: falls through to
 #     `mv`, which replaces the destination like rename(2) does.
-# Trailing slashes on either name are stripped before resolution so a
-# `mv`/`rmdir` on the clean physical path behaves, but the slash is
-# remembered: a slash-bearing name that resolves to an existing
-# non-directory is ENOTDIR on either side, and a nonexistent slash-bearing
-# source is ENOENT (the ordinary missing-source check). A nonexistent
-# slash-bearing destination simply loses its slash and the rename proceeds
-# — even from a non-directory source — matching wasmtime's cap-std
-# resolution (ADR-49; POSIX would refuse, but where the WASI spec is
-# silent dewasm follows wasmtime). Anything else `mv` still manages to
-# fail on (e.g. a permission error) defaults to EIO.
+# Trailing slashes on either name are stripped before resolution but
+# remembered: a slash-suffixed existing non-directory is ENOTDIR on either
+# side; a nonexistent slash-suffixed source is ENOENT; a nonexistent
+# slash-suffixed destination just loses the slash and the rename proceeds,
+# as wasmtime does (ADR-49). Anything else `mv` fails on defaults to EIO.
 wasi_path_rename() {
   local __p=$1 __old_dirfd=$2 __old_path_ptr=$3 __old_path_len=$4
   local __new_dirfd=$5 __new_path_ptr=$6 __new_path_len=$7

--- a/runtime/bash/units/wasi/path_symlink.sh
+++ b/runtime/bash/units/wasi/path_symlink.sh
@@ -5,10 +5,11 @@
 # dangling link is created as-is. This is a fifth namespace-mutation syscall
 # licensed (beyond ADR-34 D2's four) to shell out to a single `--`-guarded
 # `ln -s`; only the link's own parent is resolved with sandbox containment.
-# A destination that already exists is EEXIST (20); a trailing slash on a
-# not-yet-existing destination is ENOENT (44) — you cannot create a link "at a
-# directory". The target string itself is not followed, so a file-symlink
-# target does not hit the D3 pure-bash follow limitation.
+# A destination that already exists is EEXIST (20) — unless it is a
+# slash-suffixed non-directory, which is ENOTDIR (54, ADR-49); a trailing
+# slash on a not-yet-existing destination is ENOENT (44) — you cannot create
+# a link "at a directory". The target string itself is not followed, so a
+# file-symlink target does not hit the D3 pure-bash follow limitation.
 wasi_path_symlink() {
   local __p=$1 __old_ptr=$2 __old_len=$3 __dirfd=$4 __new_ptr=$5 __new_len=$6
   wasi_read_path "$__p" "$__old_ptr" "$__old_len" || return $?
@@ -22,6 +23,13 @@ wasi_path_symlink() {
   wasi_resolve_path "$__p" "$__dirfd" "$__new" 0 || return $?
   if (( R0 != 0 )); then return 0; fi
   local __dest=$R1
+  # A slash-suffixed link name over an existing *non*-directory is ENOTDIR
+  # before the plain EEXIST (wasmtime's resolution order, ADR-49; the
+  # upstream wasi-testsuite pins ENOTDIR under its strict errno modes).
+  if (( __trailing )) && [[ ( -e $__dest || -h $__dest ) && ! -d $__dest ]]; then
+    R0=54 # ENOTDIR
+    return 0
+  fi
   if [[ -e $__dest || -h $__dest ]]; then
     R0=20 # EEXIST
     return 0

--- a/runtime/bash/units/wasi/path_symlink.sh
+++ b/runtime/bash/units/wasi/path_symlink.sh
@@ -5,10 +5,9 @@
 # dangling link is created as-is. This is a fifth namespace-mutation syscall
 # licensed (beyond ADR-34 D2's four) to shell out to a single `--`-guarded
 # `ln -s`; only the link's own parent is resolved with sandbox containment.
-# A destination that already exists is EEXIST (20) — unless it is a
-# slash-suffixed non-directory, which is ENOTDIR (54, ADR-49); a trailing
-# slash on a not-yet-existing destination is ENOENT (44) — you cannot create
-# a link "at a directory". The target string itself is not followed, so a
+# A destination that already exists is EEXIST (20) — ENOTDIR (54) when it is
+# a slash-suffixed non-directory (ADR-49); a slash on a not-yet-existing
+# destination is ENOENT (44). The target string itself is not followed, so a
 # file-symlink target does not hit the D3 pure-bash follow limitation.
 wasi_path_symlink() {
   local __p=$1 __old_ptr=$2 __old_len=$3 __dirfd=$4 __new_ptr=$5 __new_len=$6
@@ -23,9 +22,8 @@ wasi_path_symlink() {
   wasi_resolve_path "$__p" "$__dirfd" "$__new" 0 || return $?
   if (( R0 != 0 )); then return 0; fi
   local __dest=$R1
-  # A slash-suffixed link name over an existing *non*-directory is ENOTDIR
-  # before the plain EEXIST (wasmtime's resolution order, ADR-49; the
-  # upstream wasi-testsuite pins ENOTDIR under its strict errno modes).
+  # A slash-suffixed existing *non*-directory is ENOTDIR before the plain
+  # EEXIST (wasmtime's resolution order, ADR-49).
   if (( __trailing )) && [[ ( -e $__dest || -h $__dest ) && ! -d $__dest ]]; then
     R0=54 # ENOTDIR
     return 0

--- a/runtime/bash/units/wasi/path_unlink_file.sh
+++ b/runtime/bash/units/wasi/path_unlink_file.sh
@@ -4,12 +4,9 @@
 # resolved physical path. unlink(2) never follows a trailing symlink (it
 # removes the link itself), so resolution uses follow_last=0, mirroring
 # runtime/ruby/units/wasi/path_unlink_file.rb. A directory target is rejected
-# up front (before ever invoking `rm`) with the errno wasmtime inherits from
-# the host unlink(2) — EPERM on macOS, EISDIR on Linux (ADR-49): this backend
-# never calls the OS unlink(2) itself (it probes `-d` first), so it emulates
-# the host split the upstream wasi-testsuite pins under its strict errno
-# modes. A missing path is ENOENT; any other `rm` failure (e.g. a permission
-# error) defaults to EIO.
+# up front with the host-split errno wasmtime inherits — EPERM on macOS,
+# EISDIR on Linux (ADR-49). A missing path is ENOENT; any other `rm` failure
+# defaults to EIO.
 wasi_path_unlink_file() {
   local __p=$1 __dirfd=$2 __path_ptr=$3 __path_len=$4
   wasi_read_path "$__p" "$__path_ptr" "$__path_len" || return $?
@@ -22,13 +19,9 @@ wasi_path_unlink_file() {
     R0=44 # ENOENT
     return 0
   fi
-  # A symlink (even to a directory, even dangling) is unlinked as the link
-  # itself; only a real directory is rejected (`-h` guards the `-d` test,
-  # which would otherwise dereference a symlink-to-directory). The errno
-  # mirrors what wasmtime inherits from the host unlink(2) (ADR-49): EPERM
-  # on macOS, EISDIR on Linux — the upstream wasi-testsuite pins exactly
-  # that split under its strict errno modes, so the one-value pick the unit
-  # header used to document is gone.
+  # A symlink is unlinked as the link itself (`-h` guards `-d`); a real
+  # directory is rejected with the host-split errno wasmtime inherits
+  # (ADR-49): EPERM on macOS, EISDIR on Linux.
   if [[ -d $__host && ! -h $__host ]]; then
     if [[ $OSTYPE == darwin* ]]; then
       R0=63 # EPERM

--- a/runtime/bash/units/wasi/path_unlink_file.sh
+++ b/runtime/bash/units/wasi/path_unlink_file.sh
@@ -4,15 +4,12 @@
 # resolved physical path. unlink(2) never follows a trailing symlink (it
 # removes the link itself), so resolution uses follow_last=0, mirroring
 # runtime/ruby/units/wasi/path_unlink_file.rb. A directory target is rejected
-# up front (before ever invoking `rm`) as EISDIR: this is the errno Linux's
-# unlink(2) raises for a directory and what most WASI runtimes (wasmtime
-# included, on the Linux hosts they mostly run on) surface — a native macOS
-# unlink(2) would instead raise EPERM, the same cross-platform split Ruby's
-# FS_ERRNO table already accepts both sides of, but this backend never calls
-# the OS unlink(2) itself (it probes `-d` first), so it picks the one value
-# rather than inheriting whichever the host OS happens to raise. A missing
-# path is ENOENT; any other `rm` failure (e.g. a permission error) defaults
-# to EIO.
+# up front (before ever invoking `rm`) with the errno wasmtime inherits from
+# the host unlink(2) — EPERM on macOS, EISDIR on Linux (ADR-49): this backend
+# never calls the OS unlink(2) itself (it probes `-d` first), so it emulates
+# the host split the upstream wasi-testsuite pins under its strict errno
+# modes. A missing path is ENOENT; any other `rm` failure (e.g. a permission
+# error) defaults to EIO.
 wasi_path_unlink_file() {
   local __p=$1 __dirfd=$2 __path_ptr=$3 __path_len=$4
   wasi_read_path "$__p" "$__path_ptr" "$__path_len" || return $?
@@ -26,10 +23,18 @@ wasi_path_unlink_file() {
     return 0
   fi
   # A symlink (even to a directory, even dangling) is unlinked as the link
-  # itself; only a real directory is EISDIR (ADR-40 — `-h` guards the `-d`
-  # test, which would otherwise dereference a symlink-to-directory).
+  # itself; only a real directory is rejected (`-h` guards the `-d` test,
+  # which would otherwise dereference a symlink-to-directory). The errno
+  # mirrors what wasmtime inherits from the host unlink(2) (ADR-49): EPERM
+  # on macOS, EISDIR on Linux — the upstream wasi-testsuite pins exactly
+  # that split under its strict errno modes, so the one-value pick the unit
+  # header used to document is gone.
   if [[ -d $__host && ! -h $__host ]]; then
-    R0=31 # EISDIR
+    if [[ $OSTYPE == darwin* ]]; then
+      R0=63 # EPERM
+    else
+      R0=31 # EISDIR
+    fi
     return 0
   fi
   if command rm -- "$__host" 2>/dev/null; then

--- a/runtime/bash/units/wasi/resolve_path.sh
+++ b/runtime/bash/units/wasi/resolve_path.sh
@@ -32,6 +32,17 @@ wasi_resolve_path() {
     R0=76 # ENOTCAPABLE: an absolute path escapes the preopen sandbox
     return 0
   fi
+  # A trailing slash constrains the final component to a directory (POSIX
+  # pathname resolution; issue #42). Strip it for resolution — the
+  # parent-plus-basename split below would otherwise read an empty basename
+  # and resolve the *whole* path as a directory (ENOENT for every
+  # slash-suffixed name over a non-directory, and even for "sub/" on mkdir) —
+  # and re-check the constraint against the resolved target before returning.
+  local __slash=0
+  if [[ $__rel == */ ]]; then
+    __slash=1
+    while [[ $__rel == */ ]]; do __rel=${__rel%/}; done
+  fi
   # Reject a path that lexically ascends above the dirfd root via `..` — an
   # escape even when the resulting physical parent does not exist (so it cannot
   # be caught by the post-resolution containment check, which would misreport it
@@ -89,6 +100,14 @@ wasi_resolve_path() {
     fi
   fi
   if [[ $__real == "$__root" || $__real == "${__root%/}/"* ]]; then
+    # The trailing-slash directory gate: `-e` follows symlinks, exactly as the
+    # slash forces, so "link-to-file/" is ENOTDIR while "link-to-dir/" passes.
+    # A missing target passes too: which errno (or success, for a create) that
+    # becomes is each caller's own business.
+    if (( __slash )) && [[ -e $__real && ! -d $__real ]]; then
+      R0=54 # ENOTDIR: a slash-suffixed name resolved to a non-directory
+      return 0
+    fi
     R1=$__real
     R0=0
     return 0

--- a/runtime/bash/units/wasi/resolve_path.sh
+++ b/runtime/bash/units/wasi/resolve_path.sh
@@ -32,12 +32,9 @@ wasi_resolve_path() {
     R0=76 # ENOTCAPABLE: an absolute path escapes the preopen sandbox
     return 0
   fi
-  # A trailing slash constrains the final component to a directory (POSIX
-  # pathname resolution; issue #42). Strip it for resolution — the
-  # parent-plus-basename split below would otherwise read an empty basename
-  # and resolve the *whole* path as a directory (ENOENT for every
-  # slash-suffixed name over a non-directory, and even for "sub/" on mkdir) —
-  # and re-check the constraint against the resolved target before returning.
+  # Strip a trailing slash for resolution (the parent/basename split below
+  # would read an empty basename and misresolve every slash-suffixed name),
+  # remember it, and re-check the directory constraint below (issue #42).
   local __slash=0
   if [[ $__rel == */ ]]; then
     __slash=1
@@ -100,10 +97,8 @@ wasi_resolve_path() {
     fi
   fi
   if [[ $__real == "$__root" || $__real == "${__root%/}/"* ]]; then
-    # The trailing-slash directory gate: `-e` follows symlinks, exactly as the
-    # slash forces, so "link-to-file/" is ENOTDIR while "link-to-dir/" passes.
-    # A missing target passes too: which errno (or success, for a create) that
-    # becomes is each caller's own business.
+    # Slash-suffixed names may only resolve to a directory; `-e` follows
+    # symlinks as the slash requires. A missing target is each caller's case.
     if (( __slash )) && [[ -e $__real && ! -d $__real ]]; then
       R0=54 # ENOTDIR: a slash-suffixed name resolved to a non-directory
       return 0

--- a/runtime/go/units/wasi/path_create_directory.go
+++ b/runtime/go/units/wasi/path_create_directory.go
@@ -1,6 +1,14 @@
 // requires: memory/read_string, wasi/resolve_path, wasi/errno_fs
 func (w *WASI) wasi_path_create_directory(dirfd, pathPtr, pathLen uint32) uint32 {
     rel := string(w.memory.read_string(uint64(pathPtr), uint64(pathLen)))
+    // mkdir names a directory by definition, so a trailing slash adds nothing
+    // but host-divergent errnos (macOS mkdir(2) reports ENOTDIR for "file/",
+    // Linux EEXIST): strip it — before resolve_path's directory gate — so the
+    // existing-target case is EEXIST uniformly and "sub/" still creates
+    // (issue #42).
+    if trimmed := strings.TrimRight(rel, "/"); trimmed != "" {
+        rel = trimmed
+    }
     // mkdir(2) never follows a trailing symlink (an existing one is EEXIST).
     hostPath, err := w.resolve_path(dirfd, rel, false)
     if err != wasiOk {

--- a/runtime/go/units/wasi/path_create_directory.go
+++ b/runtime/go/units/wasi/path_create_directory.go
@@ -1,11 +1,9 @@
 // requires: memory/read_string, wasi/resolve_path, wasi/errno_fs
 func (w *WASI) wasi_path_create_directory(dirfd, pathPtr, pathLen uint32) uint32 {
     rel := string(w.memory.read_string(uint64(pathPtr), uint64(pathLen)))
-    // mkdir names a directory by definition, so a trailing slash adds nothing
-    // but host-divergent errnos (macOS mkdir(2) reports ENOTDIR for "file/",
-    // Linux EEXIST): strip it — before resolve_path's directory gate — so the
-    // existing-target case is EEXIST uniformly and "sub/" still creates
-    // (issue #42).
+    // Strip a trailing slash before the resolver's directory gate: mkdir
+    // names a directory anyway, and EEXIST is wasmtime's answer for
+    // mkdir("file/") where the hosts split (ADR-49).
     if trimmed := strings.TrimRight(rel, "/"); trimmed != "" {
         rel = trimmed
     }

--- a/runtime/go/units/wasi/path_open.go
+++ b/runtime/go/units/wasi/path_open.go
@@ -51,6 +51,17 @@ func (w *WASI) wasi_path_open(dirfd, dirflags, pathPtr, pathLen, oflags uint32, 
         // (ENOTDIR); guests (wasi-libc's opendir) branch on the difference.
         info, e := os.Stat(hostPath)
         if e != nil {
+            // A trailing slash demands a directory, which open(2) can never
+            // create, so O_CREAT must not manufacture a plain file through
+            // the slash. The errno follows wasmtime 47 (ADR-49): EINVAL on
+            // macOS (its manual path resolution rejects the shape), EISDIR
+            // on Linux (host passthrough); a plain open stays ENOENT.
+            if hasTrailingSlash && oflags&0x2 == 0 && oflags&0x1 != 0 {
+                if runtime.GOOS == "darwin" {
+                    return wasiInval
+                }
+                return wasiIsdir
+            }
             return wasiNoent
         }
         if !info.IsDir() {

--- a/runtime/go/units/wasi/path_open.go
+++ b/runtime/go/units/wasi/path_open.go
@@ -51,11 +51,8 @@ func (w *WASI) wasi_path_open(dirfd, dirflags, pathPtr, pathLen, oflags uint32, 
         // (ENOTDIR); guests (wasi-libc's opendir) branch on the difference.
         info, e := os.Stat(hostPath)
         if e != nil {
-            // A trailing slash demands a directory, which open(2) can never
-            // create, so O_CREAT must not manufacture a plain file through
-            // the slash. The errno follows wasmtime 47 (ADR-49): EINVAL on
-            // macOS (its manual path resolution rejects the shape), EISDIR
-            // on Linux (host passthrough); a plain open stays ENOENT.
+            // O_CREAT must not create through a trailing slash; per wasmtime
+            // (ADR-49): EINVAL on macOS, EISDIR on Linux, plain open ENOENT.
             if hasTrailingSlash && oflags&0x2 == 0 && oflags&0x1 != 0 {
                 if runtime.GOOS == "darwin" {
                     return wasiInval

--- a/runtime/go/units/wasi/path_remove_directory.go
+++ b/runtime/go/units/wasi/path_remove_directory.go
@@ -7,6 +7,15 @@ func (w *WASI) wasi_path_remove_directory(dirfd, pathPtr, pathLen uint32) uint32
     if err != wasiOk {
         return err
     }
+    // wasmtime 47 (ADR-49) rejects removing an existing directory through a
+    // slash-suffixed name with EINVAL on both hosts (cap-std's final-component
+    // handling); a missing target stays ENOENT (the syscall below) and a
+    // non-directory was already ENOTDIR in resolve_path.
+    if strings.HasSuffix(rel, "/") {
+        if fi, e := os.Stat(hostPath); e == nil && fi.IsDir() {
+            return wasiInval
+        }
+    }
     if e := syscall.Rmdir(hostPath); e != nil {
         return w.fs_errno(e)
     }

--- a/runtime/go/units/wasi/path_remove_directory.go
+++ b/runtime/go/units/wasi/path_remove_directory.go
@@ -7,10 +7,8 @@ func (w *WASI) wasi_path_remove_directory(dirfd, pathPtr, pathLen uint32) uint32
     if err != wasiOk {
         return err
     }
-    // wasmtime 47 (ADR-49) rejects removing an existing directory through a
-    // slash-suffixed name with EINVAL on both hosts (cap-std's final-component
-    // handling); a missing target stays ENOENT (the syscall below) and a
-    // non-directory was already ENOTDIR in resolve_path.
+    // rmdir through a trailing slash on an existing directory is EINVAL per
+    // wasmtime (ADR-49); other shapes come from resolve_path or the syscall.
     if strings.HasSuffix(rel, "/") {
         if fi, e := os.Stat(hostPath); e == nil && fi.IsDir() {
             return wasiInval

--- a/runtime/go/units/wasi/path_rename.go
+++ b/runtime/go/units/wasi/path_rename.go
@@ -12,12 +12,9 @@ func (w *WASI) wasi_path_rename(oldDirfd, oldPathPtr, oldPathLen, newDirfd, newP
     if err != wasiOk {
         return err
     }
-    // Trailing slashes (issue #42, ADR-49: follow wasmtime): resolve_path
-    // already reported ENOTDIR for a slash-suffixed name over an existing
-    // non-directory on either side; a *nonexistent* slash-suffixed
-    // destination matches wasmtime's cap-std, which strips the slash and
-    // lets the rename proceed — exactly what the bare resolved path below
-    // does.
+    // Trailing slashes (issue #42, ADR-49): existing non-directories were
+    // ENOTDIR in resolve_path; a nonexistent slash-suffixed destination is
+    // renamed bare, as wasmtime strips it — the resolved path already is.
     // syscall.Rename, not os.Rename: Go's os.Rename wrapper Lstats the
     // destination and, when it is a directory, returns a synthetic EEXIST on
     // macOS instead of letting rename(2) replace an empty target dir — the

--- a/runtime/go/units/wasi/path_rename.go
+++ b/runtime/go/units/wasi/path_rename.go
@@ -12,21 +12,12 @@ func (w *WASI) wasi_path_rename(oldDirfd, oldPathPtr, oldPathLen, newDirfd, newP
     if err != wasiOk {
         return err
     }
-    // A slash-suffixed destination may only name an existing directory or one
-    // the rename itself creates from a directory source (POSIX pathname
-    // resolution; issue #42). resolve_path already reported ENOTDIR for an
-    // existing non-directory; the nonexistent case must not fall through — the
-    // resolved host path has lost the slash, so rename(2) would silently
-    // create a plain *file* at the name. ENOENT is the macOS/POSIX errno
-    // (Linux would say ENOTDIR), the choice the other backends normalize to
-    // (runtime/bash/units/wasi/path_rename.sh).
-    if strings.HasSuffix(newRel, "/") {
-        if _, e := os.Lstat(newHost); e != nil {
-            if fi, se := os.Lstat(oldHost); se != nil || !fi.IsDir() {
-                return wasiNoent
-            }
-        }
-    }
+    // Trailing slashes (issue #42, ADR-49: follow wasmtime): resolve_path
+    // already reported ENOTDIR for a slash-suffixed name over an existing
+    // non-directory on either side; a *nonexistent* slash-suffixed
+    // destination matches wasmtime's cap-std, which strips the slash and
+    // lets the rename proceed — exactly what the bare resolved path below
+    // does.
     // syscall.Rename, not os.Rename: Go's os.Rename wrapper Lstats the
     // destination and, when it is a directory, returns a synthetic EEXIST on
     // macOS instead of letting rename(2) replace an empty target dir — the

--- a/runtime/go/units/wasi/path_rename.go
+++ b/runtime/go/units/wasi/path_rename.go
@@ -12,6 +12,21 @@ func (w *WASI) wasi_path_rename(oldDirfd, oldPathPtr, oldPathLen, newDirfd, newP
     if err != wasiOk {
         return err
     }
+    // A slash-suffixed destination may only name an existing directory or one
+    // the rename itself creates from a directory source (POSIX pathname
+    // resolution; issue #42). resolve_path already reported ENOTDIR for an
+    // existing non-directory; the nonexistent case must not fall through — the
+    // resolved host path has lost the slash, so rename(2) would silently
+    // create a plain *file* at the name. ENOENT is the macOS/POSIX errno
+    // (Linux would say ENOTDIR), the choice the other backends normalize to
+    // (runtime/bash/units/wasi/path_rename.sh).
+    if strings.HasSuffix(newRel, "/") {
+        if _, e := os.Lstat(newHost); e != nil {
+            if fi, se := os.Lstat(oldHost); se != nil || !fi.IsDir() {
+                return wasiNoent
+            }
+        }
+    }
     // syscall.Rename, not os.Rename: Go's os.Rename wrapper Lstats the
     // destination and, when it is a directory, returns a synthetic EEXIST on
     // macOS instead of letting rename(2) replace an empty target dir — the

--- a/runtime/go/units/wasi/path_symlink.go
+++ b/runtime/go/units/wasi/path_symlink.go
@@ -10,13 +10,19 @@ func (w *WASI) wasi_path_symlink(oldPathPtr, oldPathLen, fd, newPathPtr, newPath
         return wasiNotcapable
     }
     newRel := string(w.memory.read_string(uint64(newPathPtr), uint64(newPathLen)))
-    // A trailing slash on the link name is NOENT: the link is a fresh leaf.
-    if len(newRel) > 0 && newRel[len(newRel)-1] == '/' {
-        return wasiNoent
-    }
     linkHost, err := w.resolve_path(fd, newRel, false)
     if err != wasiOk {
         return err
+    }
+    // A slash-suffixed link name can never be created; the errnos follow
+    // wasmtime 47 on both hosts (ADR-49) — an existing non-directory was
+    // already ENOTDIR in resolve_path, an existing directory is EEXIST, and
+    // nothing there at all is ENOENT.
+    if strings.HasSuffix(newRel, "/") {
+        if _, e := os.Lstat(linkHost); e == nil {
+            return wasiExist
+        }
+        return wasiNoent
     }
     if e := os.Symlink(target, linkHost); e != nil {
         return w.fs_errno(e)

--- a/runtime/go/units/wasi/path_symlink.go
+++ b/runtime/go/units/wasi/path_symlink.go
@@ -14,10 +14,8 @@ func (w *WASI) wasi_path_symlink(oldPathPtr, oldPathLen, fd, newPathPtr, newPath
     if err != wasiOk {
         return err
     }
-    // A slash-suffixed link name can never be created; the errnos follow
-    // wasmtime 47 on both hosts (ADR-49) — an existing non-directory was
-    // already ENOTDIR in resolve_path, an existing directory is EEXIST, and
-    // nothing there at all is ENOENT.
+    // Slash-suffixed link name (ADR-49): EEXIST if something is there
+    // (non-directories were ENOTDIR in resolve_path), else ENOENT.
     if strings.HasSuffix(newRel, "/") {
         if _, e := os.Lstat(linkHost); e == nil {
             return wasiExist

--- a/runtime/go/units/wasi/resolve_path.go
+++ b/runtime/go/units/wasi/resolve_path.go
@@ -49,11 +49,9 @@ func (w *WASI) resolve_path(dirfd uint32, rel string, followLast bool) (string, 
     if strings.HasPrefix(rel, "/") {
         return "", wasiNotcapable
     }
-    // A trailing slash constrains the final component to a directory (POSIX
-    // pathname resolution; issue #42). filepath.Join Cleans it away *after*
-    // the final-component bookkeeping below would have misread "" as the last
-    // component (silently degrading followLast), so strip it up front and
-    // re-check the constraint against the resolved target before returning.
+    // Strip a trailing slash before the final-component bookkeeping below (an
+    // empty last component silently degrades followLast) and re-check via
+    // trailingDirGate (issue #42).
     trailing := strings.HasSuffix(rel, "/")
     if trailing {
         rel = strings.TrimRight(rel, "/")
@@ -117,12 +115,9 @@ func (w *WASI) resolve_path(dirfd uint32, rel string, followLast bool) (string, 
     return filepath.Join(realParent, filepath.Base(joined)), wasiOk
 }
 
-// trailingDirGate enforces the trailing-slash constraint on a resolved host
-// path: a slash-suffixed guest name may only resolve to a directory, so an
-// existing non-directory target is ENOTDIR (issue #42). os.Stat follows
-// symlinks — the slash forces following, so "link-to-file/" is ENOTDIR while
-// "link-to-dir/" passes. A missing target passes too: which errno (or
-// success, for a create) that becomes is each syscall's own business.
+// trailingDirGate: a slash-suffixed name may only resolve to a directory —
+// an existing non-directory is ENOTDIR (issue #42). os.Stat follows
+// symlinks, as the slash requires; a missing target is each caller's case.
 func (w *WASI) trailingDirGate(trailing bool, host string) uint32 {
     if !trailing {
         return wasiOk

--- a/runtime/go/units/wasi/resolve_path.go
+++ b/runtime/go/units/wasi/resolve_path.go
@@ -49,6 +49,15 @@ func (w *WASI) resolve_path(dirfd uint32, rel string, followLast bool) (string, 
     if strings.HasPrefix(rel, "/") {
         return "", wasiNotcapable
     }
+    // A trailing slash constrains the final component to a directory (POSIX
+    // pathname resolution; issue #42). filepath.Join Cleans it away *after*
+    // the final-component bookkeeping below would have misread "" as the last
+    // component (silently degrading followLast), so strip it up front and
+    // re-check the constraint against the resolved target before returning.
+    trailing := strings.HasSuffix(rel, "/")
+    if trailing {
+        rel = strings.TrimRight(rel, "/")
+    }
     base := entry.hostPath
     joined := filepath.Join(base, rel)
     // Lexical containment on the cleaned path, before touching the filesystem:
@@ -74,7 +83,11 @@ func (w *WASI) resolve_path(dirfd uint32, rel string, followLast bool) (string, 
         if !w.within(base, realParent) {
             return "", wasiNotcapable
         }
-        return filepath.Join(realParent, last), wasiOk
+        host := filepath.Join(realParent, last)
+        if e := w.trailingDirGate(trailing, host); e != wasiOk {
+            return "", e
+        }
+        return host, wasiOk
     }
     if _, err := os.Lstat(joined); err == nil {
         real, err := filepath.EvalSymlinks(joined)
@@ -85,6 +98,9 @@ func (w *WASI) resolve_path(dirfd uint32, rel string, followLast bool) (string, 
         }
         if !w.within(base, real) {
             return "", wasiNotcapable
+        }
+        if e := w.trailingDirGate(trailing, real); e != wasiOk {
+            return "", e
         }
         return real, wasiOk
     }
@@ -99,4 +115,20 @@ func (w *WASI) resolve_path(dirfd uint32, rel string, followLast bool) (string, 
         return "", wasiNotcapable
     }
     return filepath.Join(realParent, filepath.Base(joined)), wasiOk
+}
+
+// trailingDirGate enforces the trailing-slash constraint on a resolved host
+// path: a slash-suffixed guest name may only resolve to a directory, so an
+// existing non-directory target is ENOTDIR (issue #42). os.Stat follows
+// symlinks — the slash forces following, so "link-to-file/" is ENOTDIR while
+// "link-to-dir/" passes. A missing target passes too: which errno (or
+// success, for a create) that becomes is each syscall's own business.
+func (w *WASI) trailingDirGate(trailing bool, host string) uint32 {
+    if !trailing {
+        return wasiOk
+    }
+    if fi, err := os.Stat(host); err == nil && !fi.IsDir() {
+        return wasiNotdir
+    }
+    return wasiOk
 }

--- a/runtime/java/units/wasi/path_create_directory.java
+++ b/runtime/java/units/wasi/path_create_directory.java
@@ -3,6 +3,18 @@ int wasi_path_create_directory(int dirfd, int pathPtr, int pathLen) {
     String rel = new String(
         memory.read_string(Integer.toUnsignedLong(pathPtr), Integer.toUnsignedLong(pathLen)),
         java.nio.charset.StandardCharsets.UTF_8);
+    // mkdir names a directory by definition, so a trailing slash adds nothing
+    // but host-divergent errnos (macOS mkdir(2) reports ENOTDIR for "file/",
+    // Linux EEXIST): strip it — before resolve_path's directory gate — so the
+    // existing-target case is EEXIST uniformly and "sub/" still creates
+    // (issue #42).
+    String trimmed = rel;
+    while (trimmed.endsWith("/")) {
+        trimmed = trimmed.substring(0, trimmed.length() - 1);
+    }
+    if (!trimmed.isEmpty()) {
+        rel = trimmed;
+    }
     // mkdir(2) never follows a trailing symlink (an existing one is EEXIST).
     Resolved r = resolve_path(dirfd, rel, false);
     if (r.errno != WASI_OK) {

--- a/runtime/java/units/wasi/path_create_directory.java
+++ b/runtime/java/units/wasi/path_create_directory.java
@@ -3,11 +3,9 @@ int wasi_path_create_directory(int dirfd, int pathPtr, int pathLen) {
     String rel = new String(
         memory.read_string(Integer.toUnsignedLong(pathPtr), Integer.toUnsignedLong(pathLen)),
         java.nio.charset.StandardCharsets.UTF_8);
-    // mkdir names a directory by definition, so a trailing slash adds nothing
-    // but host-divergent errnos (macOS mkdir(2) reports ENOTDIR for "file/",
-    // Linux EEXIST): strip it — before resolve_path's directory gate — so the
-    // existing-target case is EEXIST uniformly and "sub/" still creates
-    // (issue #42).
+    // Strip a trailing slash before the resolver's directory gate: mkdir
+    // names a directory anyway, and EEXIST is wasmtime's answer for
+    // mkdir("file/") where the hosts split (ADR-49).
     String trimmed = rel;
     while (trimmed.endsWith("/")) {
         trimmed = trimmed.substring(0, trimmed.length() - 1);

--- a/runtime/java/units/wasi/path_open.java
+++ b/runtime/java/units/wasi/path_open.java
@@ -55,11 +55,9 @@ int wasi_path_open(int dirfd, int dirflags, int pathPtr, int pathLen, int oflags
         // (ENOTDIR); guests (wasi-libc's opendir) branch on the difference.
         return exists ? WASI_NOTDIR : WASI_NOENT;
     } else if (trailingSlash) {
-        // A trailing slash demands a directory, but the target is not one. An
-        // existing non-directory is ENOTDIR; a nonexistent one is ENOENT —
-        // except under O_CREAT, which can never create a directory: wasmtime
-        // 47 (ADR-49) reports EINVAL on macOS (its manual path resolution
-        // rejects the shape) and EISDIR on Linux (host passthrough).
+        // A slash-suffixed non-directory: ENOTDIR when existing, ENOENT when
+        // missing — except O_CREAT, which must not create through the slash;
+        // per wasmtime (ADR-49): EINVAL on macOS, EISDIR on Linux.
         if (exists) {
             return WASI_NOTDIR;
         }

--- a/runtime/java/units/wasi/path_open.java
+++ b/runtime/java/units/wasi/path_open.java
@@ -55,8 +55,20 @@ int wasi_path_open(int dirfd, int dirflags, int pathPtr, int pathLen, int oflags
         // (ENOTDIR); guests (wasi-libc's opendir) branch on the difference.
         return exists ? WASI_NOTDIR : WASI_NOENT;
     } else if (trailingSlash) {
-        // A trailing slash demands a directory, but the target is not one.
-        return exists ? WASI_NOTDIR : WASI_NOENT;
+        // A trailing slash demands a directory, but the target is not one. An
+        // existing non-directory is ENOTDIR; a nonexistent one is ENOENT —
+        // except under O_CREAT, which can never create a directory: wasmtime
+        // 47 (ADR-49) reports EINVAL on macOS (its manual path resolution
+        // rejects the shape) and EISDIR on Linux (host passthrough).
+        if (exists) {
+            return WASI_NOTDIR;
+        }
+        if (create) {
+            return System.getProperty("os.name").toLowerCase().contains("mac")
+                ? WASI_INVAL
+                : WASI_ISDIR;
+        }
+        return WASI_NOENT;
     } else {
         boolean read = (fsRightsBase & 0x2) != 0; // rights::FD_READ
         boolean write = (fsRightsBase & 0x40) != 0; // rights::FD_WRITE

--- a/runtime/java/units/wasi/path_readlink.java
+++ b/runtime/java/units/wasi/path_readlink.java
@@ -11,9 +11,18 @@ int wasi_path_readlink(int fd, int pathPtr, int pathLen, int bufPtr, int bufLen,
     if (r.errno != WASI_OK) {
         return r.errno;
     }
+    java.nio.file.Path p = java.nio.file.Paths.get(r.path);
+    // A trailing slash forces following, so an existing slash-suffixed name
+    // resolves to a directory here (resolve_path already reported ENOTDIR for
+    // a non-directory, issue #42) — and a directory is never a readable
+    // symlink: EINVAL, as the host readlink(2) reports for "dir/" or
+    // "symlink-to-dir/". A missing target still falls through to ENOENT.
+    if (rel.endsWith("/") && java.nio.file.Files.exists(p)) {
+        return WASI_INVAL;
+    }
     java.nio.file.Path target;
     try {
-        target = java.nio.file.Files.readSymbolicLink(java.nio.file.Paths.get(r.path));
+        target = java.nio.file.Files.readSymbolicLink(p);
     } catch (java.io.IOException ex) {
         return fs_errno(ex);
     }

--- a/runtime/java/units/wasi/path_readlink.java
+++ b/runtime/java/units/wasi/path_readlink.java
@@ -12,11 +12,9 @@ int wasi_path_readlink(int fd, int pathPtr, int pathLen, int bufPtr, int bufLen,
         return r.errno;
     }
     java.nio.file.Path p = java.nio.file.Paths.get(r.path);
-    // A trailing slash forces following, so an existing slash-suffixed name
-    // resolves to a directory here (resolve_path already reported ENOTDIR for
-    // a non-directory, issue #42) — and a directory is never a readable
-    // symlink: EINVAL, as the host readlink(2) reports for "dir/" or
-    // "symlink-to-dir/". A missing target still falls through to ENOENT.
+    // An existing slash-suffixed name resolved (following) to a directory —
+    // non-directories were ENOTDIR in resolve_path — and a directory is not a
+    // symlink: EINVAL, like the host readlink(2). Missing falls through.
     if (rel.endsWith("/") && java.nio.file.Files.exists(p)) {
         return WASI_INVAL;
     }

--- a/runtime/java/units/wasi/path_remove_directory.java
+++ b/runtime/java/units/wasi/path_remove_directory.java
@@ -19,9 +19,8 @@ int wasi_path_remove_directory(int dirfd, int pathPtr, int pathLen) {
     if (!java.nio.file.Files.isDirectory(p, java.nio.file.LinkOption.NOFOLLOW_LINKS)) {
         return WASI_NOTDIR;
     }
-    // wasmtime 47 (ADR-49) rejects removing an existing directory through a
-    // slash-suffixed name with EINVAL on both hosts (cap-std's final-component
-    // handling).
+    // rmdir through a trailing slash on an existing directory is EINVAL per
+    // wasmtime (ADR-49).
     if (rel.endsWith("/")) {
         return WASI_INVAL;
     }

--- a/runtime/java/units/wasi/path_remove_directory.java
+++ b/runtime/java/units/wasi/path_remove_directory.java
@@ -9,10 +9,21 @@ int wasi_path_remove_directory(int dirfd, int pathPtr, int pathLen) {
         return r.errno;
     }
     java.nio.file.Path p = java.nio.file.Paths.get(r.path);
+    // A missing target is ENOENT before any shape check (Files.isDirectory is
+    // false for "missing" and "not a directory" alike).
+    if (!java.nio.file.Files.exists(p, java.nio.file.LinkOption.NOFOLLOW_LINKS)) {
+        return WASI_NOENT;
+    }
     // Files.delete would happily remove a regular file or an empty directory;
     // rmdir must fail (ENOTDIR) on a non-directory, so pre-check.
     if (!java.nio.file.Files.isDirectory(p, java.nio.file.LinkOption.NOFOLLOW_LINKS)) {
         return WASI_NOTDIR;
+    }
+    // wasmtime 47 (ADR-49) rejects removing an existing directory through a
+    // slash-suffixed name with EINVAL on both hosts (cap-std's final-component
+    // handling).
+    if (rel.endsWith("/")) {
+        return WASI_INVAL;
     }
     try {
         java.nio.file.Files.delete(p);

--- a/runtime/java/units/wasi/path_rename.java
+++ b/runtime/java/units/wasi/path_rename.java
@@ -19,6 +19,19 @@ int wasi_path_rename(int oldDirfd, int oldPathPtr, int oldPathLen, int newDirfd,
     }
     java.nio.file.Path oldP = java.nio.file.Paths.get(oldR.path);
     java.nio.file.Path newP = java.nio.file.Paths.get(newR.path);
+    // A slash-suffixed destination may only name an existing directory or one
+    // the rename itself creates from a directory source (POSIX pathname
+    // resolution; issue #42). resolve_path already reported ENOTDIR for an
+    // existing non-directory; the nonexistent case must not fall through — the
+    // resolved path has lost the slash, so Files.move would silently create a
+    // plain *file* at the name. ENOENT is the macOS/POSIX errno (Linux would
+    // say ENOTDIR), the choice the other backends normalize to
+    // (runtime/bash/units/wasi/path_rename.sh).
+    if (newRel.endsWith("/")
+        && !java.nio.file.Files.exists(newP, java.nio.file.LinkOption.NOFOLLOW_LINKS)
+        && !java.nio.file.Files.isDirectory(oldP, java.nio.file.LinkOption.NOFOLLOW_LINKS)) {
+        return WASI_NOENT;
+    }
     // rename(2) reports type mismatches between the endpoints with specific
     // errnos that Java's generic FileSystemException flattens to EIO, so
     // pre-check them: renaming a directory onto an existing non-directory is

--- a/runtime/java/units/wasi/path_rename.java
+++ b/runtime/java/units/wasi/path_rename.java
@@ -19,11 +19,9 @@ int wasi_path_rename(int oldDirfd, int oldPathPtr, int oldPathLen, int newDirfd,
     }
     java.nio.file.Path oldP = java.nio.file.Paths.get(oldR.path);
     java.nio.file.Path newP = java.nio.file.Paths.get(newR.path);
-    // Trailing slashes (issue #42, ADR-49: follow wasmtime): resolve_path
-    // already reported ENOTDIR for a slash-suffixed name over an existing
-    // non-directory on either side; a *nonexistent* slash-suffixed
-    // destination matches wasmtime's cap-std, which strips the slash and lets
-    // the rename proceed — exactly what the already-normalized Path does.
+    // Trailing slashes (issue #42, ADR-49): existing non-directories were
+    // ENOTDIR in resolve_path; a nonexistent slash-suffixed destination is
+    // renamed bare, as wasmtime strips it — the normalized Path already is.
     // rename(2) reports type mismatches between the endpoints with specific
     // errnos that Java's generic FileSystemException flattens to EIO, so
     // pre-check them: renaming a directory onto an existing non-directory is

--- a/runtime/java/units/wasi/path_rename.java
+++ b/runtime/java/units/wasi/path_rename.java
@@ -19,19 +19,11 @@ int wasi_path_rename(int oldDirfd, int oldPathPtr, int oldPathLen, int newDirfd,
     }
     java.nio.file.Path oldP = java.nio.file.Paths.get(oldR.path);
     java.nio.file.Path newP = java.nio.file.Paths.get(newR.path);
-    // A slash-suffixed destination may only name an existing directory or one
-    // the rename itself creates from a directory source (POSIX pathname
-    // resolution; issue #42). resolve_path already reported ENOTDIR for an
-    // existing non-directory; the nonexistent case must not fall through — the
-    // resolved path has lost the slash, so Files.move would silently create a
-    // plain *file* at the name. ENOENT is the macOS/POSIX errno (Linux would
-    // say ENOTDIR), the choice the other backends normalize to
-    // (runtime/bash/units/wasi/path_rename.sh).
-    if (newRel.endsWith("/")
-        && !java.nio.file.Files.exists(newP, java.nio.file.LinkOption.NOFOLLOW_LINKS)
-        && !java.nio.file.Files.isDirectory(oldP, java.nio.file.LinkOption.NOFOLLOW_LINKS)) {
-        return WASI_NOENT;
-    }
+    // Trailing slashes (issue #42, ADR-49: follow wasmtime): resolve_path
+    // already reported ENOTDIR for a slash-suffixed name over an existing
+    // non-directory on either side; a *nonexistent* slash-suffixed
+    // destination matches wasmtime's cap-std, which strips the slash and lets
+    // the rename proceed — exactly what the already-normalized Path does.
     // rename(2) reports type mismatches between the endpoints with specific
     // errnos that Java's generic FileSystemException flattens to EIO, so
     // pre-check them: renaming a directory onto an existing non-directory is

--- a/runtime/java/units/wasi/path_unlink_file.java
+++ b/runtime/java/units/wasi/path_unlink_file.java
@@ -15,10 +15,15 @@ int wasi_path_unlink_file(int dirfd, int pathPtr, int pathLen) {
         && !java.nio.file.Files.exists(p, java.nio.file.LinkOption.NOFOLLOW_LINKS)) {
         return WASI_NOENT;
     }
-    // Files.delete would remove an empty directory; unlink must fail (EISDIR)
-    // on any directory, so pre-check.
+    // Files.delete would remove an empty directory; unlink must fail on any
+    // directory, so pre-check. The errno mirrors what wasmtime inherits from
+    // the host unlink(2) (ADR-49): EPERM on macOS, EISDIR on Linux — the
+    // upstream wasi-testsuite pins exactly that split under its strict errno
+    // modes.
     if (java.nio.file.Files.isDirectory(p, java.nio.file.LinkOption.NOFOLLOW_LINKS)) {
-        return WASI_ISDIR;
+        return System.getProperty("os.name").toLowerCase().contains("mac")
+            ? WASI_PERM
+            : WASI_ISDIR;
     }
     // A trailing slash demands a directory; on a non-directory target that is
     // ENOTDIR (a plain unlink of the file without the slash still succeeds).

--- a/runtime/java/units/wasi/path_unlink_file.java
+++ b/runtime/java/units/wasi/path_unlink_file.java
@@ -16,10 +16,8 @@ int wasi_path_unlink_file(int dirfd, int pathPtr, int pathLen) {
         return WASI_NOENT;
     }
     // Files.delete would remove an empty directory; unlink must fail on any
-    // directory, so pre-check. The errno mirrors what wasmtime inherits from
-    // the host unlink(2) (ADR-49): EPERM on macOS, EISDIR on Linux — the
-    // upstream wasi-testsuite pins exactly that split under its strict errno
-    // modes.
+    // directory. Errno per host, as wasmtime inherits it (ADR-49): EPERM on
+    // macOS, EISDIR on Linux.
     if (java.nio.file.Files.isDirectory(p, java.nio.file.LinkOption.NOFOLLOW_LINKS)) {
         return System.getProperty("os.name").toLowerCase().contains("mac")
             ? WASI_PERM

--- a/runtime/java/units/wasi/path_unlink_file.java
+++ b/runtime/java/units/wasi/path_unlink_file.java
@@ -9,6 +9,12 @@ int wasi_path_unlink_file(int dirfd, int pathPtr, int pathLen) {
         return r.errno;
     }
     java.nio.file.Path p = java.nio.file.Paths.get(r.path);
+    // A missing slash-suffixed target is ENOENT, not ENOTDIR: resolve_path's
+    // directory gate only rejects *existing* non-directories (issue #42).
+    if (rel.endsWith("/")
+        && !java.nio.file.Files.exists(p, java.nio.file.LinkOption.NOFOLLOW_LINKS)) {
+        return WASI_NOENT;
+    }
     // Files.delete would remove an empty directory; unlink must fail (EISDIR)
     // on any directory, so pre-check.
     if (java.nio.file.Files.isDirectory(p, java.nio.file.LinkOption.NOFOLLOW_LINKS)) {

--- a/runtime/java/units/wasi/resolve_path.java
+++ b/runtime/java/units/wasi/resolve_path.java
@@ -53,15 +53,11 @@ Resolved resolve_path(int dirfd, String rel, boolean followLast) {
     if (!within(base, joined)) {
         return new Resolved(null, WASI_NOTCAPABLE);
     }
-    // A trailing slash constrains the final component to a directory (POSIX
-    // pathname resolution; issue #42). Paths.get has already normalized it
-    // away — no later host call could enforce it — so enforce it here:
-    // Files.exists/isDirectory follow symlinks, exactly as the slash forces,
-    // so "link-to-file/" is ENOTDIR while "link-to-dir/" passes. A missing
-    // target falls through: which errno (or success, for a create) that
-    // becomes is each syscall's own business. The slash is also stripped from
-    // the final-component bookkeeping below, which would otherwise misread ""
-    // as the last component and silently degrade followLast.
+    // A slash-suffixed name may only resolve to a directory (issue #42):
+    // Paths.get has normalized the slash away, so enforce it here — the
+    // probes follow symlinks as the slash requires; a missing target is each
+    // syscall's case. The slash is also stripped from `last` below, which
+    // would otherwise be "" and silently degrade followLast.
     boolean trailing = rel.endsWith("/");
     String core = rel;
     while (core.endsWith("/")) {

--- a/runtime/java/units/wasi/resolve_path.java
+++ b/runtime/java/units/wasi/resolve_path.java
@@ -53,13 +53,31 @@ Resolved resolve_path(int dirfd, String rel, boolean followLast) {
     if (!within(base, joined)) {
         return new Resolved(null, WASI_NOTCAPABLE);
     }
+    // A trailing slash constrains the final component to a directory (POSIX
+    // pathname resolution; issue #42). Paths.get has already normalized it
+    // away — no later host call could enforce it — so enforce it here:
+    // Files.exists/isDirectory follow symlinks, exactly as the slash forces,
+    // so "link-to-file/" is ENOTDIR while "link-to-dir/" passes. A missing
+    // target falls through: which errno (or success, for a create) that
+    // becomes is each syscall's own business. The slash is also stripped from
+    // the final-component bookkeeping below, which would otherwise misread ""
+    // as the last component and silently degrade followLast.
+    boolean trailing = rel.endsWith("/");
+    String core = rel;
+    while (core.endsWith("/")) {
+        core = core.substring(0, core.length() - 1);
+    }
+    if (trailing && java.nio.file.Files.exists(joined)
+        && !java.nio.file.Files.isDirectory(joined)) {
+        return new Resolved(null, WASI_NOTDIR);
+    }
     // The final component as the *guest* wrote it (not joined.getFileName(),
     // which has Cleaned "." / ".." away). A trailing "." or ".." is never a
     // symlink, so those fall through to full resolution.
-    String last = rel;
-    int idx = rel.lastIndexOf('/');
+    String last = core;
+    int idx = core.lastIndexOf('/');
     if (idx >= 0) {
-        last = rel.substring(idx + 1);
+        last = core.substring(idx + 1);
     }
     if (!followLast && !last.equals(".") && !last.equals("..") && !last.isEmpty()) {
         java.nio.file.Path parent = joined.getParent();

--- a/runtime/python/units/wasi/path_create_directory.py
+++ b/runtime/python/units/wasi/path_create_directory.py
@@ -1,6 +1,13 @@
 # requires: memory/read_string, wasi/resolve_path, wasi/errno_fs
 def wasi_path_create_directory(self, dirfd, path_ptr, path_len):
     rel = self.memory.read_string(path_ptr, path_len).decode("utf-8", "surrogateescape")
+    # mkdir names a directory by definition, so a trailing slash adds nothing
+    # but host-divergent errnos (macOS mkdir(2) reports ENOTDIR for "file/",
+    # Linux EEXIST): strip it so the existing-target case is EEXIST uniformly
+    # and "sub/" still creates (issue #42).
+    core = rel.rstrip("/")
+    if core:
+        rel = core
     # mkdir(2) never follows a trailing symlink (an existing one is EEXIST).
     host_path, err = self.resolve_path(dirfd, rel, False)
     if err is not None:

--- a/runtime/python/units/wasi/path_create_directory.py
+++ b/runtime/python/units/wasi/path_create_directory.py
@@ -1,10 +1,8 @@
 # requires: memory/read_string, wasi/resolve_path, wasi/errno_fs
 def wasi_path_create_directory(self, dirfd, path_ptr, path_len):
     rel = self.memory.read_string(path_ptr, path_len).decode("utf-8", "surrogateescape")
-    # mkdir names a directory by definition, so a trailing slash adds nothing
-    # but host-divergent errnos (macOS mkdir(2) reports ENOTDIR for "file/",
-    # Linux EEXIST): strip it so the existing-target case is EEXIST uniformly
-    # and "sub/" still creates (issue #42).
+    # Strip a trailing slash: mkdir names a directory anyway, and EEXIST is
+    # wasmtime's answer for mkdir("file/") where the hosts split (ADR-49).
     core = rel.rstrip("/")
     if core:
         rel = core

--- a/runtime/python/units/wasi/path_open.py
+++ b/runtime/python/units/wasi/path_open.py
@@ -33,12 +33,15 @@ def wasi_path_open(self, dirfd, dirflags, path_ptr, path_len, oflags, fs_rights_
         flags |= os.O_EXCL
     if oflags & 0x8 != 0:  # oflags::TRUNC
         flags |= os.O_TRUNC
-    # A trailing slash may only resolve to a directory (issue #42). An existing
-    # non-directory is ENOTDIR from the host open below; the nonexistent case
-    # is normalized to ENOENT here — open(2) cannot create a directory, and the
-    # hosts disagree on the O_CREAT shape (macOS/POSIX ENOENT, Linux EISDIR).
+    # A trailing slash may only resolve to a directory (issue #42), which
+    # open(2) can never create, so O_CREAT must not manufacture a plain file
+    # through the slash. The errno follows wasmtime 47 (ADR-49): EINVAL on
+    # macOS (its manual path resolution rejects the shape), EISDIR on Linux
+    # (host passthrough); a plain open is ENOENT on both.
     if host_path.endswith(os.sep) and not os.path.lexists(host_path[:-1]):
-        return self.ERRNO_NOENT
+        if oflags & 0x1 == 0:  # no oflags::CREAT
+            return self.ERRNO_NOENT
+        return self.ERRNO_INVAL if sys.platform == "darwin" else self.ERRNO_ISDIR
     try:
         fd = os.open(host_path, flags, 0o644)
     except OSError as e:

--- a/runtime/python/units/wasi/path_open.py
+++ b/runtime/python/units/wasi/path_open.py
@@ -33,11 +33,8 @@ def wasi_path_open(self, dirfd, dirflags, path_ptr, path_len, oflags, fs_rights_
         flags |= os.O_EXCL
     if oflags & 0x8 != 0:  # oflags::TRUNC
         flags |= os.O_TRUNC
-    # A trailing slash may only resolve to a directory (issue #42), which
-    # open(2) can never create, so O_CREAT must not manufacture a plain file
-    # through the slash. The errno follows wasmtime 47 (ADR-49): EINVAL on
-    # macOS (its manual path resolution rejects the shape), EISDIR on Linux
-    # (host passthrough); a plain open is ENOENT on both.
+    # O_CREAT must not create through a trailing slash (issue #42); per
+    # wasmtime (ADR-49): EINVAL on macOS, EISDIR on Linux, plain open ENOENT.
     if host_path.endswith(os.sep) and not os.path.lexists(host_path[:-1]):
         if oflags & 0x1 == 0:  # no oflags::CREAT
             return self.ERRNO_NOENT

--- a/runtime/python/units/wasi/path_open.py
+++ b/runtime/python/units/wasi/path_open.py
@@ -33,6 +33,12 @@ def wasi_path_open(self, dirfd, dirflags, path_ptr, path_len, oflags, fs_rights_
         flags |= os.O_EXCL
     if oflags & 0x8 != 0:  # oflags::TRUNC
         flags |= os.O_TRUNC
+    # A trailing slash may only resolve to a directory (issue #42). An existing
+    # non-directory is ENOTDIR from the host open below; the nonexistent case
+    # is normalized to ENOENT here — open(2) cannot create a directory, and the
+    # hosts disagree on the O_CREAT shape (macOS/POSIX ENOENT, Linux EISDIR).
+    if host_path.endswith(os.sep) and not os.path.lexists(host_path[:-1]):
+        return self.ERRNO_NOENT
     try:
         fd = os.open(host_path, flags, 0o644)
     except OSError as e:

--- a/runtime/python/units/wasi/path_remove_directory.py
+++ b/runtime/python/units/wasi/path_remove_directory.py
@@ -5,10 +5,8 @@ def wasi_path_remove_directory(self, dirfd, path_ptr, path_len):
     host_path, err = self.resolve_path(dirfd, rel, False)
     if err is not None:
         return err
-    # wasmtime 47 (ADR-49) rejects removing an existing directory through a
-    # slash-suffixed name with EINVAL on both hosts (cap-std's final-component
-    # handling); a missing target stays ENOENT and a non-directory ENOTDIR via
-    # the host call on the slash-preserved path.
+    # rmdir through a trailing slash on an existing directory is EINVAL per
+    # wasmtime (ADR-49); other shapes come from the host call.
     if host_path.endswith(os.sep) and os.path.isdir(host_path[:-1]):
         return self.ERRNO_INVAL
     try:

--- a/runtime/python/units/wasi/path_remove_directory.py
+++ b/runtime/python/units/wasi/path_remove_directory.py
@@ -5,6 +5,12 @@ def wasi_path_remove_directory(self, dirfd, path_ptr, path_len):
     host_path, err = self.resolve_path(dirfd, rel, False)
     if err is not None:
         return err
+    # wasmtime 47 (ADR-49) rejects removing an existing directory through a
+    # slash-suffixed name with EINVAL on both hosts (cap-std's final-component
+    # handling); a missing target stays ENOENT and a non-directory ENOTDIR via
+    # the host call on the slash-preserved path.
+    if host_path.endswith(os.sep) and os.path.isdir(host_path[:-1]):
+        return self.ERRNO_INVAL
     try:
         os.rmdir(host_path)
     except OSError as e:

--- a/runtime/python/units/wasi/path_rename.py
+++ b/runtime/python/units/wasi/path_rename.py
@@ -10,23 +10,17 @@ def wasi_path_rename(self, old_dirfd, old_path_ptr, old_path_len, new_dirfd, new
     new_host, err = self.resolve_path(new_dirfd, new_rel, False)
     if err is not None:
         return err
-    # Trailing-slash semantics (issue #42): resolve_path preserved the slash, so
-    # the host rename(2) enforces the uniform shapes itself — an existing
-    # non-directory behind a slash is ENOTDIR on either side, a missing
-    # slash-bearing source is ENOENT. The one shape Linux and macOS disagree on
-    # — a nonexistent slash-bearing destination with a non-directory source
-    # (macOS/POSIX ENOENT, Linux ENOTDIR) — is normalized to ENOENT here,
-    # mirroring runtime/bash/units/wasi/path_rename.sh. The probes use the
-    # slash-stripped path: stat on the slash-bearing one already fails ENOTDIR
-    # and would misread "exists as a file" as "missing".
-    if new_host.endswith(os.sep):
-        old_bare = old_host[:-1] if old_host.endswith(os.sep) else old_host
-        new_bare = new_host[:-1]
-        # When the source itself bears a slash over an existing non-directory,
-        # fall through: the host reports the source-side ENOTDIR first.
-        src_slash_ok = not old_host.endswith(os.sep) or os.path.isdir(old_bare)
-        if not os.path.lexists(new_bare) and src_slash_ok and not os.path.isdir(old_bare):
-            return self.ERRNO_NOENT
+    # Trailing-slash semantics (issue #42, ADR-49: follow wasmtime): the slash
+    # resolve_path preserved lets the host rename(2) enforce the shapes
+    # wasmtime inherits from the OS — an existing non-directory behind a slash
+    # is ENOTDIR on either side, a missing slash-suffixed source is ENOENT. A
+    # *nonexistent* slash-suffixed destination is the one shape wasmtime does
+    # not inherit: cap-std strips the slash and the rename proceeds (even from
+    # a non-directory source), so strip it here too. The existence probe uses
+    # the slash-stripped path: stat on the slash-bearing one already fails
+    # ENOTDIR and would misread "exists as a file" as "missing".
+    if new_host.endswith(os.sep) and not os.path.lexists(new_host[:-1]):
+        new_host = new_host[:-1]
     try:
         os.rename(old_host, new_host)
     except OSError as e:

--- a/runtime/python/units/wasi/path_rename.py
+++ b/runtime/python/units/wasi/path_rename.py
@@ -10,6 +10,23 @@ def wasi_path_rename(self, old_dirfd, old_path_ptr, old_path_len, new_dirfd, new
     new_host, err = self.resolve_path(new_dirfd, new_rel, False)
     if err is not None:
         return err
+    # Trailing-slash semantics (issue #42): resolve_path preserved the slash, so
+    # the host rename(2) enforces the uniform shapes itself — an existing
+    # non-directory behind a slash is ENOTDIR on either side, a missing
+    # slash-bearing source is ENOENT. The one shape Linux and macOS disagree on
+    # — a nonexistent slash-bearing destination with a non-directory source
+    # (macOS/POSIX ENOENT, Linux ENOTDIR) — is normalized to ENOENT here,
+    # mirroring runtime/bash/units/wasi/path_rename.sh. The probes use the
+    # slash-stripped path: stat on the slash-bearing one already fails ENOTDIR
+    # and would misread "exists as a file" as "missing".
+    if new_host.endswith(os.sep):
+        old_bare = old_host[:-1] if old_host.endswith(os.sep) else old_host
+        new_bare = new_host[:-1]
+        # When the source itself bears a slash over an existing non-directory,
+        # fall through: the host reports the source-side ENOTDIR first.
+        src_slash_ok = not old_host.endswith(os.sep) or os.path.isdir(old_bare)
+        if not os.path.lexists(new_bare) and src_slash_ok and not os.path.isdir(old_bare):
+            return self.ERRNO_NOENT
     try:
         os.rename(old_host, new_host)
     except OSError as e:

--- a/runtime/python/units/wasi/path_rename.py
+++ b/runtime/python/units/wasi/path_rename.py
@@ -10,15 +10,10 @@ def wasi_path_rename(self, old_dirfd, old_path_ptr, old_path_len, new_dirfd, new
     new_host, err = self.resolve_path(new_dirfd, new_rel, False)
     if err is not None:
         return err
-    # Trailing-slash semantics (issue #42, ADR-49: follow wasmtime): the slash
-    # resolve_path preserved lets the host rename(2) enforce the shapes
-    # wasmtime inherits from the OS — an existing non-directory behind a slash
-    # is ENOTDIR on either side, a missing slash-suffixed source is ENOENT. A
-    # *nonexistent* slash-suffixed destination is the one shape wasmtime does
-    # not inherit: cap-std strips the slash and the rename proceeds (even from
-    # a non-directory source), so strip it here too. The existence probe uses
-    # the slash-stripped path: stat on the slash-bearing one already fails
-    # ENOTDIR and would misread "exists as a file" as "missing".
+    # The preserved slash lets the host rename(2) enforce the existing and
+    # missing shapes; a *nonexistent* slash-suffixed destination is stripped
+    # so the rename proceeds, as wasmtime does (issue #42, ADR-49). Probe the
+    # bare path — stat on "x/" fails ENOTDIR and reads as missing.
     if new_host.endswith(os.sep) and not os.path.lexists(new_host[:-1]):
         new_host = new_host[:-1]
     try:

--- a/runtime/python/units/wasi/path_symlink.py
+++ b/runtime/python/units/wasi/path_symlink.py
@@ -10,11 +10,9 @@ def wasi_path_symlink(self, old_path_ptr, old_path_len, fd, new_path_ptr, new_pa
     link_host, err = self.resolve_path(fd, new_rel, False)
     if err is not None:
         return err
-    # A slash-suffixed link name can never be created; the errnos follow
-    # wasmtime 47 on both hosts (ADR-49) — EEXIST for an existing directory,
-    # ENOTDIR for an existing non-directory, ENOENT when nothing is there —
-    # where a raw host symlinkat would diverge (Linux reports EEXIST even for
-    # the non-directory shape). The probes use the slash-stripped path.
+    # Slash-suffixed link name, per wasmtime (ADR-49): EEXIST on a directory,
+    # ENOTDIR on a non-directory (raw Linux would say EEXIST), ENOENT when
+    # missing. Probe the slash-stripped path.
     if link_host.endswith(os.sep):
         bare = link_host[:-1]
         if os.path.lexists(bare):

--- a/runtime/python/units/wasi/path_symlink.py
+++ b/runtime/python/units/wasi/path_symlink.py
@@ -10,6 +10,16 @@ def wasi_path_symlink(self, old_path_ptr, old_path_len, fd, new_path_ptr, new_pa
     link_host, err = self.resolve_path(fd, new_rel, False)
     if err is not None:
         return err
+    # A slash-suffixed link name can never be created; the errnos follow
+    # wasmtime 47 on both hosts (ADR-49) — EEXIST for an existing directory,
+    # ENOTDIR for an existing non-directory, ENOENT when nothing is there —
+    # where a raw host symlinkat would diverge (Linux reports EEXIST even for
+    # the non-directory shape). The probes use the slash-stripped path.
+    if link_host.endswith(os.sep):
+        bare = link_host[:-1]
+        if os.path.lexists(bare):
+            return self.ERRNO_EXIST if os.path.isdir(bare) else self.ERRNO_NOTDIR
+        return self.ERRNO_NOENT
     try:
         os.symlink(target, link_host)
     except OSError as e:

--- a/runtime/ruby/units/wasi/path_create_directory.rb
+++ b/runtime/ruby/units/wasi/path_create_directory.rb
@@ -1,6 +1,11 @@
 # requires: memory/read_string, wasi/resolve_path, wasi/errno_fs
 def wasi_path_create_directory(dirfd, path_ptr, path_len)
   rel = @memory.read_string(path_ptr, path_len)
+  # mkdir names a directory by definition, so a trailing slash adds nothing
+  # but host-divergent errnos (macOS mkdir(2) reports ENOTDIR for "file/",
+  # Linux EEXIST): strip it so the existing-target case is EEXIST uniformly
+  # and "sub/" still creates (issue #42).
+  rel = rel.sub(%r{(.)/+\z}, '\1')
   # mkdir(2) never follows a trailing symlink (an existing one is EEXIST).
   host_path, err = resolve_path(dirfd, rel, follow_last: false)
   return err if err

--- a/runtime/ruby/units/wasi/path_create_directory.rb
+++ b/runtime/ruby/units/wasi/path_create_directory.rb
@@ -1,10 +1,8 @@
 # requires: memory/read_string, wasi/resolve_path, wasi/errno_fs
 def wasi_path_create_directory(dirfd, path_ptr, path_len)
   rel = @memory.read_string(path_ptr, path_len)
-  # mkdir names a directory by definition, so a trailing slash adds nothing
-  # but host-divergent errnos (macOS mkdir(2) reports ENOTDIR for "file/",
-  # Linux EEXIST): strip it so the existing-target case is EEXIST uniformly
-  # and "sub/" still creates (issue #42).
+  # Strip a trailing slash: mkdir names a directory anyway, and EEXIST is
+  # wasmtime's answer for mkdir("file/") where the hosts split (ADR-49).
   rel = rel.sub(%r{(.)/+\z}, '\1')
   # mkdir(2) never follows a trailing symlink (an existing one is EEXIST).
   host_path, err = resolve_path(dirfd, rel, follow_last: false)

--- a/runtime/ruby/units/wasi/path_open.rb
+++ b/runtime/ruby/units/wasi/path_open.rb
@@ -14,10 +14,8 @@ def wasi_path_open(dirfd, dirflags, path_ptr, path_len, oflags, base, inheriting
   follow = dirflags & 0x1 != 0 # lookupflags::SYMLINK_FOLLOW
   host_path, err = resolve_path(dirfd, rel, follow_last: follow)
   return err if err
-  # resolve_path preserves a trailing slash (issue #42); this unit's own
-  # probes and branches decide everything the slash implies, so work on the
-  # stripped path (stat on "file/" fails ENOTDIR and would misreport every
-  # probe below).
+  # This unit's branches decide the slash shapes, so strip the preserved
+  # slash (issue #42) — stat on "file/" fails ENOTDIR and misreads probes.
   trailing = host_path.end_with?("/")
   host_path = host_path.delete_suffix("/")
   # Without SYMLINK_FOLLOW, a symlink at the final component is an error
@@ -27,11 +25,8 @@ def wasi_path_open(dirfd, dirflags, path_ptr, path_len, oflags, base, inheriting
   exists = File.exist?(host_path) || File.symlink?(host_path)
   if trailing
     unless exists
-      # A trailing slash demands a directory, which open(2) can never
-      # create, so O_CREAT must not manufacture a plain file through the
-      # slash. The errno follows wasmtime 47 (ADR-49): EINVAL on macOS
-      # (its manual path resolution rejects the shape), EISDIR on Linux
-      # (host passthrough); a plain open is ENOENT on both.
+      # O_CREAT must not create through the slash; per wasmtime (ADR-49):
+      # EINVAL on macOS, EISDIR on Linux, plain open ENOENT on both.
       return ERRNO_NOENT if oflags & 0x1 == 0
       return RUBY_PLATFORM.include?("darwin") ? ERRNO_INVAL : ERRNO_ISDIR
     end

--- a/runtime/ruby/units/wasi/path_open.rb
+++ b/runtime/ruby/units/wasi/path_open.rb
@@ -26,12 +26,15 @@ def wasi_path_open(dirfd, dirflags, path_ptr, path_len, oflags, base, inheriting
 
   exists = File.exist?(host_path) || File.symlink?(host_path)
   if trailing
-    # A trailing slash demands a directory. A nonexistent target is ENOENT
-    # even with O_CREAT — open(2) cannot create a directory — normalized
-    # here because the hosts disagree on the O_CREAT shape (macOS/POSIX
-    # ENOENT, Linux EISDIR) and letting it fall through would create a
-    # plain *file* through the slash.
-    return ERRNO_NOENT unless exists
+    unless exists
+      # A trailing slash demands a directory, which open(2) can never
+      # create, so O_CREAT must not manufacture a plain file through the
+      # slash. The errno follows wasmtime 47 (ADR-49): EINVAL on macOS
+      # (its manual path resolution rejects the shape), EISDIR on Linux
+      # (host passthrough); a plain open is ENOENT on both.
+      return ERRNO_NOENT if oflags & 0x1 == 0
+      return RUBY_PLATFORM.include?("darwin") ? ERRNO_INVAL : ERRNO_ISDIR
+    end
     return ERRNO_NOTDIR unless File.directory?(host_path)
   end
 

--- a/runtime/ruby/units/wasi/path_open.rb
+++ b/runtime/ruby/units/wasi/path_open.rb
@@ -14,13 +14,26 @@ def wasi_path_open(dirfd, dirflags, path_ptr, path_len, oflags, base, inheriting
   follow = dirflags & 0x1 != 0 # lookupflags::SYMLINK_FOLLOW
   host_path, err = resolve_path(dirfd, rel, follow_last: follow)
   return err if err
+  # resolve_path preserves a trailing slash (issue #42); this unit's own
+  # probes and branches decide everything the slash implies, so work on the
+  # stripped path (stat on "file/" fails ENOTDIR and would misreport every
+  # probe below).
+  trailing = host_path.end_with?("/")
+  host_path = host_path.delete_suffix("/")
   # Without SYMLINK_FOLLOW, a symlink at the final component is an error
   # (the caller asked us not to traverse it).
   return ERRNO_LOOP if !follow && File.symlink?(host_path)
 
   exists = File.exist?(host_path) || File.symlink?(host_path)
-  # A trailing slash demands a directory.
-  return ERRNO_NOTDIR if rel.end_with?("/") && exists && !File.directory?(host_path)
+  if trailing
+    # A trailing slash demands a directory. A nonexistent target is ENOENT
+    # even with O_CREAT — open(2) cannot create a directory — normalized
+    # here because the hosts disagree on the O_CREAT shape (macOS/POSIX
+    # ENOENT, Linux EISDIR) and letting it fall through would create a
+    # plain *file* through the slash.
+    return ERRNO_NOENT unless exists
+    return ERRNO_NOTDIR unless File.directory?(host_path)
+  end
 
   wants_dir = oflags & 0x2 != 0 # oflags::DIRECTORY
   parent_inheriting = @fd_meta[dirfd][1]

--- a/runtime/ruby/units/wasi/path_remove_directory.rb
+++ b/runtime/ruby/units/wasi/path_remove_directory.rb
@@ -4,6 +4,13 @@ def wasi_path_remove_directory(dirfd, path_ptr, path_len)
   # rmdir(2) never follows a trailing symlink.
   host_path, err = resolve_path(dirfd, rel, follow_last: false)
   return err if err
+  # wasmtime 47 (ADR-49) rejects removing an existing directory through a
+  # slash-suffixed name with EINVAL on both hosts (cap-std's final-component
+  # handling); a missing target stays ENOENT and a non-directory ENOTDIR via
+  # the host call on the slash-preserved path.
+  if host_path.end_with?("/") && File.directory?(host_path.delete_suffix("/"))
+    return ERRNO_INVAL
+  end
   Dir.rmdir(host_path)
   ERRNO_SUCCESS
 rescue SystemCallError => e

--- a/runtime/ruby/units/wasi/path_remove_directory.rb
+++ b/runtime/ruby/units/wasi/path_remove_directory.rb
@@ -4,10 +4,8 @@ def wasi_path_remove_directory(dirfd, path_ptr, path_len)
   # rmdir(2) never follows a trailing symlink.
   host_path, err = resolve_path(dirfd, rel, follow_last: false)
   return err if err
-  # wasmtime 47 (ADR-49) rejects removing an existing directory through a
-  # slash-suffixed name with EINVAL on both hosts (cap-std's final-component
-  # handling); a missing target stays ENOENT and a non-directory ENOTDIR via
-  # the host call on the slash-preserved path.
+  # rmdir through a trailing slash on an existing directory is EINVAL per
+  # wasmtime (ADR-49); other shapes come from the host call.
   if host_path.end_with?("/") && File.directory?(host_path.delete_suffix("/"))
     return ERRNO_INVAL
   end

--- a/runtime/ruby/units/wasi/path_rename.rb
+++ b/runtime/ruby/units/wasi/path_rename.rb
@@ -8,23 +8,19 @@ def wasi_path_rename(old_dirfd, old_path_ptr, old_path_len, new_dirfd, new_path_
   new_rel = @memory.read_string(new_path_ptr, new_path_len)
   new_host, err = resolve_path(new_dirfd, new_rel, follow_last: false)
   return err if err
-  # Trailing-slash semantics (issue #42): resolve_path preserved the slash,
-  # so the host rename(2) enforces the uniform shapes itself — an existing
-  # non-directory behind a slash is ENOTDIR on either side, a missing
-  # slash-bearing source is ENOENT. The one shape Linux and macOS disagree
-  # on — a nonexistent slash-bearing destination with a non-directory
-  # source (macOS/POSIX ENOENT, Linux ENOTDIR) — is normalized to ENOENT
-  # here, mirroring runtime/bash/units/wasi/path_rename.sh. The probes use
-  # the slash-stripped path: stat on the slash-bearing one already fails
-  # ENOTDIR and would misread "exists as a file" as "missing".
+  # Trailing-slash semantics (issue #42, ADR-49: follow wasmtime): the
+  # slash resolve_path preserved lets the host rename(2) enforce the
+  # shapes wasmtime inherits from the OS — an existing non-directory
+  # behind a slash is ENOTDIR on either side, a missing slash-suffixed
+  # source is ENOENT. A *nonexistent* slash-suffixed destination is the
+  # one shape wasmtime does not inherit: cap-std strips the slash and the
+  # rename proceeds (even from a non-directory source), so strip it here
+  # too. The existence probe uses the slash-stripped path: stat on the
+  # slash-bearing one already fails ENOTDIR and would misread "exists as
+  # a file" as "missing".
   if new_host.end_with?("/")
-    old_bare = old_host.delete_suffix("/")
     new_bare = new_host.delete_suffix("/")
-    new_exists = File.exist?(new_bare) || File.symlink?(new_bare)
-    # When the source itself bears a slash over an existing non-directory,
-    # fall through: the host reports the source-side ENOTDIR first.
-    src_slash_ok = !old_host.end_with?("/") || File.directory?(old_bare)
-    return ERRNO_NOENT if !new_exists && src_slash_ok && !File.directory?(old_bare)
+    new_host = new_bare unless File.exist?(new_bare) || File.symlink?(new_bare)
   end
   File.rename(old_host, new_host)
   ERRNO_SUCCESS

--- a/runtime/ruby/units/wasi/path_rename.rb
+++ b/runtime/ruby/units/wasi/path_rename.rb
@@ -8,6 +8,24 @@ def wasi_path_rename(old_dirfd, old_path_ptr, old_path_len, new_dirfd, new_path_
   new_rel = @memory.read_string(new_path_ptr, new_path_len)
   new_host, err = resolve_path(new_dirfd, new_rel, follow_last: false)
   return err if err
+  # Trailing-slash semantics (issue #42): resolve_path preserved the slash,
+  # so the host rename(2) enforces the uniform shapes itself — an existing
+  # non-directory behind a slash is ENOTDIR on either side, a missing
+  # slash-bearing source is ENOENT. The one shape Linux and macOS disagree
+  # on — a nonexistent slash-bearing destination with a non-directory
+  # source (macOS/POSIX ENOENT, Linux ENOTDIR) — is normalized to ENOENT
+  # here, mirroring runtime/bash/units/wasi/path_rename.sh. The probes use
+  # the slash-stripped path: stat on the slash-bearing one already fails
+  # ENOTDIR and would misread "exists as a file" as "missing".
+  if new_host.end_with?("/")
+    old_bare = old_host.delete_suffix("/")
+    new_bare = new_host.delete_suffix("/")
+    new_exists = File.exist?(new_bare) || File.symlink?(new_bare)
+    # When the source itself bears a slash over an existing non-directory,
+    # fall through: the host reports the source-side ENOTDIR first.
+    src_slash_ok = !old_host.end_with?("/") || File.directory?(old_bare)
+    return ERRNO_NOENT if !new_exists && src_slash_ok && !File.directory?(old_bare)
+  end
   File.rename(old_host, new_host)
   ERRNO_SUCCESS
 rescue SystemCallError => e

--- a/runtime/ruby/units/wasi/path_rename.rb
+++ b/runtime/ruby/units/wasi/path_rename.rb
@@ -8,16 +8,10 @@ def wasi_path_rename(old_dirfd, old_path_ptr, old_path_len, new_dirfd, new_path_
   new_rel = @memory.read_string(new_path_ptr, new_path_len)
   new_host, err = resolve_path(new_dirfd, new_rel, follow_last: false)
   return err if err
-  # Trailing-slash semantics (issue #42, ADR-49: follow wasmtime): the
-  # slash resolve_path preserved lets the host rename(2) enforce the
-  # shapes wasmtime inherits from the OS — an existing non-directory
-  # behind a slash is ENOTDIR on either side, a missing slash-suffixed
-  # source is ENOENT. A *nonexistent* slash-suffixed destination is the
-  # one shape wasmtime does not inherit: cap-std strips the slash and the
-  # rename proceeds (even from a non-directory source), so strip it here
-  # too. The existence probe uses the slash-stripped path: stat on the
-  # slash-bearing one already fails ENOTDIR and would misread "exists as
-  # a file" as "missing".
+  # The preserved slash lets the host rename(2) enforce the existing and
+  # missing shapes; a *nonexistent* slash-suffixed destination is stripped
+  # so the rename proceeds, as wasmtime does (issue #42, ADR-49). Probe the
+  # bare path — stat on "x/" fails ENOTDIR and reads as missing.
   if new_host.end_with?("/")
     new_bare = new_host.delete_suffix("/")
     new_host = new_bare unless File.exist?(new_bare) || File.symlink?(new_bare)

--- a/runtime/ruby/units/wasi/path_symlink.rb
+++ b/runtime/ruby/units/wasi/path_symlink.rb
@@ -8,10 +8,8 @@ def wasi_path_symlink(old_ptr, old_len, dirfd, new_ptr, new_len)
   return ERRNO_NOTCAPABLE if target.start_with?("/")
   host_path, err = resolve_path(dirfd, new_rel, follow_last: false)
   return err if err
-  # A trailing slash on the link name demands an existing directory there;
-  # File.symlink would otherwise create a slash-suffixed name. The probes
-  # use the slash-stripped path — resolve_path preserves the slash (issue
-  # #42) and stat on "file/" fails ENOTDIR, misreading it as "missing".
+  # A slash-suffixed link name needs an existing directory there. Probe the
+  # slash-stripped path (stat on "file/" fails ENOTDIR, reads as missing).
   if new_rel.end_with?("/")
     bare = host_path.delete_suffix("/")
     if File.symlink?(bare) || File.exist?(bare)

--- a/runtime/ruby/units/wasi/path_symlink.rb
+++ b/runtime/ruby/units/wasi/path_symlink.rb
@@ -9,10 +9,13 @@ def wasi_path_symlink(old_ptr, old_len, dirfd, new_ptr, new_len)
   host_path, err = resolve_path(dirfd, new_rel, follow_last: false)
   return err if err
   # A trailing slash on the link name demands an existing directory there;
-  # File.symlink would otherwise create a slash-suffixed name.
+  # File.symlink would otherwise create a slash-suffixed name. The probes
+  # use the slash-stripped path — resolve_path preserves the slash (issue
+  # #42) and stat on "file/" fails ENOTDIR, misreading it as "missing".
   if new_rel.end_with?("/")
-    if File.symlink?(host_path) || File.exist?(host_path)
-      return File.directory?(host_path) ? ERRNO_EXIST : ERRNO_NOTDIR
+    bare = host_path.delete_suffix("/")
+    if File.symlink?(bare) || File.exist?(bare)
+      return File.directory?(bare) ? ERRNO_EXIST : ERRNO_NOTDIR
     end
     return ERRNO_NOENT
   end

--- a/runtime/ruby/units/wasi/path_unlink_file.rb
+++ b/runtime/ruby/units/wasi/path_unlink_file.rb
@@ -6,9 +6,15 @@ def wasi_path_unlink_file(dirfd, path_ptr, path_len)
   return err if err
   # A trailing slash requires a directory; unlink of a non-directory then
   # fails ENOTDIR. (A real directory still falls through to File.unlink,
-  # which raises EPERM/EISDIR as a directory should.)
-  if rel.end_with?("/") && !File.directory?(host_path)
-    return File.exist?(host_path) || File.symlink?(host_path) ? ERRNO_NOTDIR : ERRNO_NOENT
+  # which raises EPERM/EISDIR as a directory should.) The existence probes
+  # use the slash-stripped path — resolve_path preserves the slash (issue
+  # #42) and stat on "file/" already fails ENOTDIR, which would misread
+  # "exists as a file" as "missing".
+  if host_path.end_with?("/")
+    bare = host_path.delete_suffix("/")
+    unless File.directory?(bare)
+      return File.exist?(bare) || File.symlink?(bare) ? ERRNO_NOTDIR : ERRNO_NOENT
+    end
   end
   File.unlink(host_path)
   ERRNO_SUCCESS

--- a/runtime/ruby/units/wasi/path_unlink_file.rb
+++ b/runtime/ruby/units/wasi/path_unlink_file.rb
@@ -4,12 +4,9 @@ def wasi_path_unlink_file(dirfd, path_ptr, path_len)
   # unlink(2) never follows a trailing symlink: it removes the link.
   host_path, err = resolve_path(dirfd, rel, follow_last: false)
   return err if err
-  # A trailing slash requires a directory; unlink of a non-directory then
-  # fails ENOTDIR. (A real directory still falls through to File.unlink,
-  # which raises EPERM/EISDIR as a directory should.) The existence probes
-  # use the slash-stripped path — resolve_path preserves the slash (issue
-  # #42) and stat on "file/" already fails ENOTDIR, which would misread
-  # "exists as a file" as "missing".
+  # A slash-suffixed non-directory is ENOTDIR, missing is ENOENT; a real
+  # directory falls through to File.unlink (host EPERM/EISDIR). Probe the
+  # slash-stripped path — stat on "file/" fails ENOTDIR, reads as missing.
   if host_path.end_with?("/")
     bare = host_path.delete_suffix("/")
     unless File.directory?(bare)

--- a/runtime/ruby/units/wasi/resolve_path.rb
+++ b/runtime/ruby/units/wasi/resolve_path.rb
@@ -10,6 +10,12 @@ private :within?
 # root. Every call re-validates against its own dirfd's root, so nested
 # path_opens can't be used to launder an escape one level cheaper.
 #
+# A trailing slash is stripped for resolution but preserved on the
+# returned host path, so the underlying File/Dir call enforces the POSIX
+# "must resolve to a directory" rule (issue #42, mirroring
+# runtime/python/units/wasi/resolve_path.py) — File.basename/File.join
+# would otherwise silently drop it before the host syscall could see it.
+#
 # `follow_last: false` resolves the parent but leaves the final
 # component untouched (the AT_SYMLINK_NOFOLLOW shape), for syscalls that
 # operate on a symlink itself (lstat, unlink, rename, rmdir, mkdir). A
@@ -36,7 +42,10 @@ def resolve_path(dirfd, rel, follow_last: true)
   # (it would raise ENOENT), so a path like "a/../../etc" needs catching
   # here to report NOTCAPABLE rather than NOENT.
   return [nil, ERRNO_NOTCAPABLE] unless within?(base, File.expand_path(rel, base))
-  joined = File.join(base, rel)
+  trailing = rel.length > 1 && rel.end_with?("/")
+  suffix = trailing ? "/" : ""
+  core = rel.sub(%r{/+\z}, "")
+  joined = core.empty? ? base : File.join(base, core)
   last = File.basename(joined)
   if !follow_last && last != "." && last != ".."
     begin
@@ -49,12 +58,12 @@ def resolve_path(dirfd, rel, follow_last: true)
       return [nil, ERRNO_IO]
     end
     return [nil, ERRNO_NOTCAPABLE] unless within?(base, real_parent)
-    return [File.join(real_parent, last), nil]
+    return [File.join(real_parent, last) + suffix, nil]
   end
   begin
     real = File.realpath(joined)
     return [nil, ERRNO_NOTCAPABLE] unless within?(base, real)
-    [real, nil]
+    [real + suffix, nil]
   rescue Errno::ENOENT
     begin
       real_parent = File.realpath(File.dirname(joined))
@@ -64,7 +73,7 @@ def resolve_path(dirfd, rel, follow_last: true)
       return [nil, ERRNO_IO]
     end
     return [nil, ERRNO_NOTCAPABLE] unless within?(base, real_parent)
-    [File.join(real_parent, File.basename(joined)), nil]
+    [File.join(real_parent, File.basename(joined)) + suffix, nil]
   rescue Errno::ELOOP
     [nil, ERRNO_LOOP]
   rescue SystemCallError

--- a/runtime/ruby/units/wasi/resolve_path.rb
+++ b/runtime/ruby/units/wasi/resolve_path.rb
@@ -10,11 +10,9 @@ private :within?
 # root. Every call re-validates against its own dirfd's root, so nested
 # path_opens can't be used to launder an escape one level cheaper.
 #
-# A trailing slash is stripped for resolution but preserved on the
-# returned host path, so the underlying File/Dir call enforces the POSIX
-# "must resolve to a directory" rule (issue #42, mirroring
-# runtime/python/units/wasi/resolve_path.py) — File.basename/File.join
-# would otherwise silently drop it before the host syscall could see it.
+# A trailing slash is stripped for resolution and re-appended to the
+# returned host path, so the host call enforces it (issue #42; mirrors
+# runtime/python/units/wasi/resolve_path.py).
 #
 # `follow_last: false` resolves the parent but leaves the final
 # component untouched (the AT_SYMLINK_NOFOLLOW shape), for syscalls that


### PR DESCRIPTION
Closes #42 (sequel to #29/#41).

Every backend's path plumbing dropped trailing slashes before the host syscall could see them (`File.join`, `filepath.Join`, `Paths.get(...).normalize()`, bash's parent/basename split — which also broke `mkdir("sub/")` outright), so `rename("file/", "new")` silently renamed a regular file and the ENOTDIR family was lost across the `path_*` syscalls. In Go/Java the empty final component also silently degraded `followLast=false`.

**Policy ([ADR-49](docs/adr/49-spec-silent-follow-wasmtime.md), user-decided): where the WASI spec is silent — it is, for trailing slashes — backends copy wasmtime's observed behavior.** The shapes are inconsequential; wasmtime is the pick because the upstream testsuite encodes it, not because its behavior is better. Concretely (measured on both hosts): slash over an existing non-directory → ENOTDIR everywhere; a nonexistent slash-suffixed rename destination is stripped and renamed; `rmdir("dir/")` → EINVAL; O_CREAT through `newf/` → EINVAL(macOS)/EISDIR(Linux), wasmtime's own split; `mkdir("file/")` → EEXIST; unlink-of-directory keeps the host split (EPERM/EISDIR), emulated explicitly in Java/Bash. Unpinned (noted in the fixture headers): wasmtime's Linux-only nofollow-stat slash strip.

The wasi-testsuite runner now injects the host-matched strict errno mode (`ERRNO_MODE_MACOS`/`ERRNO_MODE_UNIX`) into the Rust suite — unset, upstream's assertions are the permissive union of per-OS arms, which is how these bugs hid. Scoped to Rust (the C/AS suites assert exact environ contents); no ledger changes needed.

Tests: two shared fixtures (`wasi_trailing_slash{,_symlink}.wat`) pin the family on all five backends; the #41 bash pin for the nonexistent-destination shape now asserts the strip. Pre-fix Ruby demonstrably failed (`a00`: renamed through the slash).

Verification: probe matrix + both fixtures measured against wasmtime 47 on macOS and Linux (docker); `fmt`, `clippy -D warnings`, workspace `cargo test`, full suites for all five backends (wasi_testsuite strict 72/72 each) on macOS; the five upstream trailing-slash trials plus both fixtures re-run per backend on Linux under `ERRNO_MODE_UNIX=1` — all pass. Runtime survey (wasmer/WasmEdge/Node) in the comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)