### PR TITLE
Trim over-explaining comments from the review-fix PRs

### DIFF
--- a/crates/dewasm-backend-python/src/lib.rs
+++ b/crates/dewasm-backend-python/src/lib.rs
@@ -240,8 +240,7 @@ impl Backend for PythonBackend {
         w.line("import struct");
         w.line("import sys");
         if opts.mode == Mode::Standalone {
-            // Backs the ADR-28 big-stack guest thread in the standalone
-            // entrypoint below; library mode never needs it.
+            // For the ADR-28 guest thread in the standalone entrypoint.
             w.line("import threading");
         }
         w.line("import time");
@@ -315,15 +314,10 @@ impl Backend for PythonBackend {
             } else {
                 w.line(format!("_inst = {class_name}()"));
             }
-            // Deep-but-valid guest recursion needs far more than CPython's
-            // default ~1000-frame limit, and raising the limit alone risks a
-            // C-stack overflow, so the guest runs on a big-stack thread with a
-            // raised recursion limit — the same values the spec harness uses
-            // (ADR-28). The thread carries any exception back so proc_exit and
-            // traps still resolve to ADR-31's exit codes via `sys.exit` on the
-            // main thread. A daemon thread lets a KeyboardInterrupt delivered
-            // to the main thread (blocked in `join`) exit the process without
-            // waiting for the guest, as when the guest ran on the main thread.
+            // ADR-28: run the guest on a big-stack thread with a raised
+            // recursion limit (the spec harness's values). The thread carries
+            // exceptions back so proc_exit/traps still exit via the main
+            // thread; daemon so Ctrl-C during `join` still terminates.
             w.line("_err = []");
             w.line("");
             w.line("def _run():");

--- a/crates/dewasm-cli/src/main.rs
+++ b/crates/dewasm-cli/src/main.rs
@@ -98,10 +98,8 @@ fn main() -> Result<()> {
                      must be written to a real path next to the generated program"
                 );
             }
-            // The sidecar and the primary source are written independently
-            // (the loop below); a --data-file that resolves to the same file
-            // as -o would clobber the freshly written source with the data
-            // blob. Fail before anything is written (ADR-0).
+            // A --data-file resolving to the same file as -o would clobber
+            // the generated source; fail before anything is written (ADR-0).
             if resolve_for_collision(path) == resolve_for_collision(&cli.output) {
                 bail!(
                     "--data-file {} resolves to the same file as the output path {}: \
@@ -160,13 +158,10 @@ fn main() -> Result<()> {
     // `sidecar_name`) goes to `--data-file`'s path, the primary source to
     // `-o` (ADR-37).
     let sidecar_name = opts.data_file.as_ref().map(|c| c.sidecar_name.as_str());
-    // Only the sidecar itself may carry `sidecar_name`: a generated source
-    // file sharing that name (e.g. the java backend's fixed `Main.java`)
-    // would be misrouted to the sidecar path and clobbered by the blob.
-    // Two shapes: with data segments the source *and* the sidecar match
-    // (`matching > 1`); without, the backend emits no sidecar and the lone
-    // matching file is the source (`matching == files.len()`). Fail before
-    // anything is written (ADR-0).
+    // A generated source sharing `sidecar_name` (e.g. java's fixed
+    // `Main.java`) would be misrouted and clobbered: `matching > 1` = source
+    // and sidecar collide, `matching == files.len()` = no sidecar emitted and
+    // the match is the source itself (ADR-0).
     if let Some(name) = sidecar_name {
         let matching = files.iter().filter(|f| f.name == name).count();
         if matching > 1 || matching == files.len() {
@@ -198,12 +193,9 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-/// Resolve `path` for the --data-file/-o collision check: canonicalize as far
-/// as the filesystem allows — the file itself when it exists, otherwise its
-/// parent directory (the write target's location) joined with the final
-/// component — so differently spelled paths (`out.py` vs `./out.py`, `..`
-/// hops, symlinked directories) compare equal. Falls back to the
-/// cwd-anchored absolute form when nothing exists yet.
+/// Canonicalize for the --data-file/-o collision check (the file, else
+/// parent + final component, else cwd-anchored absolute) so differently
+/// spelled paths compare equal.
 fn resolve_for_collision(path: &Path) -> PathBuf {
     if let Ok(resolved) = path.canonicalize() {
         return resolved;

--- a/crates/dewasm-core/src/data_merge.rs
+++ b/crates/dewasm-core/src/data_merge.rs
@@ -1,50 +1,28 @@
 //! Adjacent active-data-segment merging (ADR-41).
 //!
-//! Toolchains such as LLVM can split a program's initialized data across
-//! thousands of tiny active segments (ruby.wasm ships 7871). Every backend
-//! emits one initializer per active segment, so collapsing runs of
-//! consecutive, near-adjacent segments into a single zero-filled blob is a
-//! semantics-preserving win that composes with every downstream backend for
-//! free. This pass runs unconditionally at the end of module building.
+//! Toolchains split initialized data across thousands of tiny active segments
+//! (ruby.wasm ships 7871); merging runs of near-adjacent ones into a single
+//! zero-filled blob shrinks every backend's output. Runs at the end of module
+//! building.
 //!
-//! Four guards make the rewrite sound; failing any of them bails the whole
-//! pass (leaving `module.datas` untouched):
+//! Four guards keep the rewrite sound; failing any bails the whole pass:
 //!
-//! 1. **No bulk-memory segment references.** `memory.init` / `data.drop`
-//!    address segments *by index*; merging renumbers and drops indices, so a
-//!    single such op anywhere makes the pass unsafe.
-//! 2. **Declaration order is never reordered.** Only runs of segments already
-//!    consecutive in `module.datas` are merged; active segments initialize in
-//!    order and later writes win, so preserving order preserves the final
-//!    memory image.
-//! 3. **Active `i32.const` segments are globally ascending and
-//!    non-overlapping.** This proves no other constant-offset segment occupies
-//!    a gap between two merged segments, so zero-filling that gap cannot erase
-//!    a byte some other constant-offset segment wrote.
-//! 4. **Every active segment has an `i32.const` offset.** A `global.get`
-//!    offset writes to a runtime-unknown address that guard 3 cannot exclude
-//!    from the gaps: if it lands inside one and a merged blob is emitted after
-//!    it, the gap's zero fill silently clobbers its bytes (issue #28 — with
-//!    `[(global.get base) "XX", (i32.const 0) "ab", (i32.const 8) "cd"]` and
-//!    `base = 4`, the merged blob's zeros at 2..8 erase "XX" at 4..6). One
-//!    such segment anywhere therefore bails the whole pass, keeping guard 3's
-//!    "no segment occupies a gap" claim true for *every* segment. This forgoes
-//!    merging in mixed modules, but real toolchain output is all-const
-//!    (non-PIC) or all-`global.get __memory_base` (PIC, nothing to merge
-//!    either way), so nothing of value is lost.
+//! 1. **No `memory.init`/`data.drop`** — they address segments by index.
+//! 2. **Declaration order is preserved** — segments apply in order, later
+//!    writes win.
+//! 3. **Active `i32.const` segments are ascending and non-overlapping** — so
+//!    no const-offset segment sits inside a zero-filled gap.
+//! 4. **No `global.get` offsets** — such a segment's runtime-unknown target
+//!    could sit inside a gap and be clobbered by the blob's zeros (issue #28).
 //!
-//! Passive segments (`offset: None`) carry no standalone memory effect once
-//! guard 1 has ruled out `memory.init`, so they pass straight through without
-//! closing an open run.
+//! Passive segments carry no memory effect once guard 1 holds and pass
+//! through without closing a run.
 
 use crate::ir::{DataSegment, Expr, Module, Stmt};
 
-/// Largest byte gap between two consecutive active segments that is still worth
-/// bridging with zero fill. The bytes are emitted inline by every backend
-/// unconditionally (the `--data-file` externalization threshold is a separate,
-/// backend-visible concern; this pass runs in the core, which cannot see
-/// `GenOptions`), so the figure is tuned to the always-on inline cost rather
-/// than to wasm2go's externalize-only 4096.
+/// Largest gap worth bridging with zero fill. Tuned to the always-on inline
+/// cost (the core cannot see `GenOptions`), not wasm2go's externalize-only
+/// 4096.
 const MAX_MERGE_GAP: u64 = 64;
 
 /// Merge runs of adjacent active data segments in `module`, in place.
@@ -61,9 +39,7 @@ pub(crate) fn merge_adjacent_data_segments(module: &mut Module) {
         return;
     }
 
-    // Guard 4: no active segment may have a non-constant (global.get) offset —
-    // its runtime-unknown target could sit inside a gap a merged blob
-    // zero-fills.
+    // Guard 4: no non-constant (global.get) offsets.
     if module
         .datas
         .iter()
@@ -100,9 +76,8 @@ pub(crate) fn merge_adjacent_data_segments(module: &mut Module) {
             }
             // Passive: no standalone memory effect, keep the run open.
             None => out.push(DataSegment { offset: None, data }),
-            // Non-constant offset: unreachable under guard 4; kept as an
-            // order-preserving pass-through so a future guard change cannot
-            // silently reorder writes.
+            // Unreachable under guard 4; kept as an order-preserving
+            // pass-through.
             Some(other) => {
                 if let Some((run_start, acc)) = run.take() {
                     out.push(active_segment(run_start, acc));

--- a/runtime/java/units/memory/grow.java
+++ b/runtime/java/units/memory/grow.java
@@ -1,9 +1,6 @@
-// memory.grow: extend by `delta` pages (delta read unsigned); returns the old
-// size in pages, or -1 (i32 0xFFFFFFFF) if the request cannot be satisfied.
-// The byte size is computed in long and checked against the byte[] cap before
-// the int cast (32768 pages is already 2^31 bytes, one past what a Java array
-// can hold), and an allocation failure is likewise reported as -1 — wasm lets
-// grow fail, never crash.
+// memory.grow: returns the old size in pages, or -1 when unsatisfiable.
+// Byte size checked in long against the byte[] cap (32768 pages > max array);
+// allocation failure is also -1 — wasm lets grow fail, never crash.
 int grow(int delta) {
     int old = d.length / 65536;
     long want = (long) old + (delta & 0xFFFFFFFFL);

--- a/runtime/java/units/wasi/fd_readdir.java
+++ b/runtime/java/units/wasi/fd_readdir.java
@@ -17,9 +17,8 @@ int wasi_fd_readdir(int fd, int bufPtr, int bufLen, long cookie, int bufusedPtr)
     }
     long lim = Integer.toUnsignedLong(bufLen);
     java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
-    // The u64 cookie lives in a signed long: compare unsigned so a high-bit
-    // cookie reads as a huge position past any snapshot's end (an empty
-    // result, matching wasmtime) instead of a negative subscript.
+    // u64 cookie in a signed long: compare unsigned so a high-bit cookie is
+    // past-the-end (empty result), not a negative subscript.
     long i = cookie;
     while (Long.compareUnsigned(i, dir.entries.size()) < 0 && out.size() < lim) {
         Dirent ent = dir.entries.get((int) i);


### PR DESCRIPTION
Comment-only trim of the prose added by #36-#40 (files touched by open PR #43 are trimmed there). Verified: fmt, clippy -D warnings, fast gate for the four touched crates.

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)