### PR TITLE
Docs cleanup for 0.1: stop hard-wrapping, rewrite README intro

### DIFF
--- a/.claude/skills/adr-author/SKILL.md
+++ b/.claude/skills/adr-author/SKILL.md
@@ -10,24 +10,17 @@ description: |
 
 # Author an ADR
 
-The quality bar is defined in [`docs/adr/README.md`](../../../docs/adr/README.md) § "Adding a
-new ADR" — read it; do not re-derive it here. This skill is the mechanical procedure, which is
-where ADR authoring actually slips (numbering, index drift, missing cross-refs).
+The quality bar is defined in [`docs/adr/README.md`](../../../docs/adr/README.md) § "Adding a new ADR" — read it; do not re-derive it here. This skill is the mechanical procedure, which is where ADR authoring actually slips (numbering, index drift, missing cross-refs).
 
-The recurring authoring mistake is writing too much for the stakes, not too little. Bias toward
-brevity; a small decision must read small. ADR-5 is a reasonable length target for a
-policy-sized decision, ADR-0 for a foundation-sized one.
+The recurring authoring mistake is writing too much for the stakes, not too little. Bias toward brevity; a small decision must read small. ADR-5 is a reasonable length target for a policy-sized decision, ADR-0 for a foundation-sized one.
 
 ## Step 0 — Does this need an ADR?
 
-An ADR records a **decision with rationale and rejected alternatives**, or a standing policy.
-Not an ADR:
+An ADR records a **decision with rationale and rejected alternatives**, or a standing policy. Not an ADR:
 
 - A mechanical change with no live alternatives → commit message.
-- Behaviour the spec harness already enforces → the harness binds
-  ([ADR-3](../../../docs/adr/3-testing-strategy.md)); an ADR only ever records *why*.
-- A survey or measurement with no decision attached → keep it out, or park it in the PR/issue
-  and cite it.
+- Behaviour the spec harness already enforces → the harness binds ([ADR-3](../../../docs/adr/3-testing-strategy.md)); an ADR only ever records *why*.
+- A survey or measurement with no decision attached → keep it out, or park it in the PR/issue and cite it.
 
 If no alternatives were weighed, there is no decision to record.
 
@@ -54,18 +47,14 @@ Anchor claims to real files (`crates/.../file.rs`, `runtime/<lang>/...`).
 
 ## Step 2 — Index
 
-Add the row to the table in [`docs/adr/README.md`](../../../docs/adr/README.md), in ascending
-order, with the capped status (e.g. `Accepted (not yet implemented)`).
+Add the row to the table in [`docs/adr/README.md`](../../../docs/adr/README.md), in ascending order, with the capped status (e.g. `Accepted (not yet implemented)`).
 
 ## Step 3 — Cross-references
 
-Link related ADRs from the new one and back-link where it matters. If the decision changes how
-contributors must work, add or adjust the one-line rule in `AGENTS.md` citing the ADR — the rule
-there, the why in the ADR, never both places in full.
+Link related ADRs from the new one and back-link where it matters. If the decision changes how contributors must work, add or adjust the one-line rule in `AGENTS.md` citing the ADR — the rule there, the why in the ADR, never both places in full.
 
 ## Verification
 
-- Index row count equals ADR file count: `ls docs/adr/*.md | grep -v README | wc -l` vs. the
-  table.
+- Index row count equals ADR file count: `ls docs/adr/*.md | grep -v README | wc -l` vs. the table.
 - Every relative link in the new ADR resolves (`ls` the targets).
 - If the ADR supersedes another, the old one's Status says so and links forward.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,25 +1,17 @@
-<!--
-Maintainer notes. Block-level HTML comments are stripped before this file enters an agent's
-context:
+<!-- Maintainer notes. Block-level HTML comments are stripped before this file enters an agent's context:
 
 - Claude Code reads CLAUDE.md, not AGENTS.md; CLAUDE.md pulls this file in with `@AGENTS.md`.
-- Everything here loads into every session. Keep it short and keep it INSTRUCTIONS; explain a
-  rule's why only when the why changes what you do.
+- Everything here loads into every session. Keep it short and keep it INSTRUCTIONS; explain a rule's why only when the why changes what you do.
 - Material needed only inside one area belongs in .claude/skills/ or docs/, never here.
 -->
 
 # AGENTS.md
 
-Agent contract for dewasm. Project docs are written in English; `tests/spec` is an upstream
-submodule — never edit it.
+Agent contract for dewasm. Project docs are written in English; `tests/spec` is an upstream submodule — never edit it.
 
 ## Development environment
 
-Rust toolchain is pinned by `rust-toolchain.toml` (stable); plain `cargo` commands pick it up.
-Required tools/setup for the test suite (ruby >= 3.4, bash >= 5, the spec submodule, the `apps` cache)
-and the fail-loud-not-skip policy behind it (ADR-15) are documented in
-[`docs/testing.md`](docs/testing.md) — read it before wondering why a test panics with a setup
-instruction instead of skipping.
+Rust toolchain is pinned by `rust-toolchain.toml` (stable); plain `cargo` commands pick it up. Required tools/setup for the test suite (ruby >= 3.4, bash >= 5, the spec submodule, the `apps` cache) and the fail-loud-not-skip policy behind it (ADR-15) are documented in [`docs/testing.md`](docs/testing.md) — read it before wondering why a test panics with a setup instruction instead of skipping.
 
 ## Common commands
 
@@ -35,64 +27,21 @@ instruction instead of skipping.
 
 ## Verification
 
-After any non-trivial change, run `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`,
-and `cargo test`. Tests run in tiers ([ADR-48](docs/adr/48-slow-test-tiers.md)): `cargo test` is the
-fast gate. `--features slow_test` adds each backend's slow app cases (QuickJS, SQLite, the
-filesystem/C-API apps, the interactive-REPL pty case) plus the full spec-testsuite sweep — this is
-CI's main sweep, gated by that backend's `slow_test` cargo feature rather than an environment
-variable. `--features ultra_slow_test` (or the everything-included `cargo test -- --include-ignored`)
-additionally runs the ultra tier — the cases measured at ~1 minute or more on a CI runner (the bash
-interactive-REPL pty case, go's giant generated-program builds), which are deliberately kept out of
-CI and run only in local pre-release verification. Spec-harness failures mean a
-semantics bug: fix the cause. Adding to a per-backend `EXPECTED_FAILURES` ledger in
-`crates/dewasm-backend-<lang>/tests/spec.rs` is a last resort and requires an attribution tag plus a
-reason ([ADR-8](docs/adr/8-latest-testsuite-support-matrix.md)). When support declarations or WASI
-units change, regenerate the matrix: `cargo xtask update-support-docs` (`cargo test -p dewasm-cli
---test support_docs` fails while docs/support.md is stale).
+After any non-trivial change, run `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test`. Tests run in tiers ([ADR-48](docs/adr/48-slow-test-tiers.md)): `cargo test` is the fast gate. `--features slow_test` adds each backend's slow app cases (QuickJS, SQLite, the filesystem/C-API apps, the interactive-REPL pty case) plus the full spec-testsuite sweep — this is CI's main sweep, gated by that backend's `slow_test` cargo feature rather than an environment variable. `--features ultra_slow_test` (or the everything-included `cargo test -- --include-ignored`) additionally runs the ultra tier — the cases measured at ~1 minute or more on a CI runner (the bash interactive-REPL pty case, go's giant generated-program builds), which are deliberately kept out of CI and run only in local pre-release verification. Spec-harness failures mean a semantics bug: fix the cause. Adding to a per-backend `EXPECTED_FAILURES` ledger in `crates/dewasm-backend-<lang>/tests/spec.rs` is a last resort and requires an attribution tag plus a reason ([ADR-8](docs/adr/8-latest-testsuite-support-matrix.md)). When support declarations or WASI units change, regenerate the matrix: `cargo xtask update-support-docs` (`cargo test -p dewasm-cli --test support_docs` fails while docs/support.md is stale).
 
 ## Implementation guidelines
 
-- Where the WASI spec is silent (trailing-slash paths, errno flavors), behavior copies
-  wasmtime as measured on both CI hosts, and the wasi-testsuite Rust suite runs under
-  host-pinned strict errno modes ([ADR-49](docs/adr/49-spec-silent-follow-wasmtime.md)).
-- **The spec testsuite binds; an ADR says why** ([ADR-3](docs/adr/3-testing-strategy.md)).
-  Correctness of generated code outranks its readability ([ADR-1](docs/adr/1-ir-design.md));
-  readability improvements go into optional passes, never into semantics-relevant lowering.
-- Numeric representation conventions (masked-unsigned integers, f32 re-rounding, NaN bit paths)
-  are fixed in [ADR-2](docs/adr/2-numeric-semantics.md); new backends follow them. Per-backend
-  lowering shapes live in [ADR-4](docs/adr/4-ruby-backend-lowering.md) (Ruby) and
-  [ADR-11](docs/adr/11-bash-backend-lowering.md) (Bash — incl. the status-cascade trap
-  protocol and the `return 0` discipline the units lint enforces); Bash WASI conventions
-  (status-133 proc_exit, byte-wise binary stdio) in [ADR-12](docs/adr/12-bash-wasi.md);
-  the Bash softfloat (bit-pattern floats, the round_pack contract, the Rust-oracle test
-  in `crates/dewasm-backend-bash/tests/softfloat.rs`) in
-  [ADR-13](docs/adr/13-bash-softfloat-conventions.md); Ruby WASI filesystem support (the
-  `preopens:` provider kwarg, the fd-table model, and the accepted TOCTOU sandboxing caveat)
-  in [ADR-14](docs/adr/14-ruby-wasi-filesystem.md), completed to full WASI p1 — the symlink
-  family and the enforced per-fd rights model — by [ADR-40](docs/adr/40-wasi-p1-completion.md).
-- Runtime code lives as per-method units under `runtime/<lang>/units/` with `# requires:`
-  headers, referenced as `Rt` ([ADR-6](docs/adr/6-runtime-units.md)); keep the headers in sync
-  when editing a unit — the units lint test enforces most of it.
-- A new backend is done when the shared spec harness passes for it — not before
-  ([ADR-3](docs/adr/3-testing-strategy.md)).
-- Backends declare their capabilities directly — feature support (`Backend::feature_status`) and
-  per-function WASI p1 coverage (`Backend::has_wasi_p1`) — rendered flat into `docs/support.md`;
-  the standard goal for a new backend is wasm 1.0 + full WASI p1. Wasm 2.0+ proposals and the
-  component model are rejected outright, not a backend opt-in (ADR-24) — see
-  [ADR-25](docs/adr/25-retire-support-tiers.md) for why the former per-backend tier ladder was
-  retired.
-- Unsupported wasm features must fail at conversion time with a clear error, never at runtime
-  ([ADR-0](docs/adr/0-foundation.md)). Non-function imports, multiple tables, and table bulk ops
-  are accepted by the core IR unconditionally; a backend that hasn't implemented one must reject
-  it itself via `dewasm_backend::check_module_support` ([ADR-16](docs/adr/16-ruby-wasm1-completion.md)),
-  which also covers the `Rt::Global` box, the import-kind check, and the spec harness's `register`
-  support.
+- Where the WASI spec is silent (trailing-slash paths, errno flavors), behavior copies wasmtime as measured on both CI hosts, and the wasi-testsuite Rust suite runs under host-pinned strict errno modes ([ADR-49](docs/adr/49-spec-silent-follow-wasmtime.md)).
+- **The spec testsuite binds; an ADR says why** ([ADR-3](docs/adr/3-testing-strategy.md)). Correctness of generated code outranks its readability ([ADR-1](docs/adr/1-ir-design.md)); readability improvements go into optional passes, never into semantics-relevant lowering.
+- Numeric representation conventions (masked-unsigned integers, f32 re-rounding, NaN bit paths) are fixed in [ADR-2](docs/adr/2-numeric-semantics.md); new backends follow them. Per-backend lowering shapes live in [ADR-4](docs/adr/4-ruby-backend-lowering.md) (Ruby) and [ADR-11](docs/adr/11-bash-backend-lowering.md) (Bash — incl. the status-cascade trap protocol and the `return 0` discipline the units lint enforces); Bash WASI conventions (status-133 proc_exit, byte-wise binary stdio) in [ADR-12](docs/adr/12-bash-wasi.md); the Bash softfloat (bit-pattern floats, the round_pack contract, the Rust-oracle test in `crates/dewasm-backend-bash/tests/softfloat.rs`) in [ADR-13](docs/adr/13-bash-softfloat-conventions.md); Ruby WASI filesystem support (the `preopens:` provider kwarg, the fd-table model, and the accepted TOCTOU sandboxing caveat) in [ADR-14](docs/adr/14-ruby-wasi-filesystem.md), completed to full WASI p1 — the symlink family and the enforced per-fd rights model — by [ADR-40](docs/adr/40-wasi-p1-completion.md).
+- Runtime code lives as per-method units under `runtime/<lang>/units/` with `# requires:` headers, referenced as `Rt` ([ADR-6](docs/adr/6-runtime-units.md)); keep the headers in sync when editing a unit — the units lint test enforces most of it.
+- A new backend is done when the shared spec harness passes for it — not before ([ADR-3](docs/adr/3-testing-strategy.md)).
+- Backends declare their capabilities directly — feature support (`Backend::feature_status`) and per-function WASI p1 coverage (`Backend::has_wasi_p1`) — rendered flat into `docs/support.md`; the standard goal for a new backend is wasm 1.0 + full WASI p1. Wasm 2.0+ proposals and the component model are rejected outright, not a backend opt-in (ADR-24) — see [ADR-25](docs/adr/25-retire-support-tiers.md) for why the former per-backend tier ladder was retired.
+- Unsupported wasm features must fail at conversion time with a clear error, never at runtime ([ADR-0](docs/adr/0-foundation.md)). Non-function imports, multiple tables, and table bulk ops are accepted by the core IR unconditionally; a backend that hasn't implemented one must reject it itself via `dewasm_backend::check_module_support` ([ADR-16](docs/adr/16-ruby-wasm1-completion.md)), which also covers the `Rt::Global` box, the import-kind check, and the spec harness's `register` support.
 
 ## ADRs
 
-Significant decisions — anything with real alternatives — are recorded in
-[`docs/adr/`](docs/adr/README.md). The `adr-author` skill carries the procedure (numbering, the
-skeleton, the index update). Do not restate ADR content elsewhere; link to it.
+Significant decisions — anything with real alternatives — are recorded in [`docs/adr/`](docs/adr/README.md). The `adr-author` skill carries the procedure (numbering, the skeleton, the index update). Do not restate ADR content elsewhere; link to it.
 
 ## Commit etiquette
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,13 +1,8 @@
 @AGENTS.md
 
-<!-- The contract lives in AGENTS.md so every agent gets it; the `@AGENTS.md` import above is how
-     Claude Code loads it (it reads CLAUDE.md, not AGENTS.md). Add only Claude-specific rules
-     below — anything true for every agent belongs in AGENTS.md. -->
+<!-- The contract lives in AGENTS.md so every agent gets it; the `@AGENTS.md` import above is how Claude Code loads it (it reads CLAUDE.md, not AGENTS.md). Add only Claude-specific rules below — anything true for every agent belongs in AGENTS.md. -->
 
 ## Claude Code
 
-- Skills are auto-discovered from [`.claude/skills/`](.claude/skills/); each `SKILL.md`'s
-  `description:` routes to it, so no catalogue is kept here. `adr-author` covers writing a new
-  ADR under `docs/adr/`.
-- A subagent does not inherit this contract; restate what binds it (the spec-harness gate, the
-  `tests/spec` read-only rule) in its prompt.
+- Skills are auto-discovered from [`.claude/skills/`](.claude/skills/); each `SKILL.md`'s `description:` routes to it, so no catalogue is kept here. `adr-author` covers writing a new ADR under `docs/adr/`.
+- A subagent does not inherit this contract; restate what binds it (the spec-harness gate, the `tests/spec` read-only rule) in its prompt.

--- a/README.md
+++ b/README.md
@@ -2,17 +2,9 @@
 
 ![logo](./assets/dewasm_logo_hex_gradient.png)
 
-dewasm translates a WebAssembly binary into the **source code** of an
-ordinary programming language. The generated file embeds a small runtime and
-needs no wasm engine at all: a program compiled from C, C++, Rust, or Zig to
-`wasm32-wasip1` becomes a single `.rb`, `.sh`, `.py`, `.go`, or `.java` file
-that runs anywhere that language runs. One shared IR feeds every backend, so
-each new target is a lowering table plus runtime units rather than a fresh
-translator ([docs/related-work.md](docs/related-work.md) compares the prior
-art).
+dewasm translates a WebAssembly binary into the **source code** of an ordinary programming language. The generated file embeds a small runtime and needs no wasm engine at all: a program compiled from C, C++, Rust, or Zig to `wasm32-wasip1` becomes a single `.rb`, `.sh`, `.py`, `.go`, or `.java` file that runs anywhere that language runs. One shared IR feeds every backend, so each new target is a lowering table plus runtime units rather than a fresh translator ([docs/related-work.md](docs/related-work.md) compares the prior art).
 
-Here is `cowsay`, a C program, converted to a **pure Bash script** and run
-with nothing but a shell:
+Here is `cowsay`, a C program, converted to a **pure Bash script** and run with nothing but a shell:
 
 ```console
 $ dewasm examples/apps/cache/cowsay.wasm --target bash --mode standalone -o cowsay.sh
@@ -27,21 +19,15 @@ $ echo "Hello from Bash" | bash cowsay.sh
                 ||     ||
 ```
 
-The same binary — and much larger ones, up to SQLite and CPython — convert to
-Ruby, Python, Go, and Java just as well.
+The same binary, and much larger ones, up to SQLite and CPython, convert to Ruby, Python, Go, and Java just as well.
 
 ## Status
 
-**Early development, heading toward 0.1.** All five backends pass the
-WebAssembly core spec testsuite for the supported feature set (~29,000
-assertions each) and implement WASI preview 1. This is real, tested output,
-not a demo: real-world binaries are proven byte-identical to `wasmtime` (see
-[what it can convert](#what-it-can-convert)).
+**Early development, heading toward 0.1.** All five backends pass the WebAssembly core spec testsuite for the supported feature set (~29,000 assertions each) and implement WASI preview 1. This is real, tested output, not a demo: real-world binaries are proven byte-identical to `wasmtime` (see [what it can convert](#what-it-can-convert)).
 
 ## Target languages
 
-`--target <name>`; every backend shares the same input dialect and the same
-spec gate.
+`--target <name>`; every backend shares the same input dialect and the same spec gate.
 
 | Target | Character | Spec status |
 | --- | --- | --- |
@@ -51,19 +37,13 @@ spec gate.
 | `go` | One self-contained `package main` compiled with `go build`; full WASI p1 | spec-green |
 | `java` | One `.java` compiled with `javac`; splits huge modules across classes; full WASI p1 | spec-green |
 
-The authoritative, generated feature/WASI matrix per backend is
-[`docs/support.md`](docs/support.md). Bash is the deliberate outlier: no WASI
-filesystem, and non-function imports / multiple tables / table bulk ops are
-rejected at conversion time.
+The authoritative, generated feature/WASI matrix per backend is [`docs/support.md`](docs/support.md). Bash is the deliberate outlier: no WASI filesystem, and non-function imports / multiple tables / table bulk ops are rejected at conversion time.
 
-Later target languages, deliberately out of 0.1 scope: Haskell, OCaml, C#,
-and PHP ([ADR-24](docs/adr/24-01-scope-reset.md),
-[ADR-10](docs/adr/10-csharp-target.md)).
+Later target languages, deliberately out of 0.1 scope: Haskell, OCaml, C#, PHP, and Perl ([ADR-24](docs/adr/24-01-scope-reset.md), [ADR-10](docs/adr/10-csharp-target.md)).
 
 ## Install
 
-Build from source with the pinned Rust toolchain (picked up automatically
-from `rust-toolchain.toml`):
+Build from source with the pinned Rust toolchain (picked up automatically from `rust-toolchain.toml`):
 
 ```console
 $ cargo install --git https://github.com/dewasm/dewasm dewasm-cli
@@ -77,10 +57,7 @@ $ cd dewasm
 $ cargo build --release        # binary at target/release/dewasm
 ```
 
-dewasm itself has no runtime dependency beyond Rust. *Running* the generated
-code needs only that language's own interpreter or toolchain — `ruby`,
-`bash` 5+, `python3` 3.9+, `go` 1.18+, or a JDK 11+. Per-target details are in
-[docs/backends/](docs/backends/).
+dewasm itself has no runtime dependency beyond Rust. *Running* the generated code needs only that language's own interpreter or toolchain — `ruby`, `bash` 5+, `python3` 3.9+, `go` 1.18+, or a JDK 11+. Per-target details are in [docs/backends/](docs/backends/).
 
 ## Usage
 
@@ -89,9 +66,7 @@ $ dewasm input.wasm --target <ruby|bash|python|go|java> --mode <standalone|libra
 ```
 
 - `--target` selects the language (default `ruby`).
-- `--mode standalone` wires up WASI and runs the module's `_start`;
-  `--mode library` (default) exposes the module's exports to the host
-  language.
+- `--mode standalone` wires up WASI and runs the module's `_start`; `--mode library` (default) exposes the module's exports to the host language.
 - `.wat` text input is accepted directly (no separate assembler step).
 - `-o -` writes to stdout.
 
@@ -103,10 +78,7 @@ $ python3 hello.py
 Hello, WASI!
 ```
 
-Standalone programs share one runtime interface across every backend, modelled
-on wasmtime's CLI — guest arguments after the program, host directories mounted
-with repeatable `--dir HOST::GUEST` flags — documented in
-[docs/standalone-interface.md](docs/standalone-interface.md).
+Standalone programs share one runtime interface across every backend, modelled on wasmtime's CLI — guest arguments after the program, host directories mounted with repeatable `--dir HOST::GUEST` flags — documented in [docs/standalone-interface.md](docs/standalone-interface.md).
 
 Library mode hands you the module as a class/type to call from your own code:
 
@@ -121,97 +93,33 @@ inst.invoke("add", 2, 3)       # => 5
 inst.memory                    # linear memory, if any
 ```
 
-WASI imports work out of the box in library mode: any import the embedder does
-not supply falls back to a bundled WASI implementation (built only if actually
-used; disable with `--no-default-wasi`). You can also override individual
-imports or replace a whole namespace with a *provider* object — see the
-[getting-started guide](docs/getting-started.md) and
-[ADR-7](docs/adr/7-import-providers.md).
+WASI imports work out of the box in library mode: any import the embedder does not supply falls back to a bundled WASI implementation (built only if actually used; disable with `--no-default-wasi`). You can also override individual imports or replace a whole namespace with a *provider* object — see the [getting-started guide](docs/getting-started.md) and [ADR-7](docs/adr/7-import-providers.md).
 
-A full walkthrough — standalone and library, with a provider override —
-lives in [docs/getting-started.md](docs/getting-started.md).
+A full walkthrough — standalone and library, with a provider override — lives in [docs/getting-started.md](docs/getting-started.md).
 
 ## What it can convert
 
-Every app below is a pinned, real-world binary; the byte-for-byte comparison
-against `wasmtime` is a checked-in test gate ([docs/apps-audit.md](docs/apps-audit.md)).
-`examples/apps/fetch.sh` fetches or builds them into a local cache
-([ADR-9](docs/adr/9-example-apps-from-registry.md)).
+Every app below is a pinned, real-world binary; the byte-for-byte comparison against `wasmtime` is a checked-in test gate ([docs/apps-audit.md](docs/apps-audit.md)). `examples/apps/fetch.sh` fetches or builds them into a local cache ([ADR-9](docs/adr/9-example-apps-from-registry.md)).
 
-- **cowsay** — the C classic, byte-identical to `wasmtime` on **all five
-  backends**.
-- **minigzip** (zlib) — a binary-stdio gzip CLI, byte-exact compression on
-  **all five backends** (including Bash — it has no floats).
-- **QuickJS** — a complete JavaScript engine as one generated file: one-shot
-  `-e` eval on all backends, plus file I/O and a scripted REPL against a
-  preopened directory on the filesystem-capable backends.
-- **SQLite** — the shell (in-memory and on a real DB file) plus a C-API
-  library drive and a guest→host callback binding.
-- **ripgrep** — a recursive directory search, byte-identical to
-  `wasmtime --dir`.
-- **CPython** and **CRuby** — both language runtimes convert *and execute* on
-  the Ruby backend, each reading its stdlib from a preopened directory.
-  Converting a runtime and running it back on Ruby is the **"Ruby on Ruby"**
-  north-star, achieved.
-
-Honest caveats: the slow apps (QuickJS, SQLite, CPython, CRuby) are `#[ignore]`d
-by default in the test suite — gated behind each backend crate's `slow_test`
-cargo feature ([ADR-48](docs/adr/48-slow-test-tiers.md)) — because they are slow and large — CRuby is a ~335 MB Ruby
-source file that runs in ~60 s — and Bash skips them by default because its
-softfloat makes float-heavy programs slow. These are deliberate performance
-opt-outs, not correctness gaps ([ADR-15](docs/adr/15-tests-fail-not-skip.md)).
-
-The other north-star demo — a library-mode SQLite as a pure-Ruby `sqlite3`
-driver, real enough to run Ruby on Rails against a dewasm-converted SQLite —
-has shipped as `examples/rails`
-([ADR-45](docs/adr/45-rails-sqlite3-shim-example.md)): an unmodified Rails 8
-app served over HTTP with `libsqlite3.wasm` converted to Ruby as its only
-database engine. C/Rust tools running under plain Bash are demonstrated
-above by `cowsay` and `minigzip`.
-
-## Scope
-
-0.1 targets exactly **wasm core 1.0 + WASI preview 1**, plus the extensions
-every C/Rust/Zig toolchain enables by default: mutable globals,
-sign-extension operators, saturating float-to-int, multi-value, and bulk
-memory (`memory.copy`/`fill`/`init`, passive data segments). Wasm 2.0+
-proposals (SIMD, reference types as *constructs*, tail calls, exception
-handling) and the component model are deliberately **out of scope** and
-rejected at conversion time with a clear error, never a runtime surprise
-([ADR-0](docs/adr/0-foundation.md), [ADR-24](docs/adr/24-01-scope-reset.md)).
+- **cowsay** — the classic native application.
+- **minigzip** (zlib) — a binary-stdio gzip CLI, byte-exact compression on **all five backends** (including Bash — it has no floats).
+- **QuickJS** — a complete JavaScript engine as one generated file: one-shot `-e` eval on all backends, plus file I/O and a scripted REPL against a preopened directory on the filesystem-capable backends.
+- **SQLite** — the shell (in-memory and on a real DB file) plus a C-API library drive and a guest→host callback binding.
+- **ripgrep** — a recursive directory search.
+- **CPython** and **CRuby** — both language runtimes convert *and execute* on the Ruby backend, each reading its stdlib from a preopened directory.
 
 ## How it works
 
-- `crates/dewasm-core` decodes and validates the binary (wasmparser) and
-  builds a structured IR: wasm's control flow (block/loop/if/br) is kept
-  as-is — no relooper — and the value stack is flattened into per-slot
-  variables, wasm2c-style ([ADR-1](docs/adr/1-ir-design.md)).
-- `crates/dewasm-backend-*` lower that IR per language. The numeric strategy
-  (masked-unsigned integers, f32 re-rounding, NaN bit exactness) is decided
-  once and shared ([ADR-2](docs/adr/2-numeric-semantics.md)); per-backend
-  lowering shapes have their own ADRs, linked from
-  [docs/backends/](docs/backends/).
-- `runtime/<lang>/units/` holds the runtime as per-method units with declared
-  dependencies; only the units a module actually needs are bundled into the
-  output ([ADR-6](docs/adr/6-runtime-units.md)).
+- `crates/dewasm-core` decodes and validates the binary (wasmparser) and builds a structured IR: wasm's control flow (block/loop/if/br) is kept as-is — no relooper — and the value stack is flattened into per-slot variables, wasm2c-style ([ADR-1](docs/adr/1-ir-design.md)).
+- `crates/dewasm-backend-*` lower that IR per language. The numeric strategy (masked-unsigned integers, f32 re-rounding, NaN bit exactness) is decided once and shared ([ADR-2](docs/adr/2-numeric-semantics.md)); per-backend lowering shapes have their own ADRs, linked from [docs/backends/](docs/backends/).
+- `runtime/<lang>/units/` holds the runtime as per-method units with declared dependencies; only the units a module actually needs are bundled into the output ([ADR-6](docs/adr/6-runtime-units.md)).
 
 ## Documentation
 
 - [docs/getting-started.md](docs/getting-started.md) — a hands-on walkthrough.
-- [docs/backends/](docs/backends/) — per-target reference (output shape, how
-  to run it, requirements, caveats).
+- [docs/backends/](docs/backends/) — per-target reference (output shape, how to run it, requirements, caveats).
 - [docs/support.md](docs/support.md) — the generated feature/WASI matrix.
 - [docs/apps-audit.md](docs/apps-audit.md) — the real-world app gate record.
-- [docs/testing.md](docs/testing.md) — for contributors: what `cargo test`
-  needs.
-- [docs/adr/](docs/adr/README.md) — the design decisions; start at
-  [ADR-0](docs/adr/0-foundation.md).
+- [docs/testing.md](docs/testing.md) — for contributors: what `cargo test` needs.
+- [docs/adr/](docs/adr/README.md) — the design decisions; start at [ADR-0](docs/adr/0-foundation.md).
 - [docs/docs-policy.md](docs/docs-policy.md) — what goes where.
-
-## Toward 0.1
-
-The backends and the app gate are in place, and the GitHub repository has
-been renamed and moved to `dewasm` ([ADR-26](docs/adr/26-rename-dewasm.md)).
-Remaining before tagging 0.1:
-
-1. Cut and tag the 0.1 release.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-# dewasm
+![dewasm logo](./assets/dewasm_logo_hex_gradient.png)
 
-![logo](./assets/dewasm_logo_hex_gradient.png)
+`dewasm` translates a WebAssembly binary into the **source code** of an ordinary programming language.
 
-dewasm translates a WebAssembly binary into the **source code** of an ordinary programming language. The generated file embeds a small runtime and needs no wasm engine at all: a program compiled from C, C++, Rust, or Zig to `wasm32-wasip1` becomes a single `.rb`, `.sh`, `.py`, `.go`, or `.java` file that runs anywhere that language runs. One shared IR feeds every backend, so each new target is a lowering table plus runtime units rather than a fresh translator ([docs/related-work.md](docs/related-work.md) compares the prior art).
-
-Here is `cowsay`, a C program, converted to a **pure Bash script** and run with nothing but a shell:
+Here is [`cowsay`](https://wasmer.io/syrusakbary/cowsay), a WebAssembly binary, converted to a **pure Bash script** and run with nothing but `bash`:
 
 ```console
 $ dewasm examples/apps/cache/cowsay.wasm --target bash --mode standalone -o cowsay.sh
@@ -19,107 +17,77 @@ $ echo "Hello from Bash" | bash cowsay.sh
                 ||     ||
 ```
 
-The same binary, and much larger ones, up to SQLite and CPython, convert to Ruby, Python, Go, and Java just as well.
+As a larger example, [QuickJS-NG](https://quickjs-ng.github.io/quickjs/), a JavaScript engine written in C, can be converted just as well, this time to **pure Ruby**:
 
-## Status
+```console
+$ dewasm examples/apps/cache/qjs.wasm --target ruby --mode standalone -o qjs.rb
+$ ruby qjs.rb -e 'console.log("2**16 =", 2**16); console.log(JSON.stringify(["Ruby", "JavaScript"].sort()))'
+2**16 = 65536
+["JavaScript","Ruby"]
+```
 
-**Early development, heading toward 0.1.** All five backends pass the WebAssembly core spec testsuite for the supported feature set (~29,000 assertions each) and implement WASI preview 1. This is real, tested output, not a demo: real-world binaries are proven byte-identical to `wasmtime` (see [what it can convert](#what-it-can-convert)).
+A WebAssembly binary can also be used as a **library** instead of a standalone command.
+Here, a small example [`add.wat`](examples/wat/add.wat) is converted and its `add` export is called directly from Ruby:
 
-## Target languages
+```console
+$ dewasm examples/wat/add.wat --target ruby --mode library -o add.rb
+```
 
-`--target <name>`; every backend shares the same input dialect and the same spec gate.
+```ruby
+require_relative "add"
 
-| Target | Character | Spec status |
-| --- | --- | --- |
-| `ruby` | The most complete backend; full WASI p1 incl. the filesystem; the SQLite/CRuby north-star host | spec-green |
-| `bash` | Runs where the only dependency is a shell; integer + a pure-Bash IEEE-754 softfloat, no external commands; WASI core, no filesystem | spec-green |
-| `python` | A plain importable module; full WASI p1 incl. the filesystem | spec-green |
-| `go` | One self-contained `package main` compiled with `go build`; full WASI p1 | spec-green |
-| `java` | One `.java` compiled with `javac`; splits huge modules across classes; full WASI p1 | spec-green |
+inst = Add.new
+inst.invoke("add", 2, 3) # => 5
+```
 
-The authoritative, generated feature/WASI matrix per backend is [`docs/support.md`](docs/support.md). Bash is the deliberate outlier: no WASI filesystem, and non-function imports / multiple tables / table bulk ops are rejected at conversion time.
+This scales to real libraries too: `dewasm` converts SQLite itself to pure Ruby in [examples/rails](examples/rails), which drives a minimal Rails app with it as the only database engine.
 
-Later target languages, deliberately out of 0.1 scope: Haskell, OCaml, C#, PHP, and Perl ([ADR-24](docs/adr/24-01-scope-reset.md), [ADR-10](docs/adr/10-csharp-target.md)).
+Finally, a quick summary of `dewasm`'s features:
 
-## Install
+- `dewasm` implements most of the [Wasm 1.0](https://www.w3.org/TR/wasm-core-1/) feature set and [WASI preview 1](https://github.com/WebAssembly/WASI/tree/wasi-0.1) API surface, so it can convert most real-world WebAssembly binaries.
+- `dewasm` is polyglot; it translates one WebAssembly binary to several target languages, such as Ruby, Bash, and Go.
+- `dewasm` can output either a standalone script or library source code.
+- `dewasm` bundles only the runtime that a WebAssembly binary actually needs; the output source code contains only the functions the binary uses.
 
-Build from source with the pinned Rust toolchain (picked up automatically from `rust-toolchain.toml`):
+## Installation
+
+Currently, `dewasm` is not published to [crates.io](https://crates.io).
 
 ```console
 $ cargo install --git https://github.com/dewasm/dewasm dewasm-cli
 ```
 
-or clone and build locally:
+or:
 
 ```console
-$ git clone https://github.com/dewasm/dewasm
-$ cd dewasm
-$ cargo build --release        # binary at target/release/dewasm
+$ git clone https://github.com/dewasm/dewasm && cd dewasm
+$ cargo build --release
 ```
-
-dewasm itself has no runtime dependency beyond Rust. *Running* the generated code needs only that language's own interpreter or toolchain — `ruby`, `bash` 5+, `python3` 3.9+, `go` 1.18+, or a JDK 11+. Per-target details are in [docs/backends/](docs/backends/).
 
 ## Usage
 
 ```console
-$ dewasm input.wasm --target <ruby|bash|python|go|java> --mode <standalone|library> -o out
+$ dewasm input.<wasm|wat>
+    --target <ruby|bash|python|go|java>
+    --mode <standalone|library>
+    -o output.<rb|sh|py|go|java>
 ```
 
-- `--target` selects the language (default `ruby`).
-- `--mode standalone` wires up WASI and runs the module's `_start`; `--mode library` (default) exposes the module's exports to the host language.
-- `.wat` text input is accepted directly (no separate assembler step).
-- `-o -` writes to stdout.
+- `input` is a WebAssembly binary to be translated.
+  * `dewasm` accepts a WebAssembly text (WAT) file too.
+- `--target` (or `-t`) selects the target language (default: `ruby`).
+- `--mode` (or `-m`) specifies the translation mode (default: `library`).
+  * `--mode standalone` wires up WASI and runs the module's `_start`.
+  * `--mode library` exposes the module's exports to the target language.
+- `--output` (or `-o`) specifies the output file (default: `-`).
+  * When `-` is specified, `dewasm` outputs the result to `stdout`.
 
-Standalone is the "run this program" shape:
+Note that `dewasm` has additional command-line options such as `--module-name`.
+Please see `dewasm --help` for the full list.
 
-```console
-$ dewasm hello.wat --target python --mode standalone -o hello.py
-$ python3 hello.py
-Hello, WASI!
-```
+## Copyright
 
-Standalone programs share one runtime interface across every backend, modelled on wasmtime's CLI — guest arguments after the program, host directories mounted with repeatable `--dir HOST::GUEST` flags — documented in [docs/standalone-interface.md](docs/standalone-interface.md).
+The MIT license.
+See the [LICENSE](./LICENSE) file.
 
-Library mode hands you the module as a class/type to call from your own code:
-
-```console
-$ dewasm add.wat --target ruby --mode library -o add.rb
-```
-
-```ruby
-require_relative "add"
-inst = Add.new                 # pass an imports table if the module needs one
-inst.invoke("add", 2, 3)       # => 5
-inst.memory                    # linear memory, if any
-```
-
-WASI imports work out of the box in library mode: any import the embedder does not supply falls back to a bundled WASI implementation (built only if actually used; disable with `--no-default-wasi`). You can also override individual imports or replace a whole namespace with a *provider* object — see the [getting-started guide](docs/getting-started.md) and [ADR-7](docs/adr/7-import-providers.md).
-
-A full walkthrough — standalone and library, with a provider override — lives in [docs/getting-started.md](docs/getting-started.md).
-
-## What it can convert
-
-Every app below is a pinned, real-world binary; the byte-for-byte comparison against `wasmtime` is a checked-in test gate ([docs/apps-audit.md](docs/apps-audit.md)). `examples/apps/fetch.sh` fetches or builds them into a local cache ([ADR-9](docs/adr/9-example-apps-from-registry.md)).
-
-- **cowsay** — the classic native application.
-- **minigzip** (zlib) — a binary-stdio gzip CLI, byte-exact compression on **all five backends** (including Bash — it has no floats).
-- **QuickJS** — a complete JavaScript engine as one generated file: one-shot `-e` eval on all backends, plus file I/O and a scripted REPL against a preopened directory on the filesystem-capable backends.
-- **SQLite** — the shell (in-memory and on a real DB file) plus a C-API library drive and a guest→host callback binding.
-- **ripgrep** — a recursive directory search.
-- **CPython** and **CRuby** — both language runtimes convert *and execute* on the Ruby backend, each reading its stdlib from a preopened directory.
-
-## How it works
-
-- `crates/dewasm-core` decodes and validates the binary (wasmparser) and builds a structured IR: wasm's control flow (block/loop/if/br) is kept as-is — no relooper — and the value stack is flattened into per-slot variables, wasm2c-style ([ADR-1](docs/adr/1-ir-design.md)).
-- `crates/dewasm-backend-*` lower that IR per language. The numeric strategy (masked-unsigned integers, f32 re-rounding, NaN bit exactness) is decided once and shared ([ADR-2](docs/adr/2-numeric-semantics.md)); per-backend lowering shapes have their own ADRs, linked from [docs/backends/](docs/backends/).
-- `runtime/<lang>/units/` holds the runtime as per-method units with declared dependencies; only the units a module actually needs are bundled into the output ([ADR-6](docs/adr/6-runtime-units.md)).
-
-## Documentation
-
-- [docs/getting-started.md](docs/getting-started.md) — a hands-on walkthrough.
-- [docs/backends/](docs/backends/) — per-target reference (output shape, how to run it, requirements, caveats).
-- [docs/support.md](docs/support.md) — the generated feature/WASI matrix.
-- [docs/apps-audit.md](docs/apps-audit.md) — the real-world app gate record.
-- [docs/testing.md](docs/testing.md) — for contributors: what `cargo test` needs.
-- [docs/adr/](docs/adr/README.md) — the design decisions; start at [ADR-0](docs/adr/0-foundation.md).
-- [docs/docs-policy.md](docs/docs-policy.md) — what goes where.
+Copyright (c) 2026 Hiroya Fujinami

--- a/crates/dewasm-backend-bash/build.rs
+++ b/crates/dewasm-backend-bash/build.rs
@@ -1,5 +1,4 @@
-//! Embeds the runtime units from runtime/bash/units/ as
-//! `UNIT_SOURCES: &[(&str, &str)]` (unit id, source).
+//! Embeds the runtime units from runtime/bash/units/ as `UNIT_SOURCES: &[(&str, &str)]` (unit id, source).
 
 use std::fmt::Write as _;
 use std::path::Path;

--- a/crates/dewasm-backend-bash/src/lib.rs
+++ b/crates/dewasm-backend-bash/src/lib.rs
@@ -1,27 +1,11 @@
-//! Bash backend: translates dewasm IR into a sourceable Bash script
-//! plus a bundled runtime of flat `rt_*`/`mem_*` functions.
+//! Bash backend: translates dewasm IR into a sourceable Bash script plus a bundled runtime of flat `rt_*`/`mem_*` functions.
 //!
 //! Lowering conventions (ADR-11; numeric conventions ADR-2):
-//! - i32 is a masked-unsigned value in [0, 2^32); i64 is stored as its
-//!   signed-64 two's-complement bit pattern (bash arithmetic is signed
-//!   64-bit only). Signed/unsigned views are derived inline.
-//! - f32/f64 are their bit patterns (u32 / signed-64), computed by the
-//!   pure-Bash softfloat units (ADR-5/ADR-13); reinterprets and float
-//!   loads/stores are the identity over the integer paths.
-//! - Structured control flow maps to `while :; do ...; break; done`
-//!   wrappers; `br` becomes `break N`/`continue N` (bash counts only
-//!   loops, `if` adds no level). Unreferenced labels emit no wrapper.
-//! - Functions return values through the globals `R0, R1, ...`; traps set
-//!   `TRAP_MSG` and propagate status 134 through `|| return $?` chains.
-//!   Every generated function ends with an explicit `return 0` because a
-//!   trailing arithmetic statement would leak status 1.
-//! - One module instance per generation-time prefix: functions `<p>f<i>`,
-//!   state `<p>g<i>`/`<p>mem`/`<p>t<i>` (per unified-index-space
-//!   table), entry points `<p>init`,
-//!   `<p>invoke`, `<p>global_get`. Imported functions resolve from the
-//!   caller's `IMPORTS` array; other import kinds resolve through
-//!   `PROVIDERS` + per-kind export maps, with imported globals and imported
-//!   memory aliased in via `declare -gn` namerefs (ADR-35).
+//! - i32 is a masked-unsigned value in [0, 2^32); i64 is stored as its signed-64 two's-complement bit pattern (bash arithmetic is signed 64-bit only). Signed/unsigned views are derived inline.
+//! - f32/f64 are their bit patterns (u32 / signed-64), computed by the pure-Bash softfloat units (ADR-5/ADR-13); reinterprets and float loads/stores are the identity over the integer paths.
+//! - Structured control flow maps to `while :; do ...; break; done` wrappers; `br` becomes `break N`/`continue N` (bash counts only loops, `if` adds no level). Unreferenced labels emit no wrapper.
+//! - Functions return values through the globals `R0, R1, ...`; traps set `TRAP_MSG` and propagate status 134 through `|| return $?` chains. Every generated function ends with an explicit `return 0` because a trailing arithmetic statement would leak status 1.
+//! - One module instance per generation-time prefix: functions `<p>f<i>`, state `<p>g<i>`/`<p>mem`/`<p>t<i>` (per unified-index-space table), entry points `<p>init`, `<p>invoke`, `<p>global_get`. Imported functions resolve from the caller's `IMPORTS` array; other import kinds resolve through `PROVIDERS` + per-kind export maps, with imported globals and imported memory aliased in via `declare -gn` namerefs (ADR-35).
 //!
 //! Requires bash >= 5 (namerefs, associative arrays).
 
@@ -81,15 +65,12 @@ pub fn bundler() -> &'static RuntimeBundler {
     })
 }
 
-/// Emit a top-level shared runtime for the closure of `seeds`. Bash has no
-/// namespaces, so the "runtime" is just the flat function definitions.
+/// Emit a top-level shared runtime for the closure of `seeds`. Bash has no namespaces, so the "runtime" is just the flat function definitions.
 pub fn shared_runtime(seeds: &BTreeSet<String>) -> Result<String> {
     bundler().bundle(seeds, 0)
 }
 
-/// Locate a bash >= 5 interpreter able to run generated scripts: tries
-/// `$DEWASM_BASH`, then `bash` on PATH, then the common Homebrew/local
-/// install paths (macOS system bash is 3.2 and does not qualify).
+/// Locate a bash >= 5 interpreter able to run generated scripts: tries `$DEWASM_BASH`, then `bash` on PATH, then the common Homebrew/local install paths (macOS system bash is 3.2 and does not qualify).
 pub fn find_bash5() -> Option<std::path::PathBuf> {
     use std::path::PathBuf;
     let mut candidates: Vec<PathBuf> = Vec::new();
@@ -118,9 +99,7 @@ pub fn find_bash5() -> Option<std::path::PathBuf> {
     None
 }
 
-/// Generate one module for `module` with all names prefixed by `prefix`
-/// (e.g. `"m1_"`). Returns the source and the set of runtime units it
-/// needs; the caller decides whether to bundle them alongside.
+/// Generate one module for `module` with all names prefixed by `prefix` (e.g. `"m1_"`). Returns the source and the set of runtime units it needs; the caller decides whether to bundle them alongside.
 pub fn generate_module_with_units(
     module: &Module,
     prefix: &str,
@@ -167,31 +146,17 @@ impl Backend for BashBackend {
 
     fn feature_status(&self, feature: Feature) -> SupportStatus {
         match feature {
-            // The ADR-5 softfloat covers the full float surface; the
-            // harness now treats any float skip as a hard failure (ADR-8).
+            // The ADR-5 softfloat covers the full float surface; the harness now treats any float skip as a hard failure (ADR-8).
             Feature::Floats => SupportStatus::Supported,
-            // Defined tables now live in per-index array families keyed by
-            // structural type keys, so more than one table lowers directly.
+            // Defined tables now live in per-index array families keyed by structural type keys, so more than one table lowers directly.
             Feature::MultipleTables => SupportStatus::Supported,
-            // Imported globals alias the provider's cell via a `declare -gn`
-            // nameref (ADR-35); mutable and immutable both work through it.
+            // Imported globals alias the provider's cell via a `declare -gn` nameref (ADR-35); mutable and immutable both work through it.
             Feature::ImportedGlobals => SupportStatus::Supported,
-            // Imported memory aliases the provider's mem/pages/max_pages
-            // triplet via `declare -gn` namerefs, keyed off the owning
-            // module's flattened prefix (ADR-35); every mem/WASI unit and
-            // the inline MemoryGrow/MemorySize lowering work unchanged.
+            // Imported memory aliases the provider's mem/pages/max_pages triplet via `declare -gn` namerefs, keyed off the owning module's flattened prefix (ADR-35); every mem/WASI unit and the inline MemoryGrow/MemorySize lowering work unchanged.
             Feature::ImportedMemories => SupportStatus::Supported,
-            // Imported tables alias the provider's array/type-key
-            // array/size triplet via `declare -gn` namerefs, keyed off the
-            // target table's own base name (ADR-35); tab_init, call_indirect,
-            // and active element segments into a shared table all work
-            // unchanged through the nameref.
+            // Imported tables alias the provider's array/type-key array/size triplet via `declare -gn` namerefs, keyed off the target table's own base name (ADR-35); tab_init, call_indirect, and active element segments into a shared table all work unchanged through the nameref.
             Feature::ImportedTables => SupportStatus::Supported,
-            // Passive/declared element segments, ref.null items, and
-            // table.init/copy/elem.drop all lower onto the same
-            // `<p>t<i>`/`<p>t<i>ty` table arrays and `<p>elem<n>`/
-            // `<p>elem<n>ty` staging arrays as the active-segment path
-            // (tab/init.sh, tab/copy.sh).
+            // Passive/declared element segments, ref.null items, and table.init/copy/elem.drop all lower onto the same `<p>t<i>`/`<p>t<i>ty` table arrays and `<p>elem<n>`/ `<p>elem<n>ty` staging arrays as the active-segment path (tab/init.sh, tab/copy.sh).
             Feature::TableBulkOps => SupportStatus::Supported,
             _ => SupportStatus::Unsupported,
         }
@@ -200,8 +165,7 @@ impl Backend for BashBackend {
     fn generate(&self, module: &Module, opts: &GenOptions) -> Result<Vec<OutputFile>> {
         let prefix = func_prefix(&opts.module_name);
 
-        // The status mappings in the standalone main need these even when
-        // the module itself never references them.
+        // The status mappings in the standalone main need these even when the module itself never references them.
         let mut extra_seeds = BTreeSet::new();
         if opts.mode == Mode::Standalone {
             extra_seeds.insert("rt/trap".to_string());
@@ -229,8 +193,7 @@ impl Backend for BashBackend {
                 out.push_str(&bundler().bundle(&units, 0)?);
                 out.push('\n');
             }
-            // Runtime functions are global names in bash; an alias has
-            // nothing to emit as long as the shared bundle is sourced.
+            // Runtime functions are global names in bash; an alias has nothing to emit as long as the shared bundle is sourced.
             dewasm_backend::RuntimeLinkage::Alias(_) => {}
         }
         out.push_str(&src);
@@ -240,23 +203,10 @@ impl Backend for BashBackend {
             w.line("");
             w.line("if [[ ${BASH_SOURCE[0]} == \"$0\" ]]; then");
             w.indent();
-            // Each wasm call nests one native bash function call (ADR-11), and
-            // a deeply recursive guest (e.g. QuickJS's interactive REPL, whose
-            // startup alone reaches tens of thousands of frames) can exhaust the
-            // *process's* C stack — not the bounded, trappable wasm one
-            // (FUNCNEST) — and crash with a real SIGSEGV rather than a caught
-            // wasm trap. Raise the soft rlimit to the max this process is
-            // allowed before running any guest code; both attempts degrade
-            // silently (`|| true`) since a sandboxed environment may refuse
-            // both, in which case behavior is unchanged from before this line
-            // existed.
+            // Each wasm call nests one native bash function call (ADR-11), and a deeply recursive guest (e.g. QuickJS's interactive REPL, whose startup alone reaches tens of thousands of frames) can exhaust the *process's* C stack — not the bounded, trappable wasm one (FUNCNEST) — and crash with a real SIGSEGV rather than a caught wasm trap. Raise the soft rlimit to the max this process is allowed before running any guest code; both attempts degrade silently (`|| true`) since a sandboxed environment may refuse both, in which case behavior is unchanged from before this line existed.
             w.line("ulimit -s unlimited 2>/dev/null || ulimit -s \"$(ulimit -Hs)\" 2>/dev/null || true");
             if wasi_bundled(module, opts.default_wasi) {
-                // Standalone runtime interface (ADR-31): consume a leading run of
-                // `--dir HOST::GUEST` flags into WASI_DIRS (wasmtime-style),
-                // stopping at `--` or the first non-flag token; the rest is the
-                // guest's argv[1..]. The Bash backend now honors --dir with real
-                // filesystem support (ADR-34), mirroring the Ruby standalone parser.
+                // Standalone runtime interface (ADR-31): consume a leading run of `--dir HOST::GUEST` flags into WASI_DIRS (wasmtime-style), stopping at `--` or the first non-flag token; the rest is the guest's argv[1..]. The Bash backend now honors --dir with real filesystem support (ADR-34), mirroring the Ruby standalone parser.
                 w.line("WASI_DIRS=()");
                 w.line("while (( $# )); do");
                 w.line("  case \"$1\" in");
@@ -289,9 +239,7 @@ impl Backend for BashBackend {
     }
 }
 
-/// Sanitized state/function prefix for a module name: `add.wasm` -> `add_`.
-/// Public so multi-module e2e cases (`compose_modules`) can derive each
-/// module's prefix the same way `generate` does.
+/// Sanitized state/function prefix for a module name: `add.wasm` -> `add_`. Public so multi-module e2e cases (`compose_modules`) can derive each module's prefix the same way `generate` does.
 pub fn func_prefix(module_name: &str) -> String {
     let mut out = String::new();
     for c in module_name.chars() {
@@ -310,17 +258,14 @@ pub fn func_prefix(module_name: &str) -> String {
     out
 }
 
-/// `wasi_unstable` (snapshot 0) shares the ABI of preview 1 for
-/// everything implemented here except fd_seek's whence encoding, and
-/// fd_seek is ESPIPE-only on this backend anyway.
+/// `wasi_unstable` (snapshot 0) shares the ABI of preview 1 for everything implemented here except fd_seek's whence encoding, and fd_seek is ESPIPE-only on this backend anyway.
 const WASI_MODULES: &[&str] = &["wasi_snapshot_preview1", "wasi_unstable"];
 
 fn is_wasi_module(name: &str) -> bool {
     WASI_MODULES.contains(&name)
 }
 
-/// Whether the generated module bundles the built-in WASI as an import
-/// fallback (and therefore consumes the WASI_ARGS/WASI_ENV arrays).
+/// Whether the generated module bundles the built-in WASI as an import fallback (and therefore consumes the WASI_ARGS/WASI_ENV arrays).
 fn wasi_bundled(module: &Module, default_wasi: bool) -> bool {
     default_wasi
         && module
@@ -344,8 +289,7 @@ struct Gen<'a> {
     prefix: &'a str,
     /// Runtime units the generated code references.
     uses: RefCell<BTreeSet<String>>,
-    /// Per-statement scratch variable counter and its per-function peak
-    /// (`__t<n>` locals hold helper results used as nested operands).
+    /// Per-statement scratch variable counter and its per-function peak (`__t<n>` locals hold helper results used as nested operands).
     scratch: Cell<u32>,
     scratch_max: Cell<u32>,
     /// Whether the current function needs the call_indirect scratch vars.
@@ -363,9 +307,7 @@ impl<'a> Gen<'a> {
         self.invoke_fn(w);
         w.line("");
         self.global_get_fn(w);
-        // WASI units are prefix-parameterized flat functions; imports are
-        // bound to bare function names, so each bundled syscall gets a
-        // per-module wrapper baking the prefix in.
+        // WASI units are prefix-parameterized flat functions; imports are bound to bare function names, so each bundled syscall gets a per-module wrapper baking the prefix in.
         if self.default_wasi {
             let wrappers: BTreeSet<&str> = self
                 .module
@@ -396,32 +338,17 @@ impl<'a> Gen<'a> {
         let p = self.prefix;
         w.line(format!("{p}init() {{"));
         w.indent();
-        // Emission order mirrors the Ruby backend (ADR-35): import
-        // registries, memory, tables, WASI state, then imports resolved
-        // kind by kind, then defined state, then export maps, then start.
+        // Emission order mirrors the Ruby backend (ADR-35): import registries, memory, tables, WASI state, then imports resolved kind by kind, then defined state, then export maps, then start.
         let num_imported_globals = m.imported_globals.len();
         let has_imports = !m.imported_funcs.is_empty()
             || !m.imported_globals.is_empty()
             || !m.imported_tables.is_empty()
             || m.imported_memory.is_some();
         if has_imports {
-            // Guard-declare the two import registries up front: memory
-            // resolution (right below) needs PROVIDERS before the
-            // func/global import loops that used to be the first users of
-            // it. `declare -gA` never clears an existing array, so a
-            // caller's pre-populated IMPORTS (func overrides) / PROVIDERS
-            // (per-module export-map prefixes) survive, while an unset one
-            // becomes an empty associative array rather than being treated
-            // as indexed with its keys evaluated as arithmetic.
+            // Guard-declare the two import registries up front: memory resolution (right below) needs PROVIDERS before the func/global import loops that used to be the first users of it. `declare -gA` never clears an existing array, so a caller's pre-populated IMPORTS (func overrides) / PROVIDERS (per-module export-map prefixes) survive, while an unset one becomes an empty associative array rather than being treated as indexed with its keys evaluated as arithmetic.
             w.line("declare -gA IMPORTS PROVIDERS");
         }
-        // Imported memory (ADR-35): resolve the provider's memown prefix
-        // and alias its mem/pages/max_pages triplet in via `declare -gn`
-        // namerefs, so every mem/WASI/MemoryGrow/MemorySize unit keeps
-        // working unchanged whether the memory is owned locally or by
-        // another module. `<p>memown` records the flattened owning
-        // prefix (not a nameref itself) so a re-export just forwards the
-        // string, keeping any further nameref chain at depth 1.
+        // Imported memory (ADR-35): resolve the provider's memown prefix and alias its mem/pages/max_pages triplet in via `declare -gn` namerefs, so every mem/WASI/MemoryGrow/MemorySize unit keeps working unchanged whether the memory is owned locally or by another module. `<p>memown` records the flattened owning prefix (not a nameref itself) so a re-export just forwards the string, keeping any further nameref chain at depth 1.
         if let Some(import) = &m.imported_memory {
             self.use_unit("rt/resolve_import");
             self.use_unit("rt/link_err");
@@ -443,13 +370,7 @@ impl<'a> Gen<'a> {
             w.line(format!("{p}max_pages={}", mem.max_pages.unwrap_or(65536)));
             w.line(format!("{p}memown={p}"));
         }
-        // Imported tables (ADR-35): resolve before the defined tables so
-        // both share the unified index space. Unlike memory, a table's
-        // derived state (`t<i>`/`t<i>ty`/`t<i>sz`) does share one base name,
-        // so `rt_resolve_import`'s table kind resolves to the target's
-        // variable name directly (already flattened by the exporting
-        // module's TABLE_EXPORTS, mirroring imported globals) and each
-        // nameref points straight at the real array, one hop.
+        // Imported tables (ADR-35): resolve before the defined tables so both share the unified index space. Unlike memory, a table's derived state (`t<i>`/`t<i>ty`/`t<i>sz`) does share one base name, so `rt_resolve_import`'s table kind resolves to the target's variable name directly (already flattened by the exporting module's TABLE_EXPORTS, mirroring imported globals) and each nameref points straight at the real array, one hop.
         for (i, import) in m.imported_tables.iter().enumerate() {
             self.use_unit("rt/resolve_import");
             self.use_unit("rt/link_err");
@@ -464,8 +385,7 @@ impl<'a> Gen<'a> {
                 "declare -gn {p}t{i}=$RESOLVED {p}t{i}ty=${{RESOLVED}}ty {p}t{i}sz=${{RESOLVED}}sz"
             ));
         }
-        // Per unified-index-space defined table (imported ++ defined). The
-        // index base keeps room for the imported ones just above.
+        // Per unified-index-space defined table (imported ++ defined). The index base keeps room for the imported ones just above.
         for (i, table) in m.tables.iter().enumerate() {
             let idx = m.num_imported_tables() as usize + i;
             w.line(format!("{p}t{idx}=()"));
@@ -473,12 +393,7 @@ impl<'a> Gen<'a> {
             w.line(format!("{p}t{idx}sz={}", table.min));
         }
         if wasi_bundled(m, self.default_wasi) {
-            // Callers set the WASI_ARGS/WASI_ENV/WASI_DIRS arrays before init
-            // (the bash analogue of Ruby's args:/env:/preopens: keywords); stdio
-            // fds are preopened and fd_read/fd_write track per-fd offsets. wnext
-            // is the next fd; wpush is poll_oneoff's one-byte stdin pushback slot;
-            // init_preopens registers the --dir mounts and the filesystem
-            // fd-table arrays, failing init loudly on an unresolvable host (ADR-34).
+            // Callers set the WASI_ARGS/WASI_ENV/WASI_DIRS arrays before init (the bash analogue of Ruby's args:/env:/preopens: keywords); stdio fds are preopened and fd_read/fd_write track per-fd offsets. wnext is the next fd; wpush is poll_oneoff's one-byte stdin pushback slot; init_preopens registers the --dir mounts and the filesystem fd-table arrays, failing init loudly on an unresolvable host (ADR-34).
             w.line(format!("{p}wargs=(\"${{WASI_ARGS[@]}}\")"));
             w.line(format!("{p}wenv=(\"${{WASI_ENV[@]}}\")"));
             w.line(format!("{p}wfds=([0]=1 [1]=1 [2]=1)"));
@@ -495,9 +410,7 @@ impl<'a> Gen<'a> {
             w.line(format!("rt_resolve_import {mm} {nn} func || return $?"));
             w.line(format!("{p}if{i}=$RESOLVED"));
             if is_wasi_module(&import.module) && self.default_wasi {
-                // Fallback order (ADR-7's bash shape): resolved import ->
-                // bundled WASI unit via a per-module prefix wrapper ->
-                // ENOSYS stub for known-but-unimplemented syscalls.
+                // Fallback order (ADR-7's bash shape): resolved import -> bundled WASI unit via a per-module prefix wrapper -> ENOSYS stub for known-but-unimplemented syscalls.
                 let unit = format!("wasi/{}", import.name);
                 if bundler().has_unit(&unit) {
                     self.use_unit(&unit);
@@ -517,10 +430,7 @@ impl<'a> Gen<'a> {
                 ));
             }
         }
-        // Imported globals: resolve the provider's cell and alias it in
-        // under the unified index with a `declare -gn` nameref, so reads
-        // (`(( x = <p>g<i> ))`), mutable writes (`(( <p>g<i> = v ))`), and
-        // init-expr `global.get` offsets all reach the shared cell (ADR-35).
+        // Imported globals: resolve the provider's cell and alias it in under the unified index with a `declare -gn` nameref, so reads (`(( x = <p>g<i> ))`), mutable writes (`(( <p>g<i> = v ))`), and init-expr `global.get` offsets all reach the shared cell (ADR-35).
         for (i, import) in m.imported_globals.iter().enumerate() {
             self.use_unit("rt/resolve_import");
             self.use_unit("rt/link_err");
@@ -539,16 +449,7 @@ impl<'a> Gen<'a> {
             self.emit_assign(w, &format!("{p}g{idx}"), &global.init);
         }
         for (n, elem) in m.elems.iter().enumerate() {
-            // Stage the segment as a temporary element array (function
-            // command names, `''` for a `ref.null` item) plus its
-            // structural type keys (same convention, `''` for the null
-            // items), mirroring the data-segment mem_init staging below.
-            // `ElemItem::Global` never reaches here: a ref-typed global
-            // (the only kind `global.get` could target inside an elem
-            // expression) is rejected by dewasm-core's `val_type` as soon
-            // as the Global/Import section is parsed (module.rs), which
-            // happens before the Element section — so a module containing
-            // one never makes it past conversion in the first place.
+            // Stage the segment as a temporary element array (function command names, `''` for a `ref.null` item) plus its structural type keys (same convention, `''` for the null items), mirroring the data-segment mem_init staging below. `ElemItem::Global` never reaches here: a ref-typed global (the only kind `global.get` could target inside an elem expression) is rejected by dewasm-core's `val_type` as soon as the Global/Import section is parsed (module.rs), which happens before the Element section — so a module containing one never makes it past conversion in the first place.
             let mut names = Vec::new();
             let mut keys = Vec::new();
             for item in &elem.items {
@@ -568,9 +469,7 @@ impl<'a> Gen<'a> {
             }
             match &elem.kind {
                 ElemKind::Declared => {
-                    // Never copied into a table; keep the pair of arrays
-                    // empty so a stray table.init/elem.drop against this
-                    // index is a harmless no-op-shaped array.
+                    // Never copied into a table; keep the pair of arrays empty so a stray table.init/elem.drop against this index is a harmless no-op-shaped array.
                     w.line(format!("{p}elem{n}=()"));
                     w.line(format!("{p}elem{n}ty=()"));
                 }
@@ -591,12 +490,7 @@ impl<'a> Gen<'a> {
                         "tab_init {p}t{table_index} {p}elem{n} $(( {off} )) 0 {} || return $?",
                         elem.items.len()
                     ));
-                    // Active segments are auto-dropped right after
-                    // instantiation (spec: table.init then an implicit
-                    // elem.drop), so clear the staging array the same way
-                    // an explicit ElemDrop would — a later table.init
-                    // against this segment then traps 'out of bounds
-                    // table access' like a genuinely dropped one.
+                    // Active segments are auto-dropped right after instantiation (spec: table.init then an implicit elem.drop), so clear the staging array the same way an explicit ElemDrop would — a later table.init against this segment then traps 'out of bounds table access' like a genuinely dropped one.
                     w.line(format!("{p}elem{n}=()"));
                     w.line(format!("{p}elem{n}ty=()"));
                 }
@@ -639,11 +533,7 @@ impl<'a> Gen<'a> {
         let mut gentries = Vec::new();
         for export in &m.exports {
             if let ExportKind::Global(idx) = export.kind {
-                // Flatten to the underlying cell's variable name so a
-                // consumer's nameref stays depth <=1 (ADR-35): an exported
-                // imported global is itself a `<p>g<i>` nameref, so publish
-                // its target (`${!<p>g<i>}`); a defined global publishes its
-                // own literal variable name.
+                // Flatten to the underlying cell's variable name so a consumer's nameref stays depth <=1 (ADR-35): an exported imported global is itself a `<p>g<i>` nameref, so publish its target (`${!<p>g<i>}`); a defined global publishes its own literal variable name.
                 let value = if (idx as usize) < num_imported_globals {
                     format!("${{!{p}g{idx}}}")
                 } else {
@@ -659,12 +549,7 @@ impl<'a> Gen<'a> {
         let mut mentries = Vec::new();
         for export in &m.exports {
             if let ExportKind::Memory = export.kind {
-                // Same flattening as globals, but the value is the owning
-                // module's prefix (`<p>memown`), not a single variable name:
-                // memory's derived state (`mem`/`pages`/`max_pages`) needs
-                // the prefix to rebuild all three suffixes on the importing
-                // side, so `rt_resolve_import`'s memory kind resolves to a
-                // prefix rather than one variable name (ADR-35).
+                // Same flattening as globals, but the value is the owning module's prefix (`<p>memown`), not a single variable name: memory's derived state (`mem`/`pages`/`max_pages`) needs the prefix to rebuild all three suffixes on the importing side, so `rt_resolve_import`'s memory kind resolves to a prefix rather than one variable name (ADR-35).
                 mentries.push(format!("[{}]=${p}memown", bash_str(&export.name)));
             }
         }
@@ -676,11 +561,7 @@ impl<'a> Gen<'a> {
         let mut tentries = Vec::new();
         for export in &m.exports {
             if let ExportKind::Table(idx) = export.kind {
-                // Flatten to the underlying array's base name, exactly like
-                // a global export (ADR-35): an exported imported table is
-                // itself a `<p>t<i>` nameref, so publish its target
-                // (`${!<p>t<i>}`); a defined table publishes its own literal
-                // base name.
+                // Flatten to the underlying array's base name, exactly like a global export (ADR-35): an exported imported table is itself a `<p>t<i>` nameref, so publish its target (`${!<p>t<i>}`); a defined table publishes its own literal base name.
                 let value = if (idx as usize) < num_imported_tables {
                     format!("${{!{p}t{idx}}}")
                 } else {
@@ -748,12 +629,7 @@ impl<'a> Gen<'a> {
         self.type_key(ty)
     }
 
-    /// A structural key for a function type, e.g. `i32,i64->f32`.
-    /// call_indirect compares types structurally, and a table can be shared
-    /// across independently generated modules (imported tables), so the
-    /// runtime type tag must not be a module-local numeric index — those
-    /// disagree across modules. Deriving the tag from the type's shape
-    /// makes it match regardless of each module's type section.
+    /// A structural key for a function type, e.g. `i32,i64->f32`. call_indirect compares types structurally, and a table can be shared across independently generated modules (imported tables), so the runtime type tag must not be a module-local numeric index — those disagree across modules. Deriving the tag from the type's shape makes it match regardless of each module's type section.
     fn type_key(&self, type_idx: u32) -> String {
         let ty = &self.module.types[type_idx as usize];
         let names = |tys: &[ValType]| {
@@ -985,8 +861,7 @@ impl<'a> Gen<'a> {
                 ));
                 w.line(format!("__fn=${{{p}t{ti}[__x]-}}"));
                 w.line("[[ -n $__fn ]] || { rt_trap 'uninitialized element'; return $?; }");
-                // Structural string compare (see type_key): a numeric type
-                // id would not survive a table shared across modules.
+                // Structural string compare (see type_key): a numeric type id would not survive a table shared across modules.
                 w.line(format!(
                     "[[ ${{{p}t{ti}ty[__x]}} == '{}' ]] || {{ rt_trap 'indirect call type mismatch'; return $?; }}",
                     self.type_key(*type_idx)
@@ -1002,11 +877,7 @@ impl<'a> Gen<'a> {
             Stmt::MemoryGrow { dst, delta } => {
                 let p = self.prefix;
                 let d = self.value(w, delta);
-                // Evaluate the delta exactly once by snapshotting the candidate
-                // page count: a folded `memory.size` delta reads `pages`, which
-                // the grow mutates, so a second textual use of the fragment
-                // would see the already-updated value. The destination then
-                // takes the old size before `pages` is overwritten.
+                // Evaluate the delta exactly once by snapshotting the candidate page count: a folded `memory.size` delta reads `pages`, which the grow mutates, so a second textual use of the fragment would see the already-updated value. The destination then takes the old size before `pages` is overwritten.
                 let cand = self.as_var(w, &format!("{p}pages + ({d})"));
                 w.line(format!("if (( {cand} <= {p}max_pages )); then"));
                 w.indent();
@@ -1111,9 +982,7 @@ impl<'a> Gen<'a> {
                 self.use_unit("rt/trap");
                 w.line("rt_trap 'unreachable' || return $?");
             }
-            // REASON: DWARF source-line back-mapping is out of scope for Bash
-            // (ADR-38); the marker renders nothing, keeping output identical to
-            // a non-`--dwarf-line` build.
+            // REASON: DWARF source-line back-mapping is out of scope for Bash (ADR-38); the marker renders nothing, keeping output identical to a non-`--dwarf-line` build.
             Stmt::SourceLine(_) => {}
         }
     }
@@ -1145,8 +1014,7 @@ impl<'a> Gen<'a> {
     }
 
     fn return_stmt(&self, w: &mut CodeWriter, values: &[Expr]) {
-        // Command-shaped values are copied into scratch first, so a later
-        // helper call cannot clobber an R<i> we already assigned.
+        // Command-shaped values are copied into scratch first, so a later helper call cannot clobber an R<i> we already assigned.
         let frags: Vec<String> = values.iter().map(|v| self.value(w, v)).collect();
         for (i, frag) in frags.iter().enumerate() {
             w.line(format!("R{i}=$(( {frag} ))"));
@@ -1202,8 +1070,7 @@ impl<'a> Gen<'a> {
         }
     }
 
-    /// Evaluate `expr` to a pure arithmetic fragment, emitting helper
-    /// commands (with scratch copies) as needed.
+    /// Evaluate `expr` to a pure arithmetic fragment, emitting helper commands (with scratch copies) as needed.
     fn value(&self, w: &mut CodeWriter, expr: &Expr) -> String {
         if let Some(frag) = self.arith(expr) {
             return frag;
@@ -1220,10 +1087,7 @@ impl<'a> Gen<'a> {
             Expr::Bin(op, a, b) => {
                 let a = self.value(w, a);
                 let b = self.value(w, b);
-                // Several inline lowerings textually repeat an operand (e.g.
-                // I64ShrU references `b` four times); with folded operands that
-                // would blow up geometrically. Snapshot non-trivial operands
-                // into a scratch var first (as_var is a no-op for a bare var).
+                // Several inline lowerings textually repeat an operand (e.g. I64ShrU references `b` four times); with folded operands that would blow up geometrically. Snapshot non-trivial operands into a scratch var first (as_var is a no-op for a bare var).
                 let a = self.as_var(w, &a);
                 let b = self.as_var(w, &b);
                 if let Some(frag) = bin_inline(*op, &a, &b) {
@@ -1253,9 +1117,7 @@ impl<'a> Gen<'a> {
         }
     }
 
-    /// Emit `expr` as one helper command leaving its result in R0, when it
-    /// is directly command-shaped with pure operands. Returns false to let
-    /// the caller take the generic scratch path.
+    /// Emit `expr` as one helper command leaving its result in R0, when it is directly command-shaped with pure operands. Returns false to let the caller take the generic scratch path.
     fn emit_command(&self, w: &mut CodeWriter, expr: &Expr) -> bool {
         match expr {
             Expr::Un(op, a) => {
@@ -1335,13 +1197,9 @@ impl<'a> Gen<'a> {
     fn arith(&self, expr: &Expr) -> Option<String> {
         match expr {
             Expr::I32Const(v) => Some(v.to_string()),
-            // i64 constants are emitted as their signed-64 bit pattern;
-            // an unsigned literal above INT64_MAX would be
-            // implementation-defined in bash.
+            // i64 constants are emitted as their signed-64 bit pattern; an unsigned literal above INT64_MAX would be implementation-defined in bash.
             Expr::I64Const(v) => Some(format!("{}", *v as i64)),
-            // Floats are their bit patterns (ADR-13): f32 as u32, f64 as
-            // the signed-64 pattern (a u64 decimal >= 2^63 would wrap
-            // implementation-defined in bash).
+            // Floats are their bit patterns (ADR-13): f32 as u32, f64 as the signed-64 pattern (a u64 decimal >= 2^63 would wrap implementation-defined in bash).
             Expr::F32Const(bits) => Some(bits.to_string()),
             Expr::F64Const(bits) => Some(format!("{}", *bits as i64)),
             Expr::Temp(t) => Some(temp(*t)),
@@ -1377,8 +1235,7 @@ impl Frames {
     }
 }
 
-/// Command argument for a pure fragment: decimal literals pass through,
-/// anything else is evaluated with `$(( ))`.
+/// Command argument for a pure fragment: decimal literals pass through, anything else is evaluated with `$(( ))`.
 fn cmd_arg(frag: &str) -> String {
     let digits = frag.strip_prefix('-').unwrap_or(frag);
     if !digits.is_empty() && digits.chars().all(|c| c.is_ascii_digit()) {
@@ -1409,8 +1266,7 @@ fn un_inline(op: UnOp, a: &str) -> Option<String> {
         I64Extend8S => format!("(((({a}) & 0xff) ^ 0x80) - 0x80)"),
         I64Extend16S => format!("(((({a}) & 0xffff) ^ 0x8000) - 0x8000)"),
         I64Extend32S => format!("(((({a}) & 0xffffffff) ^ 0x80000000) - 0x80000000)"),
-        // Pure bit ops on the float patterns (payload-preserving, as the
-        // spec requires for the sign ops); reinterprets are the identity.
+        // Pure bit ops on the float patterns (payload-preserving, as the spec requires for the sign ops); reinterprets are the identity.
         F32Abs => format!("(({a}) & 0x7fffffff)"),
         F32Neg => format!("(({a}) ^ 0x80000000)"),
         F64Abs => format!("(({a}) & 0x7fffffffffffffff)"),
@@ -1493,9 +1349,7 @@ fn bin_inline(op: BinOp, a: &str, b: &str) -> Option<String> {
         I32ShrS => format!("(({} >> (({b}) & 31)) & 0xffffffff)", s32_view(a)),
         I64Shl => format!("(({a}) << (({b}) & 63))"),
         I64ShrS => format!("(({a}) >> (({b}) & 63))"),
-        // Logical right shift over the signed representation: mask off the
-        // dragged-in sign bits; a shift count of 0 must bypass the mask
-        // because bash takes shift counts mod 64.
+        // Logical right shift over the signed representation: mask off the dragged-in sign bits; a shift count of 0 must bypass the mask because bash takes shift counts mod 64.
         I64ShrU => format!(
             "(((({b}) & 63) == 0 ? ({a}) : ((({a}) >> (({b}) & 63)) & ~(-1 << (64 - (({b}) & 63))))))"
         ),
@@ -1578,8 +1432,7 @@ fn load_method(op: LoadOp) -> &'static str {
     match op {
         I32Load => "i32_load",
         I64Load => "i64_load",
-        // Floats travel as bit patterns; the integer memory units are
-        // exact (ADR-13).
+        // Floats travel as bit patterns; the integer memory units are exact (ADR-13).
         F32Load => "i32_load",
         F64Load => "i64_load",
         I32Load8S => "i32_load8_s",
@@ -1610,11 +1463,7 @@ fn store_method(op: StoreOp) -> &'static str {
     }
 }
 
-/// Lint for the bash runtime units: every reference a unit body makes to
-/// another unit must be declared in its `# requires:` header, and every
-/// unit function must end with an explicit `return`/`:` — a trailing
-/// arithmetic statement would leak status 1 into the `|| return $?` trap
-/// cascade (ADR-11). Static half of the ADR-6 drift defence.
+/// Lint for the bash runtime units: every reference a unit body makes to another unit must be declared in its `# requires:` header, and every unit function must end with an explicit `return`/`:` — a trailing arithmetic statement would leak status 1 into the `|| return $?` trap cascade (ADR-11). Static half of the ADR-6 drift defence.
 #[cfg(test)]
 mod units {
     use super::*;
@@ -1648,9 +1497,7 @@ mod units {
                     continue;
                 }
                 if !unit_ids.contains(dep.as_str()) {
-                    // Longest-match artifacts (e.g. rt_i32 inside rt_i32_clz)
-                    // cannot occur because the regex is greedy; anything else
-                    // unknown is a genuine typo.
+                    // Longest-match artifacts (e.g. rt_i32 inside rt_i32_clz) cannot occur because the regex is greedy; anything else unknown is a genuine typo.
                     problems.push(format!("{}: references unknown unit {dep}", unit.id));
                     continue;
                 }

--- a/crates/dewasm-backend-bash/tests/e2e.rs
+++ b/crates/dewasm-backend-bash/tests/e2e.rs
@@ -1,11 +1,4 @@
-//! Bash end-to-end suites (ADR-27): the shared library / WASI / apps case
-//! consts (`dewasm-test-helper`) wired up for the Bash backend. Per the
-//! ADR-27 revision this file holds ONLY the [`BackendUnderTest`] impl, named
-//! glue string constants, and per-case macro invocations. Bash has no
-//! host-language object model (ADR-12), so it invokes only the two
-//! always-available library cases (glue is Bash function calls over the R0..
-//! result globals, ADR-11), the whole-program WASI kinds it covers, and the
-//! flat-namespace multi-module case (ADR-35).
+//! Bash end-to-end suites (ADR-27): the shared library / WASI / apps case consts (`dewasm-test-helper`) wired up for the Bash backend. Per the ADR-27 revision this file holds ONLY the [`BackendUnderTest`] impl, named glue string constants, and per-case macro invocations. Bash has no host-language object model (ADR-12), so it invokes only the two always-available library cases (glue is Bash function calls over the R0.. result globals, ADR-11), the whole-program WASI kinds it covers, and the flat-namespace multi-module case (ADR-35).
 
 use std::collections::BTreeSet;
 use std::path::PathBuf;
@@ -34,17 +27,7 @@ impl BackendUnderTest for Bash {
         find_bash5().expect("bash >= 5 not found — see docs/testing.md")
     }
 
-    /// Compose several `.wat` modules for the multi-module cases (ADR-35).
-    /// Bash has no namespacing at all — every generated module is already a
-    /// bare, prefix-scoped family of global functions/arrays sharing one flat
-    /// process, so there is no separate "shared runtime" linkage to build:
-    /// generate each module (`generate_module_with_units`, prefixed by its
-    /// name via `func_prefix`), union the runtime units they reference, bundle
-    /// that union once, and concatenate the bundle with the module bodies.
-    /// `shared_runtime=false` (independent Embedded runtimes) is never
-    /// exercised for Bash: there is only ever one flat namespace, so two
-    /// independent runtimes cannot coexist without their `rt_*`/`mem_*`
-    /// function names colliding (`embedded_coexist_e2e!` is not invoked).
+    /// Compose several `.wat` modules for the multi-module cases (ADR-35). Bash has no namespacing at all — every generated module is already a bare, prefix-scoped family of global functions/arrays sharing one flat process, so there is no separate "shared runtime" linkage to build: generate each module (`generate_module_with_units`, prefixed by its name via `func_prefix`), union the runtime units they reference, bundle that union once, and concatenate the bundle with the module bodies. `shared_runtime=false` (independent Embedded runtimes) is never exercised for Bash: there is only ever one flat namespace, so two independent runtimes cannot coexist without their `rt_*`/`mem_*` function names colliding (`embedded_coexist_e2e!` is not invoked).
     fn compose_modules(&self, modules: &[(&str, &str)], shared_runtime: bool) -> String {
         assert!(
             shared_runtime,
@@ -71,8 +54,7 @@ impl BackendUnderTest for Bash {
     }
 }
 
-// ---------------------------------------------------------------------
-// Library-case glue: results come back through the R0 global (ADR-11).
+// --------------------------------------------------------------------- Library-case glue: results come back through the R0 global (ADR-11).
 
 /// `add.wat`: call the exported functions and echo each result global.
 const BASH_ADD_GLUE: &str = r#"add_init || exit 1
@@ -81,10 +63,7 @@ add_invoke add 4294967295 1; echo $R0
 add_invoke fib 10; echo $R0
 "#;
 
-/// The ADR-7 override/fallback glue: an explicit `fd_write` import wins,
-/// `random_get` falls back to the bundled WASI. Captures and prints the actual
-/// bytes the module wrote — the same observable proof of interception the other
-/// backends' override glues use.
+/// The ADR-7 override/fallback glue: an explicit `fd_write` import wins, `random_get` falls back to the bundled WASI. Captures and prints the actual bytes the module wrote — the same observable proof of interception the other backends' override glues use.
 const BASH_OVERRIDE_GLUE: &str = r#"my_fd_write() {
   # (fd, iovs, iovs_len, nwritten_ptr): capture and print the actual
   # bytes the module wrote, the same observable proof of interception
@@ -111,11 +90,7 @@ prog_init || { echo "init failed" >&2; exit 1; }
 prog_invoke '_start'
 "#;
 
-/// `SHARED_TABLE`'s driver: `shared_table_a.wat`'s module has no wasm-level
-/// name, so `compose_modules` prefixes it from the case's "TableExp" label
-/// (`func_prefix`); `shared_table_b.wat` imports it under the *wasm* module
-/// name `"a"` (unrelated to "TableExp"), so PROVIDERS maps that literal key
-/// to the exporter's generation prefix (ADR-35).
+/// `SHARED_TABLE`'s driver: `shared_table_a.wat`'s module has no wasm-level name, so `compose_modules` prefixes it from the case's "TableExp" label (`func_prefix`); `shared_table_b.wat` imports it under the *wasm* module name `"a"` (unrelated to "TableExp"), so PROVIDERS maps that literal key to the exporter's generation prefix (ADR-35).
 const BASH_SHARED_TABLE_GLUE: &str = r#"tableexp_init || { echo "init failed" >&2; exit 1; }
 declare -A PROVIDERS=([a]=tableexp_)
 tableimp_init || { echo "init failed" >&2; exit 1; }
@@ -123,13 +98,7 @@ tableimp_invoke call0
 echo $R0
 "#;
 
-/// The `wasi_suite!(Bash, Fs, ...)` template (ADR-34): fill `WASI_DIRS` with
-/// the one preopen pair, init, invoke `_start`, then surface a `proc_exit`
-/// call the same way the standalone main does — `invoke` returns status 133
-/// (ADR-12) with the code in `$EXIT_CODE` — as a trailing decimal line, the
-/// same observable the Ruby glue's `rescue Prog::Rt::Exit` produces. A case
-/// that never calls `proc_exit` just falls off the end of `_start`, so
-/// nothing is appended and the script exits 0.
+/// The `wasi_suite!(Bash, Fs, ...)` template (ADR-34): fill `WASI_DIRS` with the one preopen pair, init, invoke `_start`, then surface a `proc_exit` call the same way the standalone main does — `invoke` returns status 133 (ADR-12) with the code in `$EXIT_CODE` — as a trailing decimal line, the same observable the Ruby glue's `rescue Prog::Rt::Exit` produces. A case that never calls `proc_exit` just falls off the end of `_start`, so nothing is appended and the script exits 0.
 const BASH_FS_GLUE: &str = r#"WASI_DIRS=('{host}::{guest}')
 prog_init || { echo "init failed" >&2; exit 1; }
 prog_invoke '_start'
@@ -140,11 +109,7 @@ fi
 exit 0
 "#;
 
-/// The root-preopen containment probe's glue: preopen the filesystem root at
-/// guest `/` and call the WASI resolver directly (`wasi_resolve_path <p>
-/// <dirfd> <path> <follow>`, ADR-34) instead of running a guest — the bash
-/// analogue of Ruby's `wasi.send(:resolve_path, ...)`. `follow=1` matches
-/// Ruby's `resolve_path`'s `follow_last: true` default.
+/// The root-preopen containment probe's glue: preopen the filesystem root at guest `/` and call the WASI resolver directly (`wasi_resolve_path <p> <dirfd> <path> <follow>`, ADR-34) instead of running a guest — the bash analogue of Ruby's `wasi.send(:resolve_path, ...)`. `follow=1` matches Ruby's `resolve_path`'s `follow_last: true` default.
 const BASH_CONTAINMENT_GLUE: &str = r#"WASI_DIRS=('/::/')
 prog_init || { echo "init failed" >&2; exit 1; }
 wasi_resolve_path prog_ 3 etc 1
@@ -155,13 +120,7 @@ else
 fi
 "#;
 
-// ---------------------------------------------------------------------
-// Filesystem app glue (ADR-34): class/argv/env/preopen-guest-paths are
-// literals (`WASI_ARGS`/`WASI_ENV`/`WASI_DIRS`, the Bash analogue of Ruby's
-// `args:`/`env:`/`preopens:` kwargs); only the host scratch dir comes through
-// `{scratch}`. `invoke`'s status-133 cascade is discarded (`exit 0`), the
-// same way the Ruby glue's empty `rescue ...::Rt::Exit` swallows it — these
-// cases assert stdout/host state, never the guest's own exit code.
+// --------------------------------------------------------------------- Filesystem app glue (ADR-34): class/argv/env/preopen-guest-paths are literals (`WASI_ARGS`/`WASI_ENV`/`WASI_DIRS`, the Bash analogue of Ruby's `args:`/`env:`/`preopens:` kwargs); only the host scratch dir comes through `{scratch}`. `invoke`'s status-133 cascade is discarded (`exit 0`), the same way the Ruby glue's empty `rescue ...::Rt::Exit` swallows it — these cases assert stdout/host state, never the guest's own exit code.
 
 const BASH_QJS_FILE_IO_GLUE: &str = r#"WASI_ARGS=(qjs /work/qjs_file_io.js)
 WASI_ENV=()
@@ -187,15 +146,11 @@ sqlite3shell_invoke '_start'
 exit 0
 "#;
 
-// ---------------------------------------------------------------------
-// Suite wiring (ADR-27): each per-case macro invocation declares participation.
+// --------------------------------------------------------------------- Suite wiring (ADR-27): each per-case macro invocation declares participation.
 
 library_add_e2e!(Bash, BASH_ADD_GLUE);
 wasi_import_override_e2e!(Bash, BASH_OVERRIDE_GLUE);
-// custom_wasi_provider_e2e! / partial_override_e2e! / stdio_capture_e2e!: not
-// invoked — Bash has no host-language object model to replace WASI wholesale,
-// probe its lazy construction, or redirect stdio into an in-memory object
-// (ADR-12).
+// custom_wasi_provider_e2e! / partial_override_e2e! / stdio_capture_e2e!: not invoked — Bash has no host-language object model to replace WASI wholesale, probe its lazy construction, or redirect stdio into an in-memory object (ADR-12).
 
 wasi_suite!(Bash, Stdio);
 wasi_suite!(Bash, ArgsEnv);
@@ -206,50 +161,19 @@ standalone_dir_e2e!(Bash);
 
 cowsay_args_e2e!(Bash);
 cowsay_stdin_e2e!(Bash);
-// qjs_eval_e2e! / sqlite3_shell_e2e!: invoked, but slow — Bash's softfloat
-// makes QuickJS/SQLite take tens of seconds, so the generated tests are
-// `#[ignore]`d by default; `--features slow_test` or `-- --include-ignored` runs
-// them anyway (same as every other backend, ADR-27 revision).
+// qjs_eval_e2e! / sqlite3_shell_e2e!: invoked, but slow — Bash's softfloat makes QuickJS/SQLite take tens of seconds, so the generated tests are `#[ignore]`d by default; `--features slow_test` or `-- --include-ignored` runs them anyway (same as every other backend, ADR-27 revision).
 qjs_eval_e2e!(Bash);
 sqlite3_shell_e2e!(Bash);
-// minigzip is integer-only (no softfloat), so it runs under Bash by default,
-// unlike the slow floating-point apps (QuickJS/SQLite).
+// minigzip is integer-only (no softfloat), so it runs under Bash by default, unlike the slow floating-point apps (QuickJS/SQLite).
 gzip_e2e!(Bash);
 
-// Filesystem app cases (ADR-34): Bash's WASI filesystem now covers preopens,
-// path_open, and positioned I/O, so the three small-fixture fs apps are
-// wired (all slow, softfloat-bound QuickJS/SQLite — see qjs_eval_e2e! above).
+// Filesystem app cases (ADR-34): Bash's WASI filesystem now covers preopens, path_open, and positioned I/O, so the three small-fixture fs apps are wired (all slow, softfloat-bound QuickJS/SQLite — see qjs_eval_e2e! above).
 qjs_file_io_e2e!(Bash, BASH_QJS_FILE_IO_GLUE);
 qjs_repl_e2e!(Bash, BASH_QJS_REPL_GLUE);
 sqlite3_shell_dbfile_e2e!(Bash, BASH_SQLITE3_SHELL_DBFILE_GLUE);
-// qjs_repl_pty is not a filesystem case (no preopens) but is wired here
-// alongside them: it shares their standalone-mode QuickJS conversion. It is
-// markedly slower than every other case — every keystroke of the scripted
-// session re-enters QuickJS's interactive line editor (redraw/completion), and
-// each successive evaluation measured slower than the last (first prompt ~135s,
-// then +~65s, then +~330s for `[3,1,2].sort()`), so it exceeds the shared 180s
-// per-prompt `PTY_TIMEOUT` (`crates/dewasm-test-helper/src/qjs_repl.rs`) and
-// timed out on CI (#22). It is therefore pinned to the `ultra` tier (ADR-48):
-// kept out of CI's `slow_test` sweep and run only under
-// `--features ultra_slow_test` or `-- --include-ignored`, in local pre-release
-// verification. Left wired rather than unwired per ADR-15 (fail loud, not
-// silently skip): a timeout is still an honest signal.
+// qjs_repl_pty is not a filesystem case (no preopens) but is wired here alongside them: it shares their standalone-mode QuickJS conversion. It is markedly slower than every other case — every keystroke of the scripted session re-enters QuickJS's interactive line editor (redraw/completion), and each successive evaluation measured slower than the last (first prompt ~135s, then +~65s, then +~330s for `[3,1,2].sort()`), so it exceeds the shared 180s per-prompt `PTY_TIMEOUT` (`crates/dewasm-test-helper/src/qjs_repl.rs`) and timed out on CI (#22). It is therefore pinned to the `ultra` tier (ADR-48): kept out of CI's `slow_test` sweep and run only under `--features ultra_slow_test` or `-- --include-ignored`, in local pre-release verification. Left wired rather than unwired per ADR-15 (fail loud, not silently skip): a timeout is still an honest signal.
 qjs_repl_pty_e2e!(Bash, ultra);
-// rg_search_e2e! / cpython_hello_e2e! / cruby_hello_e2e!: not invoked — these
-// wasm binaries are tens of MB; the Bash backend's per-instruction lowering
-// (ADR-11) would generate a hundreds-of-MB script, well beyond what bash's
-// own parser can load in practice (ADR-13's softfloat perf figures already
-// put a single arithmetic op at bash-interpreter speed, and these apps are
-// orders of magnitude larger than QuickJS/SQLite) — parse feasibility, not
-// just runtime speed, is the blocker.
+// rg_search_e2e! / cpython_hello_e2e! / cruby_hello_e2e!: not invoked — these wasm binaries are tens of MB; the Bash backend's per-instruction lowering (ADR-11) would generate a hundreds-of-MB script, well beyond what bash's own parser can load in practice (ADR-13's softfloat perf figures already put a single arithmetic op at bash-interpreter speed, and these apps are orders of magnitude larger than QuickJS/SQLite) — parse feasibility, not just runtime speed, is the blocker.
 
 shared_table_e2e!(Bash, BASH_SHARED_TABLE_GLUE);
-// libsqlite3_c_api_e2e! / sqlite3_file_c_api_e2e! / sqlite3_callback_binding_e2e!
-// / pcap_compile_e2e! / treesitter_parse_e2e!: not invoked — Bash has no
-// host-language C API to plumb a pointer-returning binding through (ADR-12), and
-// the multi-MB reactor artifacts are far past what Bash's parser can load in
-// practice.
-// embedded_coexist_e2e!: not invoked — Bash has one flat global namespace
-// (no nested runtime/class construct), so two independently-generated
-// runtimes cannot coexist in one process without their rt_*/mem_* function
-// names colliding (ADR-11).
+// libsqlite3_c_api_e2e! / sqlite3_file_c_api_e2e! / sqlite3_callback_binding_e2e! / pcap_compile_e2e! / treesitter_parse_e2e!: not invoked — Bash has no host-language C API to plumb a pointer-returning binding through (ADR-12), and the multi-MB reactor artifacts are far past what Bash's parser can load in practice. embedded_coexist_e2e!: not invoked — Bash has one flat global namespace (no nested runtime/class construct), so two independently-generated runtimes cannot coexist in one process without their rt_*/mem_* function names colliding (ADR-11).

--- a/crates/dewasm-backend-bash/tests/softfloat.rs
+++ b/crates/dewasm-backend-bash/tests/softfloat.rs
@@ -1,9 +1,4 @@
-//! Softfloat oracle (ADR-13): drives the bash float units with edge and
-//! seeded-random vectors and compares every result bit-for-bit against
-//! Rust's host IEEE-754 arithmetic adjusted to wasm semantics (canonical
-//! NaN results, wasm min/max, the Ruby backend's trunc trap table). The
-//! spec harness remains the bar (ADR-3); this is the fast development
-//! net that pinpoints the exact op and operands on a regression.
+//! Softfloat oracle (ADR-13): drives the bash float units with edge and seeded-random vectors and compares every result bit-for-bit against Rust's host IEEE-754 arithmetic adjusted to wasm semantics (canonical NaN results, wasm min/max, the Ruby backend's trunc trap table). The spec harness remains the bar (ADR-3); this is the fast development net that pinpoints the exact op and operands on a regression.
 
 use std::collections::BTreeSet;
 use std::fmt::Write as _;
@@ -94,8 +89,7 @@ impl Cases {
     }
 }
 
-/// Random f64 pattern pairs whose exponents are close enough to exercise
-/// alignment, cancellation, and gradual underflow.
+/// Random f64 pattern pairs whose exponents are close enough to exercise alignment, cancellation, and gradual underflow.
 fn correlated_pair(rng: &mut Lcg) -> (i64, i64) {
     let a = rng.next() as i64;
     let ea = ((a >> 52) & 0x7ff).clamp(1, 0x7fe);
@@ -422,8 +416,7 @@ const TRUNC_EDGES32: &[u32] = &[
     0x3f000000, // 0.5
 ];
 
-/// The Ruby backend's trunc semantics: NaN and out-of-range trap; the
-/// bound check is on the truncated value.
+/// The Ruby backend's trunc semantics: NaN and out-of-range trap; the bound check is on the truncated value.
 fn oracle_trunc(x: f64, lo: f64, hi_excl: f64) -> Result<f64, &'static str> {
     if x.is_nan() {
         return Err("invalid conversion to integer");
@@ -604,8 +597,7 @@ fn softfloat_conversions() {
     run_cases(&cases);
 }
 
-/// f32 arithmetic through promote/f64/demote: the empirical check of the
-/// double-rounding theorem, biased toward the 24-bit boundary.
+/// f32 arithmetic through promote/f64/demote: the empirical check of the double-rounding theorem, biased toward the 24-bit boundary.
 #[test]
 fn softfloat_f32_arith() {
     let mut cases = Cases::new();

--- a/crates/dewasm-backend-bash/tests/spec.rs
+++ b/crates/dewasm-backend-bash/tests/spec.rs
@@ -1,12 +1,6 @@
-//! Bash side of the shared spec harness (ADR-3, ADR-27): converts modules
-//! with the Bash backend, phrases assertions as bash (`ck`/`ckt`/`cke`
-//! helpers over the R0..Rn result globals and the status-134 trap protocol),
-//! and runs the script with a discovered bash >= 5 (macOS system bash is 3.2).
+//! Bash side of the shared spec harness (ADR-3, ADR-27): converts modules with the Bash backend, phrases assertions as bash (`ck`/`ckt`/`cke` helpers over the R0..Rn result globals and the status-134 trap protocol), and runs the script with a discovered bash >= 5 (macOS system bash is 3.2).
 //!
-//! Bash executes wasm orders of magnitude slower than Ruby, so `cargo test`
-//! runs a curated file list (ADR-3 pre-accepts this); the rest are `#[ignore]`d
-//! trials, so `cargo test -- --include-ignored` sweeps everything. The generic
-//! harness lives in `dewasm-test-helper`.
+//! Bash executes wasm orders of magnitude slower than Ruby, so `cargo test` runs a curated file list (ADR-3 pre-accepts this); the rest are `#[ignore]`d trials, so `cargo test -- --include-ignored` sweeps everything. The generic harness lives in `dewasm-test-helper`.
 
 use std::collections::BTreeSet;
 use std::fmt::Write as _;
@@ -19,32 +13,10 @@ use dewasm_test_helper::{spec_suite, BackendUnderTest, Converted, SpecBackend};
 use wast::core::{NanPattern, WastArgCore, WastRetCore};
 use wast::{WastArg, WastRet};
 
-/// Known assertion-level failures (ADR-35). Cross-module linking of
-/// function, global, memory, and now table imports (through PROVIDERS and
-/// the per-kind export maps) is fully wired; `assert_unlinkable` is checked
-/// for real. Two residual clusters, both pre-existing and out of this
-/// backend's scope to fix (matching the Ruby ledger, which has already
-/// covered every import kind for a while):
+/// Known assertion-level failures (ADR-35). Cross-module linking of function, global, memory, and now table imports (through PROVIDERS and the per-kind export maps) is fully wired; `assert_unlinkable` is checked for real. Two residual clusters, both pre-existing and out of this backend's scope to fix (matching the Ruby ledger, which has already covered every import kind for a while):
 ///
-/// - `import-limits` (`imports`, `imports2`, 4 of `linking`'s 4):
-///   `rt_resolve_import` validates that a resolved import is the right
-///   *kind* (func/global/table/memory) but not the finer-grained wasm type —
-///   a function's param/result signature, a global's mutability, a table's
-///   min/max limits, or a memory's min/max limits. Every `assert_unlinkable`
-///   case testing one of those (not a kind mismatch, which is caught) links
-///   instead of failing. Same accepted gap as the Ruby ledger's
-///   `import-limits`, and now the same count (28/2/4) since Bash supports
-///   every import kind Ruby does.
-/// - `multi-memory` (`linking0`, `load1`): a second `(memory ...)`
-///   declaration or import is rejected outright by the core builder
-///   (`Feature::MultiMemory`, a post-1.0 proposal, ADR-24) regardless of
-///   backend. Both files exercise this via a module with two memories (one
-///   often an import of another module's exported memory); that module
-///   fails to convert, so the data/assertions that depended on it running
-///   observe stale (zeroed) state in a memory another, unrelated module
-///   still owns. Not a linking gap — every import in play resolves fine —
-///   and not fixable without the multi-memory proposal, which ADR-24 rejects
-///   outright.
+/// - `import-limits` (`imports`, `imports2`, 4 of `linking`'s 4): `rt_resolve_import` validates that a resolved import is the right *kind* (func/global/table/memory) but not the finer-grained wasm type — a function's param/result signature, a global's mutability, a table's min/max limits, or a memory's min/max limits. Every `assert_unlinkable` case testing one of those (not a kind mismatch, which is caught) links instead of failing. Same accepted gap as the Ruby ledger's `import-limits`, and now the same count (28/2/4) since Bash supports every import kind Ruby does.
+/// - `multi-memory` (`linking0`, `load1`): a second `(memory ...)` declaration or import is rejected outright by the core builder (`Feature::MultiMemory`, a post-1.0 proposal, ADR-24) regardless of backend. Both files exercise this via a module with two memories (one often an import of another module's exported memory); that module fails to convert, so the data/assertions that depended on it running observe stale (zeroed) state in a memory another, unrelated module still owns. Not a linking gap — every import in play resolves fine — and not fixable without the multi-memory proposal, which ADR-24 rejects outright.
 const EXPECTED_FAILURES: &[(&str, u32, &str)] = &[
     ("imports", 28, "import-limits"),
     ("imports2", 2, "import-limits"),
@@ -53,9 +25,7 @@ const EXPECTED_FAILURES: &[(&str, u32, &str)] = &[
     ("load1", 5, "multi-memory"),
 ];
 
-/// Files `cargo test` runs by default: integer-only files the backend's
-/// current milestones cover, plus files whose value is their Rust-side
-/// assert_invalid checks and attributed `floats` skips.
+/// Files `cargo test` runs by default: integer-only files the backend's current milestones cover, plus files whose value is their Rust-side assert_invalid checks and attributed `floats` skips.
 const CURATED_FILES: &[&str] = &[
     "address",
     "address0",
@@ -201,13 +171,9 @@ impl SpecBackend for BashSpec {
         registered: &[(String, String)],
     ) -> String {
         script.push_str(&conv.source);
-        // Rebuild PROVIDERS from the *current* registered set before every
-        // instantiation (ADR-35): a plain reassignment fully replaces the
-        // associative array on bash >= 5, so a module registered after a
-        // failed one never leaves a stale provider entry behind.
+        // Rebuild PROVIDERS from the *current* registered set before every instantiation (ADR-35): a plain reassignment fully replaces the associative array on bash >= 5, so a module registered after a failed one never leaves a stale provider entry behind.
         let _ = writeln!(script, "{}", providers_line(registered));
-        // A trap while instantiating a plain module directive aborts the file,
-        // mirroring an uncaught Ruby exception at toplevel.
+        // A trap while instantiating a plain module directive aborts the file, mirroring an uncaught Ruby exception at toplevel.
         let _ = writeln!(
             script,
             "{}init || {{ echo \"toplevel init failed (status $?): $TRAP_MSG\" >&2; exit 1; }}",
@@ -276,8 +242,7 @@ impl SpecBackend for BashSpec {
     }
 
     fn emit_check_exhaust(&self, script: &mut String, desc: &str, call: &str) {
-        // FUNCNEST overflow kills the shell it happens in, so exhaustion must
-        // run in a subshell; nothing else needs one.
+        // FUNCNEST overflow kills the shell it happens in, so exhaustion must run in a subshell; nothing else needs one.
         let _ = writeln!(
             script,
             "( FUNCNEST=1000; {call} ) 2>/dev/null\ncke $? {}",
@@ -312,9 +277,7 @@ fn bash_str(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
 }
 
-/// The PROVIDERS rebuild line for an instantiation: always the `spectest`
-/// host prefix plus each currently-`register`ed module mapped to its
-/// generation prefix (the `conv.handle` returned by `emit_instantiate`).
+/// The PROVIDERS rebuild line for an instantiation: always the `spectest` host prefix plus each currently-`register`ed module mapped to its generation prefix (the `conv.handle` returned by `emit_instantiate`).
 fn providers_line(registered: &[(String, String)]) -> String {
     let mut entries = vec!["[spectest]=spectest_".to_string()];
     for (name, prefix) in registered {
@@ -326,8 +289,7 @@ fn providers_line(registered: &[(String, String)]) -> String {
 fn arg_bash(arg: &WastArg<'_>) -> Result<String, String> {
     match arg {
         WastArg::Core(WastArgCore::I32(v)) => Ok((*v as u32).to_string()),
-        // i64/f64 travel as the signed-64 bit pattern, f32 as its u32 pattern
-        // (ADR-11/ADR-13).
+        // i64/f64 travel as the signed-64 bit pattern, f32 as its u32 pattern (ADR-11/ADR-13).
         WastArg::Core(WastArgCore::I64(v)) => Ok(v.to_string()),
         WastArg::Core(WastArgCore::F32(f)) => Ok(f.bits.to_string()),
         WastArg::Core(WastArgCore::F64(f)) => Ok((f.bits as i64).to_string()),
@@ -341,9 +303,7 @@ fn ret_cond(i: usize, ret: &WastRet<'_>) -> Result<String, String> {
     match ret {
         WastRet::Core(WastRetCore::I32(v)) => Ok(format!("R{i} == {}", *v as u32)),
         WastRet::Core(WastRetCore::I64(v)) => Ok(format!("R{i} == {v}")),
-        // Floats are compared as bit patterns (they already are the R
-        // registers' representation); the NaN masks mirror the ruby side's
-        // ret_cmp, as signed-64-safe integer constants.
+        // Floats are compared as bit patterns (they already are the R registers' representation); the NaN masks mirror the ruby side's ret_cmp, as signed-64-safe integer constants.
         WastRet::Core(WastRetCore::F32(pattern)) => Ok(match pattern {
             NanPattern::CanonicalNan => {
                 format!("(R{i} & 0x7fffffff) == 0x7fc00000")

--- a/crates/dewasm-backend-bash/tests/wasi_fs_regressions.rs
+++ b/crates/dewasm-backend-bash/tests/wasi_fs_regressions.rs
@@ -1,16 +1,6 @@
-//! Bash-only WASI filesystem regression pins (the issue-29 fixes): drive a
-//! converted library-mode module plus its bundled units directly under bash,
-//! the same direct-drive shape as `softfloat.rs`. These cases do not join the
-//! shared `WASI_CASES` conformance table because the other backends inherit
-//! the probed errnos from the host OS — which differs between Linux and macOS
-//! on some of them — while the bash units implement each choice
-//! deterministically; the exact codes pinned here are bash's own contract
-//! (`runtime/bash/units/wasi/path_rename.sh` / `fd_close.sh` /
-//! `fd_allocate.sh`).
+//! Bash-only WASI filesystem regression pins (the issue-29 fixes): drive a converted library-mode module plus its bundled units directly under bash, the same direct-drive shape as `softfloat.rs`. These cases do not join the shared `WASI_CASES` conformance table because the other backends inherit the probed errnos from the host OS — which differs between Linux and macOS on some of them — while the bash units implement each choice deterministically; the exact codes pinned here are bash's own contract (`runtime/bash/units/wasi/path_rename.sh` / `fd_close.sh` / `fd_allocate.sh`).
 //!
-//! The permission-based cases (a read-only parent to fail `rmdir`, a
-//! read-only file to fail the close-time flush) assume a non-root test user:
-//! root ignores permission bits and would see the operations succeed.
+//! The permission-based cases (a read-only parent to fail `rmdir`, a read-only file to fail the close-time flush) assume a non-root test user: root ignores permission bits and would see the operations succeed.
 #![cfg(unix)]
 
 use std::path::{Path, PathBuf};
@@ -20,8 +10,7 @@ use dewasm_backend::Mode;
 use dewasm_backend_bash::{find_bash5, BashBackend};
 use dewasm_test_helper::convert_bytes;
 
-/// A fresh, empty scratch directory keyed by `name`, so cases running in
-/// parallel never share host state (the `wasi.rs` helper's shape).
+/// A fresh, empty scratch directory keyed by `name`, so cases running in parallel never share host state (the `wasi.rs` helper's shape).
 fn scratch_dir(name: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!("dewasm-bash-wasi-reg-{name}"));
     let _ = std::fs::remove_dir_all(&dir);
@@ -29,9 +18,7 @@ fn scratch_dir(name: &str) -> PathBuf {
     dir
 }
 
-/// Convert `wat_src` in library mode (module name `prog`, embedded runtime,
-/// bundled WASI), append `glue`, run the script under bash >= 5, and return
-/// its stdout. The script itself must exit 0 (the glue ends in `exit 0`).
+/// Convert `wat_src` in library mode (module name `prog`, embedded runtime, bundled WASI), append `glue`, run the script under bash >= 5, and return its stdout. The script itself must exit 0 (the glue ends in `exit 0`).
 fn run_module(name: &str, wat_src: &str, glue: &str) -> String {
     let bash = find_bash5().expect("bash >= 5 not found — see docs/testing.md");
     let bytes = wat::parse_str(wat_src).expect("parse wat");
@@ -54,10 +41,7 @@ fn run_module(name: &str, wat_src: &str, glue: &str) -> String {
     String::from_utf8_lossy(&output.stdout).into_owned()
 }
 
-/// The standard `_start` glue (`e2e.rs`'s `BASH_FS_GLUE` with the preopen
-/// inlined): preopen `host` at guest `/`, run `_start`, surface a `proc_exit`
-/// code — `invoke` returns status 133 with the code in `$EXIT_CODE` (ADR-12)
-/// — as a trailing decimal line.
+/// The standard `_start` glue (`e2e.rs`'s `BASH_FS_GLUE` with the preopen inlined): preopen `host` at guest `/`, run `_start`, surface a `proc_exit` code — `invoke` returns status 133 with the code in `$EXIT_CODE` (ADR-12) — as a trailing decimal line.
 fn start_glue(host: &Path) -> String {
     format!(
         r#"WASI_DIRS=('{}::/')
@@ -73,8 +57,7 @@ exit 0
     )
 }
 
-/// A module whose `_start` calls `path_rename(3, old, 3, new)` against the
-/// first preopen and exits with the errno.
+/// A module whose `_start` calls `path_rename(3, old, 3, new)` against the first preopen and exits with the errno.
 fn rename_wat(old: &str, new: &str) -> String {
     format!(
         r#"(module
@@ -94,9 +77,7 @@ fn rename_wat(old: &str, new: &str) -> String {
     )
 }
 
-/// A module whose `_start` opens (CREAT) the file `f` with
-/// FD_READ|FD_WRITE|FD_ALLOCATE rights, calls `fd_allocate(fd, offset, len)`,
-/// and exits with the errno.
+/// A module whose `_start` opens (CREAT) the file `f` with FD_READ|FD_WRITE|FD_ALLOCATE rights, calls `fd_allocate(fd, offset, len)`, and exits with the errno.
 fn allocate_wat(offset: i64, len: i64) -> String {
     format!(
         r#"(module
@@ -129,9 +110,7 @@ fn allocate_wat(offset: i64, len: i64) -> String {
     )
 }
 
-/// A trailing slash on a source that resolves to a regular file is ENOTDIR
-/// (54), and nothing moves — before the fix the slash was silently stripped
-/// and the rename succeeded.
+/// A trailing slash on a source that resolves to a regular file is ENOTDIR (54), and nothing moves — before the fix the slash was silently stripped and the rename succeeded.
 #[test]
 fn rename_trailing_slash_on_file_source_is_enotdir() {
     let dir = scratch_dir("slash-src-file");
@@ -146,9 +125,7 @@ fn rename_trailing_slash_on_file_source_is_enotdir() {
     assert!(!dir.join("renamed").exists(), "nothing may be created");
 }
 
-/// A trailing slash on a nonexistent source is the ordinary missing-source
-/// ENOENT (44) — POSIX: rename("nonexistent/", "x") fails pathname
-/// resolution, not ENOTDIR.
+/// A trailing slash on a nonexistent source is the ordinary missing-source ENOENT (44) — POSIX: rename("nonexistent/", "x") fails pathname resolution, not ENOTDIR.
 #[test]
 fn rename_trailing_slash_missing_source_is_enoent() {
     let dir = scratch_dir("slash-src-missing");
@@ -160,8 +137,7 @@ fn rename_trailing_slash_missing_source_is_enoent() {
     assert_eq!(out, "44\n");
 }
 
-/// A trailing slash on a destination that resolves to an existing regular
-/// file is ENOTDIR (54) — without the slash this would be a legal replace.
+/// A trailing slash on a destination that resolves to an existing regular file is ENOTDIR (54) — without the slash this would be a legal replace.
 #[test]
 fn rename_trailing_slash_on_file_destination_is_enotdir() {
     let dir = scratch_dir("slash-dst-file");
@@ -177,9 +153,7 @@ fn rename_trailing_slash_on_file_destination_is_enotdir() {
     assert_eq!(std::fs::read_to_string(dir.join("dst")).unwrap(), "d");
 }
 
-/// A trailing slash on a *nonexistent* destination is stripped and the
-/// rename proceeds onto the bare name — wasmtime's behavior (ADR-49). The
-/// raw hosts diverge here (macOS ENOENT / Linux ENOTDIR), hence the pin.
+/// A trailing slash on a *nonexistent* destination is stripped and the rename proceeds onto the bare name — wasmtime's behavior (ADR-49). The raw hosts diverge here (macOS ENOENT / Linux ENOTDIR), hence the pin.
 #[test]
 fn rename_trailing_slash_missing_destination_strips_and_renames() {
     let dir = scratch_dir("slash-dst-missing");
@@ -198,8 +172,7 @@ fn rename_trailing_slash_missing_destination_strips_and_renames() {
     );
 }
 
-/// Trailing slashes on directories keep working: rename("d1/", "d2/") with a
-/// directory source and a nonexistent destination succeeds.
+/// Trailing slashes on directories keep working: rename("d1/", "d2/") with a directory source and a nonexistent destination succeeds.
 #[test]
 fn rename_trailing_slash_on_directories_still_renames() {
     let dir = scratch_dir("slash-dirs-ok");
@@ -214,13 +187,7 @@ fn rename_trailing_slash_on_directories_still_renames() {
     assert!(dir.join("d2").is_dir(), "destination must be the directory");
 }
 
-/// When the `rmdir` clearing an empty destination directory fails (here: its
-/// parent is read-only), path_rename must report the failure — before the fix
-/// the unchecked `rmdir` was followed by an unconditional `mv`, which nested
-/// the source *inside* the surviving destination and reported success. The
-/// destination is still empty afterwards, so the errno is the unit's default
-/// EIO (29); a destination that gained entries would be ENOTEMPTY (55), but
-/// that race cannot be staged deterministically here.
+/// When the `rmdir` clearing an empty destination directory fails (here: its parent is read-only), path_rename must report the failure — before the fix the unchecked `rmdir` was followed by an unconditional `mv`, which nested the source *inside* the surviving destination and reported success. The destination is still empty afterwards, so the errno is the unit's default EIO (29); a destination that gained entries would be ENOTEMPTY (55), but that race cannot be staged deterministically here.
 #[test]
 fn rename_rmdir_failure_is_reported_and_moves_nothing() {
     use std::os::unix::fs::PermissionsExt;
@@ -244,10 +211,7 @@ fn rename_rmdir_failure_is_reported_and_moves_nothing() {
     );
 }
 
-/// offset+len past i64::MAX must not wrap bash's signed-64 arithmetic into a
-/// silent no-op success: it is EIO (29), the code Ruby/Python surface when the
-/// host refuses an unsatisfiable size (their unmapped EFBIG falls through to
-/// ERRNO_IO).
+/// offset+len past i64::MAX must not wrap bash's signed-64 arithmetic into a silent no-op success: it is EIO (29), the code Ruby/Python surface when the host refuses an unsatisfiable size (their unmapped EFBIG falls through to ERRNO_IO).
 #[test]
 fn fd_allocate_overflowing_size_is_eio() {
     let dir = scratch_dir("alloc-overflow");
@@ -259,8 +223,7 @@ fn fd_allocate_overflowing_size_is_eio() {
     assert_eq!(out, "29\n");
 }
 
-/// A negative (u64 >= 2^63) len keeps its existing EINVAL (28) — the overflow
-/// guard must not shadow the sign check.
+/// A negative (u64 >= 2^63) len keeps its existing EINVAL (28) — the overflow guard must not shadow the sign check.
 #[test]
 fn fd_allocate_negative_len_is_einval() {
     let dir = scratch_dir("alloc-negative");
@@ -268,10 +231,7 @@ fn fd_allocate_negative_len_is_einval() {
     assert_eq!(out, "28\n");
 }
 
-/// A flush failure at close (the buffered file was made unwritable between
-/// the write and the close) must surface its errno — before the fix fd_close
-/// unconditionally reported 0 and the guest never learned its writes were
-/// lost. The fd state must still be released: a second close is EBADF (8).
+/// A flush failure at close (the buffered file was made unwritable between the write and the close) must surface its errno — before the fix fd_close unconditionally reported 0 and the guest never learned its writes were lost. The fd state must still be released: a second close is EBADF (8).
 #[test]
 fn fd_close_flush_failure_propagates_errno_and_releases_fd() {
     let dir = scratch_dir("close-flush-failure");
@@ -301,9 +261,7 @@ fn fd_close_flush_failure_propagates_errno_and_releases_fd() {
     (local.get $fd))
   (func (export "closefd") (param i32) (result i32)
     (call $fd_close (local.get 0))))"#;
-    // Glue: open+write, then make the file unwritable *behind the buffer* so
-    // the close-time flush fails (file_flush's truncate-open reports EIO, 29),
-    // then close twice — the second close must see a released fd (EBADF, 8).
+    // Glue: open+write, then make the file unwritable *behind the buffer* so the close-time flush fails (file_flush's truncate-open reports EIO, 29), then close twice — the second close must see a released fd (EBADF, 8).
     let glue = format!(
         r#"WASI_DIRS=('{host}::/')
 prog_init || {{ echo "init failed" >&2; exit 1; }}

--- a/crates/dewasm-backend-bash/tests/wasi_testsuite.rs
+++ b/crates/dewasm-backend-bash/tests/wasi_testsuite.rs
@@ -1,7 +1,4 @@
-//! Bash side of the official WASI p1 conformance harness (ADR-36): drives the
-//! prebuilt `WebAssembly/wasi-testsuite` modules through the Bash backend's
-//! standalone interface (real WASI filesystem, ADR-34; status-cascade exit
-//! codes, ADR-11/12). The generic harness lives in `dewasm-test-helper`.
+//! Bash side of the official WASI p1 conformance harness (ADR-36): drives the prebuilt `WebAssembly/wasi-testsuite` modules through the Bash backend's standalone interface (real WASI filesystem, ADR-34; status-cascade exit codes, ADR-11/12). The generic harness lives in `dewasm-test-helper`.
 
 use std::path::PathBuf;
 
@@ -9,27 +6,17 @@ use dewasm_backend::Backend;
 use dewasm_backend_bash::BashBackend;
 use dewasm_test_helper::{wasi_testsuite_suite, BackendUnderTest, WasiTestsuiteBackend};
 
-/// Known trial failures with their attribution (ADR-8, policy in ADR-36):
-/// `(trial, tag)` — out-of-scope syscalls (timestamps, sockets), the D3
-/// file-symlink-follow limit (pure bash has no `readlink` for path resolution,
-/// ADR-34), stat-precision gaps with no `stat` license (dev/ino), the D1
-/// whole-file-buffer divergence, and environ entries bash itself exports
-/// (PWD/SHLVL/_), which count-exact `environ_*` assertions cannot absorb
-/// (ADR-40).
+/// Known trial failures with their attribution (ADR-8, policy in ADR-36): `(trial, tag)` — out-of-scope syscalls (timestamps, sockets), the D3 file-symlink-follow limit (pure bash has no `readlink` for path resolution, ADR-34), stat-precision gaps with no `stat` license (dev/ino), the D1 whole-file-buffer divergence, and environ entries bash itself exports (PWD/SHLVL/_), which count-exact `environ_*` assertions cannot absorb (ADR-40).
 const WASI_TESTSUITE_EXPECTED_FAILURES: &[(&str, &str)] = &[
     // Sockets — out of scope (docs/support.md).
     ("c/sock_shutdown-invalid_fd", "sock_shutdown (out of scope)"),
     ("c/sock_shutdown-not_sock", "sock_shutdown (out of scope)"),
-    // Timestamp setters — deliberately not implemented: `touch` fails the
-    // ADR-34 D2 mutation-license criterion, so fd/path_filestat_set_times and
-    // the tests that exercise them stay ENOSYS.
+    // Timestamp setters — deliberately not implemented: `touch` fails the ADR-34 D2 mutation-license criterion, so fd/path_filestat_set_times and the tests that exercise them stay ENOSYS.
     ("rust/fd_filestat_set", "fd_filestat_set_times (ENOSYS)"),
     ("rust/fstflags_validate", "fd_filestat_set_times (ENOSYS)"),
     ("rust/path_filestat", "path_filestat_set_times (ENOSYS)"),
     ("rust/symlink_filestat", "path_filestat_set_times (ENOSYS)"),
-    // D3: a file symlink cannot be followed in pure bash (no readlink builtin
-    // for path *resolution*), so following one during path_open/path_filestat
-    // resolves to ELOOP where a real host would reach the pointee (ADR-34 D3).
+    // D3: a file symlink cannot be followed in pure bash (no readlink builtin for path *resolution*), so following one during path_open/path_filestat resolves to ELOOP where a real host would reach the pointee (ADR-34 D3).
     (
         "rust/symlink_create",
         "path resolution: file-symlink follow ELOOP (ADR-34 D3)",
@@ -42,23 +29,19 @@ const WASI_TESTSUITE_EXPECTED_FAILURES: &[(&str, &str)] = &[
         "rust/nofollow_errors",
         "path resolution: file-symlink follow ELOOP (ADR-34 D3)",
     ),
-    // No `stat` license (ADR-34 D6): dev/ino are always 0, so the tests that
-    // assert per-entry inode/device uniqueness cannot pass.
+    // No `stat` license (ADR-34 D6): dev/ino are always 0, so the tests that assert per-entry inode/device uniqueness cannot pass.
     (
         "rust/fd_readdir",
         "fd_readdir: d_ino uniqueness (no stat license)",
     ),
     ("c/fdopendir-with-access", "fd_readdir: d_ino uniqueness"),
     ("c/stat-dev-ino", "path_filestat_get: st_ino uniqueness"),
-    // D1 whole-file-buffer model: two fds on one file each hold their own
-    // buffer, so an unbuffered cross-fd read-back sees 0 bytes (ADR-34 D1).
+    // D1 whole-file-buffer model: two fds on one file each hold their own buffer, so an unbuffered cross-fd read-back sees 0 bytes (ADR-34 D1).
     (
         "rust/file_unbuffered_write",
         "fd_read: unbuffered read-back returns 0",
     ),
-    // Bash itself exports PWD/SHLVL/_ into every script's environment, so
-    // count-exact environ assertions cannot hold even under the harness's
-    // cleared environment (ADR-40).
+    // Bash itself exports PWD/SHLVL/_ into every script's environment, so count-exact environ assertions cannot hold even under the harness's cleared environment (ADR-40).
     (
         "assemblyscript/environ_get-multiple-variables",
         "environ: host-interpreter env injection",

--- a/crates/dewasm-backend-go/build.rs
+++ b/crates/dewasm-backend-go/build.rs
@@ -1,6 +1,4 @@
-//! Embeds the runtime units from runtime/go/units/ as
-//! `UNIT_SOURCES: &[(&str, &str)]` (unit id, source). Mirrors the Python
-//! crate's build.rs (ADR-6); only the source directory and extension differ.
+//! Embeds the runtime units from runtime/go/units/ as `UNIT_SOURCES: &[(&str, &str)]` (unit id, source). Mirrors the Python crate's build.rs (ADR-6); only the source directory and extension differ.
 
 use std::fmt::Write as _;
 use std::path::Path;

--- a/crates/dewasm-backend-go/src/lib.rs
+++ b/crates/dewasm-backend-go/src/lib.rs
@@ -1,24 +1,11 @@
-//! Go backend: translates dewasm IR into a single self-contained Go source
-//! file (`package main` plus a bundled runtime).
+//! Go backend: translates dewasm IR into a single self-contained Go source file (`package main` plus a bundled runtime).
 //!
 //! Lowering conventions (ADR-29; numeric conventions ADR-2):
-//! - i32/i64 are native `uint32`/`uint64` (masking is free — arithmetic wraps);
-//!   signed views are `int32(x)`/`int64(x)` casts. f32/f64 are native
-//!   `float32`/`float64`, so f32 re-rounding and IEEE float division need no
-//!   helper (Go floats trap-free, unlike Python/Ruby/Bash).
-//! - NaN bit paths go through `math.Float32bits`/`Float64bits`, which are
-//!   bit-preserving on native floats; only demote/promote reconstruct NaN
-//!   payloads explicitly.
-//! - Control flow maps onto Go's labeled loops: a referenced block/if becomes
-//!   `L: for { ...; break L }`, a referenced loop `L: for { ...; break L }`
-//!   with back-edges as `continue L`. Unreferenced structures are spliced
-//!   inline. Unused labels/variables are Go compile errors, so labels are
-//!   emitted only when referenced and locals/temps only when used (a pre-pass
-//!   over the body computes the read/used sets, blanking the rest with `_ =`).
+//! - i32/i64 are native `uint32`/`uint64` (masking is free — arithmetic wraps); signed views are `int32(x)`/`int64(x)` casts. f32/f64 are native `float32`/`float64`, so f32 re-rounding and IEEE float division need no helper (Go floats trap-free, unlike Python/Ruby/Bash).
+//! - NaN bit paths go through `math.Float32bits`/`Float64bits`, which are bit-preserving on native floats; only demote/promote reconstruct NaN payloads explicitly.
+//! - Control flow maps onto Go's labeled loops: a referenced block/if becomes `L: for { ...; break L }`, a referenced loop `L: for { ...; break L }` with back-edges as `continue L`. Unreferenced structures are spliced inline. Unused labels/variables are Go compile errors, so labels are emitted only when referenced and locals/temps only when used (a pre-pass over the body computes the read/used sets, blanking the rest with `_ =`).
 //!
-//! The runtime is composed from per-method units (ADR-6) referenced as
-//! `Rt.<name>` (methods on a zero-size `rt` receiver), plus package-level
-//! constructors (`newMemory`/`newTable`/`newWASI`) and a generic `rtSelect`.
+//! The runtime is composed from per-method units (ADR-6) referenced as `Rt.<name>` (methods on a zero-size `rt` receiver), plus package-level constructors (`newMemory`/`newTable`/`newWASI`) and a generic `rtSelect`.
 
 use std::cell::RefCell;
 use std::collections::BTreeSet;
@@ -37,10 +24,7 @@ use dewasm_core::ir::{
 
 include!(concat!(env!("OUT_DIR"), "/units.rs"));
 
-/// The runtime unit bundler for Go (see runtime/go/units/). Every scope has
-/// empty wrappers: Go methods and types are package-level regardless of the
-/// struct they belong to, so the bundle is a flat list of declarations
-/// (unlike Python's nested classes).
+/// The runtime unit bundler for Go (see runtime/go/units/). Every scope has empty wrappers: Go methods and types are package-level regardless of the struct they belong to, so the bundle is a flat list of declarations (unlike Python's nested classes).
 pub fn bundler() -> &'static RuntimeBundler {
     static BUNDLER: OnceLock<RuntimeBundler> = OnceLock::new();
     BUNDLER.get_or_init(|| {
@@ -85,9 +69,7 @@ pub fn bundler() -> &'static RuntimeBundler {
     })
 }
 
-/// Locate a `go` toolchain able to compile generated programs. Honors
-/// `$DEWASM_GO`, then `go` on `PATH` (ADR-15: a missing toolchain is a loud
-/// failure at the call site, not here — this only reports what qualifies).
+/// Locate a `go` toolchain able to compile generated programs. Honors `$DEWASM_GO`, then `go` on `PATH` (ADR-15: a missing toolchain is a loud failure at the call site, not here — this only reports what qualifies).
 pub fn find_go() -> Option<std::path::PathBuf> {
     use std::path::PathBuf;
     let mut candidates: Vec<PathBuf> = Vec::new();
@@ -104,9 +86,7 @@ pub fn find_go() -> Option<std::path::PathBuf> {
     })
 }
 
-/// A complete, compilable Go file bundling *every* runtime unit (with a dummy
-/// `main`), for the units lint's `go build` check that all units — not just
-/// the subset any one module uses — are valid Go.
+/// A complete, compilable Go file bundling *every* runtime unit (with a dummy `main`), for the units lint's `go build` check that all units — not just the subset any one module uses — are valid Go.
 pub fn full_bundle_go() -> Result<String> {
     let bundle = bundler().bundle_all(0)?;
     let imports = scan_imports(&bundle, false);
@@ -135,14 +115,9 @@ impl Backend for GoBackend {
 
     fn feature_status(&self, feature: Feature) -> SupportStatus {
         match feature {
-            // Go floats are native IEEE float32/float64; the NaN paths follow
-            // ADR-2 (ADR-29).
+            // Go floats are native IEEE float32/float64; the NaN paths follow ADR-2 (ADR-29).
             Feature::Floats => SupportStatus::Supported,
-            // Wasm-1.0 completion (ADR-16 for Ruby, mirrored here): imported
-            // globals/memories/tables through the provider map with a Go
-            // type-assertion kind+type check, multiple tables, and the table
-            // half of bulk memory (passive/declared element segments,
-            // table.init/copy, elem.drop).
+            // Wasm-1.0 completion (ADR-16 for Ruby, mirrored here): imported globals/memories/tables through the provider map with a Go type-assertion kind+type check, multiple tables, and the table half of bulk memory (passive/declared element segments, table.init/copy, elem.drop).
             Feature::ImportedGlobals
             | Feature::ImportedMemories
             | Feature::ImportedTables
@@ -159,10 +134,7 @@ impl Backend for GoBackend {
             name: format!("{}.go", opts.module_name),
             contents: contents.into_bytes(),
         }];
-        // The data sidecar (ADR-37): every segment's bytes concatenated in
-        // segment order, matching the `data_offsets` baked into the generated
-        // `dataBlob[o:o+len]` slices and `//go:embed`ed by the generated file.
-        // Only emitted when there is data to externalize.
+        // The data sidecar (ADR-37): every segment's bytes concatenated in segment order, matching the `data_offsets` baked into the generated `dataBlob[o:o+len]` slices and `//go:embed`ed by the generated file. Only emitted when there is data to externalize.
         if let Some(cfg) = &opts.data_file {
             if !module.datas.is_empty() {
                 let mut blob = Vec::new();
@@ -179,12 +151,7 @@ impl Backend for GoBackend {
     }
 }
 
-/// Emit just the package-level declarations for `module` (the struct, its
-/// constructor and methods, the spec-harness `invoke`/`globalGet` dispatch, and
-/// the recursion guard), for the spec harness (ADR-3): the harness bundles one
-/// shared runtime for every module in a `.wast` file, so per-module output
-/// carries no `package`/`import`/`main`. Returns the declarations and the
-/// runtime units they reference.
+/// Emit just the package-level declarations for `module` (the struct, its constructor and methods, the spec-harness `invoke`/`globalGet` dispatch, and the recursion guard), for the spec harness (ADR-3): the harness bundles one shared runtime for every module in a `.wast` file, so per-module output carries no `package`/`import`/`main`. Returns the declarations and the runtime units they reference.
 pub fn generate_program_with_units(
     module: &Module,
     type_name: &str,
@@ -218,8 +185,7 @@ fn generate_source(module: &Module, opts: &GenOptions) -> Result<String> {
         data_offsets: data_offsets(module),
     };
 
-    // Body: the generated struct + constructor + methods, into its own writer
-    // so the `uses` set is fully populated before we bundle the runtime.
+    // Body: the generated struct + constructor + methods, into its own writer so the `uses` set is fully populated before we bundle the runtime.
     let mut body = CodeWriter::new("\t");
     gen.emit_program(&mut body);
 
@@ -230,29 +196,19 @@ fn generate_source(module: &Module, opts: &GenOptions) -> Result<String> {
         gen.use_unit("rt/trap");
         gen.use_unit("rt/exit");
     } else if wasi {
-        // Library-mode WASI output is driven by host glue that instantiates
-        // and calls `_start`; that glue needs to catch a `proc_exit` (rtExit)
-        // to read the exit code, exactly as the standalone main does. Seed
-        // rt/exit so the type is always defined even for a module that never
-        // imports proc_exit itself (ADR-29).
+        // Library-mode WASI output is driven by host glue that instantiates and calls `_start`; that glue needs to catch a `proc_exit` (rtExit) to read the exit code, exactly as the standalone main does. Seed rt/exit so the type is always defined even for a module that never imports proc_exit itself (ADR-29).
         gen.use_unit("rt/exit");
     }
     let uses = gen.uses.borrow().clone();
     let bundle = bundler().bundle(&uses, 0)?;
 
     let mut imports = scan_imports(&bundle, standalone);
-    // The standalone WASI main parses `--dir` flags with `strings` (ADR-31);
-    // that code lives in main_func (not the scanned bundle), so add the import
-    // here.
+    // The standalone WASI main parses `--dir` flags with `strings` (ADR-31); that code lives in main_func (not the scanned bundle), so add the import here.
     if standalone && wasi && !imports.iter().any(|i| i == "strings") {
         imports.push("strings".to_string());
         imports.sort();
     }
-    // Library mode concatenates host glue after the generated declarations
-    // (mirroring Ruby/Bash). Go requires all imports before other
-    // declarations, so the glue cannot carry its own `import`; the generated
-    // file imports `fmt` up front (marked used below) so glue can print
-    // without one (ADR-29).
+    // Library mode concatenates host glue after the generated declarations (mirroring Ruby/Bash). Go requires all imports before other declarations, so the glue cannot carry its own `import`; the generated file imports `fmt` up front (marked used below) so glue can print without one (ADR-29).
     if !standalone && !imports.iter().any(|i| i == "fmt") {
         imports.push("fmt".to_string());
         imports.sort();
@@ -262,12 +218,7 @@ fn generate_source(module: &Module, opts: &GenOptions) -> Result<String> {
     out.push_str("package main\n\n");
     out.push_str(&import_block(&imports));
     out.push('\n');
-    // Data externalization (ADR-37): pull the segment bytes from a
-    // `//go:embed`ed sidecar. `embed` is a blank import (the package is used
-    // only through the directive, which — unlike a package-qualified selector —
-    // the import scanner cannot see; ADR-29), and the directive must sit
-    // immediately above its `var` with no intervening blank line. A separate
-    // `import` declaration is legal Go and keeps `import_block` untouched.
+    // Data externalization (ADR-37): pull the segment bytes from a `//go:embed`ed sidecar. `embed` is a blank import (the package is used only through the directive, which — unlike a package-qualified selector — the import scanner cannot see; ADR-29), and the directive must sit immediately above its `var` with no intervening blank line. A separate `import` declaration is legal Go and keeps `import_block` untouched.
     if let Some(cfg) = &opts.data_file {
         if !module.datas.is_empty() {
             out.push_str("import _ \"embed\"\n\n");
@@ -285,20 +236,13 @@ fn generate_source(module: &Module, opts: &GenOptions) -> Result<String> {
         out.push('\n');
         out.push_str(&main_func(&type_name, wasi));
     } else {
-        // Mark the always-present `fmt` import used, so appended glue can rely
-        // on it (see above).
+        // Mark the always-present `fmt` import used, so appended glue can rely on it (see above).
         out.push_str("\nvar _ = fmt.Sprint\n");
     }
     Ok(out)
 }
 
-/// The external packages a bundle references, plus `os` for a standalone main.
-/// Only the runtime bundle (controlled code) is scanned; generated program
-/// code emits no package-qualified selectors and data blobs are hex literals,
-/// so no user string can inject a false import (ADR-29). Line comments are
-/// stripped first: a prose "at instantiation time." must not pull in the `time`
-/// package (`//go:` directives survive in the emitted bundle regardless — this
-/// stripping only computes the import set).
+/// The external packages a bundle references, plus `os` for a standalone main. Only the runtime bundle (controlled code) is scanned; generated program code emits no package-qualified selectors and data blobs are hex literals, so no user string can inject a false import (ADR-29). Line comments are stripped first: a prose "at instantiation time." must not pull in the `time` package (`//go:` directives survive in the emitted bundle regardless — this stripping only computes the import set).
 fn scan_imports(bundle: &str, standalone: bool) -> Vec<String> {
     let candidates = [
         ("binary.", "encoding/binary"),
@@ -324,8 +268,7 @@ fn scan_imports(bundle: &str, standalone: bool) -> Vec<String> {
         })
         .collect::<Vec<_>>()
         .join("\n");
-    // A selector only counts at an identifier boundary: `runtime.GOOS` must
-    // not register a use of `time.`.
+    // A selector only counts at an identifier boundary: `runtime.GOOS` must not register a use of `time.`.
     fn selector_used(code: &str, sel: &str) -> bool {
         let bytes = code.as_bytes();
         let mut start = 0;
@@ -367,11 +310,7 @@ fn import_block(imports: &[String]) -> String {
 }
 
 fn main_func(type_name: &str, wasi: bool) -> String {
-    // Standalone WASI parses the runtime interface (ADR-31): a leading run of
-    // `--dir HOST::GUEST` flags mounts host directories at guest paths
-    // (wasmtime-style), stopping at `--` or the first non-flag token; the rest
-    // is the guest's argv[1..], with argv[0] the program basename. Without WASI
-    // there is nothing to preopen and no argv to deliver.
+    // Standalone WASI parses the runtime interface (ADR-31): a leading run of `--dir HOST::GUEST` flags mounts host directories at guest paths (wasmtime-style), stopping at `--` or the first non-flag token; the rest is the guest's argv[1..], with argv[0] the program basename. Without WASI there is nothing to preopen and no argv to deliver.
     let (arg_setup, args_arg, env_arg, preopen_arg) = if wasi {
         (
             "\tpreopens := map[string]string{}\n\
@@ -436,8 +375,7 @@ fn main_func(type_name: &str, wasi: bool) -> String {
     )
 }
 
-/// Derive a Go exported type name (PascalCase) from the module name, mirroring
-/// the Python backend's class_name.
+/// Derive a Go exported type name (PascalCase) from the module name, mirroring the Python backend's class_name.
 fn type_name(module_name: &str) -> String {
     let mut out = String::new();
     let mut upper = true;
@@ -487,8 +425,7 @@ fn hex_bytes(data: &[u8]) -> String {
     format!("Rt.unhex(\"{hex}\")")
 }
 
-/// Prefix sums locating each data segment in the concatenated sidecar blob
-/// (ADR-37). Only consulted when `--data-file` externalizes the segments.
+/// Prefix sums locating each data segment in the concatenated sidecar blob (ADR-37). Only consulted when `--data-file` externalizes the segments.
 fn data_offsets(module: &Module) -> Vec<usize> {
     let mut offsets = Vec::with_capacity(module.datas.len());
     let mut acc = 0usize;
@@ -507,8 +444,7 @@ fn is_wasi_module(name: &str) -> bool {
 
 pub use dewasm_backend::WASI_PREVIEW1_FUNCTIONS;
 
-/// Whether the generated code bundles the built-in WASI as an import fallback
-/// (and therefore takes `args`/`env` and constructs a `WASI`).
+/// Whether the generated code bundles the built-in WASI as an import fallback (and therefore takes `args`/`env` and constructs a `WASI`).
 fn wasi_bundled(module: &Module, default_wasi: bool) -> bool {
     default_wasi
         && module
@@ -577,15 +513,7 @@ fn go_func_type(params: &[ValType], results: &[ValType]) -> String {
     format!("func({}){}", ps, go_results(results))
 }
 
-/// The recursion-guard budget (spec-harness builds only): each generated
-/// function adds its frame's slot count (`1 + params + locals + temps`) to the
-/// global `rtStack` on entry and traps once the running total exceeds this. It
-/// bounds otherwise-uncatchable Go stack overflow (a runaway recursion aborts
-/// the process fatally, ADR-29) into a catchable "call stack exhausted" trap
-/// the spec harness can observe. Sized so every runaway/huge recursion and the
-/// one >50-slot function in the testsuite (`function-with-many-locals`, 1056
-/// locals, `skip-stack-guard-page.wast`) trip it, while every legitimately
-/// terminating recursion in the suite stays under it.
+/// The recursion-guard budget (spec-harness builds only): each generated function adds its frame's slot count (`1 + params + locals + temps`) to the global `rtStack` on entry and traps once the running total exceeds this. It bounds otherwise-uncatchable Go stack overflow (a runaway recursion aborts the process fatally, ADR-29) into a catchable "call stack exhausted" trap the spec harness can observe. Sized so every runaway/huge recursion and the one >50-slot function in the testsuite (`function-with-many-locals`, 1056 locals, `skip-stack-guard-page.wast`) trip it, while every legitimately terminating recursion in the suite stays under it.
 const SPEC_STACK_LIMIT: usize = 1024;
 
 struct Gen<'a> {
@@ -595,13 +523,9 @@ struct Gen<'a> {
     uses: RefCell<BTreeSet<String>>,
     /// Param+local types of the function currently being emitted.
     cur_locals: RefCell<Vec<ValType>>,
-    /// Spec-harness mode: emit the reflective `invoke`/`global_get` dispatch
-    /// methods and the recursion guard. Off for the shipped standalone/library
-    /// output, whose deep-but-valid recursions must not falsely trap.
+    /// Spec-harness mode: emit the reflective `invoke`/`global_get` dispatch methods and the recursion guard. Off for the shipped standalone/library output, whose deep-but-valid recursions must not falsely trap.
     spec: bool,
-    /// When `Some`, data segments are externalized into a `//go:embed`ed
-    /// binary sidecar of this filename instead of embedded as `Rt.unhex`
-    /// literals (ADR-37); `data_offsets[i]` locates segment `i` in the blob.
+    /// When `Some`, data segments are externalized into a `//go:embed`ed binary sidecar of this filename instead of embedded as `Rt.unhex` literals (ADR-37); `data_offsets[i]` locates segment `i` in the blob.
     data_file: Option<String>,
     data_offsets: Vec<usize>,
 }
@@ -611,9 +535,7 @@ impl<'a> Gen<'a> {
         self.uses.borrow_mut().insert(id.to_string());
     }
 
-    /// The Go expression yielding a data segment's bytes: a sub-slice of the
-    /// embedded blob when `--data-file` is on (no runtime helper), else an
-    /// `Rt.unhex(...)` inline hex literal (ADR-37).
+    /// The Go expression yielding a data segment's bytes: a sub-slice of the embedded blob when `--data-file` is on (no runtime helper), else an `Rt.unhex(...)` inline hex literal (ADR-37).
     fn data_expr(&self, seg: usize, data: &[u8]) -> String {
         if self.data_file.is_some() {
             let o = self.data_offsets[seg];
@@ -665,10 +587,7 @@ impl<'a> Gen<'a> {
         &self.module.types[ty_idx as usize]
     }
 
-    /// The spec-harness reflective dispatcher: `invoke(name, args...) []any`
-    /// asserts each arg to its wasm param type and boxes every result into
-    /// `[]any`, mirroring Ruby/Python's dynamic `invoke` under Go's static
-    /// typing (ADR-29). The harness compares the boxed results bit-exactly.
+    /// The spec-harness reflective dispatcher: `invoke(name, args...) []any` asserts each arg to its wasm param type and boxes every result into `[]any`, mirroring Ruby/Python's dynamic `invoke` under Go's static typing (ADR-29). The harness compares the boxed results bit-exactly.
     fn emit_invoke_method(&self, w: &mut CodeWriter) {
         w.line(format!(
             "func (p *{}) invoke(name string, args ...any) []any {{",
@@ -713,9 +632,7 @@ impl<'a> Gen<'a> {
         w.line("}");
     }
 
-    /// The spec-harness global reader: returns the boxed global's current value
-    /// boxed in a one-element `[]any`, so the harness treats it exactly like a
-    /// single-result `invoke` (`__r[0]`).
+    /// The spec-harness global reader: returns the boxed global's current value boxed in a one-element `[]any`, so the harness treats it exactly like a single-result `invoke` (`__r[0]`).
     fn emit_global_get_method(&self, w: &mut CodeWriter) {
         w.line(format!(
             "func (p *{}) globalGet(name string) []any {{",
@@ -753,8 +670,7 @@ impl<'a> Gen<'a> {
         for i in 0..num_tables {
             w.line(format!("t{i} *Table"));
         }
-        // Global index space = imported_globals ++ globals; every global is a
-        // boxed *global[T] (ADR-16).
+        // Global index space = imported_globals ++ globals; every global is a boxed *global[T] (ADR-16).
         for (i, imp) in m.imported_globals.iter().enumerate() {
             w.line(format!("g{i} {}", global_field_type(imp.ty)));
         }
@@ -805,8 +721,7 @@ impl<'a> Gen<'a> {
                 mem.min_pages as u32, max
             ));
         }
-        // Tables: imported first, then defined (index space is
-        // imported_tables ++ tables, ADR-16).
+        // Tables: imported first, then defined (index space is imported_tables ++ tables, ADR-16).
         for (i, import) in m.imported_tables.iter().enumerate() {
             self.emit_typed_import(
                 w,
@@ -851,9 +766,7 @@ impl<'a> Gen<'a> {
             self.emit_import(w, i, import);
         }
 
-        // Globals: imported first, then defined; every global is a boxed
-        // *global[T] (ADR-16). Defined globals' init exprs may read imported
-        // globals, so they must resolve after the imported ones.
+        // Globals: imported first, then defined; every global is a boxed *global[T] (ADR-16). Defined globals' init exprs may read imported globals, so they must resolve after the imported ones.
         for (i, import) in m.imported_globals.iter().enumerate() {
             self.emit_typed_import(
                 w,
@@ -918,10 +831,7 @@ impl<'a> Gen<'a> {
             }
         }
 
-        // Exports map holds every export kind as `any` so a generated instance
-        // doubles as another module's import provider (`imports["M"] =
-        // inst.Exports`) — the mechanism the spec harness's `register` support
-        // uses (ADR-16). Globals export the shared box, not its value.
+        // Exports map holds every export kind as `any` so a generated instance doubles as another module's import provider (`imports["M"] = inst.Exports`) — the mechanism the spec harness's `register` support uses (ADR-16). Globals export the shared box, not its value.
         let mut export_entries = Vec::new();
         for export in &m.exports {
             let val = match export.kind {
@@ -994,8 +904,7 @@ impl<'a> Gen<'a> {
         w.indent();
         match fallback {
             Some(f) => w.line(format!("p.if{i} = {f}")),
-            // A missing non-WASI import is a link error at instantiation, not a
-            // deferred call-time failure (ADR-0; mirrors Ruby/Python).
+            // A missing non-WASI import is a link error at instantiation, not a deferred call-time failure (ADR-0; mirrors Ruby/Python).
             None => w.line(format!(
                 "{}({})",
                 self.rt("link_error"),
@@ -1006,13 +915,7 @@ impl<'a> Gen<'a> {
         w.line("}");
     }
 
-    /// Resolve a non-function import (memory/table/global) into `target`,
-    /// asserting it to `go_ty` (`*Memory`/`*Table`/`*global[T]`). A present
-    /// wrong-kind (or wrong-type) value is a link error; a missing one is a
-    /// link error too (there is no fallback for these, unlike WASI funcs).
-    /// The Go type assertion performs the ADR-16 kind check — and, for globals,
-    /// the value-type check — inherently; mutability and min/max limits stay
-    /// unchecked (the import-limits gap).
+    /// Resolve a non-function import (memory/table/global) into `target`, asserting it to `go_ty` (`*Memory`/`*Table`/`*global[T]`). A present wrong-kind (or wrong-type) value is a link error; a missing one is a link error too (there is no fallback for these, unlike WASI funcs). The Go type assertion performs the ADR-16 kind check — and, for globals, the value-type check — inherently; mutability and min/max limits stay unchecked (the import-limits gap).
     fn emit_typed_import(
         &self,
         w: &mut CodeWriter,
@@ -1058,8 +961,7 @@ impl<'a> Gen<'a> {
         )
     }
 
-    /// An ENOSYS stub for an unimplemented WASI import: single-i32-result
-    /// syscalls return errno 52, everything else returns zero values.
+    /// An ENOSYS stub for an unimplemented WASI import: single-i32-result syscalls return errno 52, everything else returns zero values.
     fn enosys_stub(&self, ty: &dewasm_core::ir::FuncType) -> String {
         let params = ty
             .params
@@ -1102,8 +1004,7 @@ impl<'a> Gen<'a> {
                 )
             }
             ElemItem::Null => "nil".to_string(),
-            // A `global.get` element item needs a ref-typed immutable global,
-            // i.e. reference types (rejected at conversion); unreachable here.
+            // A `global.get` element item needs a ref-typed immutable global, i.e. reference types (rejected at conversion); unreachable here.
             ElemItem::Global(idx) => format!("p.g{idx}.value"),
         }
     }
@@ -1131,8 +1032,7 @@ impl<'a> Gen<'a> {
         self.type_symbol(ty_idx)
     }
 
-    /// A structural key for a function type (not a module-local index), so a
-    /// table shared across modules stays consistent.
+    /// A structural key for a function type (not a module-local index), so a table shared across modules stays consistent.
     fn type_symbol(&self, type_idx: u32) -> String {
         let ty = &self.module.types[type_idx as usize];
         let names = |tys: &[ValType]| {
@@ -1167,10 +1067,7 @@ impl<'a> Gen<'a> {
         w.indent();
 
         if self.spec {
-            // Recursion guard (spec-harness only, ADR-29): bound otherwise-fatal
-            // Go stack overflow into a catchable "call stack exhausted" trap.
-            // The defer is registered before the check so the trapping frame's
-            // own cost is unwound too.
+            // Recursion guard (spec-harness only, ADR-29): bound otherwise-fatal Go stack overflow into a catchable "call stack exhausted" trap. The defer is registered before the check so the trapping frame's own cost is unwound too.
             let cost = 1 + local_types.len() + func.temps.len();
             w.line(format!("rtStack += {cost}"));
             w.line(format!("defer func() {{ rtStack -= {cost} }}()"));
@@ -1210,9 +1107,7 @@ impl<'a> Gen<'a> {
         self.emit_seq(w, &func.body);
 
         if !ty.results.is_empty() {
-            // A trailing terminator so Go's "missing return" is satisfied even
-            // when the body's own terminator is not the syntactic last stmt
-            // (unreachable code is not a Go error, ADR-29).
+            // A trailing terminator so Go's "missing return" is satisfied even when the body's own terminator is not the syntactic last stmt (unreachable code is not a Go error, ADR-29).
             let zeros = ty
                 .results
                 .iter()
@@ -1279,10 +1174,7 @@ impl<'a> Gen<'a> {
                 }
             }
             Stmt::SourceLine(pos) => {
-                // Go honors `//line` directives only at column 1, so bypass the
-                // writer's indentation with `raw` (ADR-38). The directive sets
-                // the source position of the *following* line, which is exactly
-                // the statement this marker precedes.
+                // Go honors `//line` directives only at column 1, so bypass the writer's indentation with `raw` (ADR-38). The directive sets the source position of the *following* line, which is exactly the statement this marker precedes.
                 let file = &self.module.debug_files[pos.file as usize];
                 if pos.col > 0 {
                     w.raw(format!("//line {file}:{}:{}\n", pos.line, pos.col));
@@ -1519,10 +1411,7 @@ impl<'a> Gen<'a> {
 
     fn expr(&self, expr: &Expr) -> String {
         match expr {
-            // A folded constant may land directly inside a signed cast
-            // (int32/int64); Go rejects that conversion for a compile-time
-            // constant beyond the signed range, so launder large values
-            // through a call to keep the conversion a runtime one.
+            // A folded constant may land directly inside a signed cast (int32/int64); Go rejects that conversion for a compile-time constant beyond the signed range, so launder large values through a call to keep the conversion a runtime one.
             Expr::I32Const(v) => {
                 if *v > i32::MAX as u32 {
                     format!("{}(0x{v:x})", self.rt("i32c"))
@@ -1530,10 +1419,7 @@ impl<'a> Gen<'a> {
                     format!("uint32({v})")
                 }
             }
-            // An i64 constant is cast both to int64 (signed views) and, via
-            // i32.wrap_i64, to uint32; either conversion rejects a compile-time
-            // constant beyond its range, so launder anything above u32::MAX
-            // (the wrap target — a superset of the int64 overflow threshold).
+            // An i64 constant is cast both to int64 (signed views) and, via i32.wrap_i64, to uint32; either conversion rejects a compile-time constant beyond its range, so launder anything above u32::MAX (the wrap target — a superset of the int64 overflow threshold).
             Expr::I64Const(v) => {
                 if *v > u32::MAX as u64 {
                     format!("{}(0x{v:x})", self.rt("i64c"))
@@ -1679,10 +1565,7 @@ impl<'a> Gen<'a> {
             I64GeS => format!("{}(int64({a}) >= int64({b}))", self.rt("b2i")),
             F32Add | F64Add => format!("({a} + {b})"),
             F32Sub | F64Sub => format!("({a} - {b})"),
-            // mul/div route through //go:noinline helpers so Go's compiler
-            // cannot fuse a following add/sub into an FMA, nor fold `x * 1.0` /
-            // `x / 1.0` to `x` (which would skip the sNaN quieting wasm
-            // mandates) — see the units (ADR-2).
+            // mul/div route through //go:noinline helpers so Go's compiler cannot fuse a following add/sub into an FMA, nor fold `x * 1.0` / `x / 1.0` to `x` (which would skip the sNaN quieting wasm mandates) — see the units (ADR-2).
             F32Mul => format!("{}({a}, {b})", self.rt("f32_mul")),
             F64Mul => format!("{}({a}, {b})", self.rt("f64_mul")),
             F32Div => format!("{}({a}, {b})", self.rt("f32_div")),
@@ -1796,10 +1679,7 @@ fn collect_reads_stmt(
             targets,
             default,
         } => {
-            // Matches the emitter: with no case targets it collapses to the
-            // default branch and never evaluates the (already side-effect-free,
-            // hoisted) index, so counting it read here would leave a declared
-            // temp Go rejects as unused.
+            // Matches the emitter: with no case targets it collapses to the default branch and never evaluates the (already side-effect-free, hoisted) index, so counting it read here would leave a declared temp Go rejects as unused.
             if !targets.is_empty() {
                 e(index, read_locals, used_locals, read_temps);
             }
@@ -1904,13 +1784,7 @@ fn collect_reads_expr(
     }
 }
 
-/// Lint for the runtime units: every reference a unit body makes to another
-/// unit must be declared in its `// requires:` header. Mirrors the Python
-/// backend's units lint (ADR-6), adjusted for Go syntax: `Rt.<name>` helper
-/// calls, `.memory.<name>` memory-method calls, and per-scope sibling calls
-/// through the receiver letter (`m`/`t`/`w`). A second test compiles the full
-/// bundle with `go build`, so a syntax error in any unit — not just the subset
-/// cowsay uses — is caught.
+/// Lint for the runtime units: every reference a unit body makes to another unit must be declared in its `// requires:` header. Mirrors the Python backend's units lint (ADR-6), adjusted for Go syntax: `Rt.<name>` helper calls, `.memory.<name>` memory-method calls, and per-scope sibling calls through the receiver letter (`m`/`t`/`w`). A second test compiles the full bundle with `go build`, so a syntax error in any unit — not just the subset cowsay uses — is caught.
 #[cfg(test)]
 mod units {
     use super::*;
@@ -2004,9 +1878,7 @@ mod units {
         );
     }
 
-    /// The whole runtime — every unit, not just the subset a given module uses —
-    /// must be valid Go. Compile the full bundle with `go build` (ADR-15: a
-    /// missing toolchain fails loud, it does not skip).
+    /// The whole runtime — every unit, not just the subset a given module uses — must be valid Go. Compile the full bundle with `go build` (ADR-15: a missing toolchain fails loud, it does not skip).
     #[test]
     fn all_units_compile_as_go() {
         let go = find_go()

--- a/crates/dewasm-backend-go/tests/e2e.rs
+++ b/crates/dewasm-backend-go/tests/e2e.rs
@@ -1,18 +1,6 @@
-//! Go end-to-end suites (ADR-27): the shared library / WASI / apps case
-//! consts (`dewasm-test-helper`) wired up for the Go backend. Per the
-//! ADR-27 revision this file holds ONLY the [`BackendUnderTest`] impl, named
-//! glue string constants, and per-case macro invocations; glue is a plain `&str`
-//! argument at the callsite, and which macros this file invokes is the
-//! capability declaration (with a REASON comment at any non-invocation).
+//! Go end-to-end suites (ADR-27): the shared library / WASI / apps case consts (`dewasm-test-helper`) wired up for the Go backend. Per the ADR-27 revision this file holds ONLY the [`BackendUnderTest`] impl, named glue string constants, and per-case macro invocations; glue is a plain `&str` argument at the callsite, and which macros this file invokes is the capability declaration (with a REASON comment at any non-invocation).
 //!
-//! Go is a *compiled* backend, so it overrides `BackendUnderTest::run` (ADR-27's
-//! hook) to compile-and-execute instead of interpreting: `go build` the
-//! generated file to a content-addressed cache binary (so identical sources —
-//! e.g. cowsay's args and stdin cases — build once), then run the binary
-//! directly. Running the binary (not `go run`) is required because `go run` does
-//! not propagate the guest exit code (it prints "exit status N" and exits 1);
-//! the WASI args/env case asserts an exact exit code. Go covers full WASI
-//! preview 1 incl. the filesystem (ADR-29).
+//! Go is a *compiled* backend, so it overrides `BackendUnderTest::run` (ADR-27's hook) to compile-and-execute instead of interpreting: `go build` the generated file to a content-addressed cache binary (so identical sources — e.g. cowsay's args and stdin cases — build once), then run the binary directly. Running the binary (not `go run`) is required because `go run` does not propagate the guest exit code (it prints "exit status N" and exits 1); the WASI args/env case asserts an exact exit code. Go covers full WASI preview 1 incl. the filesystem (ADR-29).
 
 use std::collections::hash_map::DefaultHasher;
 use std::collections::BTreeSet;
@@ -42,22 +30,16 @@ impl BackendUnderTest for Go {
         &GoBackend
     }
 
-    /// Compile `source` to a cache binary (keyed by content hash) and run it
-    /// with `args`/`stdin`. A missing `go` toolchain is a loud failure
-    /// (ADR-15); a build failure is surfaced as the build command's `Output`
-    /// so the caller's `status.success()` assertion reports the compile error.
+    /// Compile `source` to a cache binary (keyed by content hash) and run it with `args`/`stdin`. A missing `go` toolchain is a loud failure (ADR-15); a build failure is surfaced as the build command's `Output` so the caller's `status.success()` assertion reports the compile error.
     fn run_bytes(&self, source: &str, args: &[&str], stdin: &[u8]) -> Output {
         match build_go(source) {
-            // A build failure is surfaced as the build `Output` so the caller's
-            // `status.success()` assertion reports the compile error.
+            // A build failure is surfaced as the build `Output` so the caller's `status.success()` assertion reports the compile error.
             Err(build) => build,
             Ok(bin) => run_command_bytes(Command::new(&bin).args(args), stdin),
         }
     }
 
-    /// Build `source` to the cache binary and run it under a pty. A build
-    /// failure fails loud (ADR-15): there is no `status` for the caller to
-    /// inspect on the pty path, so panic with the compiler output.
+    /// Build `source` to the cache binary and run it under a pty. A build failure fails loud (ADR-15): there is no `status` for the caller to inspect on the pty path, so panic with the compiler output.
     fn pty_command(&self, source: &str, args: &[&str]) -> PtyCommand {
         let bin = build_go(source).unwrap_or_else(|build| {
             panic!(
@@ -72,17 +54,7 @@ impl BackendUnderTest for Go {
         }
     }
 
-    /// Compose several `.wat` modules for the multi-module cases. `shared_runtime`
-    /// mirrors the spec harness (ADR-29): each module is emitted as bare
-    /// package-level declarations against one flat top-level runtime
-    /// (`generate_program_with_units`), the referenced units are unioned and
-    /// bundled once, and everything is assembled into a single `package main`
-    /// file — an import block covering the runtime's needs plus `fmt` (the
-    /// appended driver prints with it), the bundle, then the module decls. The
-    /// driver (`func main`) is appended afterwards by the runner, so no main is
-    /// emitted. `shared_runtime=false` (independent Embedded runtimes) is never
-    /// exercised for Go: `embedded_coexist_e2e!` is not invoked because Go emits
-    /// one flat top-level runtime shared by all modules (ADR-29).
+    /// Compose several `.wat` modules for the multi-module cases. `shared_runtime` mirrors the spec harness (ADR-29): each module is emitted as bare package-level declarations against one flat top-level runtime (`generate_program_with_units`), the referenced units are unioned and bundled once, and everything is assembled into a single `package main` file — an import block covering the runtime's needs plus `fmt` (the appended driver prints with it), the bundle, then the module decls. The driver (`func main`) is appended afterwards by the runner, so no main is emitted. `shared_runtime=false` (independent Embedded runtimes) is never exercised for Go: `embedded_coexist_e2e!` is not invoked because Go emits one flat top-level runtime shared by all modules (ADR-29).
     fn compose_modules(&self, modules: &[(&str, &str)], shared_runtime: bool) -> String {
         assert!(
             shared_runtime,
@@ -102,18 +74,13 @@ impl BackendUnderTest for Go {
             .bundle(&units, 0)
             .expect("bundle runtime");
         let decls = decls.join("\n");
-        // Cover whatever the runtime bundle and module decls reference, then
-        // force `fmt` in — the appended driver prints with it and Go forbids a
-        // later `import` after other declarations.
+        // Cover whatever the runtime bundle and module decls reference, then force `fmt` in — the appended driver prints with it and Go forbids a later `import` after other declarations.
         let mut imports = scan_imports(&format!("{bundle}\n{decls}"));
         if !imports.iter().any(|i| i == "fmt") {
             imports.push("fmt".to_string());
             imports.sort();
         }
-        // `generate_program_with_units` emits spec-mode declarations whose
-        // recursion guard references a shared `rtStack` counter, declared in the
-        // spec harness's PREAMBLE; the multi-module composition must declare it
-        // too (ADR-29).
+        // `generate_program_with_units` emits spec-mode declarations whose recursion guard references a shared `rtStack` counter, declared in the spec harness's PREAMBLE; the multi-module composition must declare it too (ADR-29).
         format!(
             "package main\n\n{}\nvar rtStack int\n\n{bundle}\n\n{decls}\n",
             import_block(&imports)
@@ -121,10 +88,7 @@ impl BackendUnderTest for Go {
     }
 }
 
-/// The external packages an assembled multi-module program references (mirrors
-/// the spec harness's scanner). Only controlled fragments — the runtime bundle
-/// and generated declarations — are scanned, so no user string can inject a
-/// false import (ADR-29).
+/// The external packages an assembled multi-module program references (mirrors the spec harness's scanner). Only controlled fragments — the runtime bundle and generated declarations — are scanned, so no user string can inject a false import (ADR-29).
 fn scan_imports(text: &str) -> Vec<String> {
     let candidates = [
         ("fmt.", "fmt"),
@@ -157,10 +121,7 @@ fn import_block(imports: &[String]) -> String {
 
 static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
-/// Compile `source` to a content-addressed cache binary (so identical sources
-/// build once) and return its path. `Err(Output)` carries the `go build`
-/// failure so a piped run can report it via `status.success()` while a pty run
-/// panics on it. A missing `go` toolchain is a loud failure (ADR-15).
+/// Compile `source` to a content-addressed cache binary (so identical sources build once) and return its path. `Err(Output)` carries the `go build` failure so a piped run can report it via `status.success()` while a pty run panics on it. A missing `go` toolchain is a loud failure (ADR-15).
 fn build_go(source: &str) -> Result<PathBuf, Output> {
     let go =
         find_go().expect("go toolchain not found on PATH (or $DEWASM_GO) — see docs/testing.md");
@@ -174,11 +135,7 @@ fn build_go(source: &str) -> Result<PathBuf, Output> {
     let bin = cache.join(format!("prog-{hash:016x}"));
 
     if !bin.exists() {
-        // Both the source and the binary get per-attempt unique names: two
-        // threads with the same hash (cowsay's args and stdin cases) may build
-        // concurrently, and a shared source path would let one truncate the
-        // file mid-read of the other's `go build` (issue #19). Only the final
-        // rename onto the cache key is shared, and that is atomic.
+        // Both the source and the binary get per-attempt unique names: two threads with the same hash (cowsay's args and stdin cases) may build concurrently, and a shared source path would let one truncate the file mid-read of the other's `go build` (issue #19). Only the final rename onto the cache key is shared, and that is atomic.
         let unique = format!(
             "{hash:016x}.{}.{}",
             std::process::id(),
@@ -204,9 +161,7 @@ fn build_go(source: &str) -> Result<PathBuf, Output> {
     Ok(bin)
 }
 
-// ---------------------------------------------------------------------
-// Library-case glue. The appended `func main` carries no `import` — the
-// generated file already imports `fmt`.
+// --------------------------------------------------------------------- Library-case glue. The appended `func main` carries no `import` — the generated file already imports `fmt`.
 
 /// `add.wat`: call the exported functions and print each result.
 const GO_ADD_GLUE: &str = r#"func main() {
@@ -217,9 +172,7 @@ const GO_ADD_GLUE: &str = r#"func main() {
 }
 "#;
 
-/// The ADR-7 override/fallback glue: an explicit `fd_write` import wins,
-/// `random_get` falls back to the bundled WASI. Mirrors the other backends'
-/// override glues — intercept fd_write and print the actual bytes written.
+/// The ADR-7 override/fallback glue: an explicit `fd_write` import wins, `random_get` falls back to the bundled WASI. Mirrors the other backends' override glues — intercept fd_write and print the actual bytes written.
 const GO_OVERRIDE_GLUE: &str = r#"func main() {
 	var captured []byte
 	var inst *Prog
@@ -236,14 +189,9 @@ const GO_OVERRIDE_GLUE: &str = r#"func main() {
 }
 "#;
 
-// ---------------------------------------------------------------------
-// WASI filesystem glue.
+// --------------------------------------------------------------------- WASI filesystem glue.
 
-/// The shared filesystem template: preopen the scratch dir (`{host}`) at guest
-/// `{guest}` (always `/`), run `_start`, and surface a `proc_exit` code (via
-/// rtExit) as a trailing decimal line. rt/exit is always seeded for library-mode
-/// WASI output, so `*rtExit` is defined even for fixtures that never import
-/// proc_exit.
+/// The shared filesystem template: preopen the scratch dir (`{host}`) at guest `{guest}` (always `/`), run `_start`, and surface a `proc_exit` code (via rtExit) as a trailing decimal line. rt/exit is always seeded for library-mode WASI output, so `*rtExit` is defined even for fixtures that never import proc_exit.
 const GO_FS_GLUE: &str = r#"func main() {
 	inst := NewProg(nil, nil, nil, map[string]string{"{guest}": "{host}"})
 	defer func() {
@@ -259,9 +207,7 @@ const GO_FS_GLUE: &str = r#"func main() {
 }
 "#;
 
-/// The root-preopen containment probe: probe the WASI resolver directly (no
-/// guest run). A `"/" => "/"` preopen must resolve a relative path rather than
-/// reject every one; fd 3 is the sole preopen, errno 0 (wasiOk) means contained.
+/// The root-preopen containment probe: probe the WASI resolver directly (no guest run). A `"/" => "/"` preopen must resolve a relative path rather than reject every one; fd 3 is the sole preopen, errno 0 (wasiOk) means contained.
 const GO_CONTAINMENT_GLUE: &str = r#"func main() {
 	w := newWASI(nil, nil, map[string]string{"/": "/"})
 	_, err := w.resolve_path(3, "etc", true)
@@ -273,11 +219,7 @@ const GO_CONTAINMENT_GLUE: &str = r#"func main() {
 }
 "#;
 
-// ---------------------------------------------------------------------
-// Filesystem app glue: class/argv/env/preopen-guest-paths are literals; only
-// the host scratch/cache dirs come through {scratch}/{cache}. One glue serves
-// both stdout-reporting and proc_exit fixtures: the former return from `_start`
-// normally, so nothing extra is printed.
+// --------------------------------------------------------------------- Filesystem app glue: class/argv/env/preopen-guest-paths are literals; only the host scratch/cache dirs come through {scratch}/{cache}. One glue serves both stdout-reporting and proc_exit fixtures: the former return from `_start` normally, so nothing extra is printed.
 
 const GO_QJS_FILE_IO_GLUE: &str = r#"func main() {
 	inst := NewQjs(nil, []string{"qjs", "/work/qjs_file_io.js"}, nil, map[string]string{"/work": "{scratch}"})
@@ -349,15 +291,9 @@ const GO_CPYTHON_GLUE: &str = r#"func main() {
 }
 "#;
 
-// ---------------------------------------------------------------------
-// C-API drive glue (sqlite3): malloc / guest-memory pointer plumbing via the
-// unexported `inst.memory` (`*Memory`). The appended `func main` carries no
-// `import` (the library file already imports `fmt`). No wasmtime golden exists
-// (the results live in guest memory), so each drive's output is pinned in the
-// shared case const. Only the file-backed case uses {scratch}.
+// --------------------------------------------------------------------- C-API drive glue (sqlite3): malloc / guest-memory pointer plumbing via the unexported `inst.memory` (`*Memory`). The appended `func main` carries no `import` (the library file already imports `fmt`). No wasmtime golden exists (the results live in guest memory), so each drive's output is pinned in the shared case const. Only the file-backed case uses {scratch}.
 
-/// The sqlite3 C API driven in memory: `_initialize`, `sqlite3_malloc` +
-/// `*Memory` pointer plumbing, open/exec/prepare/step/column/finalize/close.
+/// The sqlite3 C API driven in memory: `_initialize`, `sqlite3_malloc` + `*Memory` pointer plumbing, open/exec/prepare/step/column/finalize/close.
 const GO_LIBSQLITE3_MEM: &str = r#"func main() {
 	inst := NewLibsqlite3(nil, nil, nil, nil)
 	inst.Exports["_initialize"].(func())()
@@ -425,9 +361,7 @@ const GO_LIBSQLITE3_MEM: &str = r#"func main() {
 }
 "#;
 
-/// The sqlite3 C API against a file preopen: create+insert, close, reopen,
-/// select — the file lifecycle through the C API (same ADR-14 fs stack as the
-/// shell).
+/// The sqlite3 C API against a file preopen: create+insert, close, reopen, select — the file lifecycle through the C API (same ADR-14 fs stack as the shell).
 const GO_LIBSQLITE3_FILE: &str = r#"func main() {
 	inst := NewLibsqlite3(nil, nil, nil, map[string]string{"/db": "{scratch}"})
 	inst.Exports["_initialize"].(func())()
@@ -500,10 +434,7 @@ const GO_LIBSQLITE3_FILE: &str = r#"func main() {
 }
 "#;
 
-/// Guest->host callback round trip: the committed `sqlite3-binding.wasm` exports
-/// `run_query`, which calls `sqlite3_exec` with a C callback forwarding each row
-/// to the *imported* `env.host_row`. The glue provides `host_row` via the ADR-7
-/// import-provider map and collects the rows.
+/// Guest->host callback round trip: the committed `sqlite3-binding.wasm` exports `run_query`, which calls `sqlite3_exec` with a C callback forwarding each row to the *imported* `env.host_row`. The glue provides `host_row` via the ADR-7 import-provider map and collects the rows.
 const GO_SQLITE3_CALLBACK: &str = r#"func main() {
 	var rows []string
 	var mem *Memory
@@ -577,10 +508,7 @@ const GO_SQLITE3_CALLBACK: &str = r#"func main() {
 }
 "#;
 
-/// libpcap BPF filter compilation: drive `compile_filter` on "tcp port 80"
-/// (DLT_EN10MB, snaplen 65535), then walk the serialized program
-/// `[u32 bf_len][bf_len × {u16 code; u8 jt; u8 jf; u32 k}]` in guest memory,
-/// printing each instruction as `code jt jf k`.
+/// libpcap BPF filter compilation: drive `compile_filter` on "tcp port 80" (DLT_EN10MB, snaplen 65535), then walk the serialized program `[u32 bf_len][bf_len × {u16 code; u8 jt; u8 jf; u32 k}]` in guest memory, printing each instruction as `code jt jf k`.
 const GO_PCAP_COMPILE: &str = r#"func main() {
 	inst := NewLibpcap(nil, nil, nil, nil)
 	inst.Exports["_initialize"].(func())()
@@ -612,9 +540,7 @@ const GO_PCAP_COMPILE: &str = r#"func main() {
 }
 "#;
 
-/// tree-sitter JSON parse: drive `parse_source` on the fixed snippet
-/// `{"key": [1, true, null]}` and print the parse tree's S-expression (a
-/// malloc'd NUL-terminated C string) from guest memory.
+/// tree-sitter JSON parse: drive `parse_source` on the fixed snippet `{"key": [1, true, null]}` and print the parse tree's S-expression (a malloc'd NUL-terminated C string) from guest memory.
 const GO_TREESITTER_PARSE: &str = r#"func main() {
 	inst := NewTreesitter(nil, nil, nil, nil)
 	inst.Exports["_initialize"].(func())()
@@ -643,13 +569,9 @@ const GO_TREESITTER_PARSE: &str = r#"func main() {
 }
 "#;
 
-// ---------------------------------------------------------------------
-// Multi-module drive glue.
+// --------------------------------------------------------------------- Multi-module drive glue.
 
-/// Driver for the shared-table case: instantiate `TableExp` (exports the table),
-/// then `TableImp` linked against it via the ADR-7 provider (`otherInst.Exports`
-/// as the module provider, as the spec harness's cross-module `register` path
-/// does), and print its `call0` result (`42`).
+/// Driver for the shared-table case: instantiate `TableExp` (exports the table), then `TableImp` linked against it via the ADR-7 provider (`otherInst.Exports` as the module provider, as the spec harness's cross-module `register` path does), and print its `call0` result (`42`).
 const GO_SHARED_TABLE_GLUE: &str = r#"func main() {
 	a := NewTableExp(nil, nil, nil, nil)
 	b := NewTableImp(Imports{"a": a.Exports}, nil, nil, nil)
@@ -657,16 +579,11 @@ const GO_SHARED_TABLE_GLUE: &str = r#"func main() {
 }
 "#;
 
-// ---------------------------------------------------------------------
-// Suite wiring (ADR-27): each per-case macro invocation declares participation.
+// --------------------------------------------------------------------- Suite wiring (ADR-27): each per-case macro invocation declares participation.
 
 library_add_e2e!(Go, GO_ADD_GLUE);
 wasi_import_override_e2e!(Go, GO_OVERRIDE_GLUE);
-// custom_wasi_provider_e2e! / partial_override_e2e!: not invoked — Go's bundled
-// WASI is eagerly constructed in the ctor and there is no provider-object import
-// form (ADR-29), so the lazy-construction observable cannot hold.
-// stdio_capture_e2e!: not invoked — Go's WASI fds hold *os.File only; no
-// io.Writer indirection to inject an in-memory buffer (ADR-29).
+// custom_wasi_provider_e2e! / partial_override_e2e!: not invoked — Go's bundled WASI is eagerly constructed in the ctor and there is no provider-object import form (ADR-29), so the lazy-construction observable cannot hold. stdio_capture_e2e!: not invoked — Go's WASI fds hold *os.File only; no io.Writer indirection to inject an in-memory buffer (ADR-29).
 
 wasi_suite!(Go, Stdio);
 wasi_suite!(Go, ArgsEnv);
@@ -677,12 +594,7 @@ standalone_dir_e2e!(Go);
 
 cowsay_args_e2e!(Go);
 cowsay_stdin_e2e!(Go);
-// The `ultra`-tier cases (ADR-48) are the giant-generated-program `go build`s
-// that individually ran ~1 min+ and collectively exhausted a 4-core CI runner's
-// memory (SIGTERM, #23): kept out of CI's `slow_test` sweep, run only under
-// `--features ultra_slow_test` or `-- --include-ignored`. The other giant builds
-// (`qjs_repl`, `qjs_repl_pty`, `sqlite3_shell_dbfile`, `pcap_compile`,
-// `treesitter_parse`) stayed under the ~1-min bar and remain at the `slow` tier.
+// The `ultra`-tier cases (ADR-48) are the giant-generated-program `go build`s that individually ran ~1 min+ and collectively exhausted a 4-core CI runner's memory (SIGTERM, #23): kept out of CI's `slow_test` sweep, run only under `--features ultra_slow_test` or `-- --include-ignored`. The other giant builds (`qjs_repl`, `qjs_repl_pty`, `sqlite3_shell_dbfile`, `pcap_compile`, `treesitter_parse`) stayed under the ~1-min bar and remain at the `slow` tier.
 qjs_eval_e2e!(Go, ultra);
 sqlite3_shell_e2e!(Go, ultra);
 gzip_e2e!(Go);
@@ -692,9 +604,7 @@ qjs_repl_e2e!(Go, GO_QJS_REPL_GLUE);
 sqlite3_shell_dbfile_e2e!(Go, GO_SQLITE3_SHELL_GLUE);
 rg_search_e2e!(Go, GO_RG_SEARCH_GLUE, ultra);
 cpython_hello_e2e!(Go, GO_CPYTHON_GLUE, ultra);
-// cruby_hello_e2e!: not invoked — the ~35 MB CRuby wasm's ~242 MB Go source
-// exceeds the ADR-24 ~5-minute practicality bar under `go build` (measured
-// >6 min); see docs/apps-audit.md.
+// cruby_hello_e2e!: not invoked — the ~35 MB CRuby wasm's ~242 MB Go source exceeds the ADR-24 ~5-minute practicality bar under `go build` (measured >6 min); see docs/apps-audit.md.
 qjs_repl_pty_e2e!(Go);
 
 libsqlite3_c_api_e2e!(Go, GO_LIBSQLITE3_MEM, ultra);
@@ -704,5 +614,4 @@ pcap_compile_e2e!(Go, GO_PCAP_COMPILE);
 treesitter_parse_e2e!(Go, GO_TREESITTER_PARSE);
 
 shared_table_e2e!(Go, GO_SHARED_TABLE_GLUE);
-// embedded_coexist_e2e!: not invoked — a single flat top-level runtime is
-// shared by all modules (ADR-29); two independent runtimes cannot coexist.
+// embedded_coexist_e2e!: not invoked — a single flat top-level runtime is shared by all modules (ADR-29); two independent runtimes cannot coexist.

--- a/crates/dewasm-backend-go/tests/spec.rs
+++ b/crates/dewasm-backend-go/tests/spec.rs
@@ -1,23 +1,9 @@
-//! Go side of the shared spec harness (ADR-3, ADR-27, ADR-29): converts each
-//! module with the Go backend to package-level declarations, phrases every
-//! assertion as compiled Go (`check`/`check_trap`/`check_exhaust`/
-//! `check_unlinkable`, bit-exact float comparison via `math.Float32bits`/
-//! `math.Float64bits`), assembles one self-contained program per `.wast` file,
-//! and `go build`s + runs it. The generic harness lives in `dewasm-test-helper`.
+//! Go side of the shared spec harness (ADR-3, ADR-27, ADR-29): converts each module with the Go backend to package-level declarations, phrases every assertion as compiled Go (`check`/`check_trap`/`check_exhaust`/ `check_unlinkable`, bit-exact float comparison via `math.Float32bits`/ `math.Float64bits`), assembles one self-contained program per `.wast` file, and `go build`s + runs it. The generic harness lives in `dewasm-test-helper`.
 //!
 //! Three Go facts shape the phrasing (ADR-29):
-//! - Go is statically typed and has no dynamic `invoke`, so each generated type
-//!   carries a reflective `invoke(name, args...) []any` / `globalGet(name) any`
-//!   dispatcher (built where the module — hence every export's signature — is
-//!   known); the harness asserts the boxed `any` results to the expected type.
-//! - Type/method declarations cannot live inside `func main`, so per-module
-//!   `Converted.source` is accumulated at package scope in the harness's
-//!   file-scoped `decls` buffer (hoisted ahead of the body by `assemble`) while
-//!   only instantiation/assertion statements go in the body.
-//! - A runaway recursion overflows Go's goroutine stack *fatally* (uncatchable,
-//!   killing the process), so the spec build instruments every generated
-//!   function with a recursion guard (ADR-29) that turns exhaustion into a
-//!   catchable "call stack exhausted" trap the harness observes.
+//! - Go is statically typed and has no dynamic `invoke`, so each generated type carries a reflective `invoke(name, args...) []any` / `globalGet(name) any` dispatcher (built where the module — hence every export's signature — is known); the harness asserts the boxed `any` results to the expected type.
+//! - Type/method declarations cannot live inside `func main`, so per-module `Converted.source` is accumulated at package scope in the harness's file-scoped `decls` buffer (hoisted ahead of the body by `assemble`) while only instantiation/assertion statements go in the body.
+//! - A runaway recursion overflows Go's goroutine stack *fatally* (uncatchable, killing the process), so the spec build instruments every generated function with a recursion guard (ADR-29) that turns exhaustion into a catchable "call stack exhausted" trap the harness observes.
 
 use std::collections::hash_map::DefaultHasher;
 use std::collections::BTreeSet;
@@ -32,28 +18,12 @@ use dewasm_test_helper::{run_command_bytes, spec_suite, BackendUnderTest, Conver
 use wast::core::{AbstractHeapType, HeapType, NanPattern, WastArgCore, WastRetCore};
 use wast::{WastArg, WastRet};
 
-/// Known assertion-level failures with their attribution; the file still runs
-/// so regressions in the passing assertions are caught.
+/// Known assertion-level failures with their attribution; the file still runs so regressions in the passing assertions are caught.
 ///
-/// - `import-limits`: the Go type assertion that resolves an import checks its
-///   *kind* (func/global/table/memory) and, for functions and globals, the full
-///   value/signature type too — but not a global's mutability, nor a
-///   table/memory's min/max limits, against the import site's declared bounds.
-///   Every `assert_unlinkable` case testing one of those stays a known gap. The
-///   counts are *lower* than Ruby/Python's (ADR-16): the Go type assertion
-///   catches func-signature and global-value-type mismatches those backends'
-///   kind-only check misses, so only the mutability/limit cases remain (the two
-///   `linking` failures are both global-mutability mismatches).
-/// - `linking` (`linking0`/`load1`): downstream of an *unrelated*
-///   declared-unsupported feature (multi-memory) inside a module that also
-///   uses `register`; that module never converts, so a later assertion against
-///   the module it would have written into observes stale state. Not a
-///   cross-module-linking gap itself.
+/// - `import-limits`: the Go type assertion that resolves an import checks its *kind* (func/global/table/memory) and, for functions and globals, the full value/signature type too — but not a global's mutability, nor a table/memory's min/max limits, against the import site's declared bounds. Every `assert_unlinkable` case testing one of those stays a known gap. The counts are *lower* than Ruby/Python's (ADR-16): the Go type assertion catches func-signature and global-value-type mismatches those backends' kind-only check misses, so only the mutability/limit cases remain (the two `linking` failures are both global-mutability mismatches).
+/// - `linking` (`linking0`/`load1`): downstream of an *unrelated* declared-unsupported feature (multi-memory) inside a module that also uses `register`; that module never converts, so a later assertion against the module it would have written into observes stale state. Not a cross-module-linking gap itself.
 ///
-/// `skip-stack-guard-page` is *not* here: its `function-with-many-locals` (1056
-/// locals) is the one function in the suite whose frame cost trips the ADR-29
-/// recursion guard even at shallow depth, so all 10 of its exhaustion cases
-/// pass.
+/// `skip-stack-guard-page` is *not* here: its `function-with-many-locals` (1056 locals) is the one function in the suite whose frame cost trips the ADR-29 recursion guard even at shallow depth, so all 10 of its exhaustion cases pass.
 const EXPECTED_FAILURES: &[(&str, u32, &str)] = &[
     ("imports", 28, "import-limits"),
     ("imports2", 2, "import-limits"),
@@ -62,12 +32,7 @@ const EXPECTED_FAILURES: &[(&str, u32, &str)] = &[
     ("load1", 5, "linking"),
 ];
 
-/// Files `cargo test` runs by default (the non-ignored trials). Go compiles
-/// each `.wast` file to one program, so the default gate runs a curated list
-/// covering every semantic area (integers, floats, control flow, memory/table,
-/// globals, linking, bulk ops) plus the whole ledger; `cargo test --
-/// --include-ignored` sweeps every file (one `go build` per file — a few
-/// seconds each, dominated by compile latency).
+/// Files `cargo test` runs by default (the non-ignored trials). Go compiles each `.wast` file to one program, so the default gate runs a curated list covering every semantic area (integers, floats, control flow, memory/table, globals, linking, bulk ops) plus the whole ledger; `cargo test -- --include-ignored` sweeps every file (one `go build` per file — a few seconds each, dominated by compile latency).
 const CURATED_FILES: &[&str] = &[
     "address",
     "align",
@@ -161,10 +126,7 @@ impl BackendUnderTest for GoSpec {
         &GoBackend
     }
 
-    /// Compile `source` to a content-addressed cache binary (identical programs
-    /// build once) and run it. A missing `go` toolchain fails loud (ADR-15); a
-    /// build failure is surfaced as the build command's `Output` so the harness
-    /// reports the compile error.
+    /// Compile `source` to a content-addressed cache binary (identical programs build once) and run it. A missing `go` toolchain fails loud (ADR-15); a build failure is surfaced as the build command's `Output` so the harness reports the compile error.
     fn run_bytes(&self, source: &str, args: &[&str], stdin: &[u8]) -> Output {
         let go = find_go()
             .expect("go toolchain not found on PATH (or $DEWASM_GO) — see docs/testing.md");
@@ -218,12 +180,10 @@ impl SpecBackend for GoSpec {
             // check_trap / check_exhaust / check_unlinkable match these types.
             "rt/trap",
             "rt/link_error",
-            // float args are reconstructed bit-exactly; this also pulls in the
-            // `math` import the float result comparisons rely on.
+            // float args are reconstructed bit-exactly; this also pulls in the `math` import the float result comparisons rely on.
             "rt/f32_from_bits",
             "rt/f64_from_bits",
-            // Referenced by the _spectest fixture (PREAMBLE), not necessarily
-            // by the converted module itself.
+            // Referenced by the _spectest fixture (PREAMBLE), not necessarily by the converted module itself.
             "global/_class",
             "table/_class",
             "memory/_class",
@@ -260,8 +220,7 @@ impl SpecBackend for GoSpec {
             conv.handle,
             imports_expr(registered)
         );
-        // A module may be instantiated only for its side effects / to be
-        // registered; a never-read local is a Go compile error.
+        // A module may be instantiated only for its side effects / to be registered; a never-read local is a Go compile error.
         let _ = writeln!(script, "_ = {var}");
         var
     }
@@ -388,11 +347,7 @@ impl SpecBackend for GoSpec {
     }
 }
 
-/// The external packages the assembled program references. Every fragment
-/// scanned is controlled (runtime bundle, harness preamble, generated
-/// declarations, and a body whose only free-form strings are `file.wast:line`
-/// descriptions and wasm trap messages) so no user data can inject a false
-/// import (ADR-29).
+/// The external packages the assembled program references. Every fragment scanned is controlled (runtime bundle, harness preamble, generated declarations, and a body whose only free-form strings are `file.wast:line` descriptions and wasm trap messages) so no user data can inject a false import (ADR-29).
 fn scan_imports(text: &str) -> Vec<String> {
     let candidates = [
         ("fmt.", "fmt"),
@@ -423,9 +378,7 @@ fn import_block(imports: &[String]) -> String {
     out
 }
 
-/// `_spectest`, plus any currently-`register`ed instances merged in under their
-/// registered name — each instance's `Exports` map doubles as an ADR-7 import
-/// provider (ADR-16).
+/// `_spectest`, plus any currently-`register`ed instances merged in under their registered name — each instance's `Exports` map doubles as an ADR-7 import provider (ADR-16).
 fn imports_expr(registered: &[(String, String)]) -> String {
     let mut entries = vec!["\"spectest\": _spectest".to_string()];
     for (name, var) in registered {
@@ -454,10 +407,7 @@ fn go_str(s: &str) -> String {
     out
 }
 
-/// Attribution for a ref heap type the harness cannot express as a Go value.
-/// Ref-typed args/results only occur in reference-types modules, which fail to
-/// convert (Feature::ReferenceTypes unsupported) and so are skipped upstream;
-/// this is defensive attribution.
+/// Attribution for a ref heap type the harness cannot express as a Go value. Ref-typed args/results only occur in reference-types modules, which fail to convert (Feature::ReferenceTypes unsupported) and so are skipped upstream; this is defensive attribution.
 fn heap_type_tag(hty: &HeapType<'_>) -> String {
     match hty {
         HeapType::Abstract {
@@ -531,8 +481,7 @@ fn ret_cmp(value: &str, ret: &WastRet<'_>) -> Result<String, String> {
     }
 }
 
-/// Harness helpers + the `spectest` host fixture. `rtStack` is the recursion
-/// guard's shared counter (referenced only by spec-build generated functions).
+/// Harness helpers + the `spectest` host fixture. `rtStack` is the recursion guard's shared counter (referenced only by spec-build generated functions).
 const PREAMBLE: &str = r#"var rtStack int
 
 var _pass, _fail int
@@ -601,9 +550,7 @@ func check_exhaust(desc string, thunk func()) {
 	fmt.Printf("FAIL(want exhaustion, got %v): %s\n", r, desc)
 }
 
-// Upstream's assert_unlinkable message text never matches ours; a raised
-// rtLinkError confirms the import was correctly rejected as unlinkable. Any
-// other panic means the module linked and then crashed, which must not pass.
+// Upstream's assert_unlinkable message text never matches ours; a raised rtLinkError confirms the import was correctly rejected as unlinkable. Any other panic means the module linked and then crashed, which must not pass.
 func check_unlinkable(desc string, thunk func()) {
 	var r any
 	func() {

--- a/crates/dewasm-backend-go/tests/wasi_testsuite.rs
+++ b/crates/dewasm-backend-go/tests/wasi_testsuite.rs
@@ -1,9 +1,4 @@
-//! Go side of the official WASI p1 conformance harness (ADR-36): drives the
-//! prebuilt `WebAssembly/wasi-testsuite` modules through the Go backend's
-//! standalone interface. Go is compiled, so it overrides `pty_command` to
-//! `go build` the generated program to a content-addressed cache binary — the
-//! launch recipe the shared `run_standalone_wasi` runs with the manifest's
-//! env/args/dirs applied. The generic harness lives in `dewasm-test-helper`.
+//! Go side of the official WASI p1 conformance harness (ADR-36): drives the prebuilt `WebAssembly/wasi-testsuite` modules through the Go backend's standalone interface. Go is compiled, so it overrides `pty_command` to `go build` the generated program to a content-addressed cache binary — the launch recipe the shared `run_standalone_wasi` runs with the manifest's env/args/dirs applied. The generic harness lives in `dewasm-test-helper`.
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
@@ -16,17 +11,12 @@ use dewasm_test_helper::{
     wasi_testsuite_suite, BackendUnderTest, PtyCommand, WasiTestsuiteBackend,
 };
 
-/// Known trial failures with their attribution (ADR-8, policy in ADR-40):
-/// `(trial, tag)` — out-of-scope syscalls and the one std-portability gap the
-/// full WASI p1 filesystem support (ADR-40) cannot close on Go.
+/// Known trial failures with their attribution (ADR-8, policy in ADR-40): `(trial, tag)` — out-of-scope syscalls and the one std-portability gap the full WASI p1 filesystem support (ADR-40) cannot close on Go.
 const WASI_TESTSUITE_EXPECTED_FAILURES: &[(&str, &str)] = &[
     // No socket layer in a demo runtime (out of scope, docs/support.md).
     ("c/sock_shutdown-invalid_fd", "sock_shutdown (out of scope)"),
     ("c/sock_shutdown-not_sock", "sock_shutdown (out of scope)"),
-    // Setting a symlink's own times (NOFOLLOW) needs lutimes, which Go's std
-    // exposes no portable (darwin+linux, build-tag-free) way to call —
-    // os.Chtimes follows the link. Every regular-file times path is supported;
-    // only the symlink-target case in this one trial is out of reach (ADR-40).
+    // Setting a symlink's own times (NOFOLLOW) needs lutimes, which Go's std exposes no portable (darwin+linux, build-tag-free) way to call — os.Chtimes follows the link. Every regular-file times path is supported; only the symlink-target case in this one trial is out of reach (ADR-40).
     (
         "rust/symlink_filestat",
         "path_filestat_set_times: no portable std lutimes for a NOFOLLOW symlink",
@@ -46,9 +36,7 @@ impl BackendUnderTest for GoWasi {
         &GoBackend
     }
 
-    /// Build `source` to the content-addressed cache binary and return the run
-    /// recipe. A missing `go` toolchain fails loud (ADR-15); a build failure
-    /// panics (generated code that does not compile is a bug, not a WASI gap).
+    /// Build `source` to the content-addressed cache binary and return the run recipe. A missing `go` toolchain fails loud (ADR-15); a build failure panics (generated code that does not compile is a bug, not a WASI gap).
     fn pty_command(&self, source: &str, args: &[&str]) -> PtyCommand {
         let bin = build_go(source).unwrap_or_else(|build| {
             panic!(
@@ -64,8 +52,7 @@ impl BackendUnderTest for GoWasi {
     }
 }
 
-/// Compile `source` to a content-addressed cache binary (identical programs
-/// build once).
+/// Compile `source` to a content-addressed cache binary (identical programs build once).
 fn build_go(source: &str) -> Result<PathBuf, Output> {
     let go =
         find_go().expect("go toolchain not found on PATH (or $DEWASM_GO) — see docs/testing.md");

--- a/crates/dewasm-backend-java/build.rs
+++ b/crates/dewasm-backend-java/build.rs
@@ -1,6 +1,4 @@
-//! Embeds the runtime units from runtime/java/units/ as
-//! `UNIT_SOURCES: &[(&str, &str)]` (unit id, source). Mirrors the Go crate's
-//! build.rs (ADR-6); only the source directory and extension differ.
+//! Embeds the runtime units from runtime/java/units/ as `UNIT_SOURCES: &[(&str, &str)]` (unit id, source). Mirrors the Go crate's build.rs (ADR-6); only the source directory and extension differ.
 
 use std::fmt::Write as _;
 use std::path::Path;

--- a/crates/dewasm-backend-java/src/lib.rs
+++ b/crates/dewasm-backend-java/src/lib.rs
@@ -1,28 +1,11 @@
-//! Java backend: translates dewasm IR into a single self-contained `.java`
-//! source file (a set of package-private runtime classes plus the generated
-//! module class), compiled with `javac` and run on the JVM.
+//! Java backend: translates dewasm IR into a single self-contained `.java` source file (a set of package-private runtime classes plus the generated module class), compiled with `javac` and run on the JVM.
 //!
 //! Lowering conventions (ADR-30; numeric conventions ADR-2):
-//! - i32/i64 are native signed `int`/`long` treated as bit patterns; unsigned
-//!   ops use `Integer.*`/`Long.*` (`divideUnsigned`, `compareUnsigned`, ...).
-//!   f32/f64 are native `float`/`double` (Java is strict IEEE, no FMA
-//!   contraction, so f32 re-rounding and trap-free division need no helper).
-//!   NaN bit paths go through `Float.floatToRawIntBits`/`intBitsToFloat` etc.
-//! - Control flow uses the per-function branch register `_br` (ADR-28's Python
-//!   model, depth-insensitive and — crucially — splittable across methods):
-//!   block/if exits and the function return set `_br`; following siblings are
-//!   guarded by `if (_br == 0)`; only real loops become `while (true)`. This
-//!   avoids Java's "unreachable statement" error entirely (no bare mid-sequence
-//!   `return`/`break`), and makes the split below mechanical.
-//! - The JVM caps a method at 64KB of bytecode. A function whose estimated size
-//!   crosses a threshold is emitted with its locals/temps/`br`/`ret` hoisted to
-//!   a per-call **frame object** and its body split into numbered `part`
-//!   methods sharing that frame; because control flow is data (`_br`), the parts
-//!   are just called in order. Data segments that exceed the 64KB string-literal
-//!   limit are emitted as chunked Base64 (`Rt.data_from_b64`).
+//! - i32/i64 are native signed `int`/`long` treated as bit patterns; unsigned ops use `Integer.*`/`Long.*` (`divideUnsigned`, `compareUnsigned`, ...). f32/f64 are native `float`/`double` (Java is strict IEEE, no FMA contraction, so f32 re-rounding and trap-free division need no helper). NaN bit paths go through `Float.floatToRawIntBits`/`intBitsToFloat` etc.
+//! - Control flow uses the per-function branch register `_br` (ADR-28's Python model, depth-insensitive and — crucially — splittable across methods): block/if exits and the function return set `_br`; following siblings are guarded by `if (_br == 0)`; only real loops become `while (true)`. This avoids Java's "unreachable statement" error entirely (no bare mid-sequence `return`/`break`), and makes the split below mechanical.
+//! - The JVM caps a method at 64KB of bytecode. A function whose estimated size crosses a threshold is emitted with its locals/temps/`br`/`ret` hoisted to a per-call **frame object** and its body split into numbered `part` methods sharing that frame; because control flow is data (`_br`), the parts are just called in order. Data segments that exceed the 64KB string-literal limit are emitted as chunked Base64 (`Rt.data_from_b64`).
 //!
-//! The runtime is composed from per-method units (ADR-6) referenced as
-//! `Rt.<name>` / `Memory` / `Table` / `WASI`.
+//! The runtime is composed from per-method units (ADR-6) referenced as `Rt.<name>` / `Memory` / `Table` / `WASI`.
 
 use std::cell::{Cell, RefCell};
 use std::collections::BTreeSet;
@@ -41,47 +24,28 @@ use dewasm_core::ir::{
 
 include!(concat!(env!("OUT_DIR"), "/units.rs"));
 
-/// Estimated body-cost above which a function is split into `part` methods to
-/// stay under the JVM's 64KB per-method bytecode limit (ADR-30). Cost is an IR
-/// node count; the value is tuned so cowsay's largest functions compile.
+/// Estimated body-cost above which a function is split into `part` methods to stay under the JVM's 64KB per-method bytecode limit (ADR-30). Cost is an IR node count; the value is tuned so cowsay's largest functions compile.
 const SPLIT_THRESHOLD: usize = 900;
 
-/// Raw bytes per Base64 data chunk. Base64 of this (~43.7KB) stays under Java's
-/// 64KB (65535-byte) string-literal limit (ADR-30).
+/// Raw bytes per Base64 data chunk. Base64 of this (~43.7KB) stays under Java's 64KB (65535-byte) string-literal limit (ADR-30).
 const DATA_CHUNK: usize = 32768;
 
-/// Element-segment size above which the funcref table is built by the nested
-/// `Elem` helper class instead of inline in the constructor. A big table's
-/// thousands of funcref lambdas overflow both `<init>`'s 64KB limit and the
-/// module class's 65535-entry constant pool; the nested class has its own pool
-/// (ADR-30 third milestone). Tuned so qjs/sqlite (~550 entries) stay inline and
-/// only rg-scale tables (~4900) split.
+/// Element-segment size above which the funcref table is built by the nested `Elem` helper class instead of inline in the constructor. A big table's thousands of funcref lambdas overflow both `<init>`'s 64KB limit and the module class's 65535-entry constant pool; the nested class has its own pool (ADR-30 third milestone). Tuned so qjs/sqlite (~550 entries) stay inline and only rg-scale tables (~4900) split.
 const ELEM_SPLIT: usize = 1024;
 
-/// Funcref entries per `elem{i}_pK` part method (each ~20 bytes of bytecode per
-/// entry stays well under the 64KB method limit).
+/// Funcref entries per `elem{i}_pK` part method (each ~20 bytes of bytecode per entry stays well under the 64KB method limit).
 const ELEM_PART: usize = 512;
 
-/// Defined-function count above which the module's functions are split across
-/// nested `P{k}` helper classes, each with its own 65535-entry constant pool
-/// (ADR-30 third milestone). A single class holding thousands of functions
-/// (their numeric literals, method refs, and names) overflows the pool: qjs
-/// (~1500) and sqlite (~1970) fit, but rg (~7300) does not. Kept above sqlite's
-/// proven single-class size so only rg-scale modules partition.
+/// Defined-function count above which the module's functions are split across nested `P{k}` helper classes, each with its own 65535-entry constant pool (ADR-30 third milestone). A single class holding thousands of functions (their numeric literals, method refs, and names) overflows the pool: qjs (~1500) and sqlite (~1970) fit, but rg (~7300) does not. Kept above sqlite's proven single-class size so only rg-scale modules partition.
 const FN_PARTITION_THRESHOLD: usize = 3000;
 
-/// Defined functions per partition class. Kept under sqlite's proven
-/// single-class function count so no partition's pool overflows.
+/// Defined functions per partition class. Kept under sqlite's proven single-class function count so no partition's pool overflows.
 const FN_PER_PARTITION: usize = 1500;
 
-/// A branch-register sentinel for "return from the function", distinct from any
-/// real label id (which are small). Emitted as `-1`.
+/// A branch-register sentinel for "return from the function", distinct from any real label id (which are small). Emitted as `-1`.
 const RETURN_SENTINEL: u32 = u32::MAX;
 
-/// The runtime unit bundler for Java (see runtime/java/units/). Each scope is a
-/// top-level package-private class wrapping its unit bodies (methods / nested
-/// types); generated code refers to them as `Rt.*` / `Memory` / `Table` /
-/// `WASI` (ADR-30).
+/// The runtime unit bundler for Java (see runtime/java/units/). Each scope is a top-level package-private class wrapping its unit bodies (methods / nested types); generated code refers to them as `Rt.*` / `Memory` / `Table` / `WASI` (ADR-30).
 pub fn bundler() -> &'static RuntimeBundler {
     static BUNDLER: OnceLock<RuntimeBundler> = OnceLock::new();
     BUNDLER.get_or_init(|| {
@@ -126,8 +90,7 @@ pub fn bundler() -> &'static RuntimeBundler {
     })
 }
 
-/// Locate a `java` launcher (ADR-15: a missing toolchain is a loud failure at
-/// the call site, not here). Honors `$DEWASM_JAVA`, then `java` on `PATH`.
+/// Locate a `java` launcher (ADR-15: a missing toolchain is a loud failure at the call site, not here). Honors `$DEWASM_JAVA`, then `java` on `PATH`.
 pub fn find_java() -> Option<std::path::PathBuf> {
     find_tool("DEWASM_JAVA", "java")
 }
@@ -153,9 +116,7 @@ fn find_tool(env: &str, default: &str) -> Option<std::path::PathBuf> {
     })
 }
 
-/// A complete, compilable `.java` file bundling *every* runtime unit (plus a
-/// tiny `Main`), for the units lint's `javac` check that all units — not just
-/// the subset cowsay uses — are valid Java.
+/// A complete, compilable `.java` file bundling *every* runtime unit (plus a tiny `Main`), for the units lint's `javac` check that all units — not just the subset cowsay uses — are valid Java.
 pub fn full_bundle_java() -> Result<String> {
     let bundle = bundler().bundle_all(0)?;
     let mut out = String::from("// Generated by dewasm. Do not edit.\n");
@@ -183,11 +144,7 @@ impl Backend for JavaBackend {
         match feature {
             // Java floats are native IEEE float/double; NaN paths follow ADR-2.
             Feature::Floats => SupportStatus::Supported,
-            // Wasm-1.0 completion (ADR-16, mirrored from Go's ADR-29): imported
-            // globals/memories/tables through the provider map with an
-            // `instanceof` kind check, multiple tables, and the table half of
-            // bulk memory (passive/declared element segments, table.init/copy,
-            // elem.drop).
+            // Wasm-1.0 completion (ADR-16, mirrored from Go's ADR-29): imported globals/memories/tables through the provider map with an `instanceof` kind check, multiple tables, and the table half of bulk memory (passive/declared element segments, table.init/copy, elem.drop).
             Feature::ImportedGlobals
             | Feature::ImportedMemories
             | Feature::ImportedTables
@@ -204,10 +161,7 @@ impl Backend for JavaBackend {
             name: "Main.java".to_string(),
             contents: contents.into_bytes(),
         }];
-        // The data sidecar (ADR-37): every segment's bytes concatenated in
-        // segment order, matching the `data_offsets` prefix sums baked into the
-        // generated `Arrays.copyOfRange(DATA_BLOB, …)` slices. Only emitted when
-        // there is data to externalize (otherwise nothing reads it).
+        // The data sidecar (ADR-37): every segment's bytes concatenated in segment order, matching the `data_offsets` prefix sums baked into the generated `Arrays.copyOfRange(DATA_BLOB, …)` slices. Only emitted when there is data to externalize (otherwise nothing reads it).
         if let Some(cfg) = &opts.data_file {
             if !module.datas.is_empty() {
                 let mut blob = Vec::new();
@@ -230,8 +184,7 @@ fn is_wasi_module(name: &str) -> bool {
     WASI_MODULES.contains(&name)
 }
 
-/// Whether the generated code bundles the built-in WASI as an import fallback
-/// (and therefore takes `args`/`env` and constructs a `WASI`).
+/// Whether the generated code bundles the built-in WASI as an import fallback (and therefore takes `args`/`env` and constructs a `WASI`).
 fn wasi_bundled(module: &Module, default_wasi: bool) -> bool {
     default_wasi
         && module
@@ -240,12 +193,7 @@ fn wasi_bundled(module: &Module, default_wasi: bool) -> bool {
             .any(|f| is_wasi_module(&f.module) && bundler().has_unit(&format!("wasi/{}", f.name)))
 }
 
-/// Emit just the module class (constructor, functions, and the spec-harness
-/// `invoke`/`globalGet` dispatch methods), for the shared spec harness (ADR-3):
-/// the harness bundles one runtime for every module in a `.wast` file, so
-/// per-module output carries no runtime classes / `Main`. Multi-value results,
-/// wasm-1.0 imports, and trapping conversions are all exercised here. Returns
-/// the class source and the runtime units it references.
+/// Emit just the module class (constructor, functions, and the spec-harness `invoke`/`globalGet` dispatch methods), for the shared spec harness (ADR-3): the harness bundles one runtime for every module in a `.wast` file, so per-module output carries no runtime classes / `Main`. Multi-value results, wasm-1.0 imports, and trapping conversions are all exercised here. Returns the class source and the runtime units it references.
 pub fn generate_program_with_units(
     module: &Module,
     type_name: &str,
@@ -277,8 +225,7 @@ fn new_gen(
     default_wasi: bool,
     data_file: Option<String>,
 ) -> Gen<'_> {
-    // Prefix sums: `data_offsets[i]` is where segment `i` begins in the
-    // concatenated sidecar blob (ADR-37). Only consulted when externalizing.
+    // Prefix sums: `data_offsets[i]` is where segment `i` begins in the concatenated sidecar blob (ADR-37). Only consulted when externalizing.
     let mut data_offsets = Vec::with_capacity(module.datas.len());
     let mut acc = 0usize;
     for data in &module.datas {
@@ -312,21 +259,14 @@ fn generate_source(module: &Module, opts: &GenOptions) -> Result<String> {
         opts.default_wasi,
         opts.data_file.as_ref().map(|c| c.sidecar_name.clone()),
     );
-    // A module whose function count crosses the threshold is split across nested
-    // `P{k}` classes, each with its own constant pool (ADR-30). Set before the
-    // constructor: its exports/start emit function calls through `defined_call`,
-    // which qualifies them by partition.
+    // A module whose function count crosses the threshold is split across nested `P{k}` classes, each with its own constant pool (ADR-30). Set before the constructor: its exports/start emit function calls through `defined_call`, which qualifies them by partition.
     gen.partitioned
         .set(module.funcs.len() > FN_PARTITION_THRESHOLD);
 
-    // Emit the module class body into its own writer so `uses` is populated
-    // before the runtime bundle is assembled.
+    // Emit the module class body into its own writer so `uses` is populated before the runtime bundle is assembled.
     let mut body = CodeWriter::new("    ");
     gen.constructor(&mut body);
-    // Externalized data blob (ADR-37): a static field loaded once from the
-    // sidecar next to this program, sliced by the generated
-    // `Arrays.copyOfRange(DATA_BLOB, …)` calls. Only emitted when there is data
-    // to externalize (otherwise the generated code never reads it).
+    // Externalized data blob (ADR-37): a static field loaded once from the sidecar next to this program, sliced by the generated `Arrays.copyOfRange(DATA_BLOB, …)` calls. Only emitted when there is data to externalize (otherwise the generated code never reads it).
     if let Some(sidecar) = &gen.data_file {
         if !module.datas.is_empty() {
             body.line("");
@@ -367,8 +307,7 @@ fn generate_source(module: &Module, opts: &GenOptions) -> Result<String> {
     Ok(out)
 }
 
-/// Re-indent a block of source by `levels` (four spaces each), leaving blank
-/// lines empty.
+/// Re-indent a block of source by `levels` (four spaces each), leaving blank lines empty.
 fn reindent(src: &str, levels: usize) -> String {
     let pad = "    ".repeat(levels);
     let mut out = String::new();
@@ -384,20 +323,12 @@ fn reindent(src: &str, levels: usize) -> String {
     out
 }
 
-/// The standalone entry point: parse the runtime interface (ADR-31) —
-/// `--dir HOST::GUEST` preopens, then the guest argv with argv[0] the program
-/// name — instantiate, run `_start`, and map `proc_exit`/trap to a process exit
-/// code (a trap prints to stderr and exits 134, mirroring Ruby/Python/Go).
+/// The standalone entry point: parse the runtime interface (ADR-31) — `--dir HOST::GUEST` preopens, then the guest argv with argv[0] the program name — instantiate, run `_start`, and map `proc_exit`/trap to a process exit code (a trap prints to stderr and exits 134, mirroring Ruby/Python/Go).
 fn main_class(type_name: &str, wasi: bool) -> String {
     let args = if wasi { "wasiArgs" } else { "null" };
     let env = if wasi { "wasiEnv" } else { "new String[0]" };
     let preopens = if wasi { "preopens" } else { "null" };
-    // Standalone WASI parses a leading run of `--dir HOST::GUEST` flags
-    // (wasmtime-style), stopping at `--` or the first non-flag token; the rest
-    // is the guest's argv[1..]. The JVM does not pass the launched file name to
-    // `main`, so argv[0] is the module class name (ADR-31). The whole process
-    // environment passes through. Without WASI there is nothing to preopen and
-    // no argv to deliver.
+    // Standalone WASI parses a leading run of `--dir HOST::GUEST` flags (wasmtime-style), stopping at `--` or the first non-flag token; the rest is the guest's argv[1..]. The JVM does not pass the launched file name to `main`, so argv[0] is the module class name (ADR-31). The whole process environment passes through. Without WASI there is nothing to preopen and no argv to deliver.
     let arg_setup = if wasi {
         format!(
             "        java.util.Map<String, String> preopens = new java.util.HashMap<>();\n\
@@ -555,26 +486,15 @@ struct Gen<'a> {
     /// Base name (`f47`) and frame type (`Frame47`) of the current function.
     cur_base: RefCell<String>,
     cur_frame_ty: RefCell<String>,
-    /// Part-method definitions produced while emitting the current function,
-    /// flushed after its entry method.
+    /// Part-method definitions produced while emitting the current function, flushed after its entry method.
     part_defs: RefCell<Vec<String>>,
-    /// When true, a function value (`func_value`) captures the module instance
-    /// as `inst.` rather than referencing `this` implicitly. Set while emitting
-    /// the nested `Elem` helper class's static methods, whose funcref lambdas
-    /// live in a separate constant pool (ADR-30 third milestone).
+    /// When true, a function value (`func_value`) captures the module instance as `inst.` rather than referencing `this` implicitly. Set while emitting the nested `Elem` helper class's static methods, whose funcref lambdas live in a separate constant pool (ADR-30 third milestone).
     elem_capture: Cell<bool>,
-    /// Whether this module's functions are split across nested `P{k}` classes
-    /// (its function count crosses `FN_PARTITION_THRESHOLD`). When set, defined
-    /// functions are `static` methods taking the module instance, called
-    /// class-qualified (ADR-30 third milestone).
+    /// Whether this module's functions are split across nested `P{k}` classes (its function count crosses `FN_PARTITION_THRESHOLD`). When set, defined functions are `static` methods taking the module instance, called class-qualified (ADR-30 third milestone).
     partitioned: Cell<bool>,
-    /// True while emitting a function body inside a `P{k}` partition class, so
-    /// instance references resolve through the passed `inst` parameter.
+    /// True while emitting a function body inside a `P{k}` partition class, so instance references resolve through the passed `inst` parameter.
     in_partition: Cell<bool>,
-    /// When `Some`, data segments are externalized into a binary sidecar of
-    /// this filename (loaded once into the static `DATA_BLOB`) instead of
-    /// embedded as chunked Base64 (ADR-37); `data_offsets[i]` locates segment
-    /// `i` in the blob.
+    /// When `Some`, data segments are externalized into a binary sidecar of this filename (loaded once into the static `DATA_BLOB`) instead of embedded as chunked Base64 (ADR-37); `data_offsets[i]` locates segment `i` in the blob.
     data_file: Option<String>,
     data_offsets: Vec<usize>,
 }
@@ -584,10 +504,7 @@ impl<'a> Gen<'a> {
         self.uses.borrow_mut().insert(id.to_string());
     }
 
-    /// The Java expression yielding a data segment's bytes: a copy of a slice of
-    /// the externalized `DATA_BLOB` when `--data-file` is on, else the inline
-    /// chunked-Base64 decode (ADR-37). Both yield a fresh `byte[]`, so the
-    /// segment field stays independently mutable (`data.drop` sets it empty).
+    /// The Java expression yielding a data segment's bytes: a copy of a slice of the externalized `DATA_BLOB` when `--data-file` is on, else the inline chunked-Base64 decode (ADR-37). Both yield a fresh `byte[]`, so the segment field stays independently mutable (`data.drop` sets it empty).
     fn data_expr(&self, seg: usize, data: &[u8]) -> String {
         if self.data_file.is_some() {
             let o = self.data_offsets[seg];
@@ -601,11 +518,7 @@ impl<'a> Gen<'a> {
         }
     }
 
-    /// Emit the static `DATA_BLOB` field and its loader (ADR-37). The sidecar is
-    /// resolved relative to this program's own code source: the jar's directory
-    /// (regular file) or the class directory itself, so `java -cp <dir> Main`
-    /// finds the sidecar alongside the class. Only called when externalizing and
-    /// the module has data.
+    /// Emit the static `DATA_BLOB` field and its loader (ADR-37). The sidecar is resolved relative to this program's own code source: the jar's directory (regular file) or the class directory itself, so `java -cp <dir> Main` finds the sidecar alongside the class. Only called when externalizing and the module has data.
     fn emit_data_blob(&self, w: &mut CodeWriter, sidecar: &str) {
         w.line("static final byte[] DATA_BLOB = loadDataBlob();");
         w.line("");
@@ -647,16 +560,12 @@ impl<'a> Gen<'a> {
 
     // --- instance-reference prefixing (function partitioning, ADR-30) --------
 
-    /// Whether the code being emitted reaches the module's instance fields
-    /// through a passed `inst` parameter (a `P{k}` function body or the `Elem`
-    /// helper class) rather than an implicit `this`.
+    /// Whether the code being emitted reaches the module's instance fields through a passed `inst` parameter (a `P{k}` function body or the `Elem` helper class) rather than an implicit `this`.
     fn via_inst(&self) -> bool {
         self.in_partition.get() || self.elem_capture.get()
     }
 
-    /// Reference an instance field (`memory`, `g3`, `t0`, `if5`, `data2`,
-    /// `elem0`): `inst.<name>` when reached via a passed instance, else the bare
-    /// name (implicit `this`).
+    /// Reference an instance field (`memory`, `g3`, `t0`, `if5`, `data2`, `elem0`): `inst.<name>` when reached via a passed instance, else the bare name (implicit `this`).
     fn iref(&self, name: &str) -> String {
         if self.via_inst() {
             format!("inst.{name}")
@@ -665,8 +574,7 @@ impl<'a> Gen<'a> {
         }
     }
 
-    /// The instance to pass as the first argument of a partitioned static
-    /// function call: `inst` inside a `P{k}`/`Elem` method, else `this`.
+    /// The instance to pass as the first argument of a partitioned static function call: `inst` inside a `P{k}`/`Elem` method, else `this`.
     fn self_arg(&self) -> &'static str {
         if self.via_inst() {
             "inst"
@@ -680,10 +588,7 @@ impl<'a> Gen<'a> {
         (func_idx as usize - self.module.imported_funcs.len()) / FN_PER_PARTITION
     }
 
-    /// A function/part method head. In a partitioned module the method is
-    /// `static` and takes the module instance as its first parameter, so it can
-    /// live in a `P{k}` class with its own constant pool (ADR-30 third
-    /// milestone); otherwise it is a plain instance method.
+    /// A function/part method head. In a partitioned module the method is `static` and takes the module instance as its first parameter, so it can live in a `P{k}` class with its own constant pool (ADR-30 third milestone); otherwise it is a plain instance method.
     fn method_head(&self, ret_ty: &str, name: &str, params: &str) -> String {
         if self.partitioned.get() {
             let inst = &self.type_name;
@@ -697,10 +602,7 @@ impl<'a> Gen<'a> {
         }
     }
 
-    /// A call to a *defined* function by index, honoring partitioning: a
-    /// partitioned module calls `P{k}.f{idx}(<inst>, args)`; otherwise
-    /// `[inst.]f{idx}(args)` (the `inst.` form serves the non-partitioned `Elem`
-    /// class). `args_joined` is the already-formatted argument list.
+    /// A call to a *defined* function by index, honoring partitioning: a partitioned module calls `P{k}.f{idx}(<inst>, args)`; otherwise `[inst.]f{idx}(args)` (the `inst.` form serves the non-partitioned `Elem` class). `args_joined` is the already-formatted argument list.
     fn defined_call(&self, func_idx: u32, args_joined: &str) -> String {
         if self.partitioned.get() {
             let k = self.partition_of(func_idx);
@@ -760,8 +662,7 @@ impl<'a> Gen<'a> {
 
     fn push_part(&self, name: &str, body: String) {
         let frame = self.cur_frame_ty.borrow().clone();
-        // A partitioned module's parts are static and take the module instance
-        // alongside the frame, so instance references resolve through `inst`.
+        // A partitioned module's parts are static and take the module instance alongside the frame, so instance references resolve through `inst`.
         let head = if self.partitioned.get() {
             format!(
                 "static void {name}({} inst, {frame} f) {{\n",
@@ -801,8 +702,7 @@ impl<'a> Gen<'a> {
             ));
         }
 
-        // Tables: imported first, then defined (index space is
-        // imported_tables ++ tables, ADR-16).
+        // Tables: imported first, then defined (index space is imported_tables ++ tables, ADR-16).
         for (i, import) in m.imported_tables.iter().enumerate() {
             self.emit_typed_import(
                 w,
@@ -835,9 +735,7 @@ impl<'a> Gen<'a> {
             self.emit_import(w, i, import);
         }
 
-        // Globals: imported first, then defined; every global is a boxed
-        // `Global` (ADR-16). Defined-global inits may read imported globals, so
-        // they resolve after the imported ones.
+        // Globals: imported first, then defined; every global is a boxed `Global` (ADR-16). Defined-global inits may read imported globals, so they resolve after the imported ones.
         for (i, import) in m.imported_globals.iter().enumerate() {
             self.emit_typed_import(
                 w,
@@ -857,9 +755,7 @@ impl<'a> Gen<'a> {
             ));
         }
 
-        // Element segments. A segment over ELEM_SPLIT is built by the nested
-        // `Elem` helper class (its own constant pool, chunked part methods),
-        // else inline (ADR-30 third milestone).
+        // Element segments. A segment over ELEM_SPLIT is built by the nested `Elem` helper class (its own constant pool, chunked part methods), else inline (ADR-30 third milestone).
         let mut split_elems: Vec<usize> = Vec::new();
         for (i, elem) in m.elems.iter().enumerate() {
             let large = elem.items.len() > ELEM_SPLIT;
@@ -899,12 +795,7 @@ impl<'a> Gen<'a> {
             }
         }
 
-        // Each data segment is materialized in its own `initData{i}()` method,
-        // not inline in the constructor. A multi-MB segment lowers to a
-        // chunked-Base64 array whose initializer (plus the `memory.init` copy)
-        // would otherwise accumulate toward the 64KB `<init>` limit ADR-30
-        // predicted; splitting one method per segment keeps the constructor
-        // bounded regardless of how large or how many the segments are.
+        // Each data segment is materialized in its own `initData{i}()` method, not inline in the constructor. A multi-MB segment lowers to a chunked-Base64 array whose initializer (plus the `memory.init` copy) would otherwise accumulate toward the 64KB `<init>` limit ADR-30 predicted; splitting one method per segment keeps the constructor bounded regardless of how large or how many the segments are.
         for i in 0..m.datas.len() {
             w.line(format!("this.initData{i}();"));
         }
@@ -930,9 +821,7 @@ impl<'a> Gen<'a> {
         w.dedent();
         w.line("}");
 
-        // Per-segment data initializers, called in order from the constructor
-        // (see above). Each is a self-contained method so an oversized segment
-        // never bloats `<init>` past the 64KB method limit (ADR-30).
+        // Per-segment data initializers, called in order from the constructor (see above). Each is a self-contained method so an oversized segment never bloats `<init>` past the 64KB method limit (ADR-30).
         for (i, data) in m.datas.iter().enumerate() {
             let blob = self.data_expr(i, &data.data);
             w.line("");
@@ -946,8 +835,7 @@ impl<'a> Gen<'a> {
                         self.expr(offset),
                         data.data.len()
                     ));
-                    // Active segments are dropped after instantiation, but stay
-                    // addressable (as empty) by memory.init/data.drop.
+                    // Active segments are dropped after instantiation, but stay addressable (as empty) by memory.init/data.drop.
                     w.line(format!("this.data{i} = new byte[0];"));
                 }
                 None => {
@@ -958,20 +846,13 @@ impl<'a> Gen<'a> {
             w.line("}");
         }
 
-        // The nested `Elem` helper class builds any oversized funcref table
-        // (see the element-segment loop above). It is a separate class, so its
-        // thousands of funcref lambdas land in their own 65535-entry constant
-        // pool instead of the module class's; each table is filled by chunked
-        // `elem{i}_pK` part methods to stay under the 64KB method limit (ADR-30
-        // third milestone).
+        // The nested `Elem` helper class builds any oversized funcref table (see the element-segment loop above). It is a separate class, so its thousands of funcref lambdas land in their own 65535-entry constant pool instead of the module class's; each table is filled by chunked `elem{i}_pK` part methods to stay under the 64KB method limit (ADR-30 third milestone).
         if !split_elems.is_empty() {
             self.emit_elem_class(w, &split_elems);
         }
     }
 
-    /// Emit the nested `Elem` helper class for the oversized element segments in
-    /// `split_elems`. Each segment `i` gets an `elem{i}(inst)` factory that
-    /// allocates the array and calls chunked `elem{i}_pK(inst, a)` fillers.
+    /// Emit the nested `Elem` helper class for the oversized element segments in `split_elems`. Each segment `i` gets an `elem{i}(inst)` factory that allocates the array and calls chunked `elem{i}_pK(inst, a)` fillers.
     fn emit_elem_class(&self, w: &mut CodeWriter, split_elems: &[usize]) {
         self.elem_capture.set(true);
         w.line("");
@@ -1014,11 +895,7 @@ impl<'a> Gen<'a> {
         self.elem_capture.set(false);
     }
 
-    /// Emit the module's defined functions grouped into nested `P{k}` classes of
-    /// up to `FN_PER_PARTITION` functions each, so no single class's constant
-    /// pool overflows Java's 65535-entry limit (ADR-30 third milestone). The
-    /// functions are `static` and take the module instance; call sites reach
-    /// them class-qualified via `defined_call`.
+    /// Emit the module's defined functions grouped into nested `P{k}` classes of up to `FN_PER_PARTITION` functions each, so no single class's constant pool overflows Java's 65535-entry limit (ADR-30 third milestone). The functions are `static` and take the module instance; call sites reach them class-qualified via `defined_call`.
     fn emit_partition_classes(&self, w: &mut CodeWriter, num_imported: usize) {
         self.in_partition.set(true);
         let n = self.module.funcs.len();
@@ -1050,8 +927,7 @@ impl<'a> Gen<'a> {
         for i in 0..(m.imported_tables.len() + m.tables.len()) {
             w.line(format!("Table t{i};"));
         }
-        // Global index space = imported_globals ++ globals; each is a boxed
-        // `Global` (ADR-16).
+        // Global index space = imported_globals ++ globals; each is a boxed `Global` (ADR-16).
         for i in 0..(m.imported_globals.len() + m.globals.len()) {
             w.line(format!("Global g{i};"));
         }
@@ -1061,24 +937,18 @@ impl<'a> Gen<'a> {
         if wasi_bundled(m, self.default_wasi) {
             w.line("WASI wasi;");
         }
-        // Element segments retained for table.init (active ones are emptied
-        // after instantiation).
+        // Element segments retained for table.init (active ones are emptied after instantiation).
         for i in 0..m.elems.len() {
             w.line(format!("Rt.Funcref[] elem{i};"));
         }
-        // Every data segment is addressable by memory.init/data.drop (active
-        // ones become empty after instantiation), so all get a field.
+        // Every data segment is addressable by memory.init/data.drop (active ones become empty after instantiation), so all get a field.
         for i in 0..m.datas.len() {
             w.line(format!("byte[] data{i};"));
         }
         w.line("java.util.Map<String, Object> Exports;");
     }
 
-    /// Resolve a non-function import (memory/table/global) into `target`,
-    /// checking its *kind* via `instanceof` (ADR-16). A wrong-kind or missing
-    /// value is a link error; the finer wasm type (a global's value type and
-    /// mutability, a table/memory's limits) is not checked — the import-limits
-    /// gap, wider for Java than Go since these carry no static type (ADR-30).
+    /// Resolve a non-function import (memory/table/global) into `target`, checking its *kind* via `instanceof` (ADR-16). A wrong-kind or missing value is a link error; the finer wasm type (a global's value type and mutability, a table/memory's limits) is not checked — the import-limits gap, wider for Java than Go since these carry no static type (ADR-30).
     fn emit_typed_import(
         &self,
         w: &mut CodeWriter,
@@ -1183,10 +1053,7 @@ impl<'a> Gen<'a> {
         )
     }
 
-    /// The `Rt.Fn` value for a function export / table element. When emitting
-    /// the nested `Elem` helper class, functions are reached through the passed
-    /// module instance (`inst.`), so the lambdas can live in that class's own
-    /// constant pool (ADR-30 third milestone).
+    /// The `Rt.Fn` value for a function export / table element. When emitting the nested `Elem` helper class, functions are reached through the passed module instance (`inst.`), so the lambdas can live in that class's own constant pool (ADR-30 third milestone).
     fn func_value(&self, func_idx: u32) -> String {
         if (func_idx as usize) < self.module.imported_funcs.len() {
             return format!("(Rt.Fn) {}", self.iref(&format!("if{func_idx}")));
@@ -1217,8 +1084,7 @@ impl<'a> Gen<'a> {
                 )
             }
             ElemItem::Null => "null".to_string(),
-            // ref-typed global element items imply reference types (rejected at
-            // conversion); unreachable, but must type-check as a Funcref.
+            // ref-typed global element items imply reference types (rejected at conversion); unreachable, but must type-check as a Funcref.
             ElemItem::Global(idx) => {
                 format!("(Rt.Funcref) {}.value", self.iref(&format!("g{idx}")))
             }
@@ -1263,9 +1129,7 @@ impl<'a> Gen<'a> {
         let nparams = ty.params.len();
         let results = &ty.results;
         let has_result = !results.is_empty();
-        // A method returns one value; multi-value signatures return a boxed
-        // `Object[]` (ADR-30). The result register (`_ret` / frame `ret`) takes
-        // the same shape.
+        // A method returns one value; multi-value signatures return a boxed `Object[]` (ADR-30). The result register (`_ret` / frame `ret`) takes the same shape.
         let ret_ty = ret_slot_ty(results);
         let ret_init = ret_slot_init(results);
 
@@ -1352,10 +1216,7 @@ impl<'a> Gen<'a> {
         }
     }
 
-    /// The spec-harness reflective dispatcher: `invoke(name, args)` boxes every
-    /// result into an `Object[]` (empty for a void export, one element for a
-    /// single result, the function's own `Object[]` for multi-value). Mirrors
-    /// Go's reflective invoke under Java's static typing.
+    /// The spec-harness reflective dispatcher: `invoke(name, args)` boxes every result into an `Object[]` (empty for a void export, one element for a single result, the function's own `Object[]` for multi-value). Mirrors Go's reflective invoke under Java's static typing.
     fn emit_invoke_method(&self, w: &mut CodeWriter) {
         w.line("Object[] invoke(String name, Object[] a) {");
         w.indent();
@@ -1399,9 +1260,7 @@ impl<'a> Gen<'a> {
         w.line("}");
     }
 
-    /// The spec-harness global reader: the exported boxed global's current
-    /// value in a one-element `Object[]`, so the harness treats it exactly like
-    /// a single-result `invoke`.
+    /// The spec-harness global reader: the exported boxed global's current value in a one-element `Object[]`, so the harness treats it exactly like a single-result `invoke`.
     fn emit_global_get_method(&self, w: &mut CodeWriter) {
         w.line("Object[] globalGet(String name) {");
         w.indent();
@@ -1423,9 +1282,7 @@ impl<'a> Gen<'a> {
         w.line("}");
     }
 
-    /// Emit a statement sequence as the body of a construct (loop/if/block body
-    /// or the function entry): inline when small, or split into chained `part`
-    /// methods when the function is split and the sub-body is large.
+    /// Emit a statement sequence as the body of a construct (loop/if/block body or the function entry): inline when small, or split into chained `part` methods when the function is split and the sub-body is large.
     fn emit_body(&self, w: &mut CodeWriter, stmts: &[Stmt], guarded_in: bool) {
         if self.split.get() && seq_cost(stmts) > SPLIT_THRESHOLD {
             let part_args = if self.partitioned.get() {
@@ -1444,10 +1301,7 @@ impl<'a> Gen<'a> {
         }
     }
 
-    /// Split `stmts` into consecutive `part` methods (each below the threshold),
-    /// threading the `guarded` flag across the boundaries. Parts are called
-    /// unconditionally in order: control flow is carried by the `f.br` register
-    /// and each part self-guards, so an escaped branch simply no-ops the rest.
+    /// Split `stmts` into consecutive `part` methods (each below the threshold), threading the `guarded` flag across the boundaries. Parts are called unconditionally in order: control flow is carried by the `f.br` register and each part self-guards, so an escaped branch simply no-ops the rest.
     fn emit_parts(&self, stmts: &[Stmt], guarded_in: bool) -> Vec<String> {
         let mut names = Vec::new();
         let mut w = CodeWriter::new("    ");
@@ -1508,9 +1362,7 @@ impl<'a> Gen<'a> {
                 self.reset_marker(w, label);
                 *guarded = *guarded || !stmt_free_targets(stmt).is_empty();
             }
-            // REASON: DWARF source-line markers are out of scope for Java (ADR-38)
-            // — drop them here (not via the `_br` guard) so the guard state and
-            // emitted output stay byte-identical to a non-`--dwarf-line` build.
+            // REASON: DWARF source-line markers are out of scope for Java (ADR-38) — drop them here (not via the `_br` guard) so the guard state and emitted output stay byte-identical to a non-`--dwarf-line` build.
             Stmt::SourceLine(_) => {}
             _ => {
                 if *guarded {
@@ -1542,8 +1394,7 @@ impl<'a> Gen<'a> {
     fn emit_if(&self, w: &mut CodeWriter, guarded: bool, cond: &Expr, then: &[Stmt], els: &[Stmt]) {
         let cond_s = self.expr(cond);
         if guarded {
-            // `_br == 0 &&` short-circuits, so `cond` is not evaluated (and
-            // cannot trap) while a branch is pending.
+            // `_br == 0 &&` short-circuits, so `cond` is not evaluated (and cannot trap) while a branch is pending.
             w.line(format!("if ({} == 0 && ({cond_s}) != 0) {{", self.br()));
         } else {
             w.line(format!("if (({cond_s}) != 0) {{"));
@@ -1719,13 +1570,10 @@ impl<'a> Gen<'a> {
                 ));
             }
             Stmt::Unreachable => {
-                // Void method that throws: emitting it as a statement (not a
-                // `throw`) avoids an "unreachable statement" error after it.
+                // Void method that throws: emitting it as a statement (not a `throw`) avoids an "unreachable statement" error after it.
                 w.line(format!("{}(\"unreachable\");", self.rt("trap")));
             }
-            // REASON: source-line markers are out of scope for Java (ADR-38);
-            // `emit_stmt` drops them before routing here, so this is unreachable
-            // but kept for the exhaustive match.
+            // REASON: source-line markers are out of scope for Java (ADR-38); `emit_stmt` drops them before routing here, so this is unreachable but kept for the exhaustive match.
             Stmt::SourceLine(_) => {}
             Stmt::TableInit {
                 seg,
@@ -1801,9 +1649,7 @@ impl<'a> Gen<'a> {
                         self.temp_ref(*src)
                     ));
                 }
-                // is_loop is irrelevant: the loop trailer turns `_br == <loop
-                // id>` into a `continue`; a block/if exit is resolved by the
-                // guards skipping to the label's reset marker (ADR-30).
+                // is_loop is irrelevant: the loop trailer turns `_br == <loop id>` into a `continue`; a block/if exit is resolved by the guards skipping to the label's reset marker (ADR-30).
                 w.line(format!("{} = {};", self.br(), label));
             }
         }
@@ -1816,8 +1662,7 @@ impl<'a> Gen<'a> {
         }
     }
 
-    /// The `Object[]` a multi-value call produces: a defined method returns one
-    /// directly; an imported `Fn.invoke` returns `Object`, cast to `Object[]`.
+    /// The `Object[]` a multi-value call produces: a defined method returns one directly; an imported `Fn.invoke` returns `Object`, cast to `Object[]`.
     fn call_multi_array(&self, func_idx: u32, args: &[String]) -> String {
         if (func_idx as usize) < self.module.imported_funcs.len() {
             let boxed = args.join(", ");
@@ -1830,8 +1675,7 @@ impl<'a> Gen<'a> {
         }
     }
 
-    /// Destructure a multi-value call's `Object[]` into the result temps,
-    /// unboxing each slot to its wasm type (ADR-30).
+    /// Destructure a multi-value call's `Object[]` into the result temps, unboxing each slot to its wasm type (ADR-30).
     fn emit_multi_results(&self, w: &mut CodeWriter, results: &[Temp], arr: &str) {
         let n = self.mv_counter.get();
         self.mv_counter.set(n + 1);
@@ -1846,8 +1690,7 @@ impl<'a> Gen<'a> {
         }
     }
 
-    /// A direct call to a function by index (imported → boxed `Fn` invoke;
-    /// defined → primitive method call).
+    /// A direct call to a function by index (imported → boxed `Fn` invoke; defined → primitive method call).
     fn call_string(&self, func_idx: u32, args: &[String]) -> String {
         if (func_idx as usize) < self.module.imported_funcs.len() {
             let ty = self.func_type(func_idx);
@@ -1862,8 +1705,7 @@ impl<'a> Gen<'a> {
         }
     }
 
-    /// Invoke an `Rt.Fn` value with boxed args, unboxing the single result (if
-    /// any) to its Java primitive.
+    /// Invoke an `Rt.Fn` value with boxed args, unboxing the single result (if any) to its Java primitive.
     fn invoke_string(&self, fnv: &str, boxed_args: &str, result: Option<ValType>) -> String {
         let call = format!("{fnv}.invoke(new Object[]{{{boxed_args}}})");
         match result {
@@ -1927,8 +1769,7 @@ impl<'a> Gen<'a> {
             I64Clz => format!("(long) Long.numberOfLeadingZeros({a})"),
             I64Ctz => format!("(long) Long.numberOfTrailingZeros({a})"),
             I64Popcnt => format!("(long) Long.bitCount({a})"),
-            // abs/neg are bit ops on the sign bit: they must NOT quiet a NaN
-            // (Math.abs would leave a negative NaN's sign set) (ADR-2).
+            // abs/neg are bit ops on the sign bit: they must NOT quiet a NaN (Math.abs would leave a negative NaN's sign set) (ADR-2).
             F32Abs => format!("Float.intBitsToFloat(Float.floatToRawIntBits({a}) & 0x7fffffff)"),
             F32Neg => format!("Float.intBitsToFloat(Float.floatToRawIntBits({a}) ^ 0x80000000)"),
             F64Abs => format!(
@@ -1937,9 +1778,7 @@ impl<'a> Gen<'a> {
             F64Neg => format!(
                 "Double.longBitsToDouble(Double.doubleToRawLongBits({a}) ^ 0x8000000000000000L)"
             ),
-            // ceil/floor/nearest/sqrt canonicalize a NaN result to wasm's
-            // arithmetic NaN (Java's Math.* may pass a signaling operand through
-            // unquieted); trunc is a helper (single operand eval) (ADR-2).
+            // ceil/floor/nearest/sqrt canonicalize a NaN result to wasm's arithmetic NaN (Java's Math.* may pass a signaling operand through unquieted); trunc is a helper (single operand eval) (ADR-2).
             F32Ceil => format!("{}((float) Math.ceil({a}))", self.rt("f32_canon")),
             F32Floor => format!("{}((float) Math.floor({a}))", self.rt("f32_canon")),
             F32Trunc => format!("{}({a})", self.rt("f32_trunc")),
@@ -1951,11 +1790,7 @@ impl<'a> Gen<'a> {
             F64Nearest => format!("{}(Math.rint({a}))", self.rt("f64_canon")),
             F64Sqrt => format!("{}(Math.sqrt({a}))", self.rt("f64_canon")),
             I32WrapI64 => format!("((int) ({a}))"),
-            // Trapping float->int conversions go through helpers that trap on
-            // NaN/overflow; the source is widened to double first (exact for
-            // f32). The saturating signed forms are exactly Java's cast; the
-            // saturating unsigned forms need helpers (Java's cast wraps past the
-            // unsigned range) (ADR-2).
+            // Trapping float->int conversions go through helpers that trap on NaN/overflow; the source is widened to double first (exact for f32). The saturating signed forms are exactly Java's cast; the saturating unsigned forms need helpers (Java's cast wraps past the unsigned range) (ADR-2).
             I32TruncF32S | I32TruncF64S => format!("{}((double)({a}))", self.rt("i32_trunc_s")),
             I32TruncF32U | I32TruncF64U => format!("{}((double)({a}))", self.rt("i32_trunc_u")),
             I64TruncF32S | I64TruncF64S => format!("{}((double)({a}))", self.rt("i64_trunc_s")),
@@ -2037,10 +1872,7 @@ impl<'a> Gen<'a> {
             F32Sub | F64Sub => format!("(({a}) - ({b}))"),
             F32Mul | F64Mul => format!("(({a}) * ({b}))"),
             F32Div | F64Div => format!("(({a}) / ({b}))"),
-            // Java's Math.min/max pass a signaling NaN operand through
-            // unquieted and Math.copySign may treat NaN's sign inconsistently;
-            // wasm min/max return an arithmetic NaN and copysign is a pure sign
-            // bit op, so both go through explicit code (ADR-2).
+            // Java's Math.min/max pass a signaling NaN operand through unquieted and Math.copySign may treat NaN's sign inconsistently; wasm min/max return an arithmetic NaN and copysign is a pure sign bit op, so both go through explicit code (ADR-2).
             F32Min => format!("{}({a}, {b})", self.rt("f32_min")),
             F32Max => format!("{}({a}, {b})", self.rt("f32_max")),
             F64Min => format!("{}({a}, {b})", self.rt("f64_min")),
@@ -2055,9 +1887,7 @@ impl<'a> Gen<'a> {
     }
 }
 
-/// The Java type of a function's result register (`_ret` / frame `ret` / the
-/// method return): the single value type, `Object[]` for multi-value, or
-/// `void` for no result (ADR-30).
+/// The Java type of a function's result register (`_ret` / frame `ret` / the method return): the single value type, `Object[]` for multi-value, or `void` for no result (ADR-30).
 fn ret_slot_ty(results: &[ValType]) -> String {
     match results {
         [] => "void".to_string(),
@@ -2066,8 +1896,7 @@ fn ret_slot_ty(results: &[ValType]) -> String {
     }
 }
 
-/// The initial value of the result register: the value type's zero, or an
-/// `Object[]` of boxed zeros for multi-value.
+/// The initial value of the result register: the value type's zero, or an `Object[]` of boxed zeros for multi-value.
 fn ret_slot_init(results: &[ValType]) -> String {
     match results {
         [] => String::new(),
@@ -2094,8 +1923,7 @@ fn unbox(ty: ValType, expr: &str) -> String {
     }
 }
 
-/// An ENOSYS stub `Rt.Fn` for an unimplemented WASI import: an i32-result
-/// syscall returns errno 52, everything else returns zero values / null.
+/// An ENOSYS stub `Rt.Fn` for an unimplemented WASI import: an i32-result syscall returns errno 52, everything else returns zero values / null.
 fn enosys_stub(ty: &dewasm_core::ir::FuncType) -> String {
     match ty.results.first() {
         Some(ValType::I32) => "__a -> 52".to_string(),
@@ -2114,8 +1942,7 @@ fn boxed_zero(ty: ValType) -> &'static str {
     }
 }
 
-/// Emit a data blob as a chunked-Base64 constant decoded at runtime, staying
-/// under Java's 64KB string-literal limit (ADR-30).
+/// Emit a data blob as a chunked-Base64 constant decoded at runtime, staying under Java's 64KB string-literal limit (ADR-30).
 fn data_blob(data: &[u8]) -> String {
     use std::fmt::Write as _;
     let mut chunks = String::new();
@@ -2191,10 +2018,7 @@ fn store_method(op: StoreOp) -> &'static str {
 
 // --- branch-target free sets (drive the `_br` guard placement) --------------
 
-/// The set of label ids a statement branches to that are *not* bound within it
-/// (a `Return` contributes the RETURN sentinel). Non-empty means the statement
-/// may leave `_br` set on fall-through, so following siblings must be guarded
-/// (ADR-28/ADR-30).
+/// The set of label ids a statement branches to that are *not* bound within it (a `Return` contributes the RETURN sentinel). Non-empty means the statement may leave `_br` set on fall-through, so following siblings must be guarded (ADR-28/ADR-30).
 fn stmt_free_targets(stmt: &Stmt) -> BTreeSet<u32> {
     match stmt {
         Stmt::Br(t) | Stmt::BrIf { target: t, .. } => target_free(t),
@@ -2312,13 +2136,7 @@ fn expr_cost(expr: &Expr) -> usize {
     }
 }
 
-/// Lint for the runtime units: every reference a unit body makes to another
-/// unit must be declared in its `// requires:` header. Mirrors the Go backend's
-/// units lint (ADR-6), adjusted for Java: `Rt.<name>` helper calls,
-/// `memory.<name>` memory-method calls, and per-scope sibling calls (a bare
-/// `name(` not preceded by a `.`). A second test compiles the whole bundle with
-/// `javac`, so a syntax error in any unit — not just the subset cowsay uses — is
-/// caught (ADR-15: a missing toolchain fails loud).
+/// Lint for the runtime units: every reference a unit body makes to another unit must be declared in its `// requires:` header. Mirrors the Go backend's units lint (ADR-6), adjusted for Java: `Rt.<name>` helper calls, `memory.<name>` memory-method calls, and per-scope sibling calls (a bare `name(` not preceded by a `.`). A second test compiles the whole bundle with `javac`, so a syntax error in any unit — not just the subset cowsay uses — is caught (ADR-15: a missing toolchain fails loud).
 #[cfg(test)]
 mod units {
     use super::*;
@@ -2338,8 +2156,7 @@ mod units {
 
         let rt_call = Regex::new(r"Rt\.([a-z_][a-z0-9_]*)").unwrap();
         let memory_call = Regex::new(r"\bmemory\.([a-z_][a-z0-9_]*)").unwrap();
-        // One sibling-call matcher per scoped unit: a bare `name(` not preceded by a
-        // `.` (so `memory.init(` is not read as a call to the sibling `init`).
+        // One sibling-call matcher per scoped unit: a bare `name(` not preceded by a `.` (so `memory.init(` is not read as a call to the sibling `init`).
         let sibling_calls: Vec<(&str, Regex)> = unit_ids
             .iter()
             .filter_map(|id| {
@@ -2407,8 +2224,7 @@ mod units {
         );
     }
 
-    /// The whole runtime — every unit, not just the subset cowsay uses — must be
-    /// valid Java. Compile the full bundle with `javac` (ADR-15).
+    /// The whole runtime — every unit, not just the subset cowsay uses — must be valid Java. Compile the full bundle with `javac` (ADR-15).
     #[test]
     fn all_units_compile_as_java() {
         let javac =

--- a/crates/dewasm-backend-java/tests/e2e.rs
+++ b/crates/dewasm-backend-java/tests/e2e.rs
@@ -1,15 +1,6 @@
-//! Java end-to-end suites (ADR-27): the shared library / WASI / apps case
-//! consts (`dewasm-test-helper`) wired up for the Java backend. Per
-//! the ADR-27 revision this file holds ONLY the [`BackendUnderTest`] impl, named
-//! glue string constants, and per-case macro invocations; glue is a plain `&str`
-//! argument at the callsite, and which macros this file invokes is the
-//! capability declaration (with a REASON comment at any non-invocation).
+//! Java end-to-end suites (ADR-27): the shared library / WASI / apps case consts (`dewasm-test-helper`) wired up for the Java backend. Per the ADR-27 revision this file holds ONLY the [`BackendUnderTest`] impl, named glue string constants, and per-case macro invocations; glue is a plain `&str` argument at the callsite, and which macros this file invokes is the capability declaration (with a REASON comment at any non-invocation).
 //!
-//! Java is a compiled backend, so it overrides `BackendUnderTest::run` (ADR-27's
-//! hook) to compile-and-execute: `javac` the generated `Main.java` into a
-//! content-addressed class-dir cache (so identical sources compile once), then
-//! run `java -cp <dir> Main` (ADR-30). Java covers full WASI preview 1 incl. the
-//! filesystem.
+//! Java is a compiled backend, so it overrides `BackendUnderTest::run` (ADR-27's hook) to compile-and-execute: `javac` the generated `Main.java` into a content-addressed class-dir cache (so identical sources compile once), then run `java -cp <dir> Main` (ADR-30). Java covers full WASI preview 1 incl. the filesystem.
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
@@ -31,11 +22,7 @@ pub struct Java;
 
 static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
-/// Compile `source` (a single `Main.java`) to a content-addressed class-dir
-/// cache (so identical sources compile once) and return its path. `Err(Output)`
-/// carries the `javac` failure so a piped run can report it via
-/// `status.success()` while a pty run panics on it. A missing `javac` is a loud
-/// failure (ADR-15).
+/// Compile `source` (a single `Main.java`) to a content-addressed class-dir cache (so identical sources compile once) and return its path. `Err(Output)` carries the `javac` failure so a piped run can report it via `status.success()` while a pty run panics on it. A missing `javac` is a loud failure (ADR-15).
 fn build_java(source: &str) -> Result<PathBuf, Output> {
     let javac =
         find_javac().expect("javac not found on PATH (or $DEWASM_JAVAC) — see docs/testing.md");
@@ -49,8 +36,7 @@ fn build_java(source: &str) -> Result<PathBuf, Output> {
     let classdir = cache.join(format!("prog-{hash:016x}"));
 
     if !classdir.join("Main.class").exists() {
-        // Compile into a unique temp dir, then rename onto the cache key so
-        // concurrent test threads never hand out a half-written class dir.
+        // Compile into a unique temp dir, then rename onto the cache key so concurrent test threads never hand out a half-written class dir.
         let tmp = cache.join(format!(
             "prog-{hash:016x}.{}.{}",
             std::process::id(),
@@ -83,16 +69,12 @@ impl BackendUnderTest for Java {
         &JavaBackend
     }
 
-    /// Compile `source` (a single `Main.java`) to a content-addressed class-dir
-    /// cache and run it with `args`/`stdin`. A missing `javac`/`java` is a loud
-    /// failure (ADR-15); a compile failure is surfaced as the `javac` `Output`
-    /// so the caller's `status.success()` assertion reports it.
+    /// Compile `source` (a single `Main.java`) to a content-addressed class-dir cache and run it with `args`/`stdin`. A missing `javac`/`java` is a loud failure (ADR-15); a compile failure is surfaced as the `javac` `Output` so the caller's `status.success()` assertion reports it.
     fn run_bytes(&self, source: &str, args: &[&str], stdin: &[u8]) -> Output {
         let java =
             find_java().expect("java not found on PATH (or $DEWASM_JAVA) — see docs/testing.md");
         match build_java(source) {
-            // A compile failure is surfaced as the `javac` `Output` so the
-            // caller's `status.success()` assertion reports it.
+            // A compile failure is surfaced as the `javac` `Output` so the caller's `status.success()` assertion reports it.
             Err(build) => build,
             Ok(classdir) => run_command_bytes(
                 Command::new(&java)
@@ -105,9 +87,7 @@ impl BackendUnderTest for Java {
         }
     }
 
-    /// Compile `source` and run `java -cp <classdir> Main <args...>` under a
-    /// pty. A compile failure fails loud (ADR-15): there is no `status` for the
-    /// caller to inspect on the pty path, so panic with the `javac` output.
+    /// Compile `source` and run `java -cp <classdir> Main <args...>` under a pty. A compile failure fails loud (ADR-15): there is no `status` for the caller to inspect on the pty path, so panic with the `javac` output.
     fn pty_command(&self, source: &str, args: &[&str]) -> PtyCommand {
         let java =
             find_java().expect("java not found on PATH (or $DEWASM_JAVA) — see docs/testing.md");
@@ -130,16 +110,7 @@ impl BackendUnderTest for Java {
         }
     }
 
-    /// Compose several `.wat` modules for the multi-module cases. Java only
-    /// composes against one shared runtime (mirroring the spec harness's
-    /// `register` path): generate each module's class with
-    /// `generate_program_with_units`, union the referenced runtime units, bundle
-    /// them once, and concatenate the runtime classes followed by both module
-    /// classes into ONE default-package compilation unit. The driver
-    /// `public class Main` is appended by the runner. `shared_runtime=false` is
-    /// never requested for Java — `embedded_coexist_e2e!` is not invoked because
-    /// Java emits one flat top-level runtime shared by all modules (ADR-30) — so
-    /// it is unimplemented.
+    /// Compose several `.wat` modules for the multi-module cases. Java only composes against one shared runtime (mirroring the spec harness's `register` path): generate each module's class with `generate_program_with_units`, union the referenced runtime units, bundle them once, and concatenate the runtime classes followed by both module classes into ONE default-package compilation unit. The driver `public class Main` is appended by the runner. `shared_runtime=false` is never requested for Java — `embedded_coexist_e2e!` is not invoked because Java emits one flat top-level runtime shared by all modules (ADR-30) — so it is unimplemented.
     fn compose_modules(&self, modules: &[(&str, &str)], shared_runtime: bool) -> String {
         assert!(
             shared_runtime,
@@ -165,9 +136,7 @@ impl BackendUnderTest for Java {
     }
 }
 
-// ---------------------------------------------------------------------
-// Library-case glue (a `public class Main` appended after the generated module
-// class).
+// --------------------------------------------------------------------- Library-case glue (a `public class Main` appended after the generated module class).
 
 /// `add.wat`: call the exported functions and print each result.
 const JAVA_ADD_GLUE: &str = r#"public class Main {
@@ -180,9 +149,7 @@ const JAVA_ADD_GLUE: &str = r#"public class Main {
 }
 "#;
 
-/// The ADR-7 override/fallback glue: an explicit `fd_write` import wins,
-/// `random_get` falls back to the bundled WASI. Mirrors the other backends'
-/// override glues — intercept fd_write and print the actual bytes written.
+/// The ADR-7 override/fallback glue: an explicit `fd_write` import wins, `random_get` falls back to the bundled WASI. Mirrors the other backends' override glues — intercept fd_write and print the actual bytes written.
 const JAVA_OVERRIDE_GLUE: &str = r#"public class Main {
     public static void main(String[] a) throws Exception {
         java.io.ByteArrayOutputStream captured = new java.io.ByteArrayOutputStream();
@@ -209,12 +176,7 @@ const JAVA_OVERRIDE_GLUE: &str = r#"public class Main {
 }
 "#;
 
-/// The `wasi_stdio_capture` glue: Java's bundled WASI is built eagerly in the
-/// module ctor and holds an `OutputStream` at fd 1, so inject a
-/// `ByteArrayOutputStream` into the (package-private, default-package-reachable)
-/// `wasi.fds` map after construction — the Java mirror of Ruby's `$stdout`
-/// redirect. Run `_start` (swallowing a clean `proc_exit`), then flush the
-/// captured bytes to the real stdout.
+/// The `wasi_stdio_capture` glue: Java's bundled WASI is built eagerly in the module ctor and holds an `OutputStream` at fd 1, so inject a `ByteArrayOutputStream` into the (package-private, default-package-reachable) `wasi.fds` map after construction — the Java mirror of Ruby's `$stdout` redirect. Run `_start` (swallowing a clean `proc_exit`), then flush the captured bytes to the real stdout.
 const JAVA_STDIO_CAPTURE_GLUE: &str = r#"public class Main {
     public static void main(String[] a) throws Exception {
         Prog p = new Prog(null, null, null, null);
@@ -230,13 +192,9 @@ const JAVA_STDIO_CAPTURE_GLUE: &str = r#"public class Main {
 }
 "#;
 
-// ---------------------------------------------------------------------
-// WASI filesystem glue.
+// --------------------------------------------------------------------- WASI filesystem glue.
 
-/// The shared filesystem template: preopen the scratch dir (`{host}`) at guest
-/// `{guest}` (always `/`), run `_start`, and surface a `proc_exit` code (Rt.Exit)
-/// as a trailing decimal line. rt/exit is always seeded for library-mode WASI
-/// output, so `Rt.Exit` is defined even for fixtures that never import proc_exit.
+/// The shared filesystem template: preopen the scratch dir (`{host}`) at guest `{guest}` (always `/`), run `_start`, and surface a `proc_exit` code (Rt.Exit) as a trailing decimal line. rt/exit is always seeded for library-mode WASI output, so `Rt.Exit` is defined even for fixtures that never import proc_exit.
 const JAVA_FS_GLUE: &str = r#"public class Main {
     public static void main(String[] a) throws Exception {
         Prog p = new Prog(null, null, null, java.util.Map.of("{guest}", "{host}"));
@@ -249,9 +207,7 @@ const JAVA_FS_GLUE: &str = r#"public class Main {
 }
 "#;
 
-/// The root-preopen containment probe: probe the WASI sandbox resolver directly
-/// (no guest run): with `/` preopened at host `/`, resolving a relative path off
-/// the preopen fd (3) must stay contained (errno WASI_OK == 0).
+/// The root-preopen containment probe: probe the WASI sandbox resolver directly (no guest run): with `/` preopened at host `/`, resolving a relative path off the preopen fd (3) must stay contained (errno WASI_OK == 0).
 const JAVA_CONTAINMENT_GLUE: &str = r#"public class Main {
     public static void main(String[] a) throws Exception {
         WASI w = new WASI(null, null, java.util.Map.of("/", "/"));
@@ -261,9 +217,7 @@ const JAVA_CONTAINMENT_GLUE: &str = r#"public class Main {
 }
 "#;
 
-// ---------------------------------------------------------------------
-// Filesystem app glue: class/argv/env/preopen-guest-paths are literals; only
-// the host scratch dir comes through {scratch}.
+// --------------------------------------------------------------------- Filesystem app glue: class/argv/env/preopen-guest-paths are literals; only the host scratch dir comes through {scratch}.
 
 const JAVA_QJS_FILE_IO_GLUE: &str = r#"public class Main {
     public static void main(String[] a) throws Exception {
@@ -309,13 +263,9 @@ const JAVA_RG_SEARCH_GLUE: &str = r#"public class Main {
 }
 "#;
 
-// ---------------------------------------------------------------------
-// C-API drive glue (sqlite3): malloc/pointer plumbing via Memory. No wasmtime
-// golden — the results live in guest memory — so each drive's output is pinned
-// in the shared case const. Only the file-backed case uses {scratch}.
+// --------------------------------------------------------------------- C-API drive glue (sqlite3): malloc/pointer plumbing via Memory. No wasmtime golden — the results live in guest memory — so each drive's output is pinned in the shared case const. Only the file-backed case uses {scratch}.
 
-/// The sqlite3 C API driven in memory: `_initialize`, `sqlite3_malloc` +
-/// `Memory` pointer plumbing, open/exec/prepare/step/column/finalize/close.
+/// The sqlite3 C API driven in memory: `_initialize`, `sqlite3_malloc` + `Memory` pointer plumbing, open/exec/prepare/step/column/finalize/close.
 const JAVA_LIBSQLITE3_MEM: &str = r#"public class Main {
     static final java.nio.charset.Charset UTF_8 = java.nio.charset.StandardCharsets.UTF_8;
     static Libsqlite3 inst;
@@ -380,9 +330,7 @@ const JAVA_LIBSQLITE3_MEM: &str = r#"public class Main {
 }
 "#;
 
-/// The sqlite3 C API against a file preopen: create+insert, close, reopen,
-/// select — the file lifecycle through the C API (same ADR-14 fs stack as the
-/// shell), leaving a nonzero DB file on the host.
+/// The sqlite3 C API against a file preopen: create+insert, close, reopen, select — the file lifecycle through the C API (same ADR-14 fs stack as the shell), leaving a nonzero DB file on the host.
 const JAVA_LIBSQLITE3_FILE: &str = r#"public class Main {
     static final java.nio.charset.Charset UTF_8 = java.nio.charset.StandardCharsets.UTF_8;
     static Libsqlite3 inst;
@@ -450,11 +398,7 @@ const JAVA_LIBSQLITE3_FILE: &str = r#"public class Main {
 }
 "#;
 
-/// Guest->host callback round trip: the committed `sqlite3-binding.wasm` exports
-/// `run_query`, which calls `sqlite3_exec` with a C callback forwarding each row
-/// to the *imported* `env.host_row` (a `void(argc, argv_ptr)` — the lambda
-/// returns null). The glue provides `host_row` via the ADR-7 import provider and
-/// collects the rows.
+/// Guest->host callback round trip: the committed `sqlite3-binding.wasm` exports `run_query`, which calls `sqlite3_exec` with a C callback forwarding each row to the *imported* `env.host_row` (a `void(argc, argv_ptr)` — the lambda returns null). The glue provides `host_row` via the ADR-7 import provider and collects the rows.
 const JAVA_SQLITE3_CALLBACK: &str = r#"public class Main {
     static final java.nio.charset.Charset UTF_8 = java.nio.charset.StandardCharsets.UTF_8;
     static Sqlite3Binding inst;
@@ -523,12 +467,9 @@ const JAVA_SQLITE3_CALLBACK: &str = r#"public class Main {
 }
 "#;
 
-// ---------------------------------------------------------------------
-// Multi-module drive glue.
+// --------------------------------------------------------------------- Multi-module drive glue.
 
-/// Instantiate the table exporter, then the importer with the exporter's
-/// `Exports` map as its `"a"` import provider (the exporter's `"tab"` table),
-/// and print the `call0` result (call_indirect through the shared table → 42).
+/// Instantiate the table exporter, then the importer with the exporter's `Exports` map as its `"a"` import provider (the exporter's `"tab"` table), and print the `call0` result (call_indirect through the shared table → 42).
 const JAVA_SHARED_TABLE_GLUE: &str = r#"public class Main {
     public static void main(String[] a) throws Exception {
         TableExp exp = new TableExp(null, null, null, null);
@@ -540,15 +481,12 @@ const JAVA_SHARED_TABLE_GLUE: &str = r#"public class Main {
 }
 "#;
 
-// ---------------------------------------------------------------------
-// Suite wiring (ADR-27): each per-case macro invocation declares participation.
+// --------------------------------------------------------------------- Suite wiring (ADR-27): each per-case macro invocation declares participation.
 
 library_add_e2e!(Java, JAVA_ADD_GLUE);
 wasi_import_override_e2e!(Java, JAVA_OVERRIDE_GLUE);
 stdio_capture_e2e!(Java, JAVA_STDIO_CAPTURE_GLUE);
-// custom_wasi_provider_e2e! / partial_override_e2e!: not invoked — Java's bundled
-// WASI is eagerly constructed in the ctor and there is no provider-object import
-// form (ADR-30), so the lazy-construction observable cannot hold.
+// custom_wasi_provider_e2e! / partial_override_e2e!: not invoked — Java's bundled WASI is eagerly constructed in the ctor and there is no provider-object import form (ADR-30), so the lazy-construction observable cannot hold.
 
 wasi_suite!(Java, Stdio);
 wasi_suite!(Java, ArgsEnv);
@@ -567,13 +505,7 @@ qjs_file_io_e2e!(Java, JAVA_QJS_FILE_IO_GLUE);
 qjs_repl_e2e!(Java, JAVA_QJS_REPL_GLUE);
 sqlite3_shell_dbfile_e2e!(Java, JAVA_SQLITE3_SHELL_GLUE);
 rg_search_e2e!(Java, JAVA_RG_SEARCH_GLUE);
-// cpython_hello_e2e!: not invoked — a CPython interpreter method overflows the
-// JVM 64 KB per-method bytecode limit (`code too large`); the ADR-30
-// class-splitter does not subdivide individual methods (a hard limit; see
-// docs/apps-audit.md).
-// cruby_hello_e2e!: not invoked — the CRuby element-segment `Elem` class
-// overflows the JVM 64 K constant-pool limit (`too many constants`), a hard
-// limit (docs/apps-audit.md).
+// cpython_hello_e2e!: not invoked — a CPython interpreter method overflows the JVM 64 KB per-method bytecode limit (`code too large`); the ADR-30 class-splitter does not subdivide individual methods (a hard limit; see docs/apps-audit.md). cruby_hello_e2e!: not invoked — the CRuby element-segment `Elem` class overflows the JVM 64 K constant-pool limit (`too many constants`), a hard limit (docs/apps-audit.md).
 qjs_repl_pty_e2e!(Java);
 
 libsqlite3_c_api_e2e!(Java, JAVA_LIBSQLITE3_MEM);
@@ -581,5 +513,4 @@ sqlite3_file_c_api_e2e!(Java, JAVA_LIBSQLITE3_FILE);
 sqlite3_callback_binding_e2e!(Java, JAVA_SQLITE3_CALLBACK);
 
 shared_table_e2e!(Java, JAVA_SHARED_TABLE_GLUE);
-// embedded_coexist_e2e!: not invoked — a single flat top-level runtime is
-// shared by all modules (ADR-30); two independent runtimes cannot coexist.
+// embedded_coexist_e2e!: not invoked — a single flat top-level runtime is shared by all modules (ADR-30); two independent runtimes cannot coexist.

--- a/crates/dewasm-backend-java/tests/memory_grow.rs
+++ b/crates/dewasm-backend-java/tests/memory_grow.rs
@@ -1,15 +1,6 @@
-//! Regression tests for issue #27's memory-size overflow: Java's linear
-//! memory is a single `byte[]`, capped at `Integer.MAX_VALUE` bytes, so a
-//! spec-legal size of 32768+ pages (2 GiB+) cannot be represented.
-//! `memory.grow` must answer -1 (never `NegativeArraySizeException` from the
-//! overflowing int multiply), and instantiating a module whose *initial* size
-//! already exceeds the cap must fail with a clear trap, not the raw exception.
+//! Regression tests for issue #27's memory-size overflow: Java's linear memory is a single `byte[]`, capped at `Integer.MAX_VALUE` bytes, so a spec-legal size of 32768+ pages (2 GiB+) cannot be represented. `memory.grow` must answer -1 (never `NegativeArraySizeException` from the overflowing int multiply), and instantiating a module whose *initial* size already exceeds the cap must fail with a clear trap, not the raw exception.
 //!
-//! These cases are Java-only (the cap is a JVM artifact — the other backends
-//! can grow to 32768 pages for real, which a shared case must not force), so
-//! they live here with their own minimal `javac`-and-run plumbing, mirroring
-//! the e2e suite's compile-and-execute recipe (ADR-30). A missing
-//! `javac`/`java` fails loud (ADR-15).
+//! These cases are Java-only (the cap is a JVM artifact — the other backends can grow to 32768 pages for real, which a shared case must not force), so they live here with their own minimal `javac`-and-run plumbing, mirroring the e2e suite's compile-and-execute recipe (ADR-30). A missing `javac`/`java` fails loud (ADR-15).
 
 use std::process::{Command, Output};
 
@@ -17,9 +8,7 @@ use dewasm_backend::Mode;
 use dewasm_backend_java::{find_java, find_javac, JavaBackend};
 use dewasm_test_helper::convert_bytes;
 
-/// Convert `wat` in library mode, append `glue` (a `public class Main`),
-/// compile the single compilation unit into a fresh scratch dir keyed by
-/// `name`, and run `java -cp <dir> Main`.
+/// Convert `wat` in library mode, append `glue` (a `public class Main`), compile the single compilation unit into a fresh scratch dir keyed by `name`, and run `java -cp <dir> Main`.
 fn convert_and_run(wat: &str, glue: &str, name: &str) -> Output {
     let javac =
         find_javac().expect("javac not found on PATH (or $DEWASM_JAVAC) — see docs/testing.md");
@@ -55,10 +44,7 @@ fn convert_and_run(wat: &str, glue: &str, name: &str) -> Output {
         .expect("spawn java")
 }
 
-/// `memory.grow` to 32768 pages (2^31 bytes, one past the `byte[]` cap) must
-/// return -1 and leave the memory intact and still growable — with no
-/// declared max, `maxPages` defaults to 65536, so only the byte-size guard
-/// stands between the request and the overflowing allocation.
+/// `memory.grow` to 32768 pages (2^31 bytes, one past the `byte[]` cap) must return -1 and leave the memory intact and still growable — with no declared max, `maxPages` defaults to 65536, so only the byte-size guard stands between the request and the overflowing allocation.
 #[test]
 fn grow_beyond_byte_array_cap_returns_minus_one() {
     let wat = r#"(module
@@ -84,10 +70,7 @@ fn grow_beyond_byte_array_cap_returns_minus_one() {
     assert_eq!(String::from_utf8_lossy(&out.stdout), "-1\n1\n2\n");
 }
 
-/// A module declaring an *initial* memory past the `byte[]` cap cannot be
-/// instantiated on the JVM; that failure must be a clear `Rt.Trap` naming the
-/// page count, not a `NegativeArraySizeException` (which would escape `Main`
-/// and fail the run's exit status here).
+/// A module declaring an *initial* memory past the `byte[]` cap cannot be instantiated on the JVM; that failure must be a clear `Rt.Trap` naming the page count, not a `NegativeArraySizeException` (which would escape `Main` and fail the run's exit status here).
 #[test]
 fn initial_memory_beyond_byte_array_cap_traps_clearly() {
     let wat = r#"(module (memory 32768) (func (export "f")))"#;

--- a/crates/dewasm-backend-java/tests/spec.rs
+++ b/crates/dewasm-backend-java/tests/spec.rs
@@ -1,22 +1,8 @@
-//! Java side of the shared spec harness (ADR-3, ADR-27, ADR-30): converts each
-//! module with the Java backend to a package-private module class (carrying a
-//! reflective `invoke`/`globalGet` dispatcher), phrases every assertion as
-//! compiled Java (`check`/`check_trap`/`check_exhaust`/`check_unlinkable`,
-//! bit-exact float comparison via `Float.floatToRawIntBits` /
-//! `Double.doubleToRawLongBits`), assembles one self-contained `Main.java` per
-//! `.wast` file, and `javac`s + runs it. The generic harness lives in
-//! `dewasm-test-helper`.
+//! Java side of the shared spec harness (ADR-3, ADR-27, ADR-30): converts each module with the Java backend to a package-private module class (carrying a reflective `invoke`/`globalGet` dispatcher), phrases every assertion as compiled Java (`check`/`check_trap`/`check_exhaust`/`check_unlinkable`, bit-exact float comparison via `Float.floatToRawIntBits` / `Double.doubleToRawLongBits`), assembles one self-contained `Main.java` per `.wast` file, and `javac`s + runs it. The generic harness lives in `dewasm-test-helper`.
 //!
 //! Two Java facts shape the phrasing (ADR-30):
-//! - A JVM `StackOverflowError` is *catchable* (unlike Go's fatal goroutine
-//!   overflow), so exhaustion maps directly: `check_exhaust` catches it, exactly
-//!   as Ruby catches `SystemStackError`. No spec-build recursion guard is
-//!   instrumented into the generated functions — each assertion is independent,
-//!   so unwinding a mid-call overflow cannot corrupt a later, independent check.
-//! - Type/class declarations cannot live inside a method, so per-module classes
-//!   are accumulated in the harness's file-scoped `decls` buffer (hoisted ahead
-//!   of `main`'s body by `assemble`) while only instantiation/assertion
-//!   statements go in `main`.
+//! - A JVM `StackOverflowError` is *catchable* (unlike Go's fatal goroutine overflow), so exhaustion maps directly: `check_exhaust` catches it, exactly as Ruby catches `SystemStackError`. No spec-build recursion guard is instrumented into the generated functions — each assertion is independent, so unwinding a mid-call overflow cannot corrupt a later, independent check.
+//! - Type/class declarations cannot live inside a method, so per-module classes are accumulated in the harness's file-scoped `decls` buffer (hoisted ahead of `main`'s body by `assemble`) while only instantiation/assertion statements go in `main`.
 
 use std::collections::hash_map::DefaultHasher;
 use std::collections::BTreeSet;
@@ -31,24 +17,10 @@ use dewasm_test_helper::{run_command_bytes, spec_suite, BackendUnderTest, Conver
 use wast::core::{AbstractHeapType, HeapType, NanPattern, WastArgCore, WastRetCore};
 use wast::{WastArg, WastRet};
 
-/// Known assertion-level failures with their attribution; the file still runs
-/// so regressions in the passing assertions are caught.
+/// Known assertion-level failures with their attribution; the file still runs so regressions in the passing assertions are caught.
 ///
-/// - `import-limits`: an imported func resolves through the single `Rt.Fn`
-///   boundary (no signature is checked at all), and an imported global/table/
-///   memory is checked only for its *kind* via `instanceof` — not a func's
-///   param/result types, a global's value type or mutability, nor a
-///   table/memory's min/max limits. Every `assert_unlinkable` case testing one
-///   of those (not a kind mismatch, which is caught) stays a known gap. Java's
-///   counts match Ruby's (ADR-16), not Go's lower ones: Java's uniform `Rt.Fn`
-///   and `Object`-valued `Global` box carry no static wasm type, so the
-///   func-signature and global-value-type mismatches Go's typed assertion
-///   rejects are not caught here (ADR-30).
-/// - `linking` (`linking0`/`load1`): downstream of an *unrelated*
-///   declared-unsupported feature (multi-memory) inside a module that also uses
-///   `register`; that module never converts, so a later assertion against the
-///   module it would have written into observes stale state. Not a
-///   cross-module-linking gap itself.
+/// - `import-limits`: an imported func resolves through the single `Rt.Fn` boundary (no signature is checked at all), and an imported global/table/ memory is checked only for its *kind* via `instanceof` — not a func's param/result types, a global's value type or mutability, nor a table/memory's min/max limits. Every `assert_unlinkable` case testing one of those (not a kind mismatch, which is caught) stays a known gap. Java's counts match Ruby's (ADR-16), not Go's lower ones: Java's uniform `Rt.Fn` and `Object`-valued `Global` box carry no static wasm type, so the func-signature and global-value-type mismatches Go's typed assertion rejects are not caught here (ADR-30).
+/// - `linking` (`linking0`/`load1`): downstream of an *unrelated* declared-unsupported feature (multi-memory) inside a module that also uses `register`; that module never converts, so a later assertion against the module it would have written into observes stale state. Not a cross-module-linking gap itself.
 const EXPECTED_FAILURES: &[(&str, u32, &str)] = &[
     ("imports", 28, "import-limits"),
     ("imports2", 2, "import-limits"),
@@ -57,11 +29,7 @@ const EXPECTED_FAILURES: &[(&str, u32, &str)] = &[
     ("load1", 5, "linking"),
 ];
 
-/// Files `cargo test` runs by default (the non-ignored trials). Java compiles
-/// each `.wast` file to one `Main.java` (one `javac` per file), so the default
-/// gate runs a curated list covering every semantic area (integers, floats,
-/// control flow, memory/table, globals, linking, bulk ops) plus the whole
-/// ledger; `cargo test -- --include-ignored` sweeps every file.
+/// Files `cargo test` runs by default (the non-ignored trials). Java compiles each `.wast` file to one `Main.java` (one `javac` per file), so the default gate runs a curated list covering every semantic area (integers, floats, control flow, memory/table, globals, linking, bulk ops) plus the whole ledger; `cargo test -- --include-ignored` sweeps every file.
 const CURATED_FILES: &[&str] = &[
     "address",
     "align",
@@ -157,10 +125,7 @@ impl BackendUnderTest for JavaSpec {
         &JavaBackend
     }
 
-    /// Compile `source` (one `Main.java`) to a content-addressed class-dir cache
-    /// (identical programs compile once) and run it. A missing `javac`/`java`
-    /// fails loud (ADR-15); a `javac` failure is surfaced as its `Output` so the
-    /// harness reports the compile error.
+    /// Compile `source` (one `Main.java`) to a content-addressed class-dir cache (identical programs compile once) and run it. A missing `javac`/`java` fails loud (ADR-15); a `javac` failure is surfaced as its `Output` so the harness reports the compile error.
     fn run_bytes(&self, source: &str, args: &[&str], stdin: &[u8]) -> Output {
         let javac =
             find_javac().expect("javac not found on PATH (or $DEWASM_JAVAC) — see docs/testing.md");
@@ -197,9 +162,7 @@ impl BackendUnderTest for JavaSpec {
         }
 
         run_command_bytes(
-            // A generous per-thread stack keeps genuinely deep but terminating
-            // recursions (fac, deep br chains) under the limit while a runaway
-            // still overflows into a catchable StackOverflowError (ADR-30).
+            // A generous per-thread stack keeps genuinely deep but terminating recursions (fac, deep br chains) under the limit while a runaway still overflows into a catchable StackOverflowError (ADR-30).
             Command::new(&java)
                 .arg("-Xss16m")
                 .arg("-cp")
@@ -384,9 +347,7 @@ impl SpecBackend for JavaSpec {
     }
 }
 
-/// The imports object: `spectest`, plus any currently-`register`ed instances
-/// merged in under their registered name — each instance's `Exports` map
-/// doubles as an ADR-7 import provider (ADR-16).
+/// The imports object: `spectest`, plus any currently-`register`ed instances merged in under their registered name — each instance's `Exports` map doubles as an ADR-7 import provider (ADR-16).
 fn imports_expr(registered: &[(String, String)]) -> String {
     let mut entries = vec!["\"spectest\", _spectest".to_string()];
     for (name, var) in registered {
@@ -415,9 +376,7 @@ fn java_str(s: &str) -> String {
     out
 }
 
-/// Attribution for a ref heap type the harness cannot express as a Java value.
-/// Ref-typed args/results only occur in reference-types modules, which fail to
-/// convert and are skipped upstream; this is defensive attribution.
+/// Attribution for a ref heap type the harness cannot express as a Java value. Ref-typed args/results only occur in reference-types modules, which fail to convert and are skipped upstream; this is defensive attribution.
 fn heap_type_tag(hty: &HeapType<'_>) -> String {
     match hty {
         HeapType::Abstract {
@@ -496,8 +455,7 @@ fn ret_cmp(value: &str, ret: &WastRet<'_>) -> Result<String, String> {
     }
 }
 
-/// Harness helpers + the `spectest` host fixture + the `Main` entry point. The
-/// generated body is spliced in after this preamble by `assemble`.
+/// Harness helpers + the `spectest` host fixture + the `Main` entry point. The generated body is spliced in after this preamble by `assemble`.
 const PREAMBLE: &str = r#"public class Main {
     static int _pass = 0;
     static int _fail = 0;
@@ -546,9 +504,7 @@ const PREAMBLE: &str = r#"public class Main {
         }
     }
 
-    // A JVM StackOverflowError is catchable, so exhaustion maps to it directly
-    // (like Ruby's SystemStackError). Each assertion is independent, so
-    // unwinding a mid-call overflow cannot corrupt a later check (ADR-30).
+    // A JVM StackOverflowError is catchable, so exhaustion maps to it directly (like Ruby's SystemStackError). Each assertion is independent, so unwinding a mid-call overflow cannot corrupt a later check (ADR-30).
     static void check_exhaust(String desc, Runnable thunk) {
         try {
             thunk.run();
@@ -562,9 +518,7 @@ const PREAMBLE: &str = r#"public class Main {
         }
     }
 
-    // Upstream's assert_unlinkable message text never matches ours; a raised
-    // Rt.LinkError confirms the import was correctly rejected as unlinkable. Any
-    // other throwable means the module linked and then crashed, which must fail.
+    // Upstream's assert_unlinkable message text never matches ours; a raised Rt.LinkError confirms the import was correctly rejected as unlinkable. Any other throwable means the module linked and then crashed, which must fail.
     static void check_unlinkable(String desc, Runnable thunk) {
         try {
             thunk.run();

--- a/crates/dewasm-backend-java/tests/wasi_testsuite.rs
+++ b/crates/dewasm-backend-java/tests/wasi_testsuite.rs
@@ -1,9 +1,4 @@
-//! Java side of the official WASI p1 conformance harness (ADR-36): drives the
-//! prebuilt `WebAssembly/wasi-testsuite` modules through the Java backend's
-//! standalone interface. Java is compiled, so it overrides `pty_command` to
-//! `javac` the generated `Main.java` to a content-addressed class-dir cache —
-//! the launch recipe the shared `run_standalone_wasi` runs with the manifest's
-//! env/args/dirs applied. The generic harness lives in `dewasm-test-helper`.
+//! Java side of the official WASI p1 conformance harness (ADR-36): drives the prebuilt `WebAssembly/wasi-testsuite` modules through the Java backend's standalone interface. Java is compiled, so it overrides `pty_command` to `javac` the generated `Main.java` to a content-addressed class-dir cache — the launch recipe the shared `run_standalone_wasi` runs with the manifest's env/args/dirs applied. The generic harness lives in `dewasm-test-helper`.
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
@@ -16,21 +11,14 @@ use dewasm_test_helper::{
     wasi_testsuite_suite, BackendUnderTest, PtyCommand, WasiTestsuiteBackend,
 };
 
-/// Known trial failures with their attribution (ADR-8, policy in ADR-36):
-/// `(trial, tag)` — declared ENOSYS/out-of-scope syscalls, semantics-precision
-/// gaps on supported syscalls (tracked bugs in the shared WASI runtime), and
-/// environ entries the JVM host injects itself, which count-exact `environ_*`
-/// assertions cannot absorb (ADR-40).
+/// Known trial failures with their attribution (ADR-8, policy in ADR-36): `(trial, tag)` — declared ENOSYS/out-of-scope syscalls, semantics-precision gaps on supported syscalls (tracked bugs in the shared WASI runtime), and environ entries the JVM host injects itself, which count-exact `environ_*` assertions cannot absorb (ADR-40).
 const WASI_TESTSUITE_EXPECTED_FAILURES: &[(&str, &str)] = &[
     // Declared ENOSYS / out-of-scope syscalls (docs/support.md).
     ("c/sock_shutdown-invalid_fd", "sock_shutdown (out of scope)"),
     ("c/sock_shutdown-not_sock", "sock_shutdown (out of scope)"),
 ];
 
-/// Host-scoped failures on a macOS host: the JVM host injects environ entries
-/// of its own (macOS CoreFoundation's `__CF_USER_TEXT_ENCODING`), so
-/// count-exact environ assertions cannot hold even under the harness's cleared
-/// environment. A plain Linux JVM injects nothing, so these pass there (ADR-40).
+/// Host-scoped failures on a macOS host: the JVM host injects environ entries of its own (macOS CoreFoundation's `__CF_USER_TEXT_ENCODING`), so count-exact environ assertions cannot hold even under the harness's cleared environment. A plain Linux JVM injects nothing, so these pass there (ADR-40).
 const WASI_TESTSUITE_EXPECTED_FAILURES_MACOS: &[(&str, &str)] = &[
     (
         "assemblyscript/environ_get-multiple-variables",
@@ -46,11 +34,7 @@ const WASI_TESTSUITE_EXPECTED_FAILURES_MACOS: &[(&str, &str)] = &[
     ),
 ];
 
-/// Host-scoped failures on a Linux host: the unit passes ns-precision FileTime
-/// to `BasicFileAttributeView.setTimes` with `NOFOLLOW_LINKS`, but the Linux JDK
-/// routes the NOFOLLOW case through µs-precision `lutimes`, so the suite's ns
-/// `mtim` round-trip is truncated and fails; macOS preserves ns. Symmetric to
-/// the Go backend's ledgered lutimes gap (ADR-40).
+/// Host-scoped failures on a Linux host: the unit passes ns-precision FileTime to `BasicFileAttributeView.setTimes` with `NOFOLLOW_LINKS`, but the Linux JDK routes the NOFOLLOW case through µs-precision `lutimes`, so the suite's ns `mtim` round-trip is truncated and fails; macOS preserves ns. Symmetric to the Go backend's ledgered lutimes gap (ADR-40).
 const WASI_TESTSUITE_EXPECTED_FAILURES_LINUX: &[(&str, &str)] = &[(
     "rust/symlink_filestat",
     "path_filestat_set_times: Linux JDK sets NOFOLLOW symlink times via microsecond lutimes, truncating ns",
@@ -69,10 +53,7 @@ impl BackendUnderTest for JavaWasi {
         &JavaBackend
     }
 
-    /// Compile `source` (one `Main.java`) to the content-addressed class-dir
-    /// cache and return the run recipe. A missing `javac`/`java` fails loud
-    /// (ADR-15); a compile failure panics (generated code that does not compile
-    /// is a bug, not a WASI gap).
+    /// Compile `source` (one `Main.java`) to the content-addressed class-dir cache and return the run recipe. A missing `javac`/`java` fails loud (ADR-15); a compile failure panics (generated code that does not compile is a bug, not a WASI gap).
     fn pty_command(&self, source: &str, args: &[&str]) -> PtyCommand {
         let java =
             find_java().expect("java not found on PATH (or $DEWASM_JAVA) — see docs/testing.md");
@@ -94,8 +75,7 @@ impl BackendUnderTest for JavaWasi {
     }
 }
 
-/// Compile `source` to a content-addressed class-dir cache (identical programs
-/// compile once).
+/// Compile `source` to a content-addressed class-dir cache (identical programs compile once).
 fn build_java(source: &str) -> Result<PathBuf, Output> {
     let javac =
         find_javac().expect("javac not found on PATH (or $DEWASM_JAVAC) — see docs/testing.md");

--- a/crates/dewasm-backend-python/build.rs
+++ b/crates/dewasm-backend-python/build.rs
@@ -1,6 +1,4 @@
-//! Embeds the runtime units from runtime/python/units/ as
-//! `UNIT_SOURCES: &[(&str, &str)]` (unit id, source). Mirrors the Ruby
-//! crate's build.rs (ADR-6); only the source directory differs.
+//! Embeds the runtime units from runtime/python/units/ as `UNIT_SOURCES: &[(&str, &str)]` (unit id, source). Mirrors the Ruby crate's build.rs (ADR-6); only the source directory differs.
 
 use std::fmt::Write as _;
 use std::path::Path;

--- a/crates/dewasm-backend-python/src/lib.rs
+++ b/crates/dewasm-backend-python/src/lib.rs
@@ -1,22 +1,11 @@
-//! Python backend: translates dewasm IR into a Python module (a class plus a
-//! bundled lightweight runtime).
+//! Python backend: translates dewasm IR into a Python module (a class plus a bundled lightweight runtime).
 //!
 //! Lowering conventions (ADR-28; numeric conventions ADR-2):
-//! - i32/i64 are unsigned (masked) Python ints; signed views via `Rt.s32/s64`
-//!   only where an instruction needs them.
-//! - f32/f64 are Python floats; f32 results are re-rounded with `Rt.f32`.
-//!   Float division goes through `Rt.fdiv` because Python raises on `x/0.0`.
-//! - Python has no goto and caps nested loops/`try` at ~20 ("too many
-//!   statically nested blocks"), while `if` nests ~100 deep. So only wasm
-//!   loops become real `while True`; every forward branch (block/if exit)
-//!   is lowered with a per-function branch register `_br` and guarded
-//!   statements, and block bodies are spliced inline so block nesting adds
-//!   no Python nesting (ADR-28).
+//! - i32/i64 are unsigned (masked) Python ints; signed views via `Rt.s32/s64` only where an instruction needs them.
+//! - f32/f64 are Python floats; f32 results are re-rounded with `Rt.f32`. Float division goes through `Rt.fdiv` because Python raises on `x/0.0`.
+//! - Python has no goto and caps nested loops/`try` at ~20 ("too many statically nested blocks"), while `if` nests ~100 deep. So only wasm loops become real `while True`; every forward branch (block/if exit) is lowered with a per-function branch register `_br` and guarded statements, and block bodies are spliced inline so block nesting adds no Python nesting (ADR-28).
 //!
-//! The runtime is composed from per-method units (ADR-6) and referenced by
-//! the module-level name `Rt` (Python method scopes cannot see an enclosing
-//! class scope, so the runtime lives at module top level, not nested in the
-//! generated class as it is for Ruby).
+//! The runtime is composed from per-method units (ADR-6) and referenced by the module-level name `Rt` (Python method scopes cannot see an enclosing class scope, so the runtime lives at module top level, not nested in the generated class as it is for Ruby).
 
 use std::cell::RefCell;
 use std::collections::BTreeSet;
@@ -80,16 +69,12 @@ pub fn bundler() -> &'static RuntimeBundler {
     })
 }
 
-/// Emit a top-level shared runtime (`class Rt: ...`) for the closure of
-/// `seeds`; generated classes then use `RuntimeLinkage::Alias("Rt")`.
+/// Emit a top-level shared runtime (`class Rt: ...`) for the closure of `seeds`; generated classes then use `RuntimeLinkage::Alias("Rt")`.
 pub fn shared_runtime(seeds: &BTreeSet<String>) -> Result<String> {
     Ok(format!("class Rt:\n{}", bundler().bundle(seeds, 1)?))
 }
 
-/// Locate a python3 interpreter (>= 3.9) able to run generated scripts.
-/// Honors `$DEWASM_PYTHON`, then `python3`, then `python` (ADR-15: a missing
-/// or too-old interpreter is a loud failure at the call site, not here — this
-/// only reports what qualifies).
+/// Locate a python3 interpreter (>= 3.9) able to run generated scripts. Honors `$DEWASM_PYTHON`, then `python3`, then `python` (ADR-15: a missing or too-old interpreter is a loud failure at the call site, not here — this only reports what qualifies).
 pub fn find_python() -> Option<std::path::PathBuf> {
     use std::path::PathBuf;
     let mut candidates: Vec<PathBuf> = Vec::new();
@@ -115,8 +100,7 @@ pub fn find_python() -> Option<std::path::PathBuf> {
     None
 }
 
-/// Generate one class for `module`. Returns the class source and the set of
-/// runtime units it needs (already bundled inside for `Embedded`).
+/// Generate one class for `module`. Returns the class source and the set of runtime units it needs (already bundled inside for `Embedded`).
 pub fn generate_class_with_units(
     module: &Module,
     class_name: &str,
@@ -142,8 +126,7 @@ fn generate_class_inner(
     data_file: Option<&str>,
 ) -> Result<(String, BTreeSet<String>)> {
     check_module_support(&PythonBackend, module)?;
-    // Prefix sums: `data_offsets[i]` is where segment `i` begins in the
-    // concatenated sidecar blob (ADR-37). Only consulted when externalizing.
+    // Prefix sums: `data_offsets[i]` is where segment `i` begins in the concatenated sidecar blob (ADR-37). Only consulted when externalizing.
     let mut data_offsets = Vec::with_capacity(module.datas.len());
     let mut acc = 0usize;
     for data in &module.datas {
@@ -196,12 +179,9 @@ impl Backend for PythonBackend {
 
     fn feature_status(&self, feature: Feature) -> SupportStatus {
         match feature {
-            // Python floats are IEEE doubles; f32 re-rounding and the NaN
-            // paths follow ADR-2 (mirroring Ruby).
+            // Python floats are IEEE doubles; f32 re-rounding and the NaN paths follow ADR-2 (mirroring Ruby).
             Feature::Floats => SupportStatus::Supported,
-            // The wasm-1.0 completion (ADR-16 model): boxed globals, imported
-            // globals/memories/tables, multiple tables, and the table half of
-            // bulk memory.
+            // The wasm-1.0 completion (ADR-16 model): boxed globals, imported globals/memories/tables, multiple tables, and the table half of bulk memory.
             Feature::ImportedGlobals
             | Feature::ImportedMemories
             | Feature::ImportedTables
@@ -214,8 +194,7 @@ impl Backend for PythonBackend {
     fn generate(&self, module: &Module, opts: &GenOptions) -> Result<Vec<OutputFile>> {
         let class_name = class_name(&opts.module_name);
 
-        // The Exit/Trap handlers in the standalone main need these even when
-        // the module itself never references them.
+        // The Exit/Trap handlers in the standalone main need these even when the module itself never references them.
         let mut extra_seeds = BTreeSet::new();
         if opts.mode == Mode::Standalone {
             extra_seeds.insert("rt/trap".to_string());
@@ -244,10 +223,7 @@ impl Backend for PythonBackend {
             w.line("import threading");
         }
         w.line("import time");
-        // Externalized data blob (ADR-37): read once at import time from the
-        // sidecar next to this module, then sliced by the generated
-        // `DATA_BLOB[o:o+len]` expressions. Only emitted when there is data to
-        // externalize (otherwise the generated code never reads it).
+        // Externalized data blob (ADR-37): read once at import time from the sidecar next to this module, then sliced by the generated `DATA_BLOB[o:o+len]` expressions. Only emitted when there is data to externalize (otherwise the generated code never reads it).
         if let Some(cfg) = &opts.data_file {
             if !module.datas.is_empty() {
                 w.line("");
@@ -268,10 +244,7 @@ impl Backend for PythonBackend {
             w.line("if __name__ == \"__main__\":");
             w.indent();
             if wasi_kwargs {
-                // Parse the standalone runtime interface (ADR-31): a leading run
-                // of `--dir HOST::GUEST` flags mounts host directories at guest
-                // paths (wasmtime-style), stopping at `--` or the first non-flag
-                // token; the rest is the guest's argv[1..].
+                // Parse the standalone runtime interface (ADR-31): a leading run of `--dir HOST::GUEST` flags mounts host directories at guest paths (wasmtime-style), stopping at `--` or the first non-flag token; the rest is the guest's argv[1..].
                 w.line("_pre = {}");
                 w.line("_argv = sys.argv[1:]");
                 w.line("_i = 0");
@@ -314,10 +287,7 @@ impl Backend for PythonBackend {
             } else {
                 w.line(format!("_inst = {class_name}()"));
             }
-            // ADR-28: run the guest on a big-stack thread with a raised
-            // recursion limit (the spec harness's values). The thread carries
-            // exceptions back so proc_exit/traps still exit via the main
-            // thread; daemon so Ctrl-C during `join` still terminates.
+            // ADR-28: run the guest on a big-stack thread with a raised recursion limit (the spec harness's values). The thread carries exceptions back so proc_exit/traps still exit via the main thread; daemon so Ctrl-C during `join` still terminates.
             w.line("_err = []");
             w.line("");
             w.line("def _run():");
@@ -368,10 +338,7 @@ impl Backend for PythonBackend {
             name: format!("{}.py", opts.module_name),
             contents: w.finish().into_bytes(),
         }];
-        // The data sidecar (ADR-37): every segment's bytes concatenated in
-        // segment order, matching the `data_offsets` prefix sums baked into the
-        // generated `DATA_BLOB[o:o+len]` slices. Only emitted when there is data
-        // to externalize (otherwise the generated code never reads it).
+        // The data sidecar (ADR-37): every segment's bytes concatenated in segment order, matching the `data_offsets` prefix sums baked into the generated `DATA_BLOB[o:o+len]` slices. Only emitted when there is data to externalize (otherwise the generated code never reads it).
         if let Some(cfg) = &opts.data_file {
             if !module.datas.is_empty() {
                 let mut blob = Vec::new();
@@ -437,8 +404,7 @@ fn hex_bytes(data: &[u8]) -> String {
     format!("bytes.fromhex(\"{hex}\")")
 }
 
-/// WASI import module names the bundled runtime answers for. `wasi_unstable`
-/// (snapshot 0) shares preview 1's ABI for everything implemented here.
+/// WASI import module names the bundled runtime answers for. `wasi_unstable` (snapshot 0) shares preview 1's ABI for everything implemented here.
 const WASI_MODULES: &[&str] = &["wasi_snapshot_preview1", "wasi_unstable"];
 
 fn is_wasi_module(name: &str) -> bool {
@@ -447,8 +413,7 @@ fn is_wasi_module(name: &str) -> bool {
 
 pub use dewasm_backend::WASI_PREVIEW1_FUNCTIONS;
 
-/// Whether the generated class bundles the built-in WASI as an import
-/// fallback (and therefore takes `args`/`env`/`preopens` keyword arguments).
+/// Whether the generated class bundles the built-in WASI as an import fallback (and therefore takes `args`/`env`/`preopens` keyword arguments).
 fn wasi_bundled(module: &Module, default_wasi: bool) -> bool {
     default_wasi
         && module
@@ -474,18 +439,13 @@ struct Gen<'a> {
     default_wasi: bool,
     /// Runtime units the generated code references.
     uses: RefCell<BTreeSet<String>>,
-    /// When `Some`, data segments are externalized into a binary sidecar of
-    /// this filename (loaded once into the module-level `DATA_BLOB`) instead of
-    /// embedded as `bytes.fromhex` literals (ADR-37); `data_offsets[i]` locates
-    /// segment `i` in the blob.
+    /// When `Some`, data segments are externalized into a binary sidecar of this filename (loaded once into the module-level `DATA_BLOB`) instead of embedded as `bytes.fromhex` literals (ADR-37); `data_offsets[i]` locates segment `i` in the blob.
     data_file: Option<String>,
     data_offsets: Vec<usize>,
 }
 
 impl<'a> Gen<'a> {
-    /// The Python expression yielding a data segment's bytes: a slice of the
-    /// externalized `DATA_BLOB` when `--data-file` is on, else an inline
-    /// `bytes.fromhex` literal (ADR-37). Both yield a `bytes` object.
+    /// The Python expression yielding a data segment's bytes: a slice of the externalized `DATA_BLOB` when `--data-file` is on, else an inline `bytes.fromhex` literal (ADR-37). Both yield a `bytes` object.
     fn data_expr(&self, seg: usize, data: &[u8]) -> String {
         if self.data_file.is_some() {
             let o = self.data_offsets[seg];
@@ -643,9 +603,7 @@ impl<'a> Gen<'a> {
         }
 
         for (i, import) in m.imported_funcs.iter().enumerate() {
-            // Fallback order (ADR-7): explicit import -> bundled WASI unit
-            // (constructed lazily) -> ENOSYS stub; non-WASI imports stay
-            // mandatory (a missing one is a link error).
+            // Fallback order (ADR-7): explicit import -> bundled WASI unit (constructed lazily) -> ENOSYS stub; non-WASI imports stay mandatory (a missing one is a link error).
             let fallback = if is_wasi_module(&import.module) && self.default_wasi {
                 let unit = format!("wasi/{}", import.name);
                 if bundler().has_unit(&unit) {
@@ -782,9 +740,7 @@ impl<'a> Gen<'a> {
         w.line("return getattr(self, self.GLOBAL_EXPORTS[name]).value");
         w.dedent();
         w.line("");
-        // The boxed Rt.Global itself (not its current value), for a host
-        // embedder or another dewasm instance to import as a shared mutable
-        // cell (ADR-16).
+        // The boxed Rt.Global itself (not its current value), for a host embedder or another dewasm instance to import as a shared mutable cell (ADR-16).
         w.line("def global_export(self, name):");
         w.indent();
         w.line("return getattr(self, self.GLOBAL_EXPORTS[name])");
@@ -845,8 +801,7 @@ impl<'a> Gen<'a> {
         self.type_symbol(ty)
     }
 
-    /// A structural key for a function type (not a module-local index), so a
-    /// table shared across modules stays consistent.
+    /// A structural key for a function type (not a module-local index), so a table shared across modules stays consistent.
     fn type_symbol(&self, type_idx: u32) -> String {
         let ty = &self.module.types[type_idx as usize];
         let names = |tys: &[ValType]| {
@@ -902,8 +857,7 @@ impl<'a> Gen<'a> {
             let name = format!("l{}", ty.params.len() + i);
             w.line(format!("{name} = {}", default_value(*local_ty)));
         }
-        // Temps default to 0; every temp is assigned before any reachable read
-        // (valid wasm), so the value only guards against Python NameError.
+        // Temps default to 0; every temp is assigned before any reachable read (valid wasm), so the value only guards against Python NameError.
         let mut depths: Vec<u32> = func.temps.iter().map(|t| t.depth).collect();
         depths.dedup();
         if !depths.is_empty() {
@@ -923,10 +877,7 @@ impl<'a> Gen<'a> {
         w.dedent();
     }
 
-    /// Emit a statement sequence, threading the compile-time `guarded` flag
-    /// (whether a preceding statement may have left a branch pending in `_br`).
-    /// Block/Loop bodies are spliced inline so block nesting adds no Python
-    /// nesting; only real loops become `while` (ADR-28).
+    /// Emit a statement sequence, threading the compile-time `guarded` flag (whether a preceding statement may have left a branch pending in `_br`). Block/Loop bodies are spliced inline so block nesting adds no Python nesting; only real loops become `while` (ADR-28).
     fn emit_seq(&self, w: &mut CodeWriter, stmts: &[Stmt], guarded: &mut bool) {
         for stmt in stmts {
             match stmt {
@@ -978,11 +929,7 @@ impl<'a> Gen<'a> {
                     *guarded = before || !stmt_free_targets(stmt).is_empty();
                 }
                 Stmt::SourceLine(_) => {
-                    // A comment carries no runtime effect, so render it outside
-                    // the `_br == 0` guard: a lone comment under an indented
-                    // guard block would be an empty suite Python rejects, and
-                    // the guard state must stay exactly as the surrounding
-                    // statements left it (ADR-38).
+                    // A comment carries no runtime effect, so render it outside the `_br == 0` guard: a lone comment under an indented guard block would be an empty suite Python rejects, and the guard state must stay exactly as the surrounding statements left it (ADR-38).
                     self.simple_stmt(w, stmt);
                 }
                 _ => {
@@ -1004,8 +951,7 @@ impl<'a> Gen<'a> {
 
     fn emit_if(&self, w: &mut CodeWriter, guarded: bool, cond: &Expr, then: &[Stmt], els: &[Stmt]) {
         let cond_s = self.expr(cond);
-        // When guarded, `_br == 0 and ...` short-circuits so `cond` (which may
-        // trap on a load) is not evaluated while a branch is pending.
+        // When guarded, `_br == 0 and ...` short-circuits so `cond` (which may trap on a load) is not evaluated while a branch is pending.
         if guarded {
             w.line(format!("if _br == 0 and ({cond_s}) != 0:"));
         } else {
@@ -1216,9 +1162,7 @@ impl<'a> Gen<'a> {
                 for (dst, src) in assigns {
                     w.line(format!("{} = {}", temp(*dst), temp(*src)));
                 }
-                // is_loop is irrelevant here: the loop trailer turns `_br ==
-                // <loop id>` into a `continue`; a block/if exit is handled by
-                // the guards skipping to the label's reset marker (ADR-28).
+                // is_loop is irrelevant here: the loop trailer turns `_br == <loop id>` into a `continue`; a block/if exit is handled by the guards skipping to the label's reset marker (ADR-28).
                 w.line(format!("_br = {label}"));
             }
         }
@@ -1406,10 +1350,7 @@ impl<'a> Gen<'a> {
     }
 }
 
-/// A Python float literal that round-trips to the same double. `{:?}` on f64
-/// gives the shortest round-tripping decimal, which Python's `float()` parses
-/// back exactly; only the spelling of infinities/`e` notation differs, and
-/// non-finite values never reach here.
+/// A Python float literal that round-trips to the same double. `{:?}` on f64 gives the shortest round-tripping decimal, which Python's `float()` parses back exactly; only the spelling of infinities/`e` notation differs, and non-finite values never reach here.
 fn py_float(v: f64) -> String {
     format!("{v:?}")
 }
@@ -1425,8 +1366,7 @@ fn assign_results(results: &[Temp], call: String) -> String {
     }
 }
 
-/// Whether `stmts` contains any branch to a label (as opposed to a return),
-/// i.e. whether the function needs the `_br` branch register at all.
+/// Whether `stmts` contains any branch to a label (as opposed to a return), i.e. whether the function needs the `_br` branch register at all.
 fn seq_has_label_branch(stmts: &[Stmt]) -> bool {
     stmts.iter().any(stmt_has_label_branch)
 }
@@ -1446,9 +1386,7 @@ fn stmt_has_label_branch(stmt: &Stmt) -> bool {
     }
 }
 
-/// The set of label ids a statement branches to that are *not* bound within
-/// it. Non-empty means the statement may leave `_br` set on fall-through,
-/// so following siblings must be guarded (ADR-28).
+/// The set of label ids a statement branches to that are *not* bound within it. Non-empty means the statement may leave `_br` set on fall-through, so following siblings must be guarded (ADR-28).
 fn stmt_free_targets(stmt: &Stmt) -> BTreeSet<u32> {
     match stmt {
         Stmt::Br(t) | Stmt::BrIf { target: t, .. } => target_free(t),
@@ -1532,11 +1470,7 @@ fn store_method(op: StoreOp) -> &'static str {
     }
 }
 
-/// Lint for the runtime units: every reference a unit body makes to another
-/// unit must be declared in its `# requires:` header. Mirrors the Ruby
-/// backend's units lint (ADR-6), adjusted for Python syntax (`Rt.<name>`
-/// staticmethod/const references, `self.memory.<name>` memory calls, and
-/// `self.<name>(...)` sibling calls within a scope's nested class).
+/// Lint for the runtime units: every reference a unit body makes to another unit must be declared in its `# requires:` header. Mirrors the Ruby backend's units lint (ADR-6), adjusted for Python syntax (`Rt.<name>` staticmethod/const references, `self.memory.<name>` memory calls, and `self.<name>(...)` sibling calls within a scope's nested class).
 #[cfg(test)]
 mod units {
     use super::*;

--- a/crates/dewasm-backend-python/tests/e2e.rs
+++ b/crates/dewasm-backend-python/tests/e2e.rs
@@ -1,9 +1,4 @@
-//! Python end-to-end suites (ADR-27): the shared case consts (`dewasm-test-helper`)
-//! wired up for the Python backend. Per the ADR-27 revision this file holds ONLY
-//! the [`BackendUnderTest`] impl, named glue string constants, and per-case
-//! macro invocations. Python covers full WASI preview 1 incl. the filesystem
-//! (ADR-28), so it wires every WASI kind, the slow-tier `apps`/`fs_apps`/`capi`
-//! suites, and the shared-table multi-module case.
+//! Python end-to-end suites (ADR-27): the shared case consts (`dewasm-test-helper`) wired up for the Python backend. Per the ADR-27 revision this file holds ONLY the [`BackendUnderTest`] impl, named glue string constants, and per-case macro invocations. Python covers full WASI preview 1 incl. the filesystem (ADR-28), so it wires every WASI kind, the slow-tier `apps`/`fs_apps`/`capi` suites, and the shared-table multi-module case.
 
 use std::path::PathBuf;
 
@@ -34,10 +29,7 @@ impl BackendUnderTest for Python {
         find_python().expect("python3 >= 3.9 not found on PATH — see docs/testing.md")
     }
 
-    /// Compose several `.wat` modules. `shared_runtime` emits each against one
-    /// top-level `class Rt:` (Alias linkage) plus a single bundled runtime, so
-    /// an imported table crosses modules; otherwise it concatenates independent
-    /// Embedded conversions (only used by cases Python invokes).
+    /// Compose several `.wat` modules. `shared_runtime` emits each against one top-level `class Rt:` (Alias linkage) plus a single bundled runtime, so an imported table crosses modules; otherwise it concatenates independent Embedded conversions (only used by cases Python invokes).
     fn compose_modules(&self, modules: &[(&str, &str)], shared_runtime: bool) -> String {
         if shared_runtime {
             let mut units = std::collections::BTreeSet::new();
@@ -77,8 +69,7 @@ impl BackendUnderTest for Python {
     }
 }
 
-// ---------------------------------------------------------------------
-// Library-case glue.
+// --------------------------------------------------------------------- Library-case glue.
 
 /// `add.wat`: call the exported functions and print each result.
 const PYTHON_ADD_GLUE: &str = r#"inst = Add()
@@ -87,8 +78,7 @@ print(inst.invoke("add", 0xffffffff, 1))
 print(inst.invoke("fib", 10))
 "#;
 
-/// The ADR-7 override/fallback glue: fd_write intercepted, random_get falls
-/// back to the bundled WASI. Prints the actual bytes written.
+/// The ADR-7 override/fallback glue: fd_write intercepted, random_get falls back to the bundled WASI. Prints the actual bytes written.
 const PYTHON_OVERRIDE_GLUE: &str = r#"import sys
 _captured = bytearray()
 _holder = {}
@@ -109,9 +99,7 @@ inst.invoke("_start")  # random_get falls back to the bundled WASI
 sys.stdout.write(_captured.decode("utf-8", "surrogateescape"))
 "#;
 
-/// The `custom_wasi_provider` glue: a provider *object* (`wasm_import`/`attach`,
-/// the Python analog of Ruby's duck-typed provider) covers every import, so the
-/// bundled WASI (`_wasi`) is never lazily constructed.
+/// The `custom_wasi_provider` glue: a provider *object* (`wasm_import`/`attach`, the Python analog of Ruby's duck-typed provider) covers every import, so the bundled WASI (`_wasi`) is never lazily constructed.
 const PYTHON_CUSTOM_PROVIDER_GLUE: &str = r#"import sys
 
 
@@ -144,8 +132,7 @@ sys.stdout.write(wasi.out.decode("utf-8", "surrogateescape"))
 print("bundled wasi constructed:", "true" if inst._wasi is not None else "false")
 "#;
 
-/// The `partial_override_falls_back_to_bundled_wasi` glue: fd_write intercepted,
-/// random_get falls back — so the bundled WASI *was* lazily constructed.
+/// The `partial_override_falls_back_to_bundled_wasi` glue: fd_write intercepted, random_get falls back — so the bundled WASI *was* lazily constructed.
 const PYTHON_PARTIAL_OVERRIDE_GLUE: &str = r#"import sys
 _captured = bytearray()
 _holder = {}
@@ -167,10 +154,7 @@ sys.stdout.write(_captured.decode("utf-8", "surrogateescape"))
 print("bundled wasi constructed:", "true" if inst._wasi is not None else "false")
 "#;
 
-/// The `wasi_stdio_capture` glue: redirect `sys.stdout` (whose `.buffer` the
-/// bundled WASI captures on lazy construction) to a `BytesIO`, run, then print
-/// the captured bytes to the real stdout — the Python mirror of Ruby's StringIO
-/// idiom.
+/// The `wasi_stdio_capture` glue: redirect `sys.stdout` (whose `.buffer` the bundled WASI captures on lazy construction) to a `BytesIO`, run, then print the captured bytes to the real stdout — the Python mirror of Ruby's StringIO idiom.
 const PYTHON_STDIO_CAPTURE_GLUE: &str = r#"import io
 import sys
 
@@ -192,12 +176,9 @@ sys.stdout.buffer.write(_data)
 sys.stdout.flush()
 "#;
 
-// ---------------------------------------------------------------------
-// WASI filesystem glue.
+// --------------------------------------------------------------------- WASI filesystem glue.
 
-/// The shared filesystem template: preopen the scratch dir (`{host}`) at guest
-/// `{guest}` (always `/`), run `_start`, and surface a `proc_exit` code as a
-/// trailing decimal line.
+/// The shared filesystem template: preopen the scratch dir (`{host}`) at guest `{guest}` (always `/`), run `_start`, and surface a `proc_exit` code as a trailing decimal line.
 const PYTHON_FS_GLUE: &str = r#"inst = Prog({}, preopens={"{guest}": "{host}"})
 try:
     inst.invoke("_start")
@@ -205,16 +186,13 @@ except Rt.Exit as e:
     print(e.code)
 "#;
 
-/// The root-preopen containment probe: call the WASI resolver directly with a
-/// `"/" => "/"` preopen (no guest run) and normalize the outcome to `contained`.
+/// The root-preopen containment probe: call the WASI resolver directly with a `"/" => "/"` preopen (no guest run) and normalize the outcome to `contained`.
 const PYTHON_CONTAINMENT_GLUE: &str = r#"wasi = Rt.WASI(preopens={"/": "/"})
 _path, err = wasi.resolve_path(3, "etc")
 print("contained" if err is None else "rejected")
 "#;
 
-// ---------------------------------------------------------------------
-// Filesystem app glue: class/argv/env/preopen-guest-paths are literals; only
-// the host scratch/cache dirs come through {scratch}/{cache}.
+// --------------------------------------------------------------------- Filesystem app glue: class/argv/env/preopen-guest-paths are literals; only the host scratch/cache dirs come through {scratch}/{cache}.
 
 const PYTHON_QJS_FILE_IO_GLUE: &str = r#"inst = Qjs({}, args=["qjs", "/work/qjs_file_io.js"], env={}, preopens={"/work": "{scratch}"})
 try:
@@ -258,9 +236,7 @@ except Rt.Exit:
     pass
 "#;
 
-// ---------------------------------------------------------------------
-// C-API drive glue (sqlite3): malloc/pointer plumbing via Rt.Memory. Only the
-// file-backed case uses {scratch}.
+// --------------------------------------------------------------------- C-API drive glue (sqlite3): malloc/pointer plumbing via Rt.Memory. Only the file-backed case uses {scratch}.
 
 const PYTHON_LIBSQLITE3_MEM: &str = r#"
 db_mod = Libsqlite3({})
@@ -408,10 +384,7 @@ for r in ROWS:
 print("CALLBACK-OK")
 "#;
 
-/// libpcap BPF filter compilation: drive `compile_filter` on "tcp port 80"
-/// (DLT_EN10MB, snaplen 65535), then walk the serialized program
-/// `[u32 bf_len][bf_len × {u16 code; u8 jt; u8 jf; u32 k}]` in guest memory,
-/// printing each instruction as `code jt jf k`.
+/// libpcap BPF filter compilation: drive `compile_filter` on "tcp port 80" (DLT_EN10MB, snaplen 65535), then walk the serialized program `[u32 bf_len][bf_len × {u16 code; u8 jt; u8 jf; u32 k}]` in guest memory, printing each instruction as `code jt jf k`.
 const PYTHON_PCAP_COMPILE: &str = r#"
 inst = Libpcap({})
 inst.invoke("_initialize")
@@ -439,9 +412,7 @@ inst.invoke("free", prog)
 print("BPF-OK")
 "#;
 
-/// tree-sitter JSON parse: drive `parse_source` on the fixed snippet
-/// `{"key": [1, true, null]}` and print the parse tree's S-expression (a
-/// malloc'd NUL-terminated C string) from guest memory.
+/// tree-sitter JSON parse: drive `parse_source` on the fixed snippet `{"key": [1, true, null]}` and print the parse tree's S-expression (a malloc'd NUL-terminated C string) from guest memory.
 const PYTHON_TREESITTER_PARSE: &str = r#"
 inst = Treesitter({})
 inst.invoke("_initialize")
@@ -465,19 +436,15 @@ inst.invoke("free", r)
 print("TS-OK")
 "#;
 
-// ---------------------------------------------------------------------
-// Multi-module drive glue.
+// --------------------------------------------------------------------- Multi-module drive glue.
 
-/// Driver for the shared-table case: instantiate the exporter and the importer
-/// linked against it, then print `call0` (call_indirect through the shared
-/// table -> 42).
+/// Driver for the shared-table case: instantiate the exporter and the importer linked against it, then print `call0` (call_indirect through the shared table -> 42).
 const PYTHON_SHARED_TABLE_GLUE: &str = r#"a = TableExp()
 b = TableImp({"a": a})
 print(b.invoke("call0"))
 "#;
 
-// ---------------------------------------------------------------------
-// Suite wiring (ADR-27): each per-case macro invocation declares participation.
+// --------------------------------------------------------------------- Suite wiring (ADR-27): each per-case macro invocation declares participation.
 
 library_add_e2e!(Python, PYTHON_ADD_GLUE);
 wasi_import_override_e2e!(Python, PYTHON_OVERRIDE_GLUE);
@@ -515,7 +482,4 @@ pcap_compile_e2e!(Python, PYTHON_PCAP_COMPILE);
 treesitter_parse_e2e!(Python, PYTHON_TREESITTER_PARSE);
 
 shared_table_e2e!(Python, PYTHON_SHARED_TABLE_GLUE);
-// embedded_coexist_e2e!: not invoked — Python's library Embedded output emits
-// one top-level `class Rt:` (a sibling, redefined on concatenation), not a
-// per-class nested runtime, so two independent runtimes cannot coexist
-// (docs/apps-audit.md).
+// embedded_coexist_e2e!: not invoked — Python's library Embedded output emits one top-level `class Rt:` (a sibling, redefined on concatenation), not a per-class nested runtime, so two independent runtimes cannot coexist (docs/apps-audit.md).

--- a/crates/dewasm-backend-python/tests/spec.rs
+++ b/crates/dewasm-backend-python/tests/spec.rs
@@ -1,19 +1,8 @@
-//! Python side of the shared spec harness (ADR-3, ADR-27, ADR-28): converts
-//! modules with the Python backend, phrases assertions as Python (`check`/
-//! `check_trap`/`check_exhaust`/`check_unlinkable` helpers, bit-exact float
-//! comparison via `Rt.f32_bits`/`Rt.f64_bits`), and runs the script with the
-//! `python3` on PATH. The generic harness lives in `dewasm-test-helper`.
+//! Python side of the shared spec harness (ADR-3, ADR-27, ADR-28): converts modules with the Python backend, phrases assertions as Python (`check`/ `check_trap`/`check_exhaust`/`check_unlinkable` helpers, bit-exact float comparison via `Rt.f32_bits`/`Rt.f64_bits`), and runs the script with the `python3` on PATH. The generic harness lives in `dewasm-test-helper`.
 //!
 //! Two Python facts shape the phrasing (ADR-28):
-//! - Assertions are passed as zero-arg lambdas because Python has no
-//!   statement blocks; the value under test is bound inside the lambda with an
-//!   inner `(lambda __r: (<cmp>, __r))(<call>)`.
-//! - Deep guest recursion (call/fac) and the `assert_exhaustion` cases both
-//!   need more stack than the default; the whole assertion body runs in a
-//!   thread with a large `threading.stack_size` and a raised
-//!   `sys.setrecursionlimit`, so a runaway recursion surfaces as a catchable
-//!   `RecursionError` (mapped to `call stack exhausted`) instead of a C-stack
-//!   crash — the guest-side analogue of the harness's `convert_on_big_stack`.
+//! - Assertions are passed as zero-arg lambdas because Python has no statement blocks; the value under test is bound inside the lambda with an inner `(lambda __r: (<cmp>, __r))(<call>)`.
+//! - Deep guest recursion (call/fac) and the `assert_exhaustion` cases both need more stack than the default; the whole assertion body runs in a thread with a large `threading.stack_size` and a raised `sys.setrecursionlimit`, so a runaway recursion surfaces as a catchable `RecursionError` (mapped to `call stack exhausted`) instead of a C-stack crash — the guest-side analogue of the harness's `convert_on_big_stack`.
 
 use std::collections::BTreeSet;
 use std::fmt::Write as _;
@@ -26,15 +15,7 @@ use dewasm_test_helper::{spec_suite, BackendUnderTest, Converted, SpecBackend};
 use wast::core::{AbstractHeapType, HeapType, NanPattern, WastArgCore, WastRetCore};
 use wast::{WastArg, WastRet};
 
-/// Known assertion-level failures with their attribution; the file still runs
-/// so regressions in the passing assertions are caught. Identical in shape to
-/// the Ruby ledger (ADR-16): the only open gap is `import-limits` —
-/// `Rt.check_import_kind` validates the *kind* of a resolved import but not
-/// its finer wasm type (a global's mutability, a table/memory's min/max
-/// limits, a function's signature), so the `assert_unlinkable` cases that test
-/// those, plus the two `linking`-tagged stale-state cases downstream of a
-/// declared-unsupported feature (multi-memory) that also happens to `register`,
-/// stay known gaps.
+/// Known assertion-level failures with their attribution; the file still runs so regressions in the passing assertions are caught. Identical in shape to the Ruby ledger (ADR-16): the only open gap is `import-limits` — `Rt.check_import_kind` validates the *kind* of a resolved import but not its finer wasm type (a global's mutability, a table/memory's min/max limits, a function's signature), so the `assert_unlinkable` cases that test those, plus the two `linking`-tagged stale-state cases downstream of a declared-unsupported feature (multi-memory) that also happens to `register`, stay known gaps.
 const EXPECTED_FAILURES: &[(&str, u32, &str)] = &[
     ("imports", 28, "import-limits"),
     ("imports2", 2, "import-limits"),
@@ -43,13 +24,7 @@ const EXPECTED_FAILURES: &[(&str, u32, &str)] = &[
     ("load1", 5, "linking"),
 ];
 
-/// Files `cargo test` runs by default. Python executes wasm ~30x slower than
-/// Ruby (the full 257-file sweep takes ~2 min versus Ruby's ~4 s, dominated by
-/// per-file `python3` startup and the pure-Python numeric runtime), so — like
-/// Bash (ADR-3 pre-accepts this) — the gate runs a curated list covering every
-/// semantic area (integers, floats, control flow, memory/table, globals,
-/// linking, bulk ops) plus the whole ledger; `cargo test -- --include-ignored`
-/// sweeps everything.
+/// Files `cargo test` runs by default. Python executes wasm ~30x slower than Ruby (the full 257-file sweep takes ~2 min versus Ruby's ~4 s, dominated by per-file `python3` startup and the pure-Python numeric runtime), so — like Bash (ADR-3 pre-accepts this) — the gate runs a curated list covering every semantic area (integers, floats, control flow, memory/table, globals, linking, bulk ops) plus the whole ledger; `cargo test -- --include-ignored` sweeps everything.
 const CURATED_FILES: &[&str] = &[
     "address",
     "align",
@@ -160,15 +135,13 @@ impl SpecBackend for PythonSpec {
     fn seed_units(&self) -> &'static [&'static str] {
         &[
             "rt/trap",
-            // check_unlinkable references Rt.LinkError even when the converted
-            // modules themselves don't.
+            // check_unlinkable references Rt.LinkError even when the converted modules themselves don't.
             "rt/link_error",
             "rt/f32_bits",
             "rt/f32_from_bits",
             "rt/f64_bits",
             "rt/f64_from_bits",
-            // Referenced by the _spectest fixture (PREAMBLE below), not
-            // necessarily by the converted module itself.
+            // Referenced by the _spectest fixture (PREAMBLE below), not necessarily by the converted module itself.
             "global/_class",
             "table/_class",
             "memory/_class",
@@ -184,10 +157,7 @@ impl SpecBackend for PythonSpec {
             &RuntimeLinkage::Alias("Rt".to_string()),
             false, // spec modules import spectest, never WASI
         )?;
-        // The whole assertion body runs inside `def _main()`; a class defined
-        // there is a local class whose methods still resolve the module-level
-        // `Rt` global (ADR-28). The `Rt = Rt` alias line, however, would make
-        // `Rt` a `_main`-local name — drop it and rely on the module global.
+        // The whole assertion body runs inside `def _main()`; a class defined there is a local class whose methods still resolve the module-level `Rt` global (ADR-28). The `Rt = Rt` alias line, however, would make `Rt` a `_main`-local name — drop it and rely on the module global.
         let source = source
             .strip_prefix("Rt = Rt\n\n\n")
             .unwrap_or(&source)
@@ -302,8 +272,7 @@ impl SpecBackend for PythonSpec {
         _decls: &str,
         body: &str,
     ) -> anyhow::Result<String> {
-        // The runtime units use `math`/`struct`; the harness uses `sys` and
-        // `threading` (PREAMBLE) — shared_runtime emits only `class Rt`.
+        // The runtime units use `math`/`struct`; the harness uses `sys` and `threading` (PREAMBLE) — shared_runtime emits only `class Rt`.
         let mut script = String::from("import math\nimport struct\nimport sys\n\n");
         script.push_str(
             &dewasm_backend_python::shared_runtime(units)
@@ -311,8 +280,7 @@ impl SpecBackend for PythonSpec {
         );
         script.push('\n');
         script.push_str(PREAMBLE);
-        // The whole body (module class defs, instantiations, and assertions)
-        // runs inside `_main` so it can execute on a large-stack thread.
+        // The whole body (module class defs, instantiations, and assertions) runs inside `_main` so it can execute on a large-stack thread.
         script.push_str("\ndef _main():\n");
         for line in body.lines() {
             if line.is_empty() {
@@ -327,9 +295,7 @@ impl SpecBackend for PythonSpec {
     }
 }
 
-/// `_spectest`, plus any currently-`register`ed instances merged in under
-/// their registered name — each instance doubles as an ADR-7 import provider
-/// (`wasm_import`).
+/// `_spectest`, plus any currently-`register`ed instances merged in under their registered name — each instance doubles as an ADR-7 import provider (`wasm_import`).
 fn imports_expr(registered: &[(String, String)]) -> String {
     if registered.is_empty() {
         return "_spectest".to_string();
@@ -362,9 +328,7 @@ fn py_str(s: &str) -> String {
     out
 }
 
-/// Attribution for a null/ref heap type the harness cannot express as a Python
-/// value; the reference-types hierarchies (and their bottoms, also just
-/// `None`) are expressible.
+/// Attribution for a null/ref heap type the harness cannot express as a Python value; the reference-types hierarchies (and their bottoms, also just `None`) are expressible.
 fn heap_type_tag(hty: &HeapType<'_>) -> String {
     match hty {
         HeapType::Abstract {
@@ -406,8 +370,7 @@ fn arg_py(arg: &WastArg<'_>) -> Result<String, String> {
                 Err(heap_type_tag(hty))
             }
         }
-        // An externref (or legacy hostref) with identity `n`: the host value
-        // is the Integer itself (ADR-17: externref = raw host value).
+        // An externref (or legacy hostref) with identity `n`: the host value is the Integer itself (ADR-17: externref = raw host value).
         WastArg::Core(WastArgCore::RefExtern(n)) => Ok(n.to_string()),
         WastArg::Core(WastArgCore::RefHost(n)) => Ok(n.to_string()),
         _ => Err("component-model".to_string()),
@@ -451,13 +414,11 @@ fn ret_cmp(value: &str, ret: &WastRet<'_>) -> Result<String, String> {
         // `(ref.extern)`: any non-null externref.
         WastRet::Core(WastRetCore::RefExtern(None)) => Ok(format!("{value} is not None")),
         WastRet::Core(WastRetCore::RefHost(n)) => Ok(format!("{value} == {n}")),
-        // `(ref.func)`: any non-null funcref — in ADR-17's representation, a
-        // `[type_string, callable]` pair.
+        // `(ref.func)`: any non-null funcref — in ADR-17's representation, a `[type_string, callable]` pair.
         WastRet::Core(WastRetCore::RefFunc(None)) => Ok(format!(
             "(isinstance({value}, list) and isinstance({value}[0], str))"
         )),
-        // A specific function's identity: not expressible without an export
-        // map; no top-level testsuite file uses it.
+        // A specific function's identity: not expressible without an export map; no top-level testsuite file uses it.
         WastRet::Core(WastRetCore::RefFunc(Some(_))) => Err("funcref-identity".to_string()),
         WastRet::Core(
             WastRetCore::RefAny

--- a/crates/dewasm-backend-python/tests/wasi_testsuite.rs
+++ b/crates/dewasm-backend-python/tests/wasi_testsuite.rs
@@ -1,6 +1,4 @@
-//! Python side of the official WASI p1 conformance harness (ADR-36): drives the
-//! prebuilt `WebAssembly/wasi-testsuite` modules through the Python backend's
-//! standalone interface. The generic harness lives in `dewasm-test-helper`.
+//! Python side of the official WASI p1 conformance harness (ADR-36): drives the prebuilt `WebAssembly/wasi-testsuite` modules through the Python backend's standalone interface. The generic harness lives in `dewasm-test-helper`.
 
 use std::path::PathBuf;
 
@@ -8,20 +6,12 @@ use dewasm_backend::Backend;
 use dewasm_backend_python::PythonBackend;
 use dewasm_test_helper::{wasi_testsuite_suite, BackendUnderTest, WasiTestsuiteBackend};
 
-/// Known trial failures with their attribution (ADR-8, policy in ADR-36):
-/// `(trial, tag)` — the out-of-scope `sock_shutdown` syscall and the environ
-/// entries the CPython host injects itself, which count-exact `environ_*`
-/// assertions cannot absorb (ADR-40). The filesystem-rights, symlink, times,
-/// renumber, advise/allocate and path-semantics syscalls are now implemented
-/// (runtime/python/units/wasi/), so their former rows are gone.
+/// Known trial failures with their attribution (ADR-8, policy in ADR-36): `(trial, tag)` — the out-of-scope `sock_shutdown` syscall and the environ entries the CPython host injects itself, which count-exact `environ_*` assertions cannot absorb (ADR-40). The filesystem-rights, symlink, times, renumber, advise/allocate and path-semantics syscalls are now implemented (runtime/python/units/wasi/), so their former rows are gone.
 const WASI_TESTSUITE_EXPECTED_FAILURES: &[(&str, &str)] = &[
     // Declared out-of-scope syscall (docs/support.md).
     ("c/sock_shutdown-invalid_fd", "sock_shutdown (out of scope)"),
     ("c/sock_shutdown-not_sock", "sock_shutdown (out of scope)"),
-    // The CPython host injects environ entries of its own (macOS
-    // CoreFoundation's __CF_USER_TEXT_ENCODING plus the PEP 538 LC_CTYPE
-    // locale coercion), so count-exact environ assertions cannot hold even
-    // under the harness's cleared environment (ADR-40).
+    // The CPython host injects environ entries of its own (macOS CoreFoundation's __CF_USER_TEXT_ENCODING plus the PEP 538 LC_CTYPE locale coercion), so count-exact environ assertions cannot hold even under the harness's cleared environment (ADR-40).
     (
         "assemblyscript/environ_get-multiple-variables",
         "environ: host-interpreter env injection",

--- a/crates/dewasm-backend-ruby/build.rs
+++ b/crates/dewasm-backend-ruby/build.rs
@@ -1,5 +1,4 @@
-//! Embeds the runtime units from runtime/ruby/units/ as
-//! `UNIT_SOURCES: &[(&str, &str)]` (unit id, source).
+//! Embeds the runtime units from runtime/ruby/units/ as `UNIT_SOURCES: &[(&str, &str)]` (unit id, source).
 
 use std::fmt::Write as _;
 use std::path::Path;

--- a/crates/dewasm-backend-ruby/src/lib.rs
+++ b/crates/dewasm-backend-ruby/src/lib.rs
@@ -1,18 +1,11 @@
-//! Ruby backend: translates dewasm IR into a Ruby class plus a bundled
-//! lightweight runtime.
+//! Ruby backend: translates dewasm IR into a Ruby class plus a bundled lightweight runtime.
 //!
 //! Lowering conventions (ADR-4; numeric conventions ADR-2):
-//! - i32/i64 are unsigned (masked) Ruby Integers; signed views via
-//!   `Rt.s32/s64` only where an instruction needs them.
+//! - i32/i64 are unsigned (masked) Ruby Integers; signed views via `Rt.s32/s64` only where an instruction needs them.
 //! - f32/f64 are Ruby Floats; f32 results are re-rounded with `Rt.f32`.
-//! - `br` lowers to a method-local `__br` label-variable cascade: blocks and
-//!   referenced ifs are `begin...end while false`, loops are `while true`, and
-//!   a multi-level branch sets `__br` to the target label id and `break`s,
-//!   each crossed frame's epilogue relaying it until the target lands.
+//! - `br` lowers to a method-local `__br` label-variable cascade: blocks and referenced ifs are `begin...end while false`, loops are `while true`, and a multi-level branch sets `__br` to the target label id and `break`s, each crossed frame's epilogue relaying it until the target lands.
 //!
-//! The runtime is composed from per-method units (ADR-6) and referenced by
-//! the relative name `Rt`, so linkage (embedded per class, shared, or a
-//! future gem) is the caller's choice.
+//! The runtime is composed from per-method units (ADR-6) and referenced by the relative name `Rt`, so linkage (embedded per class, shared, or a future gem) is the caller's choice.
 
 use std::cell::RefCell;
 use std::collections::{BTreeSet, HashSet};
@@ -76,19 +69,12 @@ pub fn bundler() -> &'static RuntimeBundler {
     })
 }
 
-/// Emit a top-level shared runtime (`module Rt ... end`) for the closure
-/// of `seeds`; generated classes then use `RuntimeLinkage::Alias("::Rt")`.
+/// Emit a top-level shared runtime (`module Rt ... end`) for the closure of `seeds`; generated classes then use `RuntimeLinkage::Alias("::Rt")`.
 pub fn shared_runtime(seeds: &BTreeSet<String>) -> Result<String> {
     Ok(format!("module Rt\n{}end\n", bundler().bundle(seeds, 1)?))
 }
 
-/// Locate a ruby interpreter able to run generated scripts. Unlike
-/// `dewasm_backend_bash::find_bash5`'s version floor: no alternate-path
-/// search is needed (ruby is expected on `PATH`), but the generated
-/// runtime's memory model is `IO::Buffer`-backed (see
-/// docs/adr/33-ruby-io-buffer-memory.md), which requires Ruby >= 3.4. Per
-/// ADR-15, fail loud with a setup instruction rather than silently
-/// skipping.
+/// Locate a ruby interpreter able to run generated scripts. Unlike `dewasm_backend_bash::find_bash5`'s version floor: no alternate-path search is needed (ruby is expected on `PATH`), but the generated runtime's memory model is `IO::Buffer`-backed (see docs/adr/33-ruby-io-buffer-memory.md), which requires Ruby >= 3.4. Per ADR-15, fail loud with a setup instruction rather than silently skipping.
 pub fn find_ruby() -> Option<std::path::PathBuf> {
     let out = std::process::Command::new("ruby")
         .args(["-e", "print RUBY_VERSION"])
@@ -104,8 +90,7 @@ pub fn find_ruby() -> Option<std::path::PathBuf> {
     ((major, minor) >= (3, 4)).then(|| std::path::PathBuf::from("ruby"))
 }
 
-/// Generate one class for `module`. Returns the class source and the set
-/// of runtime units it needs (already bundled inside for `Embedded`).
+/// Generate one class for `module`. Returns the class source and the set of runtime units it needs (already bundled inside for `Embedded`).
 pub fn generate_class_with_units(
     module: &Module,
     class_name: &str,
@@ -131,19 +116,14 @@ fn generate_class_inner(
     data_file: Option<&str>,
 ) -> Result<(String, BTreeSet<String>)> {
     check_module_support(&RubyBackend, module)?;
-    // A global needs a shared mutable cell (`Rt::Global`, ADR-16) only if it
-    // can cross an instantiation boundary: imported (came from another
-    // instance) or exported (another instance may import it later). Every
-    // other global is local to this class and never observed from outside
-    // it, so it can be a plain ivar holding the value directly.
+    // A global needs a shared mutable cell (`Rt::Global`, ADR-16) only if it can cross an instantiation boundary: imported (came from another instance) or exported (another instance may import it later). Every other global is local to this class and never observed from outside it, so it can be a plain ivar holding the value directly.
     let boxed_globals: BTreeSet<u32> = (0..module.imported_globals.len() as u32)
         .chain(module.exports.iter().filter_map(|e| match e.kind {
             ExportKind::Global(idx) => Some(idx),
             _ => None,
         }))
         .collect();
-    // Prefix sums: `data_offsets[i]` is where segment `i` begins in the
-    // concatenated sidecar blob (ADR-37). Only consulted when externalizing.
+    // Prefix sums: `data_offsets[i]` is where segment `i` begins in the concatenated sidecar blob (ADR-37). Only consulted when externalizing.
     let mut data_offsets = Vec::with_capacity(module.datas.len());
     let mut acc = 0usize;
     for data in &module.datas {
@@ -195,16 +175,14 @@ impl Backend for RubyBackend {
         "rb"
     }
 
-    // The flagship backend's remaining wasm-1.0 + WASI p1 gaps: a dozen
-    // WASI p1 functions and the import-limits ledger (ADR-16).
+    // The flagship backend's remaining wasm-1.0 + WASI p1 gaps: a dozen WASI p1 functions and the import-limits ledger (ADR-16).
     fn has_wasi_p1(&self, name: &str) -> bool {
         bundler().has_unit(&format!("wasi/{name}"))
     }
 
     fn feature_status(&self, feature: Feature) -> SupportStatus {
         match feature {
-            // Part of the wasm 1.0 baseline for Ruby; the row exists for
-            // backends whose language lacks floats (ADR-5).
+            // Part of the wasm 1.0 baseline for Ruby; the row exists for backends whose language lacks floats (ADR-5).
             Feature::Floats => SupportStatus::Supported,
             Feature::ImportedGlobals
             | Feature::ImportedMemories
@@ -218,8 +196,7 @@ impl Backend for RubyBackend {
     fn generate(&self, module: &Module, opts: &GenOptions) -> Result<Vec<OutputFile>> {
         let class_name = class_name(&opts.module_name);
 
-        // The Exit/Trap rescue clauses in the standalone main need these
-        // even when the module itself never references them.
+        // The Exit/Trap rescue clauses in the standalone main need these even when the module itself never references them.
         let mut extra_seeds = BTreeSet::new();
         if opts.mode == Mode::Standalone {
             extra_seeds.insert("rt/trap".to_string());
@@ -246,10 +223,7 @@ impl Backend for RubyBackend {
             w.line("");
             w.block("if __FILE__ == $PROGRAM_NAME", "end", |w| {
                 if wasi_kwargs {
-                    // Parse the standalone runtime interface (ADR-31): a leading
-                    // run of `--dir HOST::GUEST` flags mounts host directories at
-                    // guest paths (wasmtime-style), stopping at `--` or the first
-                    // non-flag token; the rest is the guest's argv[1..].
+                    // Parse the standalone runtime interface (ADR-31): a leading run of `--dir HOST::GUEST` flags mounts host directories at guest paths (wasmtime-style), stopping at `--` or the first non-flag token; the rest is the guest's argv[1..].
                     w.line("preopens = {}");
                     w.line("argv = ARGV.dup");
                     w.line("while (a = argv.first)");
@@ -306,10 +280,7 @@ impl Backend for RubyBackend {
             name: format!("{}.rb", opts.module_name),
             contents: w.finish().into_bytes(),
         }];
-        // The data sidecar (ADR-37): every segment's bytes concatenated in
-        // segment order, matching the `data_offsets` prefix sums baked into the
-        // generated `DATA_BLOB.byteslice` calls. Only emitted when there is
-        // data to externalize (otherwise the generated code never reads it).
+        // The data sidecar (ADR-37): every segment's bytes concatenated in segment order, matching the `data_offsets` prefix sums baked into the generated `DATA_BLOB.byteslice` calls. Only emitted when there is data to externalize (otherwise the generated code never reads it).
         if let Some(cfg) = &opts.data_file {
             if !module.datas.is_empty() {
                 let mut blob = Vec::new();
@@ -372,16 +343,10 @@ fn hex_bytes(data: &[u8]) -> String {
     format!("[\"{hex}\"].pack(\"H*\")")
 }
 
-/// WASI import module names the bundled runtime answers for.
-/// `wasi_unstable` (snapshot 0) shares the ABI of preview 1 for everything
-/// we implement except fd_seek's whence encoding (snapshot 0 modules that
-/// actually seek may misbehave; acceptable until snapshot 0 gets its own
-/// units).
+/// WASI import module names the bundled runtime answers for. `wasi_unstable` (snapshot 0) shares the ABI of preview 1 for everything we implement except fd_seek's whence encoding (snapshot 0 modules that actually seek may misbehave; acceptable until snapshot 0 gets its own units).
 const WASI_MODULES: &[&str] = &["wasi_snapshot_preview1", "wasi_unstable"];
 
-/// Widest `call_indirect` signature that gets a fixed-arity `Table#callN`
-/// dispatch method (ADR-44); wider signatures fall back to the splat `call`.
-/// The `table/call0`..`table/call{MAX_FIXED_ARITY}` runtime units must exist.
+/// Widest `call_indirect` signature that gets a fixed-arity `Table#callN` dispatch method (ADR-44); wider signatures fall back to the splat `call`. The `table/call0`..`table/call{MAX_FIXED_ARITY}` runtime units must exist.
 const MAX_FIXED_ARITY: usize = 8;
 
 fn is_wasi_module(name: &str) -> bool {
@@ -390,8 +355,7 @@ fn is_wasi_module(name: &str) -> bool {
 
 pub use dewasm_backend::WASI_PREVIEW1_FUNCTIONS;
 
-/// Whether the generated class bundles the built-in WASI as an import
-/// fallback (and therefore takes `args:`/`env:` keyword arguments).
+/// Whether the generated class bundles the built-in WASI as an import fallback (and therefore takes `args:`/`env:` keyword arguments).
 fn wasi_bundled(module: &Module, default_wasi: bool) -> bool {
     default_wasi
         && module
@@ -403,32 +367,15 @@ fn wasi_bundled(module: &Module, default_wasi: bool) -> bool {
 /// Per-function frame classification for the label-variable cascade.
 #[derive(Default)]
 struct FrameSets {
-    /// Capturing frames (`Block`, `Loop`, or referenced-`If`) that a `br` from
-    /// strictly inside crosses, and so must carry a land-or-relay epilogue.
+    /// Capturing frames (`Block`, `Loop`, or referenced-`If`) that a `br` from strictly inside crosses, and so must carry a land-or-relay epilogue.
     crossed: HashSet<u32>,
-    /// Loops that a `br` targets from a *strictly nested* capturing frame, so
-    /// the branch reaches the loop head by a `break` out of an inner scope
-    /// rather than a direct `next`. Such a loop wraps its body in an inner
-    /// `begin ... end while false` (the break target) and takes its back-edge
-    /// through `__br`; every other loop keeps the lean `while true` with a
-    /// plain `next` back-edge.
+    /// Loops that a `br` targets from a *strictly nested* capturing frame, so the branch reaches the loop head by a `break` out of an inner scope rather than a direct `next`. Such a loop wraps its body in an inner `begin ... end while false` (the break target) and takes its back-edge through `__br`; every other loop keeps the lean `while true` with a plain `next` back-edge.
     wrapped: HashSet<u32>,
 }
 
 /// Compute the [`FrameSets`] for a function body.
 ///
-/// Walking with a stack of the open capturing frames (label id + is-loop), a
-/// `br` to target `T` at stack position `pos` (the innermost open frame is the
-/// top) is either a self-branch — `pos == top`, a plain `break`/`next` that
-/// leaves the innermost frame directly, marking nothing — or an outward
-/// branch, `pos < top`, which must traverse `stack[pos..=top]`: the target
-/// frame, all pass-through frames, *and* the innermost frame whose own `break`
-/// otherwise lands mid-body in its parent. Every frame on that inclusive path
-/// needs the epilogue, so all of `stack[pos..]` is `crossed`; and if `T`
-/// itself is a loop reached this way (from a nested frame), it is `wrapped`. A
-/// plain `if`, `br_if`'s wrapper `if`, and `br_table`'s `case` never capture,
-/// so they are not on the stack. `br_if`/`br_table` feed every target through
-/// the same routine.
+/// Walking with a stack of the open capturing frames (label id + is-loop), a `br` to target `T` at stack position `pos` (the innermost open frame is the top) is either a self-branch — `pos == top`, a plain `break`/`next` that leaves the innermost frame directly, marking nothing — or an outward branch, `pos < top`, which must traverse `stack[pos..=top]`: the target frame, all pass-through frames, *and* the innermost frame whose own `break` otherwise lands mid-body in its parent. Every frame on that inclusive path needs the epilogue, so all of `stack[pos..]` is `crossed`; and if `T` itself is a loop reached this way (from a nested frame), it is `wrapped`. A plain `if`, `br_if`'s wrapper `if`, and `br_table`'s `case` never capture, so they are not on the stack. `br_if`/`br_table` feed every target through the same routine.
 fn compute_frame_sets(body: &[Stmt]) -> FrameSets {
     let mut sets = FrameSets::default();
     let mut stack: Vec<(u32, bool)> = Vec::new();
@@ -479,12 +426,10 @@ fn walk_frame_sets(stmts: &[Stmt], stack: &mut Vec<(u32, bool)>, sets: &mut Fram
 fn record_target(target: &BrTarget, stack: &[(u32, bool)], sets: &mut FrameSets) {
     if let BrTarget::Label { label, .. } = target {
         if let Some(pos) = stack.iter().position(|(id, _)| id == label) {
-            // Outward branch (target is not the innermost frame): mark the
-            // whole inclusive path from the target to the innermost frame.
+            // Outward branch (target is not the innermost frame): mark the whole inclusive path from the target to the innermost frame.
             if pos + 1 < stack.len() {
                 sets.crossed.extend(stack[pos..].iter().map(|(id, _)| *id));
-                // A loop targeted from a nested frame needs its body-scope
-                // wrapper so the relayed `break` re-enters via `next`.
+                // A loop targeted from a nested frame needs its body-scope wrapper so the relayed `break` re-enters via `next`.
                 if stack[pos].1 {
                     sets.wrapped.insert(*label);
                 }
@@ -498,34 +443,19 @@ struct Gen<'a> {
     default_wasi: bool,
     /// Runtime units the generated code references.
     uses: RefCell<BTreeSet<String>>,
-    /// Per-function frame classification, set by `function()`: which frames
-    /// carry a land-or-relay epilogue and which loops wrap their body. See
-    /// `compute_frame_sets`.
+    /// Per-function frame classification, set by `function()`: which frames carry a land-or-relay epilogue and which loops wrap their body. See `compute_frame_sets`.
     frames: RefCell<FrameSets>,
-    /// Emission-time stack of capturing frames currently open (label ids),
-    /// pushed/popped around `Block`/`Loop`/referenced-`If` bodies.
-    /// `branch()` compares the top of this stack against a `br`'s target to
-    /// decide between the depth-1 fast path (a plain `break`/`next` that
-    /// leaves the innermost frame directly) and the cascade (`__br = <id>;
-    /// break`, relayed by each crossed frame's epilogue until the target
-    /// lands).
+    /// Emission-time stack of capturing frames currently open (label ids), pushed/popped around `Block`/`Loop`/referenced-`If` bodies. `branch()` compares the top of this stack against a `br`'s target to decide between the depth-1 fast path (a plain `break`/`next` that leaves the innermost frame directly) and the cascade (`__br = <id>; break`, relayed by each crossed frame's epilogue until the target lands).
     frame_stack: RefCell<Vec<u32>>,
-    /// Global indices that need the `Rt::Global` box: imported globals
-    /// (index space `0..imported_globals.len()`) and every `ExportKind::
-    /// Global` target. Computed once in `generate_class_inner`. See the
-    /// boundary criterion in the comment there and ADR-16.
+    /// Global indices that need the `Rt::Global` box: imported globals (index space `0..imported_globals.len()`) and every `ExportKind:: Global` target. Computed once in `generate_class_inner`. See the boundary criterion in the comment there and ADR-16.
     boxed_globals: BTreeSet<u32>,
-    /// When `Some`, data segments are externalized into a binary sidecar of
-    /// this filename (referenced via `__dir__`) instead of embedded as hex
-    /// literals (ADR-37); `data_offsets[i]` locates segment `i` in the blob.
+    /// When `Some`, data segments are externalized into a binary sidecar of this filename (referenced via `__dir__`) instead of embedded as hex literals (ADR-37); `data_offsets[i]` locates segment `i` in the blob.
     data_file: Option<String>,
     data_offsets: Vec<usize>,
 }
 
 impl<'a> Gen<'a> {
-    /// The Ruby expression yielding a data segment's bytes: a slice of the
-    /// externalized blob when `--data-file` is on, else an inline packed-hex
-    /// literal (ADR-37). Both yield an ASCII-8BIT (binary) string.
+    /// The Ruby expression yielding a data segment's bytes: a slice of the externalized blob when `--data-file` is on, else an inline packed-hex literal (ADR-37). Both yield an ASCII-8BIT (binary) string.
     fn data_expr(&self, seg: usize, data: &[u8]) -> String {
         if self.data_file.is_some() {
             format!(
@@ -542,36 +472,22 @@ impl<'a> Gen<'a> {
         self.uses.borrow_mut().insert(id.to_string());
     }
 
-    /// Whether `label_id`'s capturing frame is crossed by some `br` (see
-    /// `compute_frame_sets`), populated per-function by `function()`.
+    /// Whether `label_id`'s capturing frame is crossed by some `br` (see `compute_frame_sets`), populated per-function by `function()`.
     fn is_crossed(&self, label_id: u32) -> bool {
         self.frames.borrow().crossed.contains(&label_id)
     }
 
-    /// Whether `label_id`'s loop wraps its body in an inner scope because a
-    /// `br` targets it from a strictly nested frame (see `compute_frame_sets`).
+    /// Whether `label_id`'s loop wraps its body in an inner scope because a `br` targets it from a strictly nested frame (see `compute_frame_sets`).
     fn is_wrapped(&self, label_id: u32) -> bool {
         self.frames.borrow().wrapped.contains(&label_id)
     }
 
-    /// Whether the frame currently on top of `frame_stack` has an enclosing
-    /// capturing frame — i.e. a `break` emitted in its epilogue has a loop to
-    /// bind to. A bare `break` at method-body scope is a Ruby SyntaxError, so
-    /// the outermost frame omits the relay arm (a pending branch can never
-    /// target something outside it, so that arm is also dead).
+    /// Whether the frame currently on top of `frame_stack` has an enclosing capturing frame — i.e. a `break` emitted in its epilogue has a loop to bind to. A bare `break` at method-body scope is a Ruby SyntaxError, so the outermost frame omits the relay arm (a pending branch can never target something outside it, so that arm is also dead).
     fn has_enclosing_frame(&self) -> bool {
         self.frame_stack.borrow().len() > 1
     }
 
-    /// Land-or-relay epilogue for a crossed `Block`/referenced-`If`, emitted
-    /// *after* the frame's `end while false` (so a `break` out of the scope —
-    /// from a nested relay or a direct exit — skips any intervening body code
-    /// and reaches this decision): if the pending `__br` names this frame,
-    /// clear it and fall through (the wasm branch lands past the block);
-    /// otherwise a still-pending `__br` targets an ancestor, so `break` again
-    /// to relay it outward. Emitted as a single line: epilogues sit at every
-    /// crossed frame, often deeply indented, so each extra line costs its full
-    /// indent in output bytes.
+    /// Land-or-relay epilogue for a crossed `Block`/referenced-`If`, emitted *after* the frame's `end while false` (so a `break` out of the scope — from a nested relay or a direct exit — skips any intervening body code and reaches this decision): if the pending `__br` names this frame, clear it and fall through (the wasm branch lands past the block); otherwise a still-pending `__br` targets an ancestor, so `break` again to relay it outward. Emitted as a single line: epilogues sit at every crossed frame, often deeply indented, so each extra line costs its full indent in output bytes.
     fn emit_land_or_relay(&self, w: &mut CodeWriter, label_id: u32) {
         if self.has_enclosing_frame() {
             w.line(format!(
@@ -582,9 +498,7 @@ impl<'a> Gen<'a> {
         }
     }
 
-    /// An access expression for global `idx`, whichever representation it
-    /// has: `@g{idx}.value` if it's boxed (crosses an instantiation
-    /// boundary), plain `@g{idx}` otherwise. Valid on both sides of `=`.
+    /// An access expression for global `idx`, whichever representation it has: `@g{idx}.value` if it's boxed (crosses an instantiation boundary), plain `@g{idx}` otherwise. Valid on both sides of `=`.
     fn global_ref(&self, idx: u32) -> String {
         if self.boxed_globals.contains(&idx) {
             format!("@g{idx}.value")
@@ -605,10 +519,7 @@ impl<'a> Gen<'a> {
         name
     }
 
-    /// Resolve one import and validate its kind (ADR-7's mechanism,
-    /// generalized to every import kind): a present-but-wrong-kind value
-    /// raises immediately (a link error), a missing one returns nil so the
-    /// caller's `|| fallback` applies.
+    /// Resolve one import and validate its kind (ADR-7's mechanism, generalized to every import kind): a present-but-wrong-kind value raises immediately (a link error), a missing one returns nil so the caller's `|| fallback` applies.
     fn resolve_import_string(&self, kind: &str, module: &str, name: &str) -> String {
         self.use_unit("rt/resolve_import");
         self.use_unit("rt/check_import_kind");
@@ -643,9 +554,7 @@ impl<'a> Gen<'a> {
             w.line("instance_variable_get(GLOBAL_EXPORTS.fetch(name)).value");
         });
         w.line("");
-        // The boxed Rt::Global itself (not its current value), for a host
-        // embedder or another dewasm instance to import as a shared
-        // mutable cell.
+        // The boxed Rt::Global itself (not its current value), for a host embedder or another dewasm instance to import as a shared mutable cell.
         w.block("def global_export(name)", "end", |w| {
             w.line("instance_variable_get(GLOBAL_EXPORTS.fetch(name))");
         });
@@ -654,11 +563,7 @@ impl<'a> Gen<'a> {
             w.line("instance_variable_get(TABLE_EXPORTS.fetch(name))");
         });
         w.line("");
-        // ADR-7 provider protocol: an instance of a generated class is
-        // itself a valid value in another instance's `imports` table,
-        // exposing every export regardless of kind under its one
-        // (per-module) namespace — the mechanism the spec harness's
-        // `register` support (and any real cross-module linking) uses.
+        // ADR-7 provider protocol: an instance of a generated class is itself a valid value in another instance's `imports` table, exposing every export regardless of kind under its one (per-module) namespace — the mechanism the spec harness's `register` support (and any real cross-module linking) uses.
         w.block("def import(name)", "end", |w| {
             w.line("return @exports[name] if @exports.key?(name)");
             w.line("return global_export(name) if GLOBAL_EXPORTS.key?(name)");
@@ -707,9 +612,7 @@ impl<'a> Gen<'a> {
             .collect::<Vec<_>>()
             .join(", ");
         w.line(format!("MEMORY_EXPORTS = [{memory_entries}].freeze"));
-        // Externalized data blob (ADR-37): read once at class-definition time,
-        // kept binary (ASCII-8BIT, as File.binread returns). Only emitted when
-        // there is data to externalize.
+        // Externalized data blob (ADR-37): read once at class-definition time, kept binary (ASCII-8BIT, as File.binread returns). Only emitted when there is data to externalize.
         if let Some(name) = &self.data_file {
             if !m.datas.is_empty() {
                 w.line(format!(
@@ -763,9 +666,7 @@ impl<'a> Gen<'a> {
                 w.line("@wasi = nil");
             }
             for (i, import) in m.imported_funcs.iter().enumerate() {
-                // Fallback order: explicit import -> bundled WASI
-                // (constructed only when first needed) -> ENOSYS stub;
-                // non-WASI imports stay mandatory.
+                // Fallback order: explicit import -> bundled WASI (constructed only when first needed) -> ENOSYS stub; non-WASI imports stay mandatory.
                 let fallback = if is_wasi_module(&import.module) && self.default_wasi {
                     let unit = format!("wasi/{}", import.name);
                     if bundler().has_unit(&unit) {
@@ -805,8 +706,7 @@ impl<'a> Gen<'a> {
                 }
             }
             for (i, elem) in m.elems.iter().enumerate() {
-                // Built lazily: Declared segments emit an empty array and
-                // never need the rendered items.
+                // Built lazily: Declared segments emit an empty array and never need the rendered items.
                 let items = || {
                     elem.items
                         .iter()
@@ -863,8 +763,7 @@ impl<'a> Gen<'a> {
             }
             w.line(format!("@exports = {{ {} }}", export_entries.join(", ")));
 
-            // The instance is complete: let import providers bind to it
-            // (memory access etc.) before any wasm code can run.
+            // The instance is complete: let import providers bind to it (memory access etc.) before any wasm code can run.
             if !m.imported_funcs.is_empty() {
                 w.line("imports.each_value.to_a.uniq.each { |s| s.attach(self) if s.respond_to?(:attach) }");
             }
@@ -889,10 +788,7 @@ impl<'a> Gen<'a> {
         self.type_symbol(ty)
     }
 
-    /// call_indirect compares types structurally, and a table can be shared
-    /// across modules (imported tables), so the runtime type id must not come
-    /// from any module-local index space: derive an interned symbol from the
-    /// type's shape instead.
+    /// call_indirect compares types structurally, and a table can be shared across modules (imported tables), so the runtime type id must not come from any module-local index space: derive an interned symbol from the type's shape instead.
     fn type_symbol(&self, type_idx: u32) -> String {
         let ty = &self.module.types[type_idx as usize];
         let names = |tys: &[ValType]| {
@@ -919,8 +815,7 @@ impl<'a> Gen<'a> {
         }
     }
 
-    /// A funcref value: the `[type_symbol, callable]` pair tables store
-    /// (ADR-16). Element items and `call_indirect` agree on this shape.
+    /// A funcref value: the `[type_symbol, callable]` pair tables store (ADR-16). Element items and `call_indirect` agree on this shape.
     fn func_pair(&self, func_idx: u32) -> String {
         format!(
             "[{}, {}]",
@@ -958,12 +853,7 @@ impl<'a> Gen<'a> {
                 let name = format!("l{}", ty.params.len() + i);
                 w.line(format!("{name} = {}", default_value(*local_ty)));
             }
-            // Hoist all temps to method scope: assignments inside the
-            // `begin`/`while` frames would otherwise be block-local in Ruby.
-            // The pending-branch variable `__br` is hoisted alongside them
-            // whenever the function has any crossed frame (a fallthrough
-            // epilogue reads `__br` before any branch assigns it); with no
-            // crossed frame nothing ever references it.
+            // Hoist all temps to method scope: assignments inside the `begin`/`while` frames would otherwise be block-local in Ruby. The pending-branch variable `__br` is hoisted alongside them whenever the function has any crossed frame (a fallthrough epilogue reads `__br` before any branch assigns it); with no crossed frame nothing ever references it.
             let mut depths: Vec<u32> = func.temps.iter().map(|t| t.depth).collect();
             depths.dedup();
             let mut decl = String::new();
@@ -1024,12 +914,7 @@ impl<'a> Gen<'a> {
                 let wrapped = self.is_wrapped(label.id);
                 self.frame_stack.borrow_mut().push(label.id);
                 if wrapped {
-                    // A `br` targets this loop from a nested frame, arriving
-                    // with `__br` set by `break`ing out of the inner `begin`
-                    // (skipping any code left in the body). The decision then
-                    // re-enters via `next`, or `break`s the `while` so the
-                    // post-loop relay can pass `__br` further out. A plain
-                    // fallthrough leaves `__br` nil and exits the loop.
+                    // A `br` targets this loop from a nested frame, arriving with `__br` set by `break`ing out of the inner `begin` (skipping any code left in the body). The decision then re-enters via `next`, or `break`s the `while` so the post-loop relay can pass `__br` further out. A plain fallthrough leaves `__br` nil and exits the loop.
                     w.block("while true", "end", |w| {
                         w.block("begin", "end while false", |w| self.stmts(w, body));
                         w.line(format!(
@@ -1038,18 +923,13 @@ impl<'a> Gen<'a> {
                         ));
                     });
                 } else {
-                    // No `br` reaches this loop from a nested frame: a back-edge
-                    // is a plain `next` (see `branch()`), a fallthrough exits
-                    // via the trailing `break`, and an outward `br` sets `__br`
-                    // and `break`s the `while` for the post-loop relay to pass
-                    // outward.
+                    // No `br` reaches this loop from a nested frame: a back-edge is a plain `next` (see `branch()`), a fallthrough exits via the trailing `break`, and an outward `br` sets `__br` and `break`s the `while` for the post-loop relay to pass outward.
                     w.block("while true", "end", |w| {
                         self.stmts(w, body);
                         w.line("break");
                     });
                 }
-                // A `br` that passes through this loop toward an ancestor left
-                // `__br` set and `break`ed the `while`; relay it outward.
+                // A `br` that passes through this loop toward an ancestor left `__br` set and `break`ed the `while`; relay it outward.
                 if crossed && self.has_enclosing_frame() {
                     w.line("break if __br");
                 }
@@ -1135,11 +1015,7 @@ impl<'a> Gen<'a> {
                 args,
                 results,
             } => {
-                // Fixed-arity dispatch (ADR-44): a per-arity `callN` avoids
-                // building a `*args` array on either side; the splat `call`
-                // stays as the fallback for signatures wider than
-                // MAX_FIXED_ARITY (unobserved in the real-world apps, whose
-                // call_indirect arities top out at 8).
+                // Fixed-arity dispatch (ADR-44): a per-arity `callN` avoids building a `*args` array on either side; the splat `call` stays as the fallback for signatures wider than MAX_FIXED_ARITY (unobserved in the real-world apps, whose call_indirect arities top out at 8).
                 let mut call_args = vec![self.expr(index), self.type_symbol(*type_idx)];
                 call_args.extend(args.iter().map(|a| self.expr(a)));
                 let method = if args.len() <= MAX_FIXED_ARITY {
@@ -1261,14 +1137,7 @@ impl<'a> Gen<'a> {
                 for (dst, src) in assigns {
                     w.line(format!("{} = {}", temp(*dst), temp(*src)));
                 }
-                // Fast path — a br whose target is the innermost enclosing
-                // frame leaves it directly: `break` out of a block/if's
-                // `begin...end while false`, or `next` to take an unwrapped
-                // loop's back-edge. Everything else (a br to an outer frame, or
-                // a back-edge into a *wrapped* loop, whose body sits in an
-                // inner `begin`) sets the pending label variable and `break`s
-                // out of the innermost scope; each crossed frame's epilogue
-                // then relays `__br` outward until the target lands.
+                // Fast path — a br whose target is the innermost enclosing frame leaves it directly: `break` out of a block/if's `begin...end while false`, or `next` to take an unwrapped loop's back-edge. Everything else (a br to an outer frame, or a back-edge into a *wrapped* loop, whose body sits in an inner `begin`) sets the pending label variable and `break`s out of the innermost scope; each crossed frame's epilogue then relays `__br` outward until the target lands.
                 let innermost = self.frame_stack.borrow().last() == Some(label);
                 let via_var = !innermost || (*is_loop && self.is_wrapped(*label));
                 if via_var {
@@ -1440,13 +1309,7 @@ impl<'a> Gen<'a> {
             F32Mul => format!("{}({a} * {b})", self.rt("f32")),
             F32Div => format!("{}({a} / {b})", self.rt("f32")),
             F64Add => format!("({a} + {b})"),
-            // GCC-built MRI (any arch; every version probed) leaves a
-            // signaling NaN unquieted when the RHS is +0.0: the flonum decode
-            // returns +0.0 as a literal, and GCC folds `a - 0.0` to `a`,
-            // skipping the FPU sub. The host `-` therefore cannot be trusted
-            // to return an arithmetic NaN. Quiet any NaN result explicitly;
-            // the `== r` self-compare is false only for NaN, keeping the
-            // common finite path allocation- and call-free. ADR-47, issue #11.
+            // GCC-built MRI (any arch; every version probed) leaves a signaling NaN unquieted when the RHS is +0.0: the flonum decode returns +0.0 as a literal, and GCC folds `a - 0.0` to `a`, skipping the FPU sub. The host `-` therefore cannot be trusted to return an arithmetic NaN. Quiet any NaN result explicitly; the `== r` self-compare is false only for NaN, keeping the common finite path allocation- and call-free. ADR-47, issue #11.
             F64Sub => format!("((r = {a} - {b}) == r ? r : {}(r))", self.rt("quiet_nan")),
             F64Mul => format!("({a} * {b})"),
             F64Div => format!("({a} / {b})"),
@@ -1522,10 +1385,7 @@ fn store_method(op: StoreOp) -> &'static str {
     }
 }
 
-/// Lint for the runtime units: every reference a unit body makes to
-/// another unit must be declared in its `# requires:` header. This is the
-/// static half of the drift defence; the dynamic half is the spec harness
-/// running against minimal bundles (ADR-6).
+/// Lint for the runtime units: every reference a unit body makes to another unit must be declared in its `# requires:` header. This is the static half of the drift defence; the dynamic half is the spec harness running against minimal bundles (ADR-6).
 #[cfg(test)]
 mod units {
     use super::*;
@@ -1603,9 +1463,7 @@ mod units {
                 );
             }
 
-            // Bare sibling calls within the same scope (with parentheses; a
-            // parenless bare call cannot be told apart from a local variable,
-            // so those cases must keep their requires by hand).
+            // Bare sibling calls within the same scope (with parentheses; a parenless bare call cannot be told apart from a local variable, so those cases must keep their requires by hand).
             for (sibling, bare) in &bare_calls {
                 let Some(name) = sibling.strip_prefix(&format!("{scope}/")) else {
                     continue;
@@ -1626,8 +1484,7 @@ mod units {
     }
 }
 
-/// Codegen-shape checks for the label-variable cascade (ADR-42): a
-/// multi-level `br` must lower to the `__br` cascade, never to `catch`/`throw`.
+/// Codegen-shape checks for the label-variable cascade (ADR-42): a multi-level `br` must lower to the `__br` cascade, never to `catch`/`throw`.
 #[cfg(test)]
 mod cascade {
     use super::*;
@@ -1640,10 +1497,7 @@ mod cascade {
         src
     }
 
-    // block $A { loop $B { block $C { br_table $C $B $A } ... } } — a single
-    // `br_table` whose targets span all three nesting depths (self-exit,
-    // loop-continue from a nested frame, and outer-block-exit), exercising the
-    // fast path, a wrapped loop, and a relayed landing at once.
+    // block $A { loop $B { block $C { br_table $C $B $A } ... } } — a single `br_table` whose targets span all three nesting depths (self-exit, loop-continue from a nested frame, and outer-block-exit), exercising the fast path, a wrapped loop, and a relayed landing at once.
     const MIXED_DEPTHS: &str = r#"
       (module
         (func (export "f") (param i32) (result i32)
@@ -1659,8 +1513,7 @@ mod cascade {
     #[test]
     fn multi_level_br_uses_label_cascade() {
         let src = convert(MIXED_DEPTHS);
-        // The cascade: a pending-label assignment, a landing compare, and a
-        // relay arm — plus the wrapped loop's back-edge `next`.
+        // The cascade: a pending-label assignment, a landing compare, and a relay arm — plus the wrapped loop's back-edge `next`.
         assert!(src.contains("__br ="), "no `__br =` in:\n{src}");
         assert!(src.contains("if __br =="), "no landing compare in:\n{src}");
         assert!(src.contains("elsif __br"), "no relay arm in:\n{src}");

--- a/crates/dewasm-backend-ruby/tests/e2e.rs
+++ b/crates/dewasm-backend-ruby/tests/e2e.rs
@@ -1,14 +1,4 @@
-//! Ruby end-to-end suites (ADR-27): the shared case consts (`dewasm-test-helper`)
-//! wired up for the Ruby backend. Per the ADR-27 revision this file holds ONLY
-//! the [`BackendUnderTest`] impl, named glue string constants, and per-case
-//! macro invocations — every scenario's case content (fixtures, expectations,
-//! run logic) lives in a shared const, glue is a plain `&str` argument at the
-//! callsite, and which macros this file invokes is the capability declaration.
-//! The formerly Ruby-only scenarios (the ADR-7 provider model, embedded-runtime
-//! coexistence, cross-module table sharing, the sqlite3 C-API drive,
-//! WASI-filesystem internals, and the CPython/CRuby runtime demos) now run
-//! wherever a backend's declared capabilities cover them, with a REASON comment
-//! at any non-invocation.
+//! Ruby end-to-end suites (ADR-27): the shared case consts (`dewasm-test-helper`) wired up for the Ruby backend. Per the ADR-27 revision this file holds ONLY the [`BackendUnderTest`] impl, named glue string constants, and per-case macro invocations — every scenario's case content (fixtures, expectations, run logic) lives in a shared const, glue is a plain `&str` argument at the callsite, and which macros this file invokes is the capability declaration. The formerly Ruby-only scenarios (the ADR-7 provider model, embedded-runtime coexistence, cross-module table sharing, the sqlite3 C-API drive, WASI-filesystem internals, and the CPython/CRuby runtime demos) now run wherever a backend's declared capabilities cover them, with a REASON comment at any non-invocation.
 
 use std::path::PathBuf;
 
@@ -39,11 +29,7 @@ impl BackendUnderTest for Ruby {
         find_ruby().expect("ruby not found on PATH — see docs/testing.md")
     }
 
-    /// Compose several `.wat` modules for the multi-module cases. `shared_runtime`
-    /// emits each module against a single top-level `::Rt` (Alias linkage) plus
-    /// one bundled runtime, so an imported table crosses modules (as the spec
-    /// harness's `register` path does); otherwise it emits independent Embedded
-    /// classes, each with its own nested `Rt`.
+    /// Compose several `.wat` modules for the multi-module cases. `shared_runtime` emits each module against a single top-level `::Rt` (Alias linkage) plus one bundled runtime, so an imported table crosses modules (as the spec harness's `register` path does); otherwise it emits independent Embedded classes, each with its own nested `Rt`.
     fn compose_modules(&self, modules: &[(&str, &str)], shared_runtime: bool) -> String {
         if shared_runtime {
             let mut units = std::collections::BTreeSet::new();
@@ -78,8 +64,7 @@ impl BackendUnderTest for Ruby {
     }
 }
 
-// ---------------------------------------------------------------------
-// Library-case glue.
+// --------------------------------------------------------------------- Library-case glue.
 
 /// `add.wat`: call the exported functions and print each result.
 const RUBY_ADD_GLUE: &str = r#"inst = Add.new
@@ -88,9 +73,7 @@ print inst.invoke("add", 0xffffffff, 1), "\n"
 print inst.invoke("fib", 10), "\n"
 "#;
 
-/// The ADR-7 override/fallback glue (an explicit `fd_write` import wins,
-/// `random_get` falls back to the bundled WASI). Intercepts fd_write and prints
-/// the actual bytes the module wrote.
+/// The ADR-7 override/fallback glue (an explicit `fd_write` import wins, `random_get` falls back to the bundled WASI). Intercepts fd_write and prints the actual bytes the module wrote.
 const RUBY_OVERRIDE_GLUE: &str = r#"captured = +""
 holder = {}
 fd_write = lambda do |_fd, iovs, _iovs_len, out_ptr|
@@ -107,9 +90,7 @@ inst.invoke("_start") # random_get falls back to the bundled WASI
 print captured
 "#;
 
-/// The `custom_wasi_provider` glue: a provider *object* replaces the bundled
-/// WASI wholesale — `import(name)` resolves functions, `attach(instance)` binds
-/// the memory — so the bundled WASI is never constructed (`@wasi` stays nil).
+/// The `custom_wasi_provider` glue: a provider *object* replaces the bundled WASI wholesale — `import(name)` resolves functions, `attach(instance)` binds the memory — so the bundled WASI is never constructed (`@wasi` stays nil).
 const RUBY_CUSTOM_PROVIDER_GLUE: &str = r#"
 class MyWasi
   attr_reader :out
@@ -136,9 +117,7 @@ print wasi.out
 print "bundled wasi constructed: ", !inst.instance_variable_get(:@wasi).nil?, "\n"
 "#;
 
-/// The `partial_override_falls_back_to_bundled_wasi` glue: reuses the override
-/// glue (fd_write intercepted, random_get falls back) plus one line probing
-/// that the bundled WASI *was* lazily constructed (ADR-7's `@wasi ||= ...`).
+/// The `partial_override_falls_back_to_bundled_wasi` glue: reuses the override glue (fd_write intercepted, random_get falls back) plus one line probing that the bundled WASI *was* lazily constructed (ADR-7's `@wasi ||= ...`).
 const RUBY_PARTIAL_OVERRIDE_GLUE: &str = r#"captured = +""
 holder = {}
 fd_write = lambda do |_fd, iovs, _iovs_len, out_ptr|
@@ -156,9 +135,7 @@ print captured
 print "bundled wasi constructed: ", !inst.instance_variable_get(:@wasi).nil?, "\n"
 "#;
 
-/// The `wasi_stdio_capture` glue: redirect `$stdout` to a StringIO before
-/// instantiation (the standard Ruby capture idiom) so the module's output flows
-/// into it, then print the captured string to the real stdout.
+/// The `wasi_stdio_capture` glue: redirect `$stdout` to a StringIO before instantiation (the standard Ruby capture idiom) so the module's output flows into it, then print the captured string to the real stdout.
 const RUBY_STDIO_CAPTURE_GLUE: &str = r#"
 require "stringio"
 captured = StringIO.new
@@ -174,12 +151,9 @@ end
 print captured.string
 "#;
 
-// ---------------------------------------------------------------------
-// WASI filesystem glue.
+// --------------------------------------------------------------------- WASI filesystem glue.
 
-/// The shared filesystem template: preopen the scratch dir (`{host}`) at guest
-/// `{guest}` (always `/`), run `_start`, and surface a `proc_exit` code as a
-/// trailing decimal line.
+/// The shared filesystem template: preopen the scratch dir (`{host}`) at guest `{guest}` (always `/`), run `_start`, and surface a `proc_exit` code as a trailing decimal line.
 const RUBY_FS_GLUE: &str = r#"inst = Prog.new({}, preopens: { "{guest}" => "{host}" })
 begin
   inst.invoke("_start")
@@ -188,16 +162,13 @@ rescue Prog::Rt::Exit => e
 end
 "#;
 
-/// The root-preopen containment probe: call the WASI resolver directly with a
-/// `"/" => "/"` preopen (no guest run) and normalize the outcome to `contained`.
+/// The root-preopen containment probe: call the WASI resolver directly with a `"/" => "/"` preopen (no guest run) and normalize the outcome to `contained`.
 const RUBY_CONTAINMENT_GLUE: &str = r#"wasi = Prog::Rt::WASI.new(preopens: { "/" => "/" })
 _path, err = wasi.send(:resolve_path, 3, "etc")
 print(err.nil? ? "contained" : "rejected", "\n")
 "#;
 
-// ---------------------------------------------------------------------
-// Filesystem app glue: class/argv/env/preopen-guest-paths are literals; only
-// the host scratch/cache dirs come through {scratch}/{cache}.
+// --------------------------------------------------------------------- Filesystem app glue: class/argv/env/preopen-guest-paths are literals; only the host scratch/cache dirs come through {scratch}/{cache}.
 
 const RUBY_QJS_FILE_IO_GLUE: &str = r#"inst = Qjs.new({}, args: ["qjs", "/work/qjs_file_io.js"], env: {}, preopens: {"/work" => "{scratch}"})
 begin
@@ -241,13 +212,9 @@ rescue Cruby::Rt::Exit
 end
 "#;
 
-// ---------------------------------------------------------------------
-// C-API drive glue (sqlite3): malloc/pointer plumbing via Rt::Memory. No
-// wasmtime golden — the results live in guest memory — so each drive's output
-// is pinned in the shared case const. Only the file-backed case uses {scratch}.
+// --------------------------------------------------------------------- C-API drive glue (sqlite3): malloc/pointer plumbing via Rt::Memory. No wasmtime golden — the results live in guest memory — so each drive's output is pinned in the shared case const. Only the file-backed case uses {scratch}.
 
-/// The sqlite3 C API driven in memory: `_initialize`, `sqlite3_malloc` +
-/// `Rt::Memory` pointer plumbing, open/exec/prepare/step/column/finalize/close.
+/// The sqlite3 C API driven in memory: `_initialize`, `sqlite3_malloc` + `Rt::Memory` pointer plumbing, open/exec/prepare/step/column/finalize/close.
 const RUBY_LIBSQLITE3_MEM: &str = r##"
 db_mod = Libsqlite3.new
 db_mod.invoke("_initialize")
@@ -295,9 +262,7 @@ db_mod.invoke("sqlite3_close", db)
 puts "C-API-OK"
 "##;
 
-/// The sqlite3 C API against a file preopen: create+insert, close, reopen,
-/// select — the file lifecycle through the C API (same ADR-14 fs stack as the
-/// shell).
+/// The sqlite3 C API against a file preopen: create+insert, close, reopen, select — the file lifecycle through the C API (same ADR-14 fs stack as the shell).
 const RUBY_LIBSQLITE3_FILE: &str = r##"
 DB_MOD = Libsqlite3.new({}, preopens: { "/db" => "{scratch}" })
 DB_MOD.invoke("_initialize")
@@ -346,10 +311,7 @@ DB_MOD.invoke("sqlite3_close", db)
 puts "FILE-OK"
 "##;
 
-/// Guest->host callback round trip: the committed `sqlite3-binding.wasm` exports
-/// `run_query`, which calls `sqlite3_exec` with a C callback forwarding each row
-/// to the *imported* `env.host_row`. The glue provides `host_row` via the ADR-7
-/// import-provider mechanism and collects the rows.
+/// Guest->host callback round trip: the committed `sqlite3-binding.wasm` exports `run_query`, which calls `sqlite3_exec` with a C callback forwarding each row to the *imported* `env.host_row`. The glue provides `host_row` via the ADR-7 import-provider mechanism and collects the rows.
 const RUBY_SQLITE3_CALLBACK: &str = r##"
 ROWS = []
 MEM_HOLDER = {}
@@ -402,10 +364,7 @@ ROWS.each { |r| puts "row: #{r.join('|')}" }
 puts "CALLBACK-OK"
 "##;
 
-/// libpcap BPF filter compilation: drive `compile_filter` on "tcp port 80"
-/// (DLT_EN10MB, snaplen 65535), then walk the serialized program
-/// `[u32 bf_len][bf_len × {u16 code; u8 jt; u8 jf; u32 k}]` in guest memory,
-/// printing each instruction as `code jt jf k`.
+/// libpcap BPF filter compilation: drive `compile_filter` on "tcp port 80" (DLT_EN10MB, snaplen 65535), then walk the serialized program `[u32 bf_len][bf_len × {u16 code; u8 jt; u8 jf; u32 k}]` in guest memory, printing each instruction as `code jt jf k`.
 const RUBY_PCAP_COMPILE: &str = r##"
 inst = Libpcap.new
 inst.invoke("_initialize")
@@ -432,9 +391,7 @@ inst.invoke("free", prog)
 puts "BPF-OK"
 "##;
 
-/// tree-sitter JSON parse: drive `parse_source` on the fixed snippet
-/// `{"key": [1, true, null]}` and print the parse tree's S-expression (a
-/// malloc'd NUL-terminated C string) from guest memory.
+/// tree-sitter JSON parse: drive `parse_source` on the fixed snippet `{"key": [1, true, null]}` and print the parse tree's S-expression (a malloc'd NUL-terminated C string) from guest memory.
 const RUBY_TREESITTER_PARSE: &str = r##"
 inst = Treesitter.new
 inst.invoke("_initialize")
@@ -456,20 +413,15 @@ inst.invoke("free", r)
 puts "TS-OK"
 "##;
 
-// ---------------------------------------------------------------------
-// Multi-module drive glue.
+// --------------------------------------------------------------------- Multi-module drive glue.
 
-/// Driver for the shared-table case: instantiate the exporter and the importer
-/// linked against it, then print `call0` (call_indirect through the shared
-/// table -> 42).
+/// Driver for the shared-table case: instantiate the exporter and the importer linked against it, then print `call0` (call_indirect through the shared table -> 42).
 const RUBY_SHARED_TABLE_GLUE: &str = r#"a = TableExp.new
 b = TableImp.new({ "a" => a })
 print b.invoke("call0"), "\n"
 "#;
 
-/// Two Embedded artifacts coexist, each with its own nested `Rt`: exercise both,
-/// prove their trap classes are distinct, and catch one's trap. Output is
-/// normalized (`distinct-rt`/`trapped`) so it matches across languages.
+/// Two Embedded artifacts coexist, each with its own nested `Rt`: exercise both, prove their trap classes are distinct, and catch one's trap. Output is normalized (`distinct-rt`/`trapped`) so it matches across languages.
 const RUBY_EMBEDDED_COEXIST_GLUE: &str = r#"
 a = Alpha.new
 b = Beta.new
@@ -483,8 +435,7 @@ rescue Alpha::Rt::Trap
 end
 "#;
 
-// ---------------------------------------------------------------------
-// Suite wiring (ADR-27): each per-case macro invocation declares participation.
+// --------------------------------------------------------------------- Suite wiring (ADR-27): each per-case macro invocation declares participation.
 
 library_add_e2e!(Ruby, RUBY_ADD_GLUE);
 wasi_import_override_e2e!(Ruby, RUBY_OVERRIDE_GLUE);

--- a/crates/dewasm-backend-ruby/tests/spec.rs
+++ b/crates/dewasm-backend-ruby/tests/spec.rs
@@ -1,8 +1,4 @@
-//! Ruby side of the shared spec harness (ADR-3, ADR-27): converts modules
-//! with the Ruby backend, phrases assertions as Ruby (`check`/`check_trap`/
-//! `check_exhaust` helpers, bit-exact float comparison via `Rt.f32_bits`/
-//! `Rt.f64_bits`), and runs the script with the `ruby` on PATH. The generic
-//! harness lives in `dewasm-test-helper`.
+//! Ruby side of the shared spec harness (ADR-3, ADR-27): converts modules with the Ruby backend, phrases assertions as Ruby (`check`/`check_trap`/ `check_exhaust` helpers, bit-exact float comparison via `Rt.f32_bits`/ `Rt.f64_bits`), and runs the script with the `ruby` on PATH. The generic harness lives in `dewasm-test-helper`.
 
 use std::collections::BTreeSet;
 use std::fmt::Write as _;
@@ -15,25 +11,10 @@ use dewasm_test_helper::{spec_suite, BackendUnderTest, Converted, SpecBackend};
 use wast::core::{AbstractHeapType, HeapType, NanPattern, WastArgCore, WastRetCore};
 use wast::{WastArg, WastRet};
 
-/// Known assertion-level failures with their attribution; the file still runs
-/// so regressions in the passing assertions are caught.
+/// Known assertion-level failures with their attribution; the file still runs so regressions in the passing assertions are caught.
 ///
-/// - `import-limits`: `Rt.check_import_kind` validates that a resolved import
-///   is the right *kind* (func/global/table/memory/tag) but not the
-///   finer-grained wasm type — a function's param/result types, a global's
-///   mutability, a tag's parameter types, or a table/memory's min/max limits
-///   against the import site's declared bounds. Every `assert_unlinkable`
-///   case testing one of those (not a kind mismatch, which is caught) stays a
-///   known gap. The imports.wast count reverted 59 → 28 when exception
-///   handling was removed (ADR-24): its "test" fixture module exports tags, so
-///   it no longer converts — the tag export is now rejected at conversion time
-///   — and the downstream type-mismatch checks it exposed are no longer
-///   reached.
-/// - `linking` (module `linking0`/`load1`): downstream of an *unrelated*
-///   declared-unsupported feature (multi-memory) inside a module that also
-///   happens to use `register`; that module never converts, so a later
-///   assertion against the module it would have written into observes stale
-///   state. Not a cross-module-linking gap itself.
+/// - `import-limits`: `Rt.check_import_kind` validates that a resolved import is the right *kind* (func/global/table/memory/tag) but not the finer-grained wasm type — a function's param/result types, a global's mutability, a tag's parameter types, or a table/memory's min/max limits against the import site's declared bounds. Every `assert_unlinkable` case testing one of those (not a kind mismatch, which is caught) stays a known gap. The imports.wast count reverted 59 → 28 when exception handling was removed (ADR-24): its "test" fixture module exports tags, so it no longer converts — the tag export is now rejected at conversion time — and the downstream type-mismatch checks it exposed are no longer reached.
+/// - `linking` (module `linking0`/`load1`): downstream of an *unrelated* declared-unsupported feature (multi-memory) inside a module that also happens to use `register`; that module never converts, so a later assertion against the module it would have written into observes stale state. Not a cross-module-linking gap itself.
 const EXPECTED_FAILURES: &[(&str, u32, &str)] = &[
     ("imports", 28, "import-limits"),
     ("imports2", 2, "import-limits"),
@@ -64,23 +45,20 @@ impl SpecBackend for RubySpec {
     }
 
     fn curated_files(&self) -> Option<&'static [&'static str]> {
-        // Ruby is fast enough to run the whole testsuite by default; nothing is
-        // marked ignored.
+        // Ruby is fast enough to run the whole testsuite by default; nothing is marked ignored.
         None
     }
 
     fn seed_units(&self) -> &'static [&'static str] {
         &[
             "rt/trap",
-            // check_unlinkable's rescue clause references Rt::LinkError even
-            // when the converted modules themselves don't.
+            // check_unlinkable's rescue clause references Rt::LinkError even when the converted modules themselves don't.
             "rt/link_error",
             "rt/f32_bits",
             "rt/f32_from_bits",
             "rt/f64_bits",
             "rt/f64_from_bits",
-            // Referenced by the $spectest fixture (PREAMBLE below), not
-            // necessarily by the converted module itself.
+            // Referenced by the $spectest fixture (PREAMBLE below), not necessarily by the converted module itself.
             "global/_class",
             "table/_class",
             "memory/_class",
@@ -223,9 +201,7 @@ impl SpecBackend for RubySpec {
     }
 }
 
-/// `$spectest`, plus any currently-`register`ed instances merged in under
-/// their registered name — each instance doubles as an ADR-7 import provider
-/// (`Gen::body`'s generated `import(name)` method).
+/// `$spectest`, plus any currently-`register`ed instances merged in under their registered name — each instance doubles as an ADR-7 import provider (`Gen::body`'s generated `import(name)` method).
 fn imports_expr(registered: &[(String, String)]) -> String {
     if registered.is_empty() {
         return "$spectest".to_string();
@@ -255,9 +231,7 @@ fn ruby_str(s: &str) -> String {
     out
 }
 
-/// Attribution for a null/ref heap type the harness cannot express as a Ruby
-/// value; the two reference-types hierarchies (and their bottoms, which are
-/// also just `nil`) are expressible.
+/// Attribution for a null/ref heap type the harness cannot express as a Ruby value; the two reference-types hierarchies (and their bottoms, which are also just `nil`) are expressible.
 fn heap_type_tag(hty: &HeapType<'_>) -> String {
     match hty {
         HeapType::Abstract {
@@ -299,8 +273,7 @@ fn arg_rb(arg: &WastArg<'_>) -> Result<String, String> {
                 Err(heap_type_tag(hty))
             }
         }
-        // An externref (or legacy hostref) with identity `n`: the host value
-        // is the Integer itself (ADR-17: externref = raw host value).
+        // An externref (or legacy hostref) with identity `n`: the host value is the Integer itself (ADR-17: externref = raw host value).
         WastArg::Core(WastArgCore::RefExtern(n)) => Ok(n.to_string()),
         WastArg::Core(WastArgCore::RefHost(n)) => Ok(n.to_string()),
         _ => Err("component-model".to_string()),
@@ -344,13 +317,11 @@ fn ret_cmp(value: &str, ret: &WastRet<'_>) -> Result<String, String> {
         // `(ref.extern)`: any non-null externref.
         WastRet::Core(WastRetCore::RefExtern(None)) => Ok(format!("!{value}.nil?")),
         WastRet::Core(WastRetCore::RefHost(n)) => Ok(format!("{value} == {n}")),
-        // `(ref.func)`: any non-null funcref — in ADR-17's representation, a
-        // `[type_symbol, callable]` pair.
+        // `(ref.func)`: any non-null funcref — in ADR-17's representation, a `[type_symbol, callable]` pair.
         WastRet::Core(WastRetCore::RefFunc(None)) => Ok(format!(
             "({value}.is_a?(Array) && {value}[0].is_a?(Symbol))"
         )),
-        // A specific function's identity: not expressible without an export
-        // map; no top-level testsuite file uses it.
+        // A specific function's identity: not expressible without an export map; no top-level testsuite file uses it.
         WastRet::Core(WastRetCore::RefFunc(Some(_))) => Err("funcref-identity".to_string()),
         WastRet::Core(
             WastRetCore::RefAny

--- a/crates/dewasm-backend-ruby/tests/wasi_testsuite.rs
+++ b/crates/dewasm-backend-ruby/tests/wasi_testsuite.rs
@@ -1,6 +1,4 @@
-//! Ruby side of the official WASI p1 conformance harness (ADR-36): drives the
-//! prebuilt `WebAssembly/wasi-testsuite` modules through the Ruby backend's
-//! standalone interface. The generic harness lives in `dewasm-test-helper`.
+//! Ruby side of the official WASI p1 conformance harness (ADR-36): drives the prebuilt `WebAssembly/wasi-testsuite` modules through the Ruby backend's standalone interface. The generic harness lives in `dewasm-test-helper`.
 
 use std::path::PathBuf;
 
@@ -8,30 +6,16 @@ use dewasm_backend::Backend;
 use dewasm_backend_ruby::RubyBackend;
 use dewasm_test_helper::{wasi_testsuite_suite, BackendUnderTest, WasiTestsuiteBackend};
 
-/// Known trial failures with their attribution (ADR-8, policy in ADR-36):
-/// `(trial, tag)`. Two kinds remain, both attributed honestly:
-///   * declared out-of-scope syscalls (`sock_shutdown`; docs/support.md) —
-///     filling the gap later flips the entry to a hard failure, exactly ADR-8's
-///     contract;
-///   * environment variables the host interpreter itself injects (macOS
-///     CoreFoundation's `__CF_USER_TEXT_ENCODING`), which the guest
-///     legitimately observes, so count-exact `environ_*` assertions cannot
-///     hold even though the harness runs trials with a cleared environment
-///     (ADR-40).
+/// Known trial failures with their attribution (ADR-8, policy in ADR-36): `(trial, tag)`. Two kinds remain, both attributed honestly: * declared out-of-scope syscalls (`sock_shutdown`; docs/support.md) — filling the gap later flips the entry to a hard failure, exactly ADR-8's contract; * environment variables the host interpreter itself injects (macOS CoreFoundation's `__CF_USER_TEXT_ENCODING`), which the guest legitimately observes, so count-exact `environ_*` assertions cannot hold even though the harness runs trials with a cleared environment (ADR-40).
 ///
-/// The former filesystem ledger (per-fd rights/fdflags, symlink/link/readlink,
-/// renumber, advise/allocate, set_times, path-resolution errno precision) is
-/// now implemented — see the `wasi/` runtime units and ADR-40.
+/// The former filesystem ledger (per-fd rights/fdflags, symlink/link/readlink, renumber, advise/allocate, set_times, path-resolution errno precision) is now implemented — see the `wasi/` runtime units and ADR-40.
 const WASI_TESTSUITE_EXPECTED_FAILURES: &[(&str, &str)] = &[
     // Declared out-of-scope syscalls.
     ("c/sock_shutdown-invalid_fd", "sock_shutdown (out of scope)"),
     ("c/sock_shutdown-not_sock", "sock_shutdown (out of scope)"),
 ];
 
-/// Host-scoped failures on a macOS host: macOS CoreFoundation injects
-/// `__CF_USER_TEXT_ENCODING` into the CF-linked ruby process, so the guest sees
-/// one extra environ entry and count-exact `environ_*` assertions cannot hold.
-/// Plain Linux ruby injects nothing, so these pass there (ADR-40).
+/// Host-scoped failures on a macOS host: macOS CoreFoundation injects `__CF_USER_TEXT_ENCODING` into the CF-linked ruby process, so the guest sees one extra environ entry and count-exact `environ_*` assertions cannot hold. Plain Linux ruby injects nothing, so these pass there (ADR-40).
 const WASI_TESTSUITE_EXPECTED_FAILURES_MACOS: &[(&str, &str)] = &[
     (
         "assemblyscript/environ_get-multiple-variables",

--- a/crates/dewasm-backend/src/lib.rs
+++ b/crates/dewasm-backend/src/lib.rs
@@ -1,5 +1,4 @@
-//! Backend trait and code emission utilities shared by all language
-//! backends.
+//! Backend trait and code emission utilities shared by all language backends.
 
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
@@ -16,24 +15,18 @@ pub enum SupportStatus {
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Mode {
-    /// Emit a module that is instantiated with an imports object and exposes
-    /// its exports to the host language.
+    /// Emit a module that is instantiated with an imports object and exposes its exports to the host language.
     Library,
     /// Emit a runnable program that wires up WASI and calls `_start`.
     Standalone,
 }
 
-/// How generated code gets its runtime. Generated code always refers to
-/// the runtime by the relative name `Rt` (or the backend's equivalent);
-/// linkage only decides where that name is defined.
+/// How generated code gets its runtime. Generated code always refers to the runtime by the relative name `Rt` (or the backend's equivalent); linkage only decides where that name is defined.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RuntimeLinkage {
-    /// Nest the needed runtime units inside the generated module itself
-    /// (single self-contained file; multiple generated artifacts never
-    /// collide).
+    /// Nest the needed runtime units inside the generated module itself (single self-contained file; multiple generated artifacts never collide).
     Embedded,
-    /// Emit only an alias to a runtime defined elsewhere (a shared bundle
-    /// in the same program, or a future runtime package/gem).
+    /// Emit only an alias to a runtime defined elsewhere (a shared bundle in the same program, or a future runtime package/gem).
     Alias(String),
 }
 
@@ -43,25 +36,16 @@ pub struct GenOptions {
     /// Class/package/module name for the generated code.
     pub module_name: String,
     pub runtime: RuntimeLinkage,
-    /// Bundle the built-in WASI implementation as a fallback for
-    /// `wasi_snapshot_preview1` imports the embedder does not provide.
-    /// Disable to keep generated libraries free of ambient authority.
+    /// Bundle the built-in WASI implementation as a fallback for `wasi_snapshot_preview1` imports the embedder does not provide. Disable to keep generated libraries free of ambient authority.
     pub default_wasi: bool,
-    /// Externalize data-segment bytes into a binary sidecar instead of
-    /// embedding them as hex literals (ADR-37). When `Some`, the backend
-    /// emits load-from-sidecar code and returns a second `OutputFile`
-    /// carrying the blob. Only backends that declare support honor it (the
-    /// CLI rejects it for the rest); a backend that ignores it keeps
-    /// embedding.
+    /// Externalize data-segment bytes into a binary sidecar instead of embedding them as hex literals (ADR-37). When `Some`, the backend emits load-from-sidecar code and returns a second `OutputFile` carrying the blob. Only backends that declare support honor it (the CLI rejects it for the rest); a backend that ignores it keeps embedding.
     pub data_file: Option<DataFileConfig>,
 }
 
 /// Configuration for data-segment externalization (ADR-37).
 #[derive(Clone, Debug)]
 pub struct DataFileConfig {
-    /// The filename the generated program references relative to itself
-    /// (e.g. via `__dir__`/`//go:embed`). The matching sidecar `OutputFile`
-    /// carries this exact `name`; the CLI routes it to the requested path.
+    /// The filename the generated program references relative to itself (e.g. via `__dir__`/`//go:embed`). The matching sidecar `OutputFile` carries this exact `name`; the CLI routes it to the requested path.
     pub sidecar_name: String,
 }
 
@@ -75,32 +59,22 @@ pub trait Backend {
     fn file_extension(&self) -> &str;
     fn generate(&self, module: &ir::Module, opts: &GenOptions) -> anyhow::Result<Vec<OutputFile>>;
 
-    /// Declared support level per feature (ADR-8). The spec harness only
-    /// tolerates skips attributable to features that are not `Supported`;
-    /// flipping a feature to `Supported` makes its skips hard failures.
+    /// Declared support level per feature (ADR-8). The spec harness only tolerates skips attributable to features that are not `Supported`; flipping a feature to `Supported` makes its skips hard failures.
     fn feature_status(&self, feature: Feature) -> SupportStatus {
         let _ = feature;
         SupportStatus::Unsupported
     }
 
-    /// Whether the backend bundles a WASI preview 1 runtime unit for
-    /// `name` (e.g. `"fd_write"`). Feeds the generated support docs
-    /// (ADR-25).
+    /// Whether the backend bundles a WASI preview 1 runtime unit for `name` (e.g. `"fd_write"`). Feeds the generated support docs (ADR-25).
     fn has_wasi_p1(&self, name: &str) -> bool {
         let _ = name;
         false
     }
 }
 
-/// Reject, with the same `UnsupportedError` attribution the core converter
-/// uses (ADR-0), any construct the shared IR now represents but this
-/// specific `backend` has not declared `Supported` (ADR-8). The core
-/// builder is backend-agnostic and accepts every wasm-1.0-scoped
-/// construct; a backend that hasn't implemented one of them yet must
-/// refuse it itself, at conversion time, rather than mis-lower it.
+/// Reject, with the same `UnsupportedError` attribution the core converter uses (ADR-0), any construct the shared IR now represents but this specific `backend` has not declared `Supported` (ADR-8). The core builder is backend-agnostic and accepts every wasm-1.0-scoped construct; a backend that hasn't implemented one of them yet must refuse it itself, at conversion time, rather than mis-lower it.
 pub fn check_module_support(backend: &dyn Backend, module: &ir::Module) -> Result<()> {
-    // `used` is a closure so the usage scan (an IR walk for TableBulkOps)
-    // only runs for features the backend has *not* declared Supported.
+    // `used` is a closure so the usage scan (an IR walk for TableBulkOps) only runs for features the backend has *not* declared Supported.
     let require = |feature: Feature, used: &dyn Fn() -> bool, detail: &str| -> Result<()> {
         if backend.feature_status(feature) != SupportStatus::Supported && used() {
             return Err(UnsupportedError::new(feature, detail.to_string()).into());
@@ -144,10 +118,7 @@ pub fn check_module_support(backend: &dyn Backend, module: &ir::Module) -> Resul
 }
 
 fn stmts_use_table_bulk_ops(stmts: &[ir::Stmt]) -> bool {
-    // Exhaustive on purpose: a future body-carrying Stmt variant must
-    // show up here as a compile error, not silently stop the recursion
-    // (which would let an Unsupported backend mis-lower instead of
-    // rejecting at conversion time, violating ADR-0).
+    // Exhaustive on purpose: a future body-carrying Stmt variant must show up here as a compile error, not silently stop the recursion (which would let an Unsupported backend mis-lower instead of rejecting at conversion time, violating ADR-0).
     stmts.iter().any(|stmt| match stmt {
         ir::Stmt::TableInit { .. } | ir::Stmt::TableCopy { .. } | ir::Stmt::ElemDrop { .. } => true,
         ir::Stmt::Block { body, .. } | ir::Stmt::Loop { body, .. } => {
@@ -176,12 +147,7 @@ fn stmts_use_table_bulk_ops(stmts: &[ir::Stmt]) -> bool {
     })
 }
 
-/// The full WASI preview 1 surface, for the generated support docs; which
-/// of these a backend implements is derived from its runtime units
-/// (`bundler().has_unit("wasi/<name>")`). The bool marks whether the
-/// function is in scope: `false` for the out-of-scope surface (sockets,
-/// `proc_raise`) that no toolchain output exercises and even wasmtime
-/// leaves unimplemented (ADR-25).
+/// The full WASI preview 1 surface, for the generated support docs; which of these a backend implements is derived from its runtime units (`bundler().has_unit("wasi/<name>")`). The bool marks whether the function is in scope: `false` for the out-of-scope surface (sockets, `proc_raise`) that no toolchain output exercises and even wasmtime leaves unimplemented (ADR-25).
 pub const WASI_PREVIEW1_FUNCTIONS: &[(&str, bool)] = &[
     ("args_get", true),
     ("args_sizes_get", true),
@@ -231,30 +197,23 @@ pub const WASI_PREVIEW1_FUNCTIONS: &[(&str, bool)] = &[
     ("sock_shutdown", false),
 ];
 
-/// One runtime unit: a single method (or an inseparable scope prelude),
-/// with its dependencies declared in `<comment> requires:` header lines.
+/// One runtime unit: a single method (or an inseparable scope prelude), with its dependencies declared in `<comment> requires:` header lines.
 pub struct RuntimeUnit {
     pub id: String,
     pub requires: Vec<String>,
     pub body: String,
 }
 
-/// A named scope units can live in (e.g. a class nested in the runtime
-/// module). `prefix` is the unit-id path segment; `open`/`close` wrap the
-/// scope's units; the root scope uses empty wrappers.
+/// A named scope units can live in (e.g. a class nested in the runtime module). `prefix` is the unit-id path segment; `open`/`close` wrap the scope's units; the root scope uses empty wrappers.
 pub struct RuntimeScope {
     pub prefix: &'static str,
     pub open: &'static str,
     pub close: &'static str,
-    /// Unit implicitly required by every unit of this scope (class
-    /// skeleton, constants); also force-included for the root scope.
+    /// Unit implicitly required by every unit of this scope (class skeleton, constants); also force-included for the root scope.
     pub prelude: Option<&'static str>,
 }
 
-/// Resolves `requires:` closures over runtime units and emits the bundle,
-/// grouped by scope in declaration order, deterministically sorted within
-/// a scope. Language-agnostic: syntax comes from the scopes and the
-/// caller-provided wrapper around the whole bundle.
+/// Resolves `requires:` closures over runtime units and emits the bundle, grouped by scope in declaration order, deterministically sorted within a scope. Language-agnostic: syntax comes from the scopes and the caller-provided wrapper around the whole bundle.
 pub struct RuntimeBundler {
     scopes: Vec<RuntimeScope>,
     units: BTreeMap<String, RuntimeUnit>,
@@ -336,8 +295,7 @@ impl RuntimeBundler {
         self.units.values()
     }
 
-    /// Compute the dependency closure of `seeds`, including scope preludes
-    /// and the root scope's prelude.
+    /// Compute the dependency closure of `seeds`, including scope preludes and the root scope's prelude.
     pub fn closure(&self, seeds: &BTreeSet<String>) -> Result<BTreeSet<String>> {
         let mut closure = BTreeSet::new();
         let mut queue: VecDeque<String> = seeds.iter().cloned().collect();
@@ -362,9 +320,7 @@ impl RuntimeBundler {
         Ok(closure)
     }
 
-    /// Emit the bundle for `seeds`' closure. `base_indent` is the indent
-    /// level of the bundle's root-scope members (the caller wraps the
-    /// result in the runtime module/namespace itself).
+    /// Emit the bundle for `seeds`' closure. `base_indent` is the indent level of the bundle's root-scope members (the caller wraps the result in the runtime module/namespace itself).
     pub fn bundle(&self, seeds: &BTreeSet<String>, base_indent: usize) -> Result<String> {
         let closure = self.closure(seeds)?;
         let mut out = String::new();

--- a/crates/dewasm-cli/src/lib.rs
+++ b/crates/dewasm-cli/src/lib.rs
@@ -1,7 +1,3 @@
-//! Library surface of the `dewasm-cli` crate. The `dewasm` binary
-//! (`src/main.rs`) is the primary product; this library exists so that code
-//! needing every backend at once — currently only the `docs/support.md`
-//! rendering — has a single shared home instead of being duplicated between
-//! the `support_docs` test and `cargo xtask update-support-docs`.
+//! Library surface of the `dewasm-cli` crate. The `dewasm` binary (`src/main.rs`) is the primary product; this library exists so that code needing every backend at once — currently only the `docs/support.md` rendering — has a single shared home instead of being duplicated between the `support_docs` test and `cargo xtask update-support-docs`.
 
 pub mod support_docs;

--- a/crates/dewasm-cli/src/main.rs
+++ b/crates/dewasm-cli/src/main.rs
@@ -20,13 +20,11 @@ struct Cli {
     #[arg(short, long, default_value = "ruby")]
     target: String,
 
-    /// Output mode: "library" exposes exports to the host language,
-    /// "standalone" wires up WASI and runs _start.
+    /// Output mode: "library" exposes exports to the host language, "standalone" wires up WASI and runs _start.
     #[arg(short, long, default_value = "library")]
     mode: String,
 
-    /// Name used for the generated class/module (defaults to the input
-    /// file stem)
+    /// Name used for the generated class/module (defaults to the input file stem)
     #[arg(long)]
     module_name: Option<String>,
 
@@ -34,24 +32,15 @@ struct Cli {
     #[arg(short, long, default_value = "-")]
     output: PathBuf,
 
-    /// Do not bundle the built-in WASI implementation as a fallback for
-    /// wasi_snapshot_preview1 imports (all imports must then be provided
-    /// by the embedder). Incompatible with --mode standalone.
+    /// Do not bundle the built-in WASI implementation as a fallback for wasi_snapshot_preview1 imports (all imports must then be provided by the embedder). Incompatible with --mode standalone.
     #[arg(long)]
     no_default_wasi: bool,
 
-    /// Externalize data-segment bytes into a binary sidecar written to this
-    /// path instead of embedding them as literals in the source (ADR-37).
-    /// The generated program loads the sidecar relative to itself, so keep it
-    /// next to the output file. Supported for ruby and go; incompatible with
-    /// `-o -`.
+    /// Externalize data-segment bytes into a binary sidecar written to this path instead of embedding them as literals in the source (ADR-37). The generated program loads the sidecar relative to itself, so keep it next to the output file. Supported for ruby and go; incompatible with `-o -`.
     #[arg(long)]
     data_file: Option<PathBuf>,
 
-    /// Parse the module's DWARF `.debug_*` sections and emit source-position
-    /// markers (Go `//line`, Ruby/Python comments) so generated-code stack
-    /// traces point into the original source (ADR-38). A module without DWARF
-    /// simply yields no markers.
+    /// Parse the module's DWARF `.debug_*` sections and emit source-position markers (Go `//line`, Ruby/Python comments) so generated-code stack traces point into the original source (ADR-38). A module without DWARF simply yields no markers.
     #[arg(long)]
     dwarf_line: bool,
 }
@@ -77,10 +66,7 @@ fn main() -> Result<()> {
         bail!("--no-default-wasi cannot be combined with --mode standalone");
     }
 
-    // Data-segment externalization (ADR-37): opt-in; ruby/go/python/java only,
-    // needs a real sidecar path (not stdout). Reject the unsupported
-    // combinations at the front with a clear, attributed error rather than
-    // mis-emitting.
+    // Data-segment externalization (ADR-37): opt-in; ruby/go/python/java only, needs a real sidecar path (not stdout). Reject the unsupported combinations at the front with a clear, attributed error rather than mis-emitting.
     let data_file = match &cli.data_file {
         Some(path) => {
             match cli.target.as_str() {
@@ -98,8 +84,7 @@ fn main() -> Result<()> {
                      must be written to a real path next to the generated program"
                 );
             }
-            // A --data-file resolving to the same file as -o would clobber
-            // the generated source; fail before anything is written (ADR-0).
+            // A --data-file resolving to the same file as -o would clobber the generated source; fail before anything is written (ADR-0).
             if resolve_for_collision(path) == resolve_for_collision(&cli.output) {
                 bail!(
                     "--data-file {} resolves to the same file as the output path {}: \
@@ -137,8 +122,7 @@ fn main() -> Result<()> {
         default_wasi: !cli.no_default_wasi,
         data_file,
     };
-    // Component-model binaries (layer 1) are out of scope (ADR-24): reject
-    // them at conversion time with a clear, attributed error (ADR-0).
+    // Component-model binaries (layer 1) are out of scope (ADR-24): reject them at conversion time with a clear, attributed error (ADR-0).
     if dewasm_core::is_component(&bytes) {
         return Err(dewasm_core::feature::UnsupportedError::new(
             dewasm_core::feature::Feature::ComponentModel,
@@ -154,14 +138,9 @@ fn main() -> Result<()> {
     )?;
     let files = backend.generate(&module, &opts)?;
 
-    // Route by name: the data sidecar (its `name` is the configured
-    // `sidecar_name`) goes to `--data-file`'s path, the primary source to
-    // `-o` (ADR-37).
+    // Route by name: the data sidecar (its `name` is the configured `sidecar_name`) goes to `--data-file`'s path, the primary source to `-o` (ADR-37).
     let sidecar_name = opts.data_file.as_ref().map(|c| c.sidecar_name.as_str());
-    // A generated source sharing `sidecar_name` (e.g. java's fixed
-    // `Main.java`) would be misrouted and clobbered: `matching > 1` = source
-    // and sidecar collide, `matching == files.len()` = no sidecar emitted and
-    // the match is the source itself (ADR-0).
+    // A generated source sharing `sidecar_name` (e.g. java's fixed `Main.java`) would be misrouted and clobbered: `matching > 1` = source and sidecar collide, `matching == files.len()` = no sidecar emitted and the match is the source itself (ADR-0).
     if let Some(name) = sidecar_name {
         let matching = files.iter().filter(|f| f.name == name).count();
         if matching > 1 || matching == files.len() {
@@ -193,9 +172,7 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-/// Canonicalize for the --data-file/-o collision check (the file, else
-/// parent + final component, else cwd-anchored absolute) so differently
-/// spelled paths compare equal.
+/// Canonicalize for the --data-file/-o collision check (the file, else parent + final component, else cwd-anchored absolute) so differently spelled paths compare equal.
 fn resolve_for_collision(path: &Path) -> PathBuf {
     if let Ok(resolved) = path.canonicalize() {
         return resolved;

--- a/crates/dewasm-cli/src/main.rs
+++ b/crates/dewasm-cli/src/main.rs
@@ -24,23 +24,23 @@ struct Cli {
     #[arg(short, long, default_value = "library")]
     mode: String,
 
-    /// Name used for the generated class/module (defaults to the input file stem)
-    #[arg(long)]
-    module_name: Option<String>,
-
     /// Output file path ("-" for stdout)
     #[arg(short, long, default_value = "-")]
     output: PathBuf,
 
-    /// Do not bundle the built-in WASI implementation as a fallback for wasi_snapshot_preview1 imports (all imports must then be provided by the embedder). Incompatible with --mode standalone.
+    /// Name used for the generated class/module (defaults to the input file stem)
+    #[arg(long)]
+    module_name: Option<String>,
+
+    /// Do not bundle the built-in WASI implementation for wasi_snapshot_preview1 imports. Incompatible with --mode standalone.
     #[arg(long)]
     no_default_wasi: bool,
 
-    /// Externalize data-segment bytes into a binary sidecar written to this path instead of embedding them as literals in the source (ADR-37). The generated program loads the sidecar relative to itself, so keep it next to the output file. Supported for ruby and go; incompatible with `-o -`.
+    /// Externalize data-segment bytes into a binary sidecar written to this path instead of embedding them as literals in the source.
     #[arg(long)]
     data_file: Option<PathBuf>,
 
-    /// Parse the module's DWARF `.debug_*` sections and emit source-position markers (Go `//line`, Ruby/Python comments) so generated-code stack traces point into the original source (ADR-38). A module without DWARF simply yields no markers.
+    /// Parse the module's DWARF `.debug_*` sections and emit source-position markers.
     #[arg(long)]
     dwarf_line: bool,
 }

--- a/crates/dewasm-cli/src/support_docs.rs
+++ b/crates/dewasm-cli/src/support_docs.rs
@@ -1,8 +1,4 @@
-//! Rendering for `docs/support.md` (ADR-8): the support matrix is rendered
-//! from the code's own declarations, so the document cannot drift from
-//! reality. Shared by the compare-only `support_docs_in_sync` test
-//! (`tests/support_docs.rs`) and `cargo xtask update-support-docs`, which
-//! writes the rendered output to disk.
+//! Rendering for `docs/support.md` (ADR-8): the support matrix is rendered from the code's own declarations, so the document cannot drift from reality. Shared by the compare-only `support_docs_in_sync` test (`tests/support_docs.rs`) and `cargo xtask update-support-docs`, which writes the rendered output to disk.
 
 use std::fmt::Write as _;
 
@@ -14,12 +10,7 @@ use dewasm_backend_python::PythonBackend;
 use dewasm_backend_ruby::RubyBackend;
 use dewasm_core::feature::Feature;
 
-/// The features a backend can meaningfully differ on post-excision
-/// (ADR-25): everything the core IR accepts unconditionally and leaves to
-/// each backend to reject or implement. The remaining `Feature` variants
-/// (SIMD, reference types, the component model, ...) are rejected by the
-/// core for every backend (ADR-24), so a per-backend row for them would
-/// always read "unsupported" and says nothing.
+/// The features a backend can meaningfully differ on post-excision (ADR-25): everything the core IR accepts unconditionally and leaves to each backend to reject or implement. The remaining `Feature` variants (SIMD, reference types, the component model, ...) are rejected by the core for every backend (ADR-24), so a per-backend row for them would always read "unsupported" and says nothing.
 const IN_SCOPE_FEATURES: &[Feature] = &[
     Feature::ImportedGlobals,
     Feature::ImportedMemories,
@@ -42,14 +33,10 @@ pub fn render_support_docs() -> String {
     let mut out = String::new();
     out.push_str("# Backend Support Matrix\n\n");
     out.push_str(
-        "<!-- AUTO-GENERATED from the backend declarations; do not edit by hand.\n     \
-         Regenerate: cargo xtask update-support-docs -->\n\n",
+        "<!-- AUTO-GENERATED from the backend declarations; do not edit by hand. Regenerate: cargo xtask update-support-docs -->\n\n",
     );
     out.push_str(
-        "The spec harness only tolerates test skips attributable to a feature that is\n\
-         not `Supported` here ([ADR-8](adr/8-latest-testsuite-support-matrix.md)); an\n\
-         unattributable failure is treated as a bug. Flipping a feature to supported\n\
-         turns its remaining skips into hard failures until the tests pass.\n\n",
+        "The spec harness only tolerates test skips attributable to a feature that is not `Supported` here ([ADR-8](adr/8-latest-testsuite-support-matrix.md)); an unattributable failure is treated as a bug. Flipping a feature to supported turns its remaining skips into hard failures until the tests pass.\n\n",
     );
 
     let feature_cell =
@@ -61,8 +48,7 @@ pub fn render_support_docs() -> String {
 
     out.push_str("## Features\n\n");
     out.push_str(
-        "The wasm 1.0 features a backend can meaningfully differ on ([ADR-25](adr/25-retire-support-tiers.md));\n\
-         every other `Feature` variant is rejected by the core for every backend ([ADR-24](adr/24-01-scope-reset.md)).\n\n",
+        "The wasm 1.0 features a backend can meaningfully differ on ([ADR-25](adr/25-retire-support-tiers.md)); every other `Feature` variant is rejected by the core for every backend ([ADR-24](adr/24-01-scope-reset.md)).\n\n",
     );
     let mut header = String::from("| Feature ");
     let mut rule = String::from("| --- ");
@@ -81,10 +67,7 @@ pub fn render_support_docs() -> String {
 
     out.push_str("\n## WASI preview 1\n\n");
     out.push_str(
-        "Derived from the runtime units; unimplemented syscalls resolve to an ENOSYS\n\
-         stub ([ADR-7](adr/7-import-providers.md), bash conventions in\n\
-         [ADR-12](adr/12-bash-wasi.md)). `—` marks the out-of-scope surface (sockets,\n\
-         `proc_raise`) no toolchain output exercises (ADR-25).\n\n",
+        "Derived from the runtime units; unimplemented syscalls resolve to an ENOSYS stub ([ADR-7](adr/7-import-providers.md), bash conventions in [ADR-12](adr/12-bash-wasi.md)). `—` marks the out-of-scope surface (sockets, `proc_raise`) no toolchain output exercises (ADR-25).\n\n",
     );
     let mut header = String::from("| Function ");
     let mut rule = String::from("| --- ");

--- a/crates/dewasm-cli/tests/data_file.rs
+++ b/crates/dewasm-cli/tests/data_file.rs
@@ -1,15 +1,6 @@
-//! End-to-end coverage for `--data-file` data-segment externalization
-//! (ADR-37). For Ruby, Go, Python and Java: convert a module both embedded and
-//! with a sidecar, run each generated program, and assert byte-identical
-//! stdout/exit plus a smaller source file. Also pins the loud rejections (the
-//! bash target, `-o -`).
+//! End-to-end coverage for `--data-file` data-segment externalization (ADR-37). For Ruby, Go, Python and Java: convert a module both embedded and with a sidecar, run each generated program, and assert byte-identical stdout/exit plus a smaller source file. Also pins the loud rejections (the bash target, `-o -`).
 //!
-//! The inline fixture carries an active segment, a passive segment initialized
-//! via `memory.init` + `data.drop`, and a bulky third segment so the sidecar
-//! form provably shrinks the source. The slow real-app cases (`qjs.wasm`) are
-//! `#[ignore]`d unless the `slow_test` feature is on, matching the project's
-//! tier convention (ADR-48) for cases that pay a multi-second `go build` /
-//! interpreter startup (run with `--features slow_test` or `--include-ignored`).
+//! The inline fixture carries an active segment, a passive segment initialized via `memory.init` + `data.drop`, and a bulky third segment so the sidecar form provably shrinks the source. The slow real-app cases (`qjs.wasm`) are `#[ignore]`d unless the `slow_test` feature is on, matching the project's tier convention (ADR-48) for cases that pay a multi-second `go build` / interpreter startup (run with `--features slow_test` or `--include-ignored`).
 
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
@@ -24,11 +15,7 @@ fn dewasm_bin() -> &'static str {
     env!("CARGO_BIN_EXE_dewasm")
 }
 
-/// A standalone module exercising every data-emission path: an active segment
-/// (index 0), a passive segment written by `memory.init` then `data.drop`ped
-/// (index 1), and a 2 KiB third segment (index 2) whose bytes only exist to
-/// make the embedded hex dwarf the externalized sidecar. `_start` prints
-/// `Active!\nPassive!\n`.
+/// A standalone module exercising every data-emission path: an active segment (index 0), a passive segment written by `memory.init` then `data.drop`ped (index 1), and a 2 KiB third segment (index 2) whose bytes only exist to make the embedded hex dwarf the externalized sidecar. `_start` prints `Active!\nPassive!\n`.
 fn fixture_wat() -> String {
     let bulk = "x".repeat(2000);
     format!(
@@ -83,8 +70,7 @@ fn write(path: &Path, contents: &str) {
     std::fs::write(path, contents).unwrap();
 }
 
-/// Run a Ruby program from its own directory (so `__dir__`-relative sidecar
-/// loads resolve), returning (stdout, exit code).
+/// Run a Ruby program from its own directory (so `__dir__`-relative sidecar loads resolve), returning (stdout, exit code).
 fn run_ruby(prog: &Path, args: &[&str]) -> (Vec<u8>, i32) {
     let ruby = find_ruby().expect("ruby >= 3.4 not found on PATH — see docs/testing.md");
     let out = Command::new(ruby)
@@ -96,8 +82,7 @@ fn run_ruby(prog: &Path, args: &[&str]) -> (Vec<u8>, i32) {
     (out.stdout, out.status.code().unwrap_or(-1))
 }
 
-/// `go build` a program in its own directory (so `//go:embed` resolves) and run
-/// the resulting binary, returning (stdout, exit code).
+/// `go build` a program in its own directory (so `//go:embed` resolves) and run the resulting binary, returning (stdout, exit code).
 fn run_go(prog: &Path, args: &[&str]) -> (Vec<u8>, i32) {
     let go =
         find_go().expect("go toolchain not found on PATH (or $DEWASM_GO) — see docs/testing.md");
@@ -124,8 +109,7 @@ fn run_go(prog: &Path, args: &[&str]) -> (Vec<u8>, i32) {
     (out.stdout, out.status.code().unwrap_or(-1))
 }
 
-/// Run a Python program from its own directory (so the sidecar, resolved via
-/// `os.path.dirname(__file__)`, is found), returning (stdout, exit code).
+/// Run a Python program from its own directory (so the sidecar, resolved via `os.path.dirname(__file__)`, is found), returning (stdout, exit code).
 fn run_python(prog: &Path, args: &[&str]) -> (Vec<u8>, i32) {
     let python = find_python().expect("python3 not found on PATH — see docs/testing.md");
     let out = Command::new(python)
@@ -155,9 +139,7 @@ fn compile_java(src: &Path, classdir: &Path) {
     );
 }
 
-/// Run `Main` from `classdir` on the classpath (so its `DATA_BLOB` loader
-/// resolves the sidecar sitting alongside `Main.class`), returning (stdout,
-/// exit code).
+/// Run `Main` from `classdir` on the classpath (so its `DATA_BLOB` loader resolves the sidecar sitting alongside `Main.class`), returning (stdout, exit code).
 fn run_java(classdir: &Path, args: &[&str]) -> (Vec<u8>, i32) {
     let java = find_java().expect("java not found on PATH (or $DEWASM_JAVA) — see docs/testing.md");
     let out = Command::new(&java)
@@ -170,8 +152,7 @@ fn run_java(classdir: &Path, args: &[&str]) -> (Vec<u8>, i32) {
     (out.stdout, out.status.code().unwrap_or(-1))
 }
 
-// --------------------------------------------------------------------------
-// Inline-fixture parity (default gate).
+// -------------------------------------------------------------------------- Inline-fixture parity (default gate).
 
 #[test]
 fn ruby_data_file_matches_embedded() {
@@ -374,8 +355,7 @@ fn java_data_file_matches_embedded() {
     let embedded = dir.join("embedded").join("Main.java");
     let ecls = dir.join("embedded-cls");
     std::fs::create_dir_all(embedded.parent().unwrap()).unwrap();
-    // Externalized: the sidecar lands directly in the run-time class dir so the
-    // `DATA_BLOB` code-source loader finds it next to `Main.class`.
+    // Externalized: the sidecar lands directly in the run-time class dir so the `DATA_BLOB` code-source loader finds it next to `Main.class`.
     let ext = dir.join("ext").join("Main.java");
     let xcls = dir.join("ext-cls");
     std::fs::create_dir_all(ext.parent().unwrap()).unwrap();
@@ -435,8 +415,7 @@ fn java_data_file_matches_embedded() {
     assert_eq!(code_e, code_x);
 }
 
-// --------------------------------------------------------------------------
-// Loud rejections (default gate).
+// -------------------------------------------------------------------------- Loud rejections (default gate).
 
 #[test]
 fn rejects_unsupported_targets_and_stdout() {
@@ -447,8 +426,7 @@ fn rejects_unsupported_targets_and_stdout() {
     let sidecar = dir.join("d.bin");
     let sc = sidecar.to_str().unwrap();
 
-    // Bash is the sole target that rejects `--data-file` (its data lives in the
-    // runtime, ADR-37); the error names the target.
+    // Bash is the sole target that rejects `--data-file` (its data lives in the runtime, ADR-37); the error names the target.
     let out = dir.join("out.bash");
     let r = run_dewasm(&[
         watp,
@@ -487,10 +465,7 @@ fn rejects_unsupported_targets_and_stdout() {
     );
 }
 
-/// A `--data-file` resolving to the same file as `-o` is rejected before
-/// anything is written: the blob would otherwise clobber the freshly written
-/// source (#30). Covers both the identical spelling and a `..`-hop alias of
-/// the same path.
+/// A `--data-file` resolving to the same file as `-o` is rejected before anything is written: the blob would otherwise clobber the freshly written source (#30). Covers both the identical spelling and a `..`-hop alias of the same path.
 #[test]
 fn rejects_data_file_colliding_with_output_path() {
     let dir = tempdir("collide-output");
@@ -521,8 +496,7 @@ fn rejects_data_file_colliding_with_output_path() {
     );
     assert_eq!(std::fs::read_to_string(&out).unwrap(), "sentinel");
 
-    // A differently spelled alias of the same file ("dir/../dir/out.py") must
-    // be caught too: the check compares resolved paths, not strings.
+    // A differently spelled alias of the same file ("dir/../dir/out.py") must be caught too: the check compares resolved paths, not strings.
     let alias = dir.join("..").join(dir.file_name().unwrap()).join("out.py");
     let r = run_dewasm(&[
         watp,
@@ -539,11 +513,7 @@ fn rejects_data_file_colliding_with_output_path() {
     assert_eq!(std::fs::read_to_string(&out).unwrap(), "sentinel");
 }
 
-/// A `--data-file` whose filename collides with a generated output file's
-/// name is rejected: routing is by name, so the java backend's fixed
-/// `Main.java` source would be misrouted to the sidecar path and clobbered by
-/// the blob (#30). Covered with data segments (source and sidecar share the
-/// name) and without (the lone source itself matches the sidecar name).
+/// A `--data-file` whose filename collides with a generated output file's name is rejected: routing is by name, so the java backend's fixed `Main.java` source would be misrouted to the sidecar path and clobbered by the blob (#30). Covered with data segments (source and sidecar share the name) and without (the lone source itself matches the sidecar name).
 #[test]
 fn rejects_data_file_colliding_with_generated_name() {
     let dir = tempdir("collide-name");
@@ -575,9 +545,7 @@ fn rejects_data_file_colliding_with_generated_name() {
     assert!(!out.exists(), "no source may be written on rejection");
     assert!(!sidecar.exists(), "no sidecar may be written on rejection");
 
-    // Same collision with a data-less module: the backend emits no sidecar,
-    // so the lone `Main.java` source itself matches the sidecar name and
-    // would be misrouted; it must be rejected identically.
+    // Same collision with a data-less module: the backend emits no sidecar, so the lone `Main.java` source itself matches the sidecar name and would be misrouted; it must be rejected identically.
     let nodata = dir.join("nodata.wat");
     write(&nodata, "(module (func (export \"_start\")))\n");
     let r = run_dewasm(&[
@@ -599,9 +567,7 @@ fn rejects_data_file_colliding_with_generated_name() {
     assert!(!sidecar.exists(), "no sidecar may be written on rejection");
 }
 
-// --------------------------------------------------------------------------
-// Real-app parity (slow: `#[ignore]`d unless `--features slow_test`; also run
-// with --include-ignored).
+// -------------------------------------------------------------------------- Real-app parity (slow: `#[ignore]`d unless `--features slow_test`; also run with --include-ignored).
 
 fn qjs_wasm() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("../../examples/apps/cache/qjs.wasm")

--- a/crates/dewasm-cli/tests/dwarf_line.rs
+++ b/crates/dewasm-cli/tests/dwarf_line.rs
@@ -1,16 +1,8 @@
 //! End-to-end coverage for `--dwarf-line` source back-mapping (ADR-38).
 //!
-//! Semantics-neutrality is the whole contract: the flag adds source-position
-//! markers (Go `//line`, Ruby comments) and changes nothing else. Each case
-//! converts the cached DWARF fixture both with and without the flag, then
-//! asserts (a) the flagged output actually carries fixture markers, (b) it
-//! renders and runs to the same stdout/exit as the plain output, and (c)
-//! stripping the marker lines from the flagged source yields the plain source
-//! byte-for-byte.
+//! Semantics-neutrality is the whole contract: the flag adds source-position markers (Go `//line`, Ruby comments) and changes nothing else. Each case converts the cached DWARF fixture both with and without the flag, then asserts (a) the flagged output actually carries fixture markers, (b) it renders and runs to the same stdout/exit as the plain output, and (c) stripping the marker lines from the flagged source yields the plain source byte-for-byte.
 //!
-//! The Go case additionally pins the two `//line` gotchas: the directive is
-//! emitted at column 1 (Go honors it nowhere else) and never with a `line 0`
-//! (which `go build` rejects).
+//! The Go case additionally pins the two `//line` gotchas: the directive is emitted at column 1 (Go honors it nowhere else) and never with a `line 0` (which `go build` rejects).
 
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
@@ -79,8 +71,7 @@ fn convert(target: &str, out: &Path, dwarf: bool) -> String {
     std::fs::read_to_string(out).unwrap()
 }
 
-/// `go build` a program in its own directory and run it, returning
-/// (stdout, exit code). A missing toolchain fails loud (ADR-15).
+/// `go build` a program in its own directory and run it, returning (stdout, exit code). A missing toolchain fails loud (ADR-15).
 fn run_go(prog: &Path) -> (String, i32) {
     let go =
         find_go().expect("go toolchain not found on PATH (or $DEWASM_GO) — see docs/testing.md");
@@ -123,8 +114,7 @@ fn run_ruby(prog: &Path) -> (String, i32) {
     )
 }
 
-/// Drop the source-line marker lines, so the remainder must equal the plain
-/// (no-flag) output. `is_marker` recognizes a backend's marker line.
+/// Drop the source-line marker lines, so the remainder must equal the plain (no-flag) output. `is_marker` recognizes a backend's marker line.
 fn strip_markers(src: &str, is_marker: impl Fn(&str) -> bool) -> String {
     src.lines()
         .filter(|l| !is_marker(l))
@@ -223,10 +213,7 @@ fn ruby_dwarf_line_markers_are_neutral_and_run() {
     assert_eq!((out_p, code_p), (out_d, code_d));
 }
 
-/// Backends without a marker rendering (Bash, Java, Python here checked for
-/// Python's comment form too) must still accept the flag and convert cleanly —
-/// the flag is universally accepted, semantics-neutral, and simply renders
-/// nothing where a backend opts out (ADR-38).
+/// Backends without a marker rendering (Bash, Java, Python here checked for Python's comment form too) must still accept the flag and convert cleanly — the flag is universally accepted, semantics-neutral, and simply renders nothing where a backend opts out (ADR-38).
 #[test]
 fn dwarf_line_flag_is_accepted_by_all_targets() {
     for target in ["bash", "python", "java"] {

--- a/crates/dewasm-cli/tests/support_docs.rs
+++ b/crates/dewasm-cli/tests/support_docs.rs
@@ -1,8 +1,6 @@
-//! Golden-file gate for docs/support.md (ADR-8): the support matrix is
-//! rendered from the code's own declarations, so the document cannot
-//! drift from reality. Compare-only; regenerate with:
+//! Golden-file gate for docs/support.md (ADR-8): the support matrix is rendered from the code's own declarations, so the document cannot drift from reality. Compare-only; regenerate with:
 //!
-//!     cargo xtask update-support-docs
+//! cargo xtask update-support-docs
 
 use std::path::Path;
 

--- a/crates/dewasm-core/src/bin/feature-audit.rs
+++ b/crates/dewasm-core/src/bin/feature-audit.rs
@@ -1,14 +1,8 @@
-//! Report, per wasm binary, the minimal set of post-baseline proposals it
-//! needs to validate, plus its WASI preview 1 import surface.
+//! Report, per wasm binary, the minimal set of post-baseline proposals it needs to validate, plus its WASI preview 1 import surface.
 //!
-//! This is the ADR-24 app audit gate: before an app is pinned as a
-//! conversion target, run this tool on its binary; an app that needs a
-//! proposal outside the 0.1 scope (wasm 1.0 + the universally-emitted
-//! baseline) is deferred and documented in `docs/apps-audit.md`.
+//! This is the ADR-24 app audit gate: before an app is pinned as a conversion target, run this tool on its binary; an app that needs a proposal outside the 0.1 scope (wasm 1.0 + the universally-emitted baseline) is deferred and documented in `docs/apps-audit.md`.
 //!
-//! Deliberately built on raw `wasmparser::WasmFeatures` bits rather than
-//! the crate's `Feature` enum, so it keeps naming proposals the converter
-//! itself no longer models.
+//! Deliberately built on raw `wasmparser::WasmFeatures` bits rather than the crate's `Feature` enum, so it keeps naming proposals the converter itself no longer models.
 //!
 //! Usage: cargo run -p dewasm-core --bin feature-audit -- <file.wasm>...
 
@@ -17,8 +11,7 @@ use std::process::ExitCode;
 
 use wasmparser::{Parser, Payload, TypeRef, Validator, WasmFeatures};
 
-/// The 0.1 input scope of ADR-24: wasm 1.0 plus the baseline extensions
-/// every current toolchain emits.
+/// The 0.1 input scope of ADR-24: wasm 1.0 plus the baseline extensions every current toolchain emits.
 fn baseline() -> WasmFeatures {
     WasmFeatures::WASM1
         | WasmFeatures::SIGN_EXTENSION
@@ -27,8 +20,7 @@ fn baseline() -> WasmFeatures {
         | WasmFeatures::BULK_MEMORY
 }
 
-/// Every post-baseline proposal this toolchain's validator knows, with
-/// the extra bits it implies (e.g. relaxed-simd needs simd).
+/// Every post-baseline proposal this toolchain's validator knows, with the extra bits it implies (e.g. relaxed-simd needs simd).
 fn proposals() -> Vec<(&'static str, WasmFeatures)> {
     vec![
         ("reference-types", WasmFeatures::REFERENCE_TYPES),
@@ -57,9 +49,7 @@ fn validates(bytes: &[u8], extra: &[(&str, WasmFeatures)]) -> bool {
         .is_ok()
 }
 
-/// Greedy minimization, same shape as `classify_validation_failure` in
-/// `module.rs`: start from all known proposals, drop any whose absence
-/// still validates.
+/// Greedy minimization, same shape as `classify_validation_failure` in `module.rs`: start from all known proposals, drop any whose absence still validates.
 fn minimal_proposals(bytes: &[u8]) -> Option<Vec<&'static str>> {
     let mut active = proposals();
     if !validates(bytes, &active) {
@@ -75,8 +65,7 @@ fn minimal_proposals(bytes: &[u8]) -> Option<Vec<&'static str>> {
     Some(active.into_iter().map(|(name, _)| name).collect())
 }
 
-/// Imports grouped by module, so the WASI p1 surface an app actually uses
-/// is visible next to the feature verdict.
+/// Imports grouped by module, so the WASI p1 surface an app actually uses is visible next to the feature verdict.
 fn import_surface(bytes: &[u8]) -> BTreeMap<String, Vec<String>> {
     let mut by_module: BTreeMap<String, Vec<String>> = BTreeMap::new();
     for payload in Parser::new(0).parse_all(bytes) {
@@ -99,12 +88,7 @@ fn import_surface(bytes: &[u8]) -> BTreeMap<String, Vec<String>> {
     by_module
 }
 
-/// LLVM keeps `call_indirect` immediates as padded (overlong) LEBs when
-/// reference-types is enabled, so wasip1 binaries from clang/zig/rustc
-/// commonly *validate* only with the reference-types bit while using no
-/// construct from the proposal. Distinguish that encoding artifact from a
-/// real use: return a description of the first genuine reference-types
-/// construct, or `None` if the module is MVP-shaped.
+/// LLVM keeps `call_indirect` immediates as padded (overlong) LEBs when reference-types is enabled, so wasip1 binaries from clang/zig/rustc commonly *validate* only with the reference-types bit while using no construct from the proposal. Distinguish that encoding artifact from a real use: return a description of the first genuine reference-types construct, or `None` if the module is MVP-shaped.
 fn first_ref_types_construct(bytes: &[u8]) -> Option<String> {
     use wasmparser::{CompositeInnerType, Operator, ValType};
     let is_ref = |ty: &ValType| matches!(ty, ValType::Ref(_));
@@ -226,8 +210,7 @@ fn audit(path: &str) -> Result<bool, String> {
                     "{name}: needs {} — outside the 0.1 scope",
                     needed.join(", ")
                 );
-                // Name the first offending construct so the audit record can
-                // say *why* the proposal is required, not just that it is.
+                // Name the first offending construct so the audit record can say *why* the proposal is required, not just that it is.
                 if let Err(err) = Validator::new_with_features(baseline()).validate_all(&bytes) {
                     println!("  first offense under baseline: {err}");
                 }
@@ -262,9 +245,7 @@ fn main() -> ExitCode {
             }
         }
     }
-    // Nonzero when any binary needs out-of-scope features, so scripts can
-    // gate on the verdict; the human decision (defer vs. rethink) is
-    // recorded in docs/apps-audit.md.
+    // Nonzero when any binary needs out-of-scope features, so scripts can gate on the verdict; the human decision (defer vs. rethink) is recorded in docs/apps-audit.md.
     if all_clean {
         ExitCode::SUCCESS
     } else {

--- a/crates/dewasm-core/src/data_merge.rs
+++ b/crates/dewasm-core/src/data_merge.rs
@@ -1,40 +1,29 @@
 //! Adjacent active-data-segment merging (ADR-41).
 //!
-//! Toolchains split initialized data across thousands of tiny active segments
-//! (ruby.wasm ships 7871); merging runs of near-adjacent ones into a single
-//! zero-filled blob shrinks every backend's output. Runs at the end of module
-//! building.
+//! Toolchains split initialized data across thousands of tiny active segments (ruby.wasm ships 7871); merging runs of near-adjacent ones into a single zero-filled blob shrinks every backend's output. Runs at the end of module building.
 //!
 //! Four guards keep the rewrite sound; failing any bails the whole pass:
 //!
 //! 1. **No `memory.init`/`data.drop`** — they address segments by index.
-//! 2. **Declaration order is preserved** — segments apply in order, later
-//!    writes win.
-//! 3. **Active `i32.const` segments are ascending and non-overlapping** — so
-//!    no const-offset segment sits inside a zero-filled gap.
-//! 4. **No `global.get` offsets** — such a segment's runtime-unknown target
-//!    could sit inside a gap and be clobbered by the blob's zeros (issue #28).
+//! 2. **Declaration order is preserved** — segments apply in order, later writes win.
+//! 3. **Active `i32.const` segments are ascending and non-overlapping** — so no const-offset segment sits inside a zero-filled gap.
+//! 4. **No `global.get` offsets** — such a segment's runtime-unknown target could sit inside a gap and be clobbered by the blob's zeros (issue #28).
 //!
-//! Passive segments carry no memory effect once guard 1 holds and pass
-//! through without closing a run.
+//! Passive segments carry no memory effect once guard 1 holds and pass through without closing a run.
 
 use crate::ir::{DataSegment, Expr, Module, Stmt};
 
-/// Largest gap worth bridging with zero fill. Tuned to the always-on inline
-/// cost (the core cannot see `GenOptions`), not wasm2go's externalize-only
-/// 4096.
+/// Largest gap worth bridging with zero fill. Tuned to the always-on inline cost (the core cannot see `GenOptions`), not wasm2go's externalize-only 4096.
 const MAX_MERGE_GAP: u64 = 64;
 
 /// Merge runs of adjacent active data segments in `module`, in place.
 pub(crate) fn merge_adjacent_data_segments(module: &mut Module) {
-    // Guard 1: any body that references a segment by index (bulk memory) makes
-    // renumbering unsafe.
+    // Guard 1: any body that references a segment by index (bulk memory) makes renumbering unsafe.
     if module.funcs.iter().any(|f| body_refs_segment(&f.body)) {
         return;
     }
 
-    // Guard 3: the active i32.const segments must be globally ascending and
-    // non-overlapping.
+    // Guard 3: the active i32.const segments must be globally ascending and non-overlapping.
     if !active_const_segments_ascending(&module.datas) {
         return;
     }
@@ -61,8 +50,7 @@ pub(crate) fn merge_adjacent_data_segments(module: &mut Module) {
                     None => run = Some((start, data)),
                     Some((run_start, mut acc)) => {
                         let run_end = run_start + acc.len() as u64;
-                        // Guard 3 guarantees `start >= run_end`; the gap bound
-                        // is the only real merge condition.
+                        // Guard 3 guarantees `start >= run_end`; the gap bound is the only real merge condition.
                         if start >= run_end && start - run_end < MAX_MERGE_GAP {
                             acc.resize(acc.len() + (start - run_end) as usize, 0);
                             acc.extend_from_slice(&data);
@@ -76,8 +64,7 @@ pub(crate) fn merge_adjacent_data_segments(module: &mut Module) {
             }
             // Passive: no standalone memory effect, keep the run open.
             None => out.push(DataSegment { offset: None, data }),
-            // Unreachable under guard 4; kept as an order-preserving
-            // pass-through.
+            // Unreachable under guard 4; kept as an order-preserving pass-through.
             Some(other) => {
                 if let Some((run_start, acc)) = run.take() {
                     out.push(active_segment(run_start, acc));
@@ -104,8 +91,7 @@ fn active_segment(start: u64, data: Vec<u8>) -> DataSegment {
     }
 }
 
-/// Whether any statement (recursing into nested control flow) references a data
-/// segment by index via `memory.init` or `data.drop`.
+/// Whether any statement (recursing into nested control flow) references a data segment by index via `memory.init` or `data.drop`.
 fn body_refs_segment(stmts: &[Stmt]) -> bool {
     stmts.iter().any(|s| match s {
         Stmt::MemoryInit { .. } | Stmt::DataDrop { .. } => true,
@@ -115,9 +101,7 @@ fn body_refs_segment(stmts: &[Stmt]) -> bool {
     })
 }
 
-/// Whether every active `i32.const` segment starts at or after the running
-/// maximum end of all earlier such segments (globally ascending, non-overlapping
-/// in declaration order). `global.get`-offset and passive segments are ignored.
+/// Whether every active `i32.const` segment starts at or after the running maximum end of all earlier such segments (globally ascending, non-overlapping in declaration order). `global.get`-offset and passive segments are ignored.
 fn active_const_segments_ascending(datas: &[DataSegment]) -> bool {
     let mut max_end: u64 = 0;
     for seg in datas {

--- a/crates/dewasm-core/src/debug_line.rs
+++ b/crates/dewasm-core/src/debug_line.rs
@@ -1,6 +1,4 @@
-//! Parse a wasm module's `.debug_line` DWARF program into an
-//! address-to-source-position lookup, for the opt-in `--dwarf-line` back-mapping
-//! (ADR-38). gimli lives here and here only; backends never see it.
+//! Parse a wasm module's `.debug_line` DWARF program into an address-to-source-position lookup, for the opt-in `--dwarf-line` back-mapping (ADR-38). gimli lives here and here only; backends never see it.
 
 use std::collections::HashMap;
 
@@ -11,24 +9,14 @@ use crate::ir::SourcePos;
 
 /// The wasm DWARF code-address convention.
 ///
-/// In a linked wasm binary produced by clang/lld (what `zig cc` emits), a DWARF
-/// code address is the byte offset of the instruction **relative to the start
-/// of the code section's contents**, not an absolute module-file offset. But
-/// `wasmparser`'s `OperatorsReader` reports operator positions as absolute
-/// module-file offsets. So to look a resolved operator up in the line table we
-/// subtract the code section's content start — that is the address base.
+/// In a linked wasm binary produced by clang/lld (what `zig cc` emits), a DWARF code address is the byte offset of the instruction **relative to the start of the code section's contents**, not an absolute module-file offset. But `wasmparser`'s `OperatorsReader` reports operator positions as absolute module-file offsets. So to look a resolved operator up in the line table we subtract the code section's content start — that is the address base.
 ///
-/// This is calibrated, not assumed: the fixture test (ADR-38) asserts that a
-/// known function's directive lands on its real source line, which fails for
-/// any wrong base. Keeping it a single named function makes a re-calibration a
-/// one-line change should a toolchain ever emit a different convention.
+/// This is calibrated, not assumed: the fixture test (ADR-38) asserts that a known function's directive lands on its real source line, which fails for any wrong base. Keeping it a single named function makes a re-calibration a one-line change should a toolchain ever emit a different convention.
 fn address_base(code_section_start: u64) -> u64 {
     code_section_start
 }
 
-/// One decoded line-program row: a code address and the source position that
-/// begins there, or `None` for an `end_sequence` row (an exclusive upper bound
-/// with no mapping).
+/// One decoded line-program row: a code address and the source position that begins there, or `None` for an `end_sequence` row (an exclusive upper bound with no mapping).
 struct Row {
     address: u64,
     pos: Option<SourcePos>,
@@ -44,10 +32,7 @@ pub struct LineTable {
 }
 
 impl LineTable {
-    /// Parse the collected `.debug_*` section blobs (keyed by section name,
-    /// e.g. `.debug_line`). `code_section_start` is the module file offset of
-    /// the code section's contents, used only for address-base calibration.
-    /// Returns `None` when there is no line program to speak of.
+    /// Parse the collected `.debug_*` section blobs (keyed by section name, e.g. `.debug_line`). `code_section_start` is the module file offset of the code section's contents, used only for address-base calibration. Returns `None` when there is no line program to speak of.
     pub fn parse(
         sections: &HashMap<String, Vec<u8>>,
         code_section_start: u64,
@@ -77,11 +62,7 @@ impl LineTable {
             };
             let mut state = program.rows();
             while let Some((header, row)) = state.next_row().context("reading a line-table row")? {
-                // An `end_sequence` boundary, or a row DWARF marks as having no
-                // source line (line 0 — a compiler-generated prologue or
-                // epilogue), maps to nothing: record it as a gap so a lookup
-                // landing there yields no position rather than a bogus `line 0`
-                // directive (which Go's `//line` rejects).
+                // An `end_sequence` boundary, or a row DWARF marks as having no source line (line 0 — a compiler-generated prologue or epilogue), maps to nothing: record it as a gap so a lookup landing there yields no position rather than a bogus `line 0` directive (which Go's `//line` rejects).
                 if row.end_sequence() || row.line().is_none() {
                     rows.push(Row {
                         address: row.address(),
@@ -93,8 +74,7 @@ impl LineTable {
                     continue;
                 };
                 let file = intern(&mut files, &mut files_map, name);
-                // `line().is_none()` (line 0) is handled as a gap above, so a
-                // real row always has a nonzero line here.
+                // `line().is_none()` (line 0) is handled as a gap above, so a real row always has a nonzero line here.
                 let line = row.line().map_or(0, |l| l.get() as u32);
                 let col = match row.column() {
                     gimli::ColumnType::LeftEdge => 0,
@@ -107,10 +87,7 @@ impl LineTable {
             }
         }
 
-        // Rows come per-sequence (already ascending) but sequences and units
-        // are not globally ordered, so sort. At an equal address, order a real
-        // row after an `end_sequence` boundary so a lookup landing exactly on a
-        // sequence start resolves the mapped row, not the preceding gap.
+        // Rows come per-sequence (already ascending) but sequences and units are not globally ordered, so sort. At an equal address, order a real row after an `end_sequence` boundary so a lookup landing exactly on a sequence start resolves the mapped row, not the preceding gap.
         rows.sort_by_key(|r| (r.address, r.pos.is_some()));
 
         Ok(Some(LineTable {
@@ -120,9 +97,7 @@ impl LineTable {
         }))
     }
 
-    /// Resolve a module file offset (an operator's `original_position`) to the
-    /// source position of the greatest line-table row whose address is `<=` it,
-    /// honoring `end_sequence` rows (which map to `None`).
+    /// Resolve a module file offset (an operator's `original_position`) to the source position of the greatest line-table row whose address is `<=` it, honoring `end_sequence` rows (which map to `None`).
     pub fn lookup(&self, module_offset: u64) -> Option<SourcePos> {
         let addr = module_offset.checked_sub(self.base)?;
         let i = self.rows.partition_point(|r| r.address <= addr);
@@ -144,8 +119,7 @@ fn intern(files: &mut Vec<String>, map: &mut HashMap<String, u32>, name: String)
     id
 }
 
-/// Build a file path string from a line-program file entry: its directory
-/// entry joined with the file name (an absolute file name stands alone).
+/// Build a file path string from a line-program file entry: its directory entry joined with the file name (an absolute file name stands alone).
 fn resolve_file(
     dwarf: &gimli::Dwarf<EndianSlice<'_, LittleEndian>>,
     unit: &gimli::Unit<EndianSlice<'_, LittleEndian>>,

--- a/crates/dewasm-core/src/feature.rs
+++ b/crates/dewasm-core/src/feature.rs
@@ -1,8 +1,6 @@
 //! Feature taxonomy for the support matrix (ADR-8).
 //!
-//! Every "unsupported" conversion error is attributed to one or more
-//! `Feature`s so the spec harness can tell declared gaps from regressions,
-//! and so docs/support.md can be generated from code.
+//! Every "unsupported" conversion error is attributed to one or more `Feature`s so the spec harness can tell declared gaps from regressions, and so docs/support.md can be generated from code.
 
 use std::fmt;
 
@@ -10,19 +8,14 @@ use wasmparser::WasmFeatures;
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum Feature {
-    // Wasm 1.0 core capabilities dewasm has not implemented yet
-    // (explicit debt, first in line on the roadmap).
+    // Wasm 1.0 core capabilities dewasm has not implemented yet (explicit debt, first in line on the roadmap).
     ImportedGlobals,
     ImportedMemories,
     ImportedTables,
     MultipleTables,
-    /// The table half of bulk memory: passive/declared element segments,
-    /// expression element items, table.init/copy, elem.drop. (The memory
-    /// half is supported.)
+    /// The table half of bulk memory: passive/declared element segments, expression element items, table.init/copy, elem.drop. (The memory half is supported.)
     TableBulkOps,
-    /// f32/f64 values and operations. Core wasm 1.0, but a backend whose
-    /// language has no usable floats (Bash, until the ADR-5 softfloat
-    /// lands) refuses float-using modules at conversion time.
+    /// f32/f64 values and operations. Core wasm 1.0, but a backend whose language has no usable floats (Bash, until the ADR-5 softfloat lands) refuses float-using modules at conversion time.
     Floats,
     // Post-1.0 proposals.
     ReferenceTypes,
@@ -38,8 +31,7 @@ pub enum Feature {
     ExceptionHandling,
     WideArithmetic,
     CustomPageSizes,
-    /// The component model (and with it WASI preview 2): a layer-1 binary
-    /// wrapping core modules with canonical-ABI adapters.
+    /// The component model (and with it WASI preview 2): a layer-1 binary wrapping core modules with canonical-ABI adapters.
     ComponentModel,
 }
 
@@ -122,9 +114,7 @@ impl Feature {
         }
     }
 
-    /// Validator feature bits that this proposal gates, for attributing
-    /// validation failures. `None` for capabilities that validate fine
-    /// under the base feature set and are rejected during IR building.
+    /// Validator feature bits that this proposal gates, for attributing validation failures. `None` for capabilities that validate fine under the base feature set and are rejected during IR building.
     pub fn validator_bits(self) -> Option<WasmFeatures> {
         Some(match self {
             Feature::FunctionReferences => WasmFeatures::FUNCTION_REFERENCES,
@@ -151,9 +141,7 @@ impl fmt::Display for Feature {
     }
 }
 
-/// A conversion refusal attributed to declared-unsupported features.
-/// Anything the converter rejects *without* this attribution is treated
-/// as a bug by the spec harness.
+/// A conversion refusal attributed to declared-unsupported features. Anything the converter rejects *without* this attribution is treated as a bug by the spec harness.
 #[derive(Debug)]
 pub struct UnsupportedError {
     pub features: Vec<Feature>,

--- a/crates/dewasm-core/src/func.rs
+++ b/crates/dewasm-core/src/func.rs
@@ -1,16 +1,6 @@
-//! Translate a wasm function body (stack machine) into structured IR with
-//! build-time expression folding.
+//! Translate a wasm function body (stack machine) into structured IR with build-time expression folding.
 //!
-//! The operand stack is modeled as a stack of `Slot`s. Each pushed value is
-//! kept as a *pending* expression (with its read/trap `Effects` and node
-//! count) rather than being materialized into a temp immediately. A pending is
-//! spilled to a temp (`sN = <expr>`) only when a later statement's effects
-//! could be observed by it, when it crosses a control-flow boundary, or when a
-//! consumer would grow it past `MAX_FOLD_SIZE` nodes. Single-use values thus
-//! fold directly into their consumer, cutting the statement count for every
-//! backend. Evaluation order and trap points are preserved by the spill
-//! discipline. Dead code after an unconditional branch is skipped while
-//! tracking block nesting only.
+//! The operand stack is modeled as a stack of `Slot`s. Each pushed value is kept as a *pending* expression (with its read/trap `Effects` and node count) rather than being materialized into a temp immediately. A pending is spilled to a temp (`sN = <expr>`) only when a later statement's effects could be observed by it, when it crosses a control-flow boundary, or when a consumer would grow it past `MAX_FOLD_SIZE` nodes. Single-use values thus fold directly into their consumer, cutting the statement count for every backend. Evaluation order and trap points are preserved by the spill discipline. Dead code after an unconditional branch is skipped while tracking block nesting only.
 
 use std::collections::BTreeSet;
 
@@ -24,36 +14,24 @@ use crate::ir::{
 };
 use crate::module::{unsupported, val_type};
 
-/// Node-count cap for a folded expression tree. Once a consumer would build a
-/// tree larger than this, its operands are spilled to temps first. The cap
-/// keeps the generated expressions shallow enough not to blow the recursive
-/// descent parser of any target language (Ruby/Python and friends parse
-/// expressions recursively and have finite stack budgets), and bounds the
-/// worst-case textual blow-up of backends whose inline lowerings duplicate an
-/// operand.
+/// Node-count cap for a folded expression tree. Once a consumer would build a tree larger than this, its operands are spilled to temps first. The cap keeps the generated expressions shallow enough not to blow the recursive descent parser of any target language (Ruby/Python and friends parse expressions recursively and have finite stack budgets), and bounds the worst-case textual blow-up of backends whose inline lowerings duplicate an operand.
 const MAX_FOLD_SIZE: u32 = 32;
 
-/// Whether values fold. Kept as a knob so the pending-stack machinery can be
-/// introduced without behavioral change (every push materializes immediately),
-/// then flipped on once verified. Always `true` in shipped builds.
+/// Whether values fold. Kept as a knob so the pending-stack machinery can be introduced without behavioral change (every push materializes immediately), then flipped on once verified. Always `true` in shipped builds.
 const FOLD: bool = true;
 
-/// Side effects a pending expression carries, used to decide when it must be
-/// spilled before a later statement so it cannot observe that statement's
-/// effect (or so its own trap fires at the right point).
+/// Side effects a pending expression carries, used to decide when it must be spilled before a later statement so it cannot observe that statement's effect (or so its own trap fires at the right point).
 #[derive(Clone, Copy, Default)]
 struct Effects {
     /// Bitmask of read locals with index < 64.
     locals: u64,
-    /// A local with index >= 64 is read (a conservative catch-all so the
-    /// bitmask stays a single word).
+    /// A local with index >= 64 is read (a conservative catch-all so the bitmask stays a single word).
     any_high_local: bool,
     /// Reads a global.
     globals: bool,
     /// Reads memory (a load) or `memory.size`.
     memory: bool,
-    /// May trap (a load, a divide/remainder, or a non-saturating float->int
-    /// truncation).
+    /// May trap (a load, a divide/remainder, or a non-saturating float->int truncation).
     trap: bool,
 }
 
@@ -97,8 +75,7 @@ struct Pending {
     size: u32,
 }
 
-/// One operand-stack slot: its type, and a pending expression when the value
-/// has not been spilled to a temp yet.
+/// One operand-stack slot: its type, and a pending expression when the value has not been spilled to a temp yet.
 struct Slot {
     ty: ValType,
     pending: Option<Pending>,
@@ -106,8 +83,7 @@ struct Slot {
 
 pub struct FuncBuilder<'a> {
     module: &'a ir::Module,
-    /// Type indices of all defined functions (the code section is being
-    /// translated, so `module.funcs` is still incomplete).
+    /// Type indices of all defined functions (the code section is being translated, so `module.funcs` is still incomplete).
     defined_func_types: &'a [u32],
     type_idx: u32,
     /// params ++ declared locals
@@ -118,19 +94,11 @@ pub struct FuncBuilder<'a> {
     temps: BTreeSet<Temp>,
     next_label: u32,
     result: Option<ir::Func>,
-    /// DWARF line table for source back-mapping, when `--dwarf-line` is on
-    /// (ADR-38). `None` leaves the whole marker path inert.
+    /// DWARF line table for source back-mapping, when `--dwarf-line` is on (ADR-38). `None` leaves the whole marker path inert.
     line_table: Option<&'a LineTable>,
-    /// The most recent source position resolved from an operator's offset while
-    /// streaming this body. Updated per operator (holding its last *known* value
-    /// across offsets that map to nothing), then consulted when a statement is
-    /// emitted. Tracking it as operators stream — rather than resolving only the
-    /// emit-triggering operator — is what lets a folded expression (whose
-    /// consuming operator, e.g. the function `end`, may sit on a line-table gap)
-    /// still carry the source line of the operators that built it.
+    /// The most recent source position resolved from an operator's offset while streaming this body. Updated per operator (holding its last *known* value across offsets that map to nothing), then consulted when a statement is emitted. Tracking it as operators stream — rather than resolving only the emit-triggering operator — is what lets a folded expression (whose consuming operator, e.g. the function `end`, may sit on a line-table gap) still carry the source line of the operators that built it.
     cur_pos: Option<SourcePos>,
-    /// The last source position actually emitted as a marker in this function,
-    /// so only change points produce one (per-function: reset for every body).
+    /// The last source position actually emitted as a marker in this function, so only change points produce one (per-function: reset for every body).
     last_pos: Option<SourcePos>,
 }
 
@@ -181,9 +149,7 @@ impl<'a> FuncBuilder<'a> {
         }
     }
 
-    /// Attach the DWARF line table so `emit` injects source-position markers
-    /// (ADR-38). A no-op with `None` (the default), keeping non-`--dwarf-line`
-    /// output byte-identical.
+    /// Attach the DWARF line table so `emit` injects source-position markers (ADR-38). A no-op with `None` (the default), keeping non-`--dwarf-line` output byte-identical.
     pub fn with_line_table(mut self, line_table: Option<&'a LineTable>) -> Self {
         self.line_table = line_table;
         self
@@ -224,11 +190,7 @@ impl<'a> FuncBuilder<'a> {
         self.cur().stmts.push(stmt);
     }
 
-    /// Resolve `offset` (an operator's module-file position) against the line
-    /// table and remember it as the current source position, so the next
-    /// emitted statement can be annotated. An offset that maps to nothing (a
-    /// line-table gap or `end_sequence` boundary) leaves the last known position
-    /// in place rather than clearing it. A no-op without a line table (ADR-38).
+    /// Resolve `offset` (an operator's module-file position) against the line table and remember it as the current source position, so the next emitted statement can be annotated. An offset that maps to nothing (a line-table gap or `end_sequence` boundary) leaves the last known position in place rather than clearing it. A no-op without a line table (ADR-38).
     fn track_source_pos(&mut self, offset: usize) {
         let Some(table) = self.line_table else {
             return;
@@ -238,11 +200,7 @@ impl<'a> FuncBuilder<'a> {
         }
     }
 
-    /// The [`Stmt::SourceLine`] marker to place before the statement about to be
-    /// emitted, or `None` when the current source position is unchanged from the
-    /// last marker emitted (change points only) or back-mapping is off (ADR-38).
-    /// The caller pushes the returned marker; the two emit paths (`emit` and the
-    /// function's fallthrough return) share this so both are annotated.
+    /// The [`Stmt::SourceLine`] marker to place before the statement about to be emitted, or `None` when the current source position is unchanged from the last marker emitted (change points only) or back-mapping is off (ADR-38). The caller pushes the returned marker; the two emit paths (`emit` and the function's fallthrough return) share this so both are annotated.
     fn source_marker(&mut self) -> Option<Stmt> {
         self.line_table?;
         let pos = self.cur_pos?;
@@ -253,9 +211,7 @@ impl<'a> FuncBuilder<'a> {
         Some(Stmt::SourceLine(pos))
     }
 
-    /// Push a materialized value: allocate a temp for the top slot and record
-    /// it in `self.temps`. Used for values that are never folded (call
-    /// results, `memory.grow`) and by `spill`.
+    /// Push a materialized value: allocate a temp for the top slot and record it in `self.temps`. Used for values that are never folded (call results, `memory.grow`) and by `spill`.
     fn push_temp(&mut self, ty: ValType) -> Temp {
         let temp = Temp {
             depth: self.stack.len() as u32,
@@ -278,8 +234,7 @@ impl<'a> FuncBuilder<'a> {
         }
     }
 
-    /// Pop the top slot as an expression: its pending expression if any, else
-    /// a reference to the temp it was materialized into.
+    /// Pop the top slot as an expression: its pending expression if any, else a reference to the temp it was materialized into.
     fn pop_expr(&mut self) -> (Expr, Effects, u32) {
         let slot = self.stack.pop().expect("value stack is not empty");
         match slot.pending {
@@ -303,8 +258,7 @@ impl<'a> FuncBuilder<'a> {
         self.stack[idx].pending.as_ref().is_some_and(|p| p.fx.trap)
     }
 
-    /// Materialize the pending value at stack index `idx` into its temp,
-    /// emitting the assignment. A no-op if already materialized.
+    /// Materialize the pending value at stack index `idx` into its temp, emitting the assignment. A no-op if already materialized.
     fn spill(&mut self, idx: usize) {
         let ty = self.stack[idx].ty;
         if let Some(p) = self.stack[idx].pending.take() {
@@ -320,9 +274,7 @@ impl<'a> FuncBuilder<'a> {
         }
     }
 
-    /// Spill every pending whose effects match `pred`, in ascending depth
-    /// order (= wasm evaluation order, so their statements and traps land in
-    /// the right sequence).
+    /// Spill every pending whose effects match `pred`, in ascending depth order (= wasm evaluation order, so their statements and traps land in the right sequence).
     fn spill_if(&mut self, pred: impl Fn(&Effects) -> bool) {
         for idx in 0..self.stack.len() {
             let hit = match &self.stack[idx].pending {
@@ -403,8 +355,7 @@ impl<'a> FuncBuilder<'a> {
     fn store(&mut self, op: StoreOp, memarg: &wasmparser::MemArg) {
         let (value, _, _) = self.pop_expr();
         let (addr, _, _) = self.pop_expr();
-        // The store writes memory; earlier memory reads and pending traps must
-        // be resolved first.
+        // The store writes memory; earlier memory reads and pending traps must be resolved first.
         self.spill_if(|fx| fx.memory || fx.trap);
         self.emit(Stmt::Store {
             op,
@@ -415,10 +366,7 @@ impl<'a> FuncBuilder<'a> {
     }
 
     fn select(&mut self) {
-        // Stack: [then, els, cond] with cond on top. The backends lower Select
-        // to a conditionally-evaluated ternary, so a trapping then/els arm
-        // (which wasm evaluates eagerly) must be spilled to keep its trap. The
-        // cond folds freely.
+        // Stack: [then, els, cond] with cond on top. The backends lower Select to a conditionally-evaluated ternary, so a trapping then/els arm (which wasm evaluates eagerly) must be spilled to keep its trap. The cond folds freely.
         let n = self.stack.len();
         let cond_i = n - 1;
         let els_i = n - 2;
@@ -493,10 +441,7 @@ impl<'a> FuncBuilder<'a> {
         &self.module.types[ty_idx as usize]
     }
 
-    /// Resolve a branch depth into a target, computing the moves from the
-    /// current stack top into the target frame's result (or loop param)
-    /// slots. Marks the target label as referenced. The caller must have
-    /// spilled the stack first, so the sources read from materialized temps.
+    /// Resolve a branch depth into a target, computing the moves from the current stack top into the target frame's result (or loop param) slots. Marks the target label as referenced. The caller must have spilled the stack first, so the sources read from materialized temps.
     fn branch_target(&mut self, relative_depth: u32) -> BrTarget {
         let idx = self.frames.len() - 1 - relative_depth as usize;
         let (arity_tys, base, is_loop, is_func, label_id) = {
@@ -555,9 +500,7 @@ impl<'a> FuncBuilder<'a> {
     }
 
     fn handle_else(&mut self) {
-        // Materialize the then-branch's fallthrough values (into the frame's
-        // result slots) before capturing its body. Skipped when the then
-        // branch ended unreachable (its stack shape is stale).
+        // Materialize the then-branch's fallthrough values (into the frame's result slots) before capturing its body. Skipped when the then branch ended unreachable (its stack shape is stale).
         if !self.cur().unreachable {
             self.spill_all();
         }
@@ -578,9 +521,7 @@ impl<'a> FuncBuilder<'a> {
     }
 
     fn handle_end(&mut self) {
-        // Spill the frame's live values into its own body before it is popped
-        // (so control-boundary-crossing temps are materialized). The function
-        // frame folds its fallthrough return instead.
+        // Spill the frame's live values into its own body before it is popped (so control-boundary-crossing temps are materialized). The function frame folds its fallthrough return instead.
         let is_func = matches!(self.cur().kind, FrameKind::Func);
         if !self.cur().entered_dead && !self.cur().unreachable && !is_func {
             self.spill_all();
@@ -588,8 +529,7 @@ impl<'a> FuncBuilder<'a> {
 
         let frame = self.frames.pop().expect("frame stack is not empty");
         if frame.entered_dead {
-            // The whole frame was dead code; the parent stays unreachable and
-            // the stack was never touched.
+            // The whole frame was dead code; the parent stays unreachable and the stack was never touched.
             return;
         }
 
@@ -602,9 +542,7 @@ impl<'a> FuncBuilder<'a> {
                     for i in (0..arity).rev() {
                         values[i] = self.pop_expr().0;
                     }
-                    // The fallthrough return does not route through `emit`, so
-                    // annotate it here too (ADR-38); folded bodies frequently
-                    // collapse to just this statement.
+                    // The fallthrough return does not route through `emit`, so annotate it here too (ADR-38); folded bodies frequently collapse to just this statement.
                     if let Some(marker) = self.source_marker() {
                         body.push(marker);
                     }
@@ -620,8 +558,7 @@ impl<'a> FuncBuilder<'a> {
                 });
             }
             kind => {
-                // Fallthrough values already live at the result slots; formally
-                // rebuild the stack shape for the parent frame.
+                // Fallthrough values already live at the result slots; formally rebuild the stack shape for the parent frame.
                 self.stack.truncate(frame.base);
                 for ty in &frame.results {
                     self.push_temp(*ty);
@@ -713,8 +650,7 @@ impl<'a> FuncBuilder<'a> {
             // -- control flow
             Operator::Nop => {}
             Operator::Unreachable => {
-                // A pending OOB load must trap with its own message before the
-                // "unreachable" trap, so resolve trapping pendings first.
+                // A pending OOB load must trap with its own message before the "unreachable" trap, so resolve trapping pendings first.
                 self.spill_if(|fx| fx.trap);
                 self.emit(Stmt::Unreachable);
                 self.cur().unreachable = true;
@@ -747,9 +683,7 @@ impl<'a> FuncBuilder<'a> {
             Operator::Br { relative_depth } => {
                 let idx = self.frames.len() - 1 - relative_depth as usize;
                 if matches!(self.frames[idx].kind, FrameKind::Func) {
-                    // A branch to the function frame is a return: fold the
-                    // values, but first flush any deeper trapping pending that
-                    // wasm would have evaluated before the branch.
+                    // A branch to the function frame is a return: fold the values, but first flush any deeper trapping pending that wasm would have evaluated before the branch.
                     let arity = self.frames[idx].results.len();
                     let mut values = vec![Expr::I32Const(0); arity];
                     for i in (0..arity).rev() {
@@ -766,10 +700,7 @@ impl<'a> FuncBuilder<'a> {
             }
             Operator::BrIf { relative_depth } => {
                 let (cond, _, _) = self.pop_expr();
-                // A not-taken br_if must leave the operands reusable, and
-                // branch_target reads them at canonical depths, so materialize
-                // the whole stack. Return values are not folded under br_if
-                // (the not-taken path would double-consume them).
+                // A not-taken br_if must leave the operands reusable, and branch_target reads them at canonical depths, so materialize the whole stack. Return values are not folded under br_if (the not-taken path would double-consume them).
                 self.spill_all();
                 let target = self.branch_target(relative_depth);
                 self.emit(Stmt::BrIf { cond, target });
@@ -801,9 +732,7 @@ impl<'a> FuncBuilder<'a> {
             }
             Operator::Call { function_index } => {
                 let ty = self.func_type_of(function_index).clone();
-                // A call can read/write globals and memory and can trap;
-                // pending values that observe any of those must be spilled.
-                // Pure-local args survive and fold into the call.
+                // A call can read/write globals and memory and can trap; pending values that observe any of those must be spilled. Pure-local args survive and fold into the call.
                 self.spill_if(|fx| fx.globals || fx.memory || fx.trap);
                 let mut args = vec![Expr::I32Const(0); ty.params.len()];
                 for i in (0..ty.params.len()).rev() {
@@ -821,10 +750,7 @@ impl<'a> FuncBuilder<'a> {
                 table_index,
                 ..
             } => {
-                // Spill effectful operands (and deeper pendings) first: this
-                // both preserves wasm order and makes the remaining index/arg
-                // fragments pure, so a backend that evaluates the index before
-                // the args cannot reorder an observable effect.
+                // Spill effectful operands (and deeper pendings) first: this both preserves wasm order and makes the remaining index/arg fragments pure, so a backend that evaluates the index before the args cannot reorder an observable effect.
                 self.spill_if(|fx| fx.globals || fx.memory || fx.trap);
                 let ty = self.module.types[type_index as usize].clone();
                 let (index, _, _) = self.pop_expr();
@@ -842,8 +768,7 @@ impl<'a> FuncBuilder<'a> {
                 });
             }
             Operator::Drop => {
-                // A dropped value with a pending trap must still evaluate so
-                // the trap fires; a pure one is simply discarded.
+                // A dropped value with a pending trap must still evaluate so the trap fires; a pure one is simply discarded.
                 let top = self.stack.len() - 1;
                 if self.slot_traps(top) {
                     self.spill(top);
@@ -851,8 +776,7 @@ impl<'a> FuncBuilder<'a> {
                 self.pop_expr();
             }
             Operator::TypedSelect { ty } => {
-                // A numeric typed select is just an annotated select; a
-                // ref-typed one is a reference-types construct (ADR-24).
+                // A numeric typed select is just an annotated select; a ref-typed one is a reference-types construct (ADR-24).
                 val_type(ty)?;
                 self.select();
             }
@@ -870,8 +794,7 @@ impl<'a> FuncBuilder<'a> {
             }
             Operator::LocalSet { local_index } => {
                 let (value, _, _) = self.pop_expr();
-                // Earlier pendings that read this local must observe its old
-                // value, so spill them before the assignment.
+                // Earlier pendings that read this local must observe its old value, so spill them before the assignment.
                 self.spill_if(|fx| fx.reads_local(local_index));
                 self.emit(Stmt::LocalSet {
                     idx: local_index,
@@ -886,8 +809,7 @@ impl<'a> FuncBuilder<'a> {
                     idx: local_index,
                     expr: value,
                 });
-                // The value stays on the stack; a later `local.set` on the
-                // same local spills this via the reads-local rule.
+                // The value stays on the stack; a later `local.set` on the same local spills this via the reads-local rule.
                 self.push_pending(
                     ty,
                     Expr::LocalGet(local_index),
@@ -905,8 +827,7 @@ impl<'a> FuncBuilder<'a> {
             }
             Operator::GlobalSet { global_index } => {
                 let (value, _, _) = self.pop_expr();
-                // Post-trap global state is observable (the spec asserts it),
-                // so spill both global reads and trapping pendings first.
+                // Post-trap global state is observable (the spec asserts it), so spill both global reads and trapping pendings first.
                 self.spill_if(|fx| fx.globals || fx.trap);
                 self.emit(Stmt::GlobalSet {
                     idx: global_index,
@@ -1013,9 +934,7 @@ impl<'a> FuncBuilder<'a> {
                 self.emit(Stmt::ElemDrop { seg: elem_index });
             }
 
-            // -- reference types: the validator tolerates the encoding
-            // (features() keeps the bit for overlong call_indirect
-            // immediates), but every actual construct is rejected (ADR-24).
+            // -- reference types: the validator tolerates the encoding (features() keeps the bit for overlong call_indirect immediates), but every actual construct is rejected (ADR-24).
             Operator::RefNull { .. }
             | Operator::RefFunc { .. }
             | Operator::RefIsNull
@@ -1216,8 +1135,7 @@ fn bin_traps(op: BinOp) -> bool {
     )
 }
 
-/// Unary ops that may trap: the non-saturating float->int truncations (the
-/// saturating `*_sat_*` forms do not trap).
+/// Unary ops that may trap: the non-saturating float->int truncations (the saturating `*_sat_*` forms do not trap).
 fn un_traps(op: UnOp) -> bool {
     use UnOp::*;
     matches!(
@@ -1233,10 +1151,7 @@ fn un_traps(op: UnOp) -> bool {
     )
 }
 
-/// Attribute an untranslated operator to a feature. Operators gated by
-/// validator features never reach this point; what does reach it are the
-/// families our base validation accepts — an unclassified operator here is
-/// a dewasm bug and the spec harness treats it as such.
+/// Attribute an untranslated operator to a feature. Operators gated by validator features never reach this point; what does reach it are the families our base validation accepts — an unclassified operator here is a dewasm bug and the spec harness treats it as such.
 fn classify_op(name: &str) -> Option<Feature> {
     let starts = |prefixes: &[&str]| prefixes.iter().any(|p| name.starts_with(p));
     if starts(&[

--- a/crates/dewasm-core/src/ir.rs
+++ b/crates/dewasm-core/src/ir.rs
@@ -1,11 +1,6 @@
 //! Intermediate representation of a wasm module.
 //!
-//! The IR keeps wasm's structured control flow (block/loop/if/br) as-is and
-//! flattens the value stack into "temps": one variable per (stack depth, type)
-//! pair, in the style of wasm2c. Every value-producing instruction is
-//! materialized into a temp assignment, which keeps evaluation order and trap
-//! points trivially correct. Expression folding for readability is a future
-//! optimization pass.
+//! The IR keeps wasm's structured control flow (block/loop/if/br) as-is and flattens the value stack into "temps": one variable per (stack depth, type) pair, in the style of wasm2c. Every value-producing instruction is materialized into a temp assignment, which keeps evaluation order and trap points trivially correct. Expression folding for readability is a future optimization pass.
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, PartialOrd, Ord)]
 pub enum ValType {
@@ -13,14 +8,11 @@ pub enum ValType {
     I64,
     F32,
     F64,
-    /// A nullable reference to a wasm function. Legal only as a table
-    /// element type (ADR-16 table bulk ops); reference types used as value
-    /// types are rejected at conversion time (ADR-24).
+    /// A nullable reference to a wasm function. Legal only as a table element type (ADR-16 table bulk ops); reference types used as value types are rejected at conversion time (ADR-24).
     FuncRef,
 }
 
-/// A flattened stack slot. `depth` is the value-stack depth the value lives
-/// at; the same (depth, ty) pair always maps to the same target variable.
+/// A flattened stack slot. `depth` is the value-stack depth the value lives at; the same (depth, ty) pair always maps to the same target variable.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, PartialOrd, Ord)]
 pub struct Temp {
     pub depth: u32,
@@ -51,9 +43,7 @@ pub struct Module {
     pub elems: Vec<ElemSegment>,
     pub datas: Vec<DataSegment>,
     pub start: Option<u32>,
-    /// Interned source file paths referenced by [`Stmt::SourceLine`] markers,
-    /// indexed by [`SourcePos::file`]. Empty unless DWARF line back-mapping was
-    /// requested (`BuildOptions::debug_line`, ADR-38).
+    /// Interned source file paths referenced by [`Stmt::SourceLine`] markers, indexed by [`SourcePos::file`]. Empty unless DWARF line back-mapping was requested (`BuildOptions::debug_line`, ADR-38).
     pub debug_files: Vec<String>,
 }
 
@@ -167,8 +157,7 @@ pub enum ElemKind {
     Active { table_index: u32, offset: Expr },
     /// Retained for `table.init`; droppable.
     Passive,
-    /// Never copied into a table (only makes `ref.func` targets valid
-    /// under reference-types validation); droppable, otherwise inert.
+    /// Never copied into a table (only makes `ref.func` targets valid under reference-types validation); droppable, otherwise inert.
     Declared,
 }
 
@@ -209,8 +198,7 @@ pub struct Func {
 #[derive(Clone, Copy, Debug)]
 pub struct Label {
     pub id: u32,
-    /// Whether any `br` targets this label. Unreferenced labels need no
-    /// branch machinery in backends.
+    /// Whether any `br` targets this label. Unreferenced labels need no branch machinery in backends.
     pub referenced: bool,
 }
 
@@ -219,9 +207,7 @@ pub struct Label {
 pub enum BrTarget {
     /// Branch to the function's outermost frame == return.
     Return { values: Vec<Expr> },
-    /// Branch to a labelled frame. `assigns` moves the branch operands into
-    /// the frame's result temps (or param temps for loops); self-assignments
-    /// are already filtered out.
+    /// Branch to a labelled frame. `assigns` moves the branch operands into the frame's result temps (or param temps for loops); self-assignments are already filtered out.
     Label {
         label: u32,
         /// true: continue the loop; false: exit the block/if.
@@ -230,9 +216,7 @@ pub enum BrTarget {
     },
 }
 
-/// A resolved source position, indexing [`Module::debug_files`]. Carried by
-/// [`Stmt::SourceLine`] markers for DWARF line back-mapping (ADR-38); a `col`
-/// of 0 means the column is unknown (DWARF's "left edge").
+/// A resolved source position, indexing [`Module::debug_files`]. Carried by [`Stmt::SourceLine`] markers for DWARF line back-mapping (ADR-38); a `col` of 0 means the column is unknown (DWARF's "left edge").
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct SourcePos {
     pub file: u32,
@@ -242,10 +226,7 @@ pub struct SourcePos {
 
 #[derive(Debug)]
 pub enum Stmt {
-    /// A source-position marker emitted just before the statement it annotates
-    /// when DWARF line back-mapping is on (ADR-38). Semantically inert: a
-    /// backend renders it as a position directive/comment or drops it, and its
-    /// presence never changes the surrounding statements' meaning.
+    /// A source-position marker emitted just before the statement it annotates when DWARF line back-mapping is on (ADR-38). Semantically inert: a backend renders it as a position directive/comment or drops it, and its presence never changes the surrounding statements' meaning.
     SourceLine(SourcePos),
     Assign {
         dst: Temp,

--- a/crates/dewasm-core/src/lib.rs
+++ b/crates/dewasm-core/src/lib.rs
@@ -1,5 +1,4 @@
-//! dewasm-core: decode + validate wasm binaries and build the structured
-//! IR shared by all language backends.
+//! dewasm-core: decode + validate wasm binaries and build the structured IR shared by all language backends.
 
 pub mod feature;
 pub mod ir;

--- a/crates/dewasm-core/src/module.rs
+++ b/crates/dewasm-core/src/module.rs
@@ -13,12 +13,10 @@ use crate::feature::{Feature, UnsupportedError};
 use crate::func::FuncBuilder;
 use crate::ir;
 
-/// Knobs for [`build_module_with_options`]. Defaults reproduce
-/// [`build_module`] exactly, so every existing call site is byte-identical.
+/// Knobs for [`build_module_with_options`]. Defaults reproduce [`build_module`] exactly, so every existing call site is byte-identical.
 #[derive(Debug, Default, Clone)]
 pub struct BuildOptions {
-    /// Parse `.debug_*` custom sections and emit [`ir::Stmt::SourceLine`]
-    /// markers at source-line change points (ADR-38). Off by default.
+    /// Parse `.debug_*` custom sections and emit [`ir::Stmt::SourceLine`] markers at source-line change points (ADR-38). Off by default.
     pub debug_line: bool,
 }
 
@@ -26,15 +24,7 @@ pub(crate) fn unsupported(feature: Feature, detail: impl Into<String>) -> anyhow
     UnsupportedError::new(feature, detail).into()
 }
 
-/// Wasm feature set accepted by the core converter: Wasm 1.0 plus the
-/// universally-emitted baseline (sign-extension, saturating truncation,
-/// multi-value, bulk memory). The `REFERENCE_TYPES` bit is kept purely as
-/// an *encoding relaxation* (ADR-24): LLVM toolchains emit overlong
-/// `call_indirect` immediates when the reference-types target feature is
-/// on, so real wasip1 binaries only validate with the bit — but every
-/// actual reference-types construct is rejected during IR building.
-/// Whether a specific backend lowers a construct is its own declaration
-/// (`check_module_support`).
+/// Wasm feature set accepted by the core converter: Wasm 1.0 plus the universally-emitted baseline (sign-extension, saturating truncation, multi-value, bulk memory). The `REFERENCE_TYPES` bit is kept purely as an *encoding relaxation* (ADR-24): LLVM toolchains emit overlong `call_indirect` immediates when the reference-types target feature is on, so real wasip1 binaries only validate with the bit — but every actual reference-types construct is rejected during IR building. Whether a specific backend lowers a construct is its own declaration (`check_module_support`).
 pub fn features() -> WasmFeatures {
     WasmFeatures::WASM1
         | WasmFeatures::SIGN_EXTENSION
@@ -44,10 +34,7 @@ pub fn features() -> WasmFeatures {
         | WasmFeatures::REFERENCE_TYPES
 }
 
-/// Whether `bytes` is a component-model binary (layer 1) rather than a core
-/// module (layer 0). Core modules carry version 1 / layer 0 in bytes 4..8;
-/// components use layer 1 (`[.., 0x01, 0x00]`). Used to reject components
-/// with a clear error (ADR-24).
+/// Whether `bytes` is a component-model binary (layer 1) rather than a core module (layer 0). Core modules carry version 1 / layer 0 in bytes 4..8; components use layer 1 (`[.., 0x01, 0x00]`). Used to reject components with a clear error (ADR-24).
 pub fn is_component(bytes: &[u8]) -> bool {
     bytes.len() >= 8 && bytes[0..4] == *b"\0asm" && bytes[6..8] == [0x01, 0x00]
 }
@@ -56,11 +43,7 @@ pub fn build_module(bytes: &[u8]) -> Result<ir::Module> {
     build_module_with_options(bytes, &BuildOptions::default())
 }
 
-/// Pre-pass (only when DWARF line back-mapping is requested): scan the payloads
-/// for `.debug_*` custom sections and the code section's content start, then
-/// build the line table. It runs before the main loop because `.debug_line`
-/// custom sections normally appear *after* the code section, so the table must
-/// exist before any function body is translated.
+/// Pre-pass (only when DWARF line back-mapping is requested): scan the payloads for `.debug_*` custom sections and the code section's content start, then build the line table. It runs before the main loop because `.debug_line` custom sections normally appear *after* the code section, so the table must exist before any function body is translated.
 fn collect_line_table(bytes: &[u8]) -> Result<Option<LineTable>> {
     let mut debug_sections: HashMap<String, Vec<u8>> = HashMap::new();
     let mut code_section_start: u64 = 0;
@@ -80,9 +63,7 @@ fn collect_line_table(bytes: &[u8]) -> Result<Option<LineTable>> {
 
 pub fn build_module_with_options(bytes: &[u8], options: &BuildOptions) -> Result<ir::Module> {
     if let Err(err) = Validator::new_with_features(features()).validate_all(bytes) {
-        // Attribute the refusal to the proposals whose validator features
-        // would make the module validate (ADR-8); an empty feature list
-        // means "newer than this toolchain knows".
+        // Attribute the refusal to the proposals whose validator features would make the module validate (ADR-8); an empty feature list means "newer than this toolchain knows".
         let needed = classify_validation_failure(bytes).unwrap_or_default();
         return Err(anyhow::Error::new(UnsupportedError {
             features: needed,
@@ -90,8 +71,7 @@ pub fn build_module_with_options(bytes: &[u8], options: &BuildOptions) -> Result
         }));
     }
 
-    // Build the DWARF line table up front (pre-pass), so every function body
-    // can resolve its operator offsets while translating (ADR-38).
+    // Build the DWARF line table up front (pre-pass), so every function body can resolve its operator offsets while translating (ADR-38).
     let line_table = if options.debug_line {
         collect_line_table(bytes)?
     } else {
@@ -352,17 +332,13 @@ pub fn build_module_with_options(bytes: &[u8], options: &BuildOptions) -> Result
         }
     }
 
-    // Collapse runs of adjacent active data segments into single blobs
-    // (ADR-41). Semantics-preserving and unconditional: every backend emits one
-    // initializer per active segment, so the reduction composes downstream.
+    // Collapse runs of adjacent active data segments into single blobs (ADR-41). Semantics-preserving and unconditional: every backend emits one initializer per active segment, so the reduction composes downstream.
     crate::data_merge::merge_adjacent_data_segments(&mut module);
 
     Ok(module)
 }
 
-/// Find the minimal set of known proposals that makes `bytes` validate,
-/// or `None` if even all of them do not suffice (the module is newer than
-/// this toolchain, or genuinely malformed).
+/// Find the minimal set of known proposals that makes `bytes` validate, or `None` if even all of them do not suffice (the module is newer than this toolchain, or genuinely malformed).
 fn classify_validation_failure(bytes: &[u8]) -> Option<Vec<Feature>> {
     let candidates: Vec<Feature> = Feature::ALL
         .iter()
@@ -392,10 +368,7 @@ fn classify_validation_failure(bytes: &[u8]) -> Option<Vec<Feature>> {
     Some(active)
 }
 
-/// Map a wasm value type (as it appears in signatures, locals, globals, and
-/// block types) to the IR. Reference types are never legal as *value* types
-/// (ADR-24): funcref stays representable only via `table_elem_type` for a
-/// table's element typing; any reference type here is rejected.
+/// Map a wasm value type (as it appears in signatures, locals, globals, and block types) to the IR. Reference types are never legal as *value* types (ADR-24): funcref stays representable only via `table_elem_type` for a table's element typing; any reference type here is rejected.
 pub(crate) fn val_type(ty: wasmparser::ValType) -> Result<ir::ValType> {
     Ok(match ty {
         wasmparser::ValType::I32 => ir::ValType::I32,
@@ -420,9 +393,7 @@ pub(crate) fn val_type(ty: wasmparser::ValType) -> Result<ir::ValType> {
     })
 }
 
-/// Map a table's element type to the IR. Only funcref tables are supported
-/// (ADR-16); externref (and every other reference type) is rejected with
-/// the proposal that introduced it (ADR-24).
+/// Map a table's element type to the IR. Only funcref tables are supported (ADR-16); externref (and every other reference type) is rejected with the proposal that introduced it (ADR-24).
 pub(crate) fn table_elem_type(r: &wasmparser::RefType) -> Result<ir::ValType> {
     if *r == wasmparser::RefType::FUNCREF {
         return Ok(ir::ValType::FuncRef);
@@ -438,8 +409,7 @@ pub(crate) fn table_elem_type(r: &wasmparser::RefType) -> Result<ir::ValType> {
 pub(crate) fn heap_type_feature(hty: &wasmparser::HeapType) -> Feature {
     use wasmparser::AbstractHeapType as A;
     match hty {
-        // Non-nullable/exact forms of these reach here (the nullable ones
-        // are handled before); those come from typed function references.
+        // Non-nullable/exact forms of these reach here (the nullable ones are handled before); those come from typed function references.
         wasmparser::HeapType::Abstract {
             ty: A::Func | A::Extern,
             ..
@@ -455,12 +425,7 @@ pub(crate) fn heap_type_feature(hty: &wasmparser::HeapType) -> Feature {
     }
 }
 
-/// Evaluate a constant expression: a plain constant, or (MVP rule) a
-/// `global.get` of an imported immutable global — the validator already
-/// enforces that constraint, so the index is used as-is. Reference
-/// constants only appear in element items (`elem_item_expr`); a global
-/// whose init is a reference constant is rejected earlier by `val_type`
-/// refusing its ref-typed content type.
+/// Evaluate a constant expression: a plain constant, or (MVP rule) a `global.get` of an imported immutable global — the validator already enforces that constraint, so the index is used as-is. Reference constants only appear in element items (`elem_item_expr`); a global whose init is a reference constant is rejected earlier by `val_type` refusing its ref-typed content type.
 fn const_expr(expr: &ConstExpr<'_>) -> Result<ir::Expr> {
     let mut reader = expr.get_operators_reader();
     let value = match reader.read()? {
@@ -485,10 +450,7 @@ fn const_expr_unsupported(op: &Operator<'_>) -> anyhow::Error {
     )
 }
 
-/// One item of an expression-encoded element segment: `ref.func $i`,
-/// `ref.null` (an intentionally-empty slot), or `global.get $i` of a
-/// ref-typed immutable global. Anything else comes from extended constant
-/// expressions (or a proposal the validator would have refused first).
+/// One item of an expression-encoded element segment: `ref.func $i`, `ref.null` (an intentionally-empty slot), or `global.get $i` of a ref-typed immutable global. Anything else comes from extended constant expressions (or a proposal the validator would have refused first).
 fn elem_item_expr(expr: &ConstExpr<'_>) -> Result<ir::ElemItem> {
     let mut reader = expr.get_operators_reader();
     let value = match reader.read()? {

--- a/crates/dewasm-core/tests/data_merge.rs
+++ b/crates/dewasm-core/tests/data_merge.rs
@@ -1,7 +1,4 @@
-//! The adjacent active-data-segment merging pass (ADR-41): assert the
-//! `module.datas` shape the pass produces from small wat inputs — merged runs,
-//! zero-filled gaps, the gap threshold, and every bail condition (bulk-memory
-//! ops, overlapping/descending offsets, `global.get` offsets).
+//! The adjacent active-data-segment merging pass (ADR-41): assert the `module.datas` shape the pass produces from small wat inputs — merged runs, zero-filled gaps, the gap threshold, and every bail condition (bulk-memory ops, overlapping/descending offsets, `global.get` offsets).
 
 use dewasm_core::build_module;
 use dewasm_core::ir::{DataSegment, Expr, Module};
@@ -22,9 +19,7 @@ fn const_offset(seg: &DataSegment) -> Option<u64> {
 
 #[test]
 fn adjacent_segments_merge_with_zero_filled_gap() {
-    // Two active segments at 0 (`ab`) and 4 (`cd`) with a 2-byte hole: they sit
-    // within the 64-byte threshold, so they collapse into one blob at offset 0
-    // whose gap is zero-filled.
+    // Two active segments at 0 (`ab`) and 4 (`cd`) with a 2-byte hole: they sit within the 64-byte threshold, so they collapse into one blob at offset 0 whose gap is zero-filled.
     let m = module(
         r#"(module (memory 1)
             (data (i32.const 0) "ab")
@@ -49,8 +44,7 @@ fn touching_segments_merge_without_a_gap() {
 
 #[test]
 fn gap_at_or_above_threshold_keeps_segments_separate() {
-    // The second segment starts 64 bytes past the end of the first (exactly the
-    // threshold, which is exclusive), so no merge happens.
+    // The second segment starts 64 bytes past the end of the first (exactly the threshold, which is exclusive), so no merge happens.
     let m = module(
         r#"(module (memory 1)
             (data (i32.const 0) "ab")
@@ -65,9 +59,7 @@ fn gap_at_or_above_threshold_keeps_segments_separate() {
 
 #[test]
 fn global_get_offset_bails_the_whole_pass() {
-    // A `global.get` offset writes to a runtime-unknown address, so its
-    // presence anywhere bails the pass: nothing merges, everything passes
-    // through unchanged.
+    // A `global.get` offset writes to a runtime-unknown address, so its presence anywhere bails the pass: nothing merges, everything passes through unchanged.
     let m = module(
         r#"(module
             (import "env" "base" (global $base i32))
@@ -95,11 +87,7 @@ fn global_get_offset_bails_the_whole_pass() {
 
 #[test]
 fn global_get_before_mergeable_consts_bails_the_whole_pass() {
-    // Issue #28 regression. With `base = 4` at instantiation, "XX" lands at
-    // 4..6 — inside the 2..8 gap that merging the two const segments would
-    // zero-fill. The merged blob is emitted *after* the global.get segment,
-    // so its zeros would clobber "XX". The pass must therefore leave every
-    // segment untouched, keeping the final memory image identical.
+    // Issue #28 regression. With `base = 4` at instantiation, "XX" lands at 4..6 — inside the 2..8 gap that merging the two const segments would zero-fill. The merged blob is emitted *after* the global.get segment, so its zeros would clobber "XX". The pass must therefore leave every segment untouched, keeping the final memory image identical.
     let m = module(
         r#"(module
             (import "env" "base" (global $base i32))
@@ -127,8 +115,7 @@ fn global_get_before_mergeable_consts_bails_the_whole_pass() {
 
 #[test]
 fn descending_offsets_bail_the_whole_pass() {
-    // The second segment starts before the first ends: not globally ascending,
-    // so the pass leaves every segment untouched (no merge anywhere).
+    // The second segment starts before the first ends: not globally ascending, so the pass leaves every segment untouched (no merge anywhere).
     let m = module(
         r#"(module (memory 1)
             (data (i32.const 4) "ab")
@@ -156,9 +143,7 @@ fn overlapping_offsets_bail_the_whole_pass() {
 
 #[test]
 fn memory_init_or_data_drop_bails_the_whole_pass() {
-    // Bulk-memory ops reference segments by index; merging would renumber them,
-    // so their presence bails the pass even for the mergeable active segments.
-    // (Mirrors the shape of the CLI data_file fixture.)
+    // Bulk-memory ops reference segments by index; merging would renumber them, so their presence bails the pass even for the mergeable active segments. (Mirrors the shape of the CLI data_file fixture.)
     let m = module(
         r#"(module (memory 1)
             (data (i32.const 0) "ab")
@@ -179,9 +164,7 @@ fn memory_init_or_data_drop_bails_the_whole_pass() {
 
 #[test]
 fn passive_interleaved_between_actives_lets_them_merge() {
-    // A passive segment carries no standalone memory effect (no `memory.init`
-    // here), so it does not close the active run: the actives on either side
-    // still merge, and the passive survives in the output.
+    // A passive segment carries no standalone memory effect (no `memory.init` here), so it does not close the active run: the actives on either side still merge, and the passive survives in the output.
     let m = module(
         r#"(module (memory 1)
             (data (i32.const 0) "ab")

--- a/crates/dewasm-core/tests/debug_line.rs
+++ b/crates/dewasm-core/tests/debug_line.rs
@@ -1,14 +1,6 @@
-//! Core coverage for DWARF `.debug_line` source back-mapping (ADR-38): the
-//! `BuildOptions::debug_line` opt-in produces [`ir::Stmt::SourceLine`] markers
-//! resolved through the interned [`ir::Module::debug_files`], and the default
-//! build stays byte-for-byte marker-free.
+//! Core coverage for DWARF `.debug_line` source back-mapping (ADR-38): the `BuildOptions::debug_line` opt-in produces [`ir::Stmt::SourceLine`] markers resolved through the interned [`ir::Module::debug_files`], and the default build stays byte-for-byte marker-free.
 //!
-//! The fixture (`examples/apps/src/dwarf_fixture.c`, built by fetch.sh into the
-//! cache with `-g -O1`) pins the one calibration constant this feature has —
-//! the DWARF address base. `add_mul` is a folded, single-statement function
-//! whose only marker must land on the exact source line of its first statement;
-//! a wrong base shifts that line (or drops the marker entirely), so this test
-//! fails loudly for any miscalibration.
+//! The fixture (`examples/apps/src/dwarf_fixture.c`, built by fetch.sh into the cache with `-g -O1`) pins the one calibration constant this feature has — the DWARF address base. `add_mul` is a folded, single-statement function whose only marker must land on the exact source line of its first statement; a wrong base shifts that line (or drops the marker entirely), so this test fails loudly for any miscalibration.
 
 use std::path::{Path, PathBuf};
 
@@ -27,8 +19,7 @@ fn fixture_bytes() -> Vec<u8> {
     })
 }
 
-/// The `[Stmt::SourceLine]` positions in the body of the exported function
-/// named `export`, as `(file_path, line, col)`.
+/// The `[Stmt::SourceLine]` positions in the body of the exported function named `export`, as `(file_path, line, col)`.
 fn export_source_positions<'m>(
     module: &'m dewasm_core::ir::Module,
     export: &str,
@@ -100,10 +91,7 @@ fn debug_line_calibration_pins_add_mul_first_statement() {
     let bytes = fixture_bytes();
     let module = build_module_with_options(&bytes, &BuildOptions { debug_line: true }).unwrap();
 
-    // `add_mul` folds to a single `Return`, so its lone marker is the one the
-    // fallthrough-return path emits — and it must resolve to the exact source
-    // line of `int product = a * b;` (line 22 of dwarf_fixture.c). This is the
-    // address-base calibration: a wrong base moves this line or yields none.
+    // `add_mul` folds to a single `Return`, so its lone marker is the one the fallthrough-return path emits — and it must resolve to the exact source line of `int product = a * b;` (line 22 of dwarf_fixture.c). This is the address-base calibration: a wrong base moves this line or yields none.
     let positions = export_source_positions(&module, "add_mul");
     let (file, line, _col) = *positions
         .first()
@@ -118,8 +106,7 @@ fn debug_line_calibration_pins_add_mul_first_statement() {
          a different line means the DWARF address base is miscalibrated"
     );
 
-    // `sum_prefix` spans several source lines, so it must yield more than one
-    // change-point marker, all inside the fixture source.
+    // `sum_prefix` spans several source lines, so it must yield more than one change-point marker, all inside the fixture source.
     let sp = export_source_positions(&module, "sum_prefix");
     assert!(
         sp.len() >= 2,

--- a/crates/dewasm-core/tests/folding.rs
+++ b/crates/dewasm-core/tests/folding.rs
@@ -1,6 +1,4 @@
-//! Build-time expression folding: assert the IR shapes the func builder
-//! produces from small wat inputs (single-use folding, the spill rules, the
-//! node-count cap, and what ends up in `Func.temps`).
+//! Build-time expression folding: assert the IR shapes the func builder produces from small wat inputs (single-use folding, the spill rules, the node-count cap, and what ends up in `Func.temps`).
 
 use dewasm_core::build_module;
 use dewasm_core::ir::{BinOp, Expr, Func, Stmt};
@@ -81,8 +79,7 @@ fn count_assigns(stmts: &[Stmt]) -> usize {
 
 #[test]
 fn single_use_values_fold_into_the_consumer() {
-    // add(a, b) folds to a single `return a + b`: no temps, no assigns, the
-    // return value is the composed expression.
+    // add(a, b) folds to a single `return a + b`: no temps, no assigns, the return value is the composed expression.
     let f = func(
         "(module (func (param i32 i32) (result i32)
             local.get 0 local.get 1 i32.add))",
@@ -104,8 +101,7 @@ fn single_use_values_fold_into_the_consumer() {
 
 #[test]
 fn local_set_spills_a_pending_that_reads_the_local() {
-    // The first `local.get 0` must be spilled before `local.set 0` so it keeps
-    // the old value.
+    // The first `local.get 0` must be spilled before `local.set 0` so it keeps the old value.
     let f = func(
         "(module (func (param i32) (result i32)
             local.get 0
@@ -131,8 +127,7 @@ fn local_set_spills_a_pending_that_reads_the_local() {
 
 #[test]
 fn a_call_spills_pending_memory_reads() {
-    // A pending load cannot cross the call (which may write memory), so it is
-    // spilled before the call.
+    // A pending load cannot cross the call (which may write memory), so it is spilled before the call.
     let f = func(
         "(module
             (memory 1)
@@ -161,8 +156,7 @@ fn a_call_spills_pending_memory_reads() {
 
 #[test]
 fn local_tee_folds_its_value_and_leaves_a_local_read() {
-    // tee lowers to a local.set with the value inlined; the value left on the
-    // stack folds on into the following add.
+    // tee lowers to a local.set with the value inlined; the value left on the stack folds on into the following add.
     let f = func(
         "(module (func (param i32) (result i32)
             i32.const 5 local.tee 0
@@ -187,8 +181,7 @@ fn local_tee_folds_its_value_and_leaves_a_local_read() {
 
 #[test]
 fn select_spills_a_trapping_arm() {
-    // The backends lower select to a conditionally-evaluated ternary, so a
-    // trapping `then` arm (a load) must be spilled to keep its trap eager.
+    // The backends lower select to a conditionally-evaluated ternary, so a trapping `then` arm (a load) must be spilled to keep its trap eager.
     let f = func(
         "(module (memory 1)
             (func (param i32) (result i32)
@@ -217,8 +210,7 @@ fn select_spills_a_trapping_arm() {
 
 #[test]
 fn deep_expressions_are_capped() {
-    // Chain enough adds to exceed the node cap; the builder must spill so no
-    // single expression tree grows past MAX_FOLD_SIZE, and temps appear.
+    // Chain enough adds to exceed the node cap; the builder must spill so no single expression tree grows past MAX_FOLD_SIZE, and temps appear.
     let mut body = String::from("local.get 0\n");
     for _ in 0..40 {
         body.push_str("local.get 0 i32.add\n");
@@ -237,8 +229,7 @@ fn deep_expressions_are_capped() {
 
 #[test]
 fn return_value_is_inlined_and_temps_track_materialization() {
-    // A value produced by a call is materialized (call results never fold),
-    // then that single temp is the inlined return value.
+    // A value produced by a call is materialized (call results never fold), then that single temp is the inlined return value.
     let f = func(
         "(module
             (func $g (result i32) i32.const 7)

--- a/crates/dewasm-test-helper/src/apps.rs
+++ b/crates/dewasm-test-helper/src/apps.rs
@@ -1,19 +1,6 @@
-//! End-to-end cases over real-world apps (examples/apps/, ADR-9): convert
-//! each cached app with a backend and require byte-identical stdout and exit
-//! status against a golden output captured once from wasmtime and checked
-//! into `examples/apps/golden/` (ADR-15) — running these does not itself need
-//! `wasmtime` installed.
+//! End-to-end cases over real-world apps (examples/apps/, ADR-9): convert each cached app with a backend and require byte-identical stdout and exit status against a golden output captured once from wasmtime and checked into `examples/apps/golden/` (ADR-15) — running these does not itself need `wasmtime` installed.
 //!
-//! Per ADR-15, missing prerequisites (the interpreter, or the cache populated
-//! by `examples/apps/fetch.sh`) fail the test, they don't skip it. Each case
-//! is a `pub const` [`AppCase`] driven by its own per-case macro
-//! (`cowsay_args_e2e!`, `cowsay_stdin_e2e!`, `qjs_eval_e2e!`,
-//! `sqlite3_shell_e2e!`, ADR-27 revision). `qjs_eval_e2e!`/`sqlite3_shell_e2e!`
-//! are slow — softfloat makes QuickJS/SQLite take tens of seconds under
-//! Bash — so the macro expands their generated `#[test]` as `#[ignore]`d
-//! unless the expanding backend crate's `slow_test` feature is enabled; see
-//! [`run_slow_app_case`], which just runs the case unconditionally now that
-//! the gating lives at the macro/feature level.
+//! Per ADR-15, missing prerequisites (the interpreter, or the cache populated by `examples/apps/fetch.sh`) fail the test, they don't skip it. Each case is a `pub const` [`AppCase`] driven by its own per-case macro (`cowsay_args_e2e!`, `cowsay_stdin_e2e!`, `qjs_eval_e2e!`, `sqlite3_shell_e2e!`, ADR-27 revision). `qjs_eval_e2e!`/`sqlite3_shell_e2e!` are slow — softfloat makes QuickJS/SQLite take tens of seconds under Bash — so the macro expands their generated `#[test]` as `#[ignore]`d unless the expanding backend crate's `slow_test` feature is enabled; see [`run_slow_app_case`], which just runs the case unconditionally now that the gating lives at the macro/feature level.
 
 use dewasm_backend::Mode;
 
@@ -24,8 +11,7 @@ pub struct AppCase {
     pub name: &'static str,
     pub args: &'static [&'static str],
     pub stdin: &'static str,
-    /// Captured once via `wasmtime run` (ADR-15); the golden reference this
-    /// case's generated-language output must match exactly.
+    /// Captured once via `wasmtime run` (ADR-15); the golden reference this case's generated-language output must match exactly.
     pub expect_stdout: &'static str,
     pub expect_code: i32,
 }
@@ -48,8 +34,7 @@ pub const COWSAY_STDIN: AppCase = AppCase {
     expect_code: 0,
 };
 
-/// QuickJS `-e` one-liner eval (slow tier: softfloat-bound interpreters skip by
-/// default, see [`run_slow_app_case`]).
+/// QuickJS `-e` one-liner eval (slow tier: softfloat-bound interpreters skip by default, see [`run_slow_app_case`]).
 pub const QJS_EVAL: AppCase = AppCase {
     name: "qjs",
     args: &[
@@ -61,8 +46,7 @@ pub const QJS_EVAL: AppCase = AppCase {
     expect_code: 0,
 };
 
-/// sqlite3 shell against an in-memory database (slow tier: softfloat-bound
-/// interpreters skip by default, see [`run_slow_app_case`]).
+/// sqlite3 shell against an in-memory database (slow tier: softfloat-bound interpreters skip by default, see [`run_slow_app_case`]).
 pub const SQLITE3_SHELL: AppCase = AppCase {
     name: "sqlite3-shell",
     args: &[],
@@ -74,8 +58,7 @@ pub const SQLITE3_SHELL: AppCase = AppCase {
     expect_code: 0,
 };
 
-/// Convert the cached app `case` names with `lang`'s backend, run it, and diff
-/// against the case's golden output.
+/// Convert the cached app `case` names with `lang`'s backend, run it, and diff against the case's golden output.
 fn run_app_case_inner(lang: &dyn BackendUnderTest, case: &AppCase) {
     let wasm_path = apps_cache_dir().join(format!("{}.wasm", case.name));
     assert!(
@@ -110,34 +93,19 @@ fn run_app_case_inner(lang: &dyn BackendUnderTest, case: &AppCase) {
     );
 }
 
-/// Run a fast [`AppCase`] (`COWSAY_ARGS`/`COWSAY_STDIN`) for `lang`
-/// unconditionally.
+/// Run a fast [`AppCase`] (`COWSAY_ARGS`/`COWSAY_STDIN`) for `lang` unconditionally.
 pub fn run_app_case(lang: &dyn BackendUnderTest, case: &AppCase) {
     run_app_case_inner(lang, case);
 }
 
-/// Run a slow-tier [`AppCase`] (`QJS_EVAL`/`SQLITE3_SHELL`) for `lang`
-/// unconditionally. The perf opt-out now lives at the macro/feature level
-/// (`qjs_eval_e2e!`/`sqlite3_shell_e2e!` expand their `#[test]` as
-/// `#[ignore]`d unless the `slow_test` feature is on), so this runner — also used
-/// directly by the wasmtime suite — never needs to gate itself.
+/// Run a slow-tier [`AppCase`] (`QJS_EVAL`/`SQLITE3_SHELL`) for `lang` unconditionally. The perf opt-out now lives at the macro/feature level (`qjs_eval_e2e!`/`sqlite3_shell_e2e!` expand their `#[test]` as `#[ignore]`d unless the `slow_test` feature is on), so this runner — also used directly by the wasmtime suite — never needs to gate itself.
 pub fn run_slow_app_case(lang: &dyn BackendUnderTest, case: &AppCase) {
     run_app_case_inner(lang, case);
 }
 
-/// The gzip byte-stdio stress cases (minigzip, the Phase 5b compression CLI):
-/// binary stdin/stdout the text-only app cases cannot carry (their `&str`
-/// stdin and `include_str!` goldens require valid UTF-8; a gz stream is
-/// neither). Runs under *every* backend — Ruby and Bash both — since it is
-/// integer-only (no softfloat) and therefore fast even under Bash. Two cases:
+/// The gzip byte-stdio stress cases (minigzip, the Phase 5b compression CLI): binary stdin/stdout the text-only app cases cannot carry (their `&str` stdin and `include_str!` goldens require valid UTF-8; a gz stream is neither). Runs under *every* backend — Ruby and Bash both — since it is integer-only (no softfloat) and therefore fast even under Bash. Two cases:
 ///
-///   * *compress* — feed a fixed text input on stdin, require the compressed
-///     stdout to be byte-identical to the golden captured from `wasmtime`
-///     (`examples/apps/golden/minigzip_compress.gz`). zlib's gz stream is
-///     deterministic here (mtime 0, OS byte 3), so this is a stable equality.
-///   * *round trip* — compress, then decompress that output with `-d`, and
-///     require the result to equal the original input (self-checking; proves
-///     both directions of the binary stdio path).
+/// * *compress* — feed a fixed text input on stdin, require the compressed stdout to be byte-identical to the golden captured from `wasmtime` (`examples/apps/golden/minigzip_compress.gz`). zlib's gz stream is deterministic here (mtime 0, OS byte 3), so this is a stable equality. * *round trip* — compress, then decompress that output with `-d`, and require the result to equal the original input (self-checking; proves both directions of the binary stdio path).
 pub fn run_gzip_cases(lang: &dyn BackendUnderTest) {
     let wasm_path = apps_cache_dir().join("minigzip.wasm");
     assert!(

--- a/crates/dewasm-test-helper/src/apps_capi.rs
+++ b/crates/dewasm-test-helper/src/apps_capi.rs
@@ -1,24 +1,6 @@
-//! C-API-driving app cases (ADR-27): a converted library-mode artifact whose
-//! C API is driven directly from host-language glue — `sqlite3_malloc`,
-//! guest-memory pointer plumbing, and (for the callback case) an imported
-//! `env.host_row` provider. Unlike the `apps`/`fs_apps` suites there is **no
-//! wasmtime golden**: the CLI cannot drive a C-API flow whose results live in
-//! guest memory, so each case pins a fixed expected string, every value in it
-//! anchored by the amalgamation version pinned in `examples/apps/fetch.sh`.
+//! C-API-driving app cases (ADR-27): a converted library-mode artifact whose C API is driven directly from host-language glue — `sqlite3_malloc`, guest-memory pointer plumbing, and (for the callback case) an imported `env.host_row` provider. Unlike the `apps`/`fs_apps` suites there is **no wasmtime golden**: the CLI cannot drive a C-API flow whose results live in guest memory, so each case pins a fixed expected string, every value in it anchored by the amalgamation version pinned in `examples/apps/fetch.sh`.
 //!
-//! Each case is a `pub const` [`CApiCase`] driven by a per-case macro
-//! (`libsqlite3_c_api_e2e!`, `sqlite3_file_c_api_e2e!`,
-//! `sqlite3_callback_binding_e2e!`). The per-language variation is the named
-//! glue const passed to that macro (malloc/pointer plumbing/memory
-//! access/provider registration written out literally in the backend's
-//! language); the file-backed case's runtime scratch path arrives through the
-//! `{scratch}` placeholder the runner fills. Which backends invoke a macro is
-//! the capability declaration (ADR-27 revision): Ruby/Python/Go/Java, not Bash
-//! — it has no WASI filesystem and no host-language object model to plumb a C
-//! API through (ADR-12). These cases reconvert the ~5 MB sqlite3 artifacts, so
-//! each per-case macro expands its generated `#[test]` as `#[ignore]`d unless
-//! the expanding backend crate's `slow_test` feature is enabled; [`run_capi_case`]
-//! itself just runs the case unconditionally.
+//! Each case is a `pub const` [`CApiCase`] driven by a per-case macro (`libsqlite3_c_api_e2e!`, `sqlite3_file_c_api_e2e!`, `sqlite3_callback_binding_e2e!`). The per-language variation is the named glue const passed to that macro (malloc/pointer plumbing/memory access/provider registration written out literally in the backend's language); the file-backed case's runtime scratch path arrives through the `{scratch}` placeholder the runner fills. Which backends invoke a macro is the capability declaration (ADR-27 revision): Ruby/Python/Go/Java, not Bash — it has no WASI filesystem and no host-language object model to plumb a C API through (ADR-12). These cases reconvert the ~5 MB sqlite3 artifacts, so each per-case macro expands its generated `#[test]` as `#[ignore]`d unless the expanding backend crate's `slow_test` feature is enabled; [`run_capi_case`] itself just runs the case unconditionally.
 
 use std::path::{Path, PathBuf};
 
@@ -28,19 +10,16 @@ use crate::backend::BackendUnderTest;
 use crate::fixtures::{apps_cache_dir, fresh_scratch_dir};
 use crate::glue::fill;
 
-/// A C-API-driving case: convert `wasm` (cache stem) to library class `class`,
-/// append the backend's glue, run it, and require exactly `expect_stdout`.
+/// A C-API-driving case: convert `wasm` (cache stem) to library class `class`, append the backend's glue, run it, and require exactly `expect_stdout`.
 pub struct CApiCase {
     pub name: &'static str,
-    /// Cache-binary stem (`examples/apps/cache/<wasm>.wasm`), also the
-    /// conversion module name (every backend PascalCases it to `class`).
+    /// Cache-binary stem (`examples/apps/cache/<wasm>.wasm`), also the conversion module name (every backend PascalCases it to `class`).
     pub wasm: &'static str,
     /// The library class name the glue instantiates (PascalCase of `wasm`).
     pub class: &'static str,
     /// The fixed stdout the drive must produce (no wasmtime golden possible).
     pub expect_stdout: &'static str,
-    /// Host-side assertion over the scratch dir after the run (file cases);
-    /// `assert_none` when there is nothing to check.
+    /// Host-side assertion over the scratch dir after the run (file cases); `assert_none` when there is nothing to check.
     pub assert_host: fn(&Path),
 }
 
@@ -59,9 +38,7 @@ fn assert_dbfile(scratch: &Path) {
     );
 }
 
-/// The library half of the sqlite3 build (ADR-22): the C API driven in memory.
-/// version + two SELECT rows + a sentinel, all pinned by the amalgamation
-/// version. In-memory (`:memory:`), so the `{scratch}` placeholder goes unused.
+/// The library half of the sqlite3 build (ADR-22): the C API driven in memory. version + two SELECT rows + a sentinel, all pinned by the amalgamation version. In-memory (`:memory:`), so the `{scratch}` placeholder goes unused.
 pub const LIBSQLITE3_C_API: CApiCase = CApiCase {
     name: "libsqlite3_c_api",
     wasm: "libsqlite3",
@@ -70,10 +47,7 @@ pub const LIBSQLITE3_C_API: CApiCase = CApiCase {
     assert_host: assert_none,
 };
 
-/// The same C API opening a *file* under a preopen (ADR-22): create+insert,
-/// close, reopen, select — proving the C-API path hits the same ADR-14 fs stack
-/// as the shell. The glue preopens the fresh scratch dir via `{scratch}` and
-/// leaves a nonzero DB file on the host.
+/// The same C API opening a *file* under a preopen (ADR-22): create+insert, close, reopen, select — proving the C-API path hits the same ADR-14 fs stack as the shell. The glue preopens the fresh scratch dir via `{scratch}` and leaves a nonzero DB file on the host.
 pub const SQLITE3_FILE_C_API: CApiCase = CApiCase {
     name: "sqlite3_file_c_api",
     wasm: "libsqlite3",
@@ -82,11 +56,7 @@ pub const SQLITE3_FILE_C_API: CApiCase = CApiCase {
     assert_host: assert_dbfile,
 };
 
-/// Guest->host callback round trip (ADR-22): our own committed C
-/// (examples/apps/src/sqlite3_binding.c) exports `run_query`, which calls
-/// `sqlite3_exec` with a C callback forwarding each row to the *imported*
-/// `env.host_row`. The glue provides `host_row` via the ADR-7 import provider
-/// and collects the rows.
+/// Guest->host callback round trip (ADR-22): our own committed C (examples/apps/src/sqlite3_binding.c) exports `run_query`, which calls `sqlite3_exec` with a C callback forwarding each row to the *imported* `env.host_row`. The glue provides `host_row` via the ADR-7 import provider and collects the rows.
 pub const SQLITE3_CALLBACK_BINDING: CApiCase = CApiCase {
     name: "sqlite3_callback_binding",
     wasm: "sqlite3-binding",
@@ -95,16 +65,7 @@ pub const SQLITE3_CALLBACK_BINDING: CApiCase = CApiCase {
     assert_host: assert_none,
 };
 
-/// libpcap BPF filter compilation (ADR-22): our own committed C
-/// (examples/apps/src/pcap_binding.c) exports `compile_filter`, which runs
-/// libpcap's platform-independent BPF compiler (`pcap_compile_nopcap`) on a
-/// textual filter and serializes the resulting program into guest memory as
-/// `[u32 bf_len][bf_len × {u16 code; u8 jt; u8 jf; u32 k}]`. The glue drives
-/// `compile_filter("tcp port 80", DLT_EN10MB=1, 65535)`, prints each insn as
-/// `code jt jf k`, and a sentinel. The pinned output is the canonical
-/// tcp-port-80 filter (ethertype IPv6 0x86dd/IPv4 0x0800, IP proto TCP=6,
-/// port 80), deterministic because BPF programs hold offsets/constants only,
-/// no addresses. In-memory, so `{scratch}` goes unused.
+/// libpcap BPF filter compilation (ADR-22): our own committed C (examples/apps/src/pcap_binding.c) exports `compile_filter`, which runs libpcap's platform-independent BPF compiler (`pcap_compile_nopcap`) on a textual filter and serializes the resulting program into guest memory as `[u32 bf_len][bf_len × {u16 code; u8 jt; u8 jf; u32 k}]`. The glue drives `compile_filter("tcp port 80", DLT_EN10MB=1, 65535)`, prints each insn as `code jt jf k`, and a sentinel. The pinned output is the canonical tcp-port-80 filter (ethertype IPv6 0x86dd/IPv4 0x0800, IP proto TCP=6, port 80), deterministic because BPF programs hold offsets/constants only, no addresses. In-memory, so `{scratch}` goes unused.
 pub const PCAP_COMPILE: CApiCase = CApiCase {
     name: "pcap_compile",
     wasm: "libpcap",
@@ -116,14 +77,7 @@ pub const PCAP_COMPILE: CApiCase = CApiCase {
     assert_host: assert_none,
 };
 
-/// tree-sitter JSON parse (ADR-22): our own committed C
-/// (examples/apps/src/treesitter_binding.c) exports `parse_source`, which
-/// parses a source string with the tree-sitter runtime + the pre-generated
-/// tree-sitter-json grammar and returns the parse tree's S-expression (a
-/// malloc'd C string) via `ts_node_string`. The glue parses the fixed snippet
-/// `{"key": [1, true, null]}`, prints the S-expression, and a sentinel. The
-/// output is deterministic (tree-sitter's node naming is fixed by the pinned
-/// grammar). In-memory, so `{scratch}` goes unused.
+/// tree-sitter JSON parse (ADR-22): our own committed C (examples/apps/src/treesitter_binding.c) exports `parse_source`, which parses a source string with the tree-sitter runtime + the pre-generated tree-sitter-json grammar and returns the parse tree's S-expression (a malloc'd C string) via `ts_node_string`. The glue parses the fixed snippet `{"key": [1, true, null]}`, prints the S-expression, and a sentinel. The output is deterministic (tree-sitter's node naming is fixed by the pinned grammar). In-memory, so `{scratch}` goes unused.
 pub const TREESITTER_PARSE: CApiCase = CApiCase {
     name: "treesitter_parse",
     wasm: "treesitter",
@@ -133,10 +87,7 @@ pub const TREESITTER_PARSE: CApiCase = CApiCase {
     assert_host: assert_none,
 };
 
-/// Run one [`CApiCase`] for `lang` with its per-language `glue`
-/// unconditionally (the perf opt-out lives at the macro/feature level, see the
-/// module docs). Fills `{scratch}` in `glue` with a fresh scratch dir (the
-/// file-backed case's preopen; unused by the in-memory cases).
+/// Run one [`CApiCase`] for `lang` with its per-language `glue` unconditionally (the perf opt-out lives at the macro/feature level, see the module docs). Fills `{scratch}` in `glue` with a fresh scratch dir (the file-backed case's preopen; unused by the in-memory cases).
 pub fn run_capi_case(lang: &dyn BackendUnderTest, case: &CApiCase, glue: &str) {
     let cache = apps_cache_dir();
     let wasm_path = cache.join(format!("{}.wasm", case.wasm));

--- a/crates/dewasm-test-helper/src/apps_fs.rs
+++ b/crates/dewasm-test-helper/src/apps_fs.rs
@@ -1,26 +1,8 @@
-//! Filesystem-exercising app cases (ADR-27), shared across every backend with
-//! WASI filesystem support (Ruby/Python/Go/Java) and re-run by wasmtime as the
-//! ground-truth engine. Each case converts a cached app to a library-mode
-//! class, stages fixtures into a fresh scratch dir preopened into the guest,
-//! and runs one or more invocations, diffing stdout against the same
-//! `examples/apps/golden/` files the always-on `apps` suite uses (ADR-15) and
-//! asserting the host-side effects the guest was supposed to produce.
+//! Filesystem-exercising app cases (ADR-27), shared across every backend with WASI filesystem support (Ruby/Python/Go/Java) and re-run by wasmtime as the ground-truth engine. Each case converts a cached app to a library-mode class, stages fixtures into a fresh scratch dir preopened into the guest, and runs one or more invocations, diffing stdout against the same `examples/apps/golden/` files the always-on `apps` suite uses (ADR-15) and asserting the host-side effects the guest was supposed to produce.
 //!
-//! Each case is a `pub const` [`FsAppCase`] driven by a per-case macro
-//! (`qjs_file_io_e2e!`, `sqlite3_shell_dbfile_e2e!`, ...). The per-language
-//! instantiation glue is a named const passed to that macro: it writes out the
-//! class name, argv, env, and preopen *guest* paths literally and takes only the
-//! runtime host paths through the `{scratch}`/`{cache}` placeholders the runner
-//! fills. wasmtime does not use the glue: it overrides
-//! [`BackendUnderTest::run_app_fs`] to exec the cached binary with `--dir`
-//! preopens directly, so the same case consts feed both the backend macros and
-//! the wasmtime suite (via [`run_fs_app_case`], called directly).
+//! Each case is a `pub const` [`FsAppCase`] driven by a per-case macro (`qjs_file_io_e2e!`, `sqlite3_shell_dbfile_e2e!`, ...). The per-language instantiation glue is a named const passed to that macro: it writes out the class name, argv, env, and preopen *guest* paths literally and takes only the runtime host paths through the `{scratch}`/`{cache}` placeholders the runner fills. wasmtime does not use the glue: it overrides [`BackendUnderTest::run_app_fs`] to exec the cached binary with `--dir` preopens directly, so the same case consts feed both the backend macros and the wasmtime suite (via [`run_fs_app_case`], called directly).
 //!
-//! These cases are slow (they reconvert qjs/sqlite and stage ripgrep's 22 MB
-//! binary), so the perf opt-out lives at the macro/feature level: each
-//! per-case macro (`qjs_file_io_e2e!`, ...) expands its generated `#[test]` as
-//! `#[ignore]`d unless the expanding backend crate's `slow_test` feature is
-//! enabled. [`run_fs_app_case`] itself just runs the case unconditionally.
+//! These cases are slow (they reconvert qjs/sqlite and stage ripgrep's 22 MB binary), so the perf opt-out lives at the macro/feature level: each per-case macro (`qjs_file_io_e2e!`, ...) expands its generated `#[test]` as `#[ignore]`d unless the expanding backend crate's `slow_test` feature is enabled. [`run_fs_app_case`] itself just runs the case unconditionally.
 
 use std::path::{Path, PathBuf};
 
@@ -30,9 +12,7 @@ use crate::backend::BackendUnderTest;
 use crate::fixtures::{apps_cache_dir, apps_fixtures_dir, fresh_scratch_dir};
 use crate::glue::fill;
 
-/// One fixture-staging step, run into the case's fresh scratch dir before the
-/// guest runs. `src` is relative to [`apps_fixtures_dir`]; `dst` is relative to
-/// the scratch dir (`""` = the scratch root).
+/// One fixture-staging step, run into the case's fresh scratch dir before the guest runs. `src` is relative to [`apps_fixtures_dir`]; `dst` is relative to the scratch dir (`""` = the scratch root).
 pub enum Stage {
     /// Copy a single file `src` -> `dst`.
     File {
@@ -46,42 +26,28 @@ pub enum Stage {
     },
 }
 
-/// One invocation of a filesystem-app case. Multiple runs of a case share the
-/// same scratch dir (e.g. sqlite3: create the DB file, then reopen it).
+/// One invocation of a filesystem-app case. Multiple runs of a case share the same scratch dir (e.g. sqlite3: create the DB file, then reopen it).
 pub struct FsRun {
-    /// Full argv, argv0 included (backends bake it into the glue; wasmtime
-    /// injects argv0 itself and uses `args[1..]`).
+    /// Full argv, argv0 included (backends bake it into the glue; wasmtime injects argv0 itself and uses `args[1..]`).
     pub args: &'static [&'static str],
     pub stdin: &'static str,
-    /// The `include_str!` golden this run's stdout must match, or `None` when
-    /// only the host-side effect is asserted (e.g. the sqlite3 create run).
+    /// The `include_str!` golden this run's stdout must match, or `None` when only the host-side effect is asserted (e.g. the sqlite3 create run).
     pub expect_stdout: Option<&'static str>,
-    /// Host-side assertion over the scratch dir after this run (e.g. a file
-    /// the guest was supposed to write). `assert_none` when there is nothing
-    /// to check.
+    /// Host-side assertion over the scratch dir after this run (e.g. a file the guest was supposed to write). `assert_none` when there is nothing to check.
     pub assert_host: fn(&Path),
 }
 
-/// A filesystem-exercising app case: convert `wasm` (cache stem) to library
-/// class `class`, stage `stage` into a scratch dir, preopen `preopens`, and
-/// run each of `runs`. The static `env`/`preopens`/`cache_preopens` are used by
-/// the wasmtime override (which execs the binary with those host mounts) and to
-/// stage/mount the scratch and cache trees; the backends read the same facts
-/// out of the glue const, where they are written literally.
+/// A filesystem-exercising app case: convert `wasm` (cache stem) to library class `class`, stage `stage` into a scratch dir, preopen `preopens`, and run each of `runs`. The static `env`/`preopens`/`cache_preopens` are used by the wasmtime override (which execs the binary with those host mounts) and to stage/mount the scratch and cache trees; the backends read the same facts out of the glue const, where they are written literally.
 pub struct FsAppCase {
     pub name: &'static str,
-    /// Cache-binary stem (`examples/apps/cache/<wasm>.wasm`), also the
-    /// conversion module name — every backend PascalCases it to `class`.
+    /// Cache-binary stem (`examples/apps/cache/<wasm>.wasm`), also the conversion module name — every backend PascalCases it to `class`.
     pub wasm: &'static str,
     /// The library class name the glue instantiates (PascalCase of `wasm`).
     pub class: &'static str,
     pub env: &'static [(&'static str, &'static str)],
     /// Guest path -> scratch-relative subdir (`""` = scratch root).
     pub preopens: &'static [(&'static str, &'static str)],
-    /// Guest path -> cache-relative subdir, preopened **directly from the app
-    /// cache** (`examples/apps/cache/<rel>`) rather than copied into scratch.
-    /// The language-runtime apps (CPython/CRuby) mount their multi-hundred-MB
-    /// stdlib trees this way — copying them per run would be prohibitive.
+    /// Guest path -> cache-relative subdir, preopened **directly from the app cache** (`examples/apps/cache/<rel>`) rather than copied into scratch. The language-runtime apps (CPython/CRuby) mount their multi-hundred-MB stdlib trees this way — copying them per run would be prohibitive.
     pub cache_preopens: &'static [(&'static str, &'static str)],
     pub stage: &'static [Stage],
     pub runs: &'static [FsRun],
@@ -111,9 +77,7 @@ fn assert_sqlite_dbfile(scratch: &Path) {
     );
 }
 
-/// QuickJS with file I/O (Phase 5a #1a): the `qjs:std` module writes a file
-/// into the preopened dir, reads it back, and prints it. Asserts both guest
-/// stdout (golden) and the host-side file content.
+/// QuickJS with file I/O (Phase 5a #1a): the `qjs:std` module writes a file into the preopened dir, reads it back, and prints it. Asserts both guest stdout (golden) and the host-side file content.
 pub const QJS_FILE_IO: FsAppCase = FsAppCase {
     name: "qjs_file_io",
     wasm: "qjs",
@@ -135,8 +99,7 @@ pub const QJS_FILE_IO: FsAppCase = FsAppCase {
     }],
 };
 
-/// QuickJS scripted REPL over piped stdin (Phase 5a #1b): the pinned
-/// read-eval-print loop fixture exercises the stdin-read + evalScript path.
+/// QuickJS scripted REPL over piped stdin (Phase 5a #1b): the pinned read-eval-print loop fixture exercises the stdin-read + evalScript path.
 pub const QJS_REPL: FsAppCase = FsAppCase {
     name: "qjs_repl",
     wasm: "qjs",
@@ -158,9 +121,7 @@ pub const QJS_REPL: FsAppCase = FsAppCase {
     }],
 };
 
-/// sqlite3 shell reading/writing a DB *file* (Phase 5a #2a): one invocation
-/// creates and populates `/db/test.db`, a second reopens it and SELECTs. Both
-/// runs share the scratch dir.
+/// sqlite3 shell reading/writing a DB *file* (Phase 5a #2a): one invocation creates and populates `/db/test.db`, a second reopens it and SELECTs. Both runs share the scratch dir.
 pub const SQLITE3_SHELL_DBFILE: FsAppCase = FsAppCase {
     name: "sqlite3_shell_dbfile",
     wasm: "sqlite3-shell",
@@ -190,9 +151,7 @@ pub const SQLITE3_SHELL_DBFILE: FsAppCase = FsAppCase {
     ],
 };
 
-/// ripgrep searching a small fixture directory tree (Phase 5b): recursive
-/// directory walking over a preopened tree. `--sort path` forces a
-/// deterministic order so the `wasmtime --dir` golden is stable.
+/// ripgrep searching a small fixture directory tree (Phase 5b): recursive directory walking over a preopened tree. `--sort path` forces a deterministic order so the `wasmtime --dir` golden is stable.
 pub const RG_SEARCH: FsAppCase = FsAppCase {
     name: "rg_search",
     wasm: "rg",
@@ -211,12 +170,7 @@ pub const RG_SEARCH: FsAppCase = FsAppCase {
     }],
 };
 
-/// CPython 3.14.6 executing a one-liner (Phase 5b), reading its stdlib from the
-/// cache-preopened `cache/cpython-lib/lib` tree at guest `/lib`. The heaviest
-/// interpreter case: a ~30 MB wasm. Ground truth (wasmtime):
-///   wasmtime --dir cache/cpython-lib/lib::/lib --env PYTHONHOME=/ \
-///     --env PYTHONPATH=/lib/python3.14 cache/cpython.wasm \
-///     -c 'print("hello from cpython", 6 * 7)'
+/// CPython 3.14.6 executing a one-liner (Phase 5b), reading its stdlib from the cache-preopened `cache/cpython-lib/lib` tree at guest `/lib`. The heaviest interpreter case: a ~30 MB wasm. Ground truth (wasmtime): wasmtime --dir cache/cpython-lib/lib::/lib --env PYTHONHOME=/ \ --env PYTHONPATH=/lib/python3.14 cache/cpython.wasm \ -c 'print("hello from cpython", 6 * 7)'
 pub const CPYTHON_HELLO: FsAppCase = FsAppCase {
     name: "cpython_hello",
     wasm: "cpython",
@@ -233,12 +187,7 @@ pub const CPYTHON_HELLO: FsAppCase = FsAppCase {
     }],
 };
 
-/// CRuby 3.4 executing a one-liner (Phase 5b) — the "Ruby on Ruby" north-star
-/// demo — reading its stdlib from the cache-preopened `cache/ruby-lib/usr` tree
-/// at guest `/usr`. The heaviest case overall: a ~35 MB wasm. Ground truth
-/// (wasmtime):
-///   wasmtime --dir cache/ruby-lib/usr::/usr cache/ruby.wasm \
-///     -e 'puts "hello from cruby #{6*7}"'
+/// CRuby 3.4 executing a one-liner (Phase 5b) — the "Ruby on Ruby" north-star demo — reading its stdlib from the cache-preopened `cache/ruby-lib/usr` tree at guest `/usr`. The heaviest case overall: a ~35 MB wasm. Ground truth (wasmtime): wasmtime --dir cache/ruby-lib/usr::/usr cache/ruby.wasm \ -e 'puts "hello from cruby #{6*7}"'
 pub const CRUBY_HELLO: FsAppCase = FsAppCase {
     name: "cruby_hello",
     wasm: "ruby",
@@ -269,11 +218,7 @@ fn copy_tree(src: &Path, dst: &Path) {
     }
 }
 
-/// Run one [`FsAppCase`] for `lang` with its per-language `glue`
-/// unconditionally. The perf opt-out lives at the macro/feature level (see
-/// the module docs), so this runner — also called directly by the wasmtime
-/// suite, which passes an empty `glue` since its `run_app_fs` override
-/// ignores it — never needs to gate itself.
+/// Run one [`FsAppCase`] for `lang` with its per-language `glue` unconditionally. The perf opt-out lives at the macro/feature level (see the module docs), so this runner — also called directly by the wasmtime suite, which passes an empty `glue` since its `run_app_fs` override ignores it — never needs to gate itself.
 pub fn run_fs_app_case(lang: &dyn BackendUnderTest, case: &FsAppCase, glue: &str) {
     let cache = apps_cache_dir();
     let fixtures = apps_fixtures_dir();
@@ -306,8 +251,7 @@ pub fn run_fs_app_case(lang: &dyn BackendUnderTest, case: &FsAppCase, glue: &str
             };
             (*guest, host)
         })
-        // Cache-preopened stdlib trees are mounted straight from the app cache
-        // (read-only), never copied into scratch (they are hundreds of MB).
+        // Cache-preopened stdlib trees are mounted straight from the app cache (read-only), never copied into scratch (they are hundreds of MB).
         .chain(case.cache_preopens.iter().map(|(guest, rel)| {
             let host = cache.join(rel);
             assert!(
@@ -330,15 +274,9 @@ pub fn run_fs_app_case(lang: &dyn BackendUnderTest, case: &FsAppCase, glue: &str
         case.wasm
     );
     let bytes = std::fs::read(&wasm_path).expect("read wasm");
-    // Convert under `class`, not the cache stem: the stem and the class name
-    // diverge for CRuby (cache file `ruby.wasm`, but a `Ruby` class collides
-    // with MRI's predefined `Ruby` constant, so the class is `Cruby`). The class
-    // name is already PascalCase, and every backend's PascalCasing is
-    // idempotent, so this yields exactly `class` for every case. wasmtime
-    // ignores the name (it runs the bytes directly).
+    // Convert under `class`, not the cache stem: the stem and the class name diverge for CRuby (cache file `ruby.wasm`, but a `Ruby` class collides with MRI's predefined `Ruby` constant, so the class is `Cruby`). The class name is already PascalCase, and every backend's PascalCasing is idempotent, so this yields exactly `class` for every case. wasmtime ignores the name (it runs the bytes directly).
     let program = lang.convert_app(&bytes, Mode::Library, case.class);
-    // Resolve the runtime host paths the glue const left as placeholders. The
-    // scratch preopen and the cache root are all any current case needs.
+    // Resolve the runtime host paths the glue const left as placeholders. The scratch preopen and the cache root are all any current case needs.
     let filled_glue = fill(
         glue,
         &[

--- a/crates/dewasm-test-helper/src/backend.rs
+++ b/crates/dewasm-test-helper/src/backend.rs
@@ -1,9 +1,4 @@
-//! The base backend-under-test abstraction (ADR-27) and the process
-//! plumbing every suite shares. `BackendUnderTest` is the layer that even a
-//! pre-spec backend (the "cowsay first" bring-up path of ADR-24) can
-//! implement: name it, hand back its `Backend`, and say how to run generated
-//! output. Interpreted backends get `run` for free from `interpreter`;
-//! compiled targets override `run` itself.
+//! The base backend-under-test abstraction (ADR-27) and the process plumbing every suite shares. `BackendUnderTest` is the layer that even a pre-spec backend (the "cowsay first" bring-up path of ADR-24) can implement: name it, hand back its `Backend`, and say how to run generated output. Interpreted backends get `run` for free from `interpreter`; compiled targets override `run` itself.
 
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
@@ -12,19 +7,13 @@ use dewasm_backend::{Backend, Mode};
 
 use crate::pty::PtyCommand;
 
-/// A target backend wired into the shared case tables and the spec harness.
-/// The spec layer ([`crate::SpecBackend`]) extends this with the
-/// script-phrasing surface; everything a backend needs to run app/e2e suites
-/// is here.
+/// A target backend wired into the shared case tables and the spec harness. The spec layer ([`crate::SpecBackend`]) extends this with the script-phrasing surface; everything a backend needs to run app/e2e suites is here.
 pub trait BackendUnderTest: Sync {
     fn name(&self) -> &'static str;
-    /// The backend itself. `+ Sync` so app conversion can run on a scoped
-    /// worker thread (`convert_on_big_stack`).
+    /// The backend itself. `+ Sync` so app conversion can run on a scoped worker thread (`convert_on_big_stack`).
     fn backend(&self) -> &'static (dyn Backend + Sync);
 
-    /// Interpreter used by `run`'s default implementation. Per ADR-15 a
-    /// missing interpreter must panic (fail loud), never skip. Compiled
-    /// backends override `run` directly and need not implement this.
+    /// Interpreter used by `run`'s default implementation. Per ADR-15 a missing interpreter must panic (fail loud), never skip. Compiled backends override `run` directly and need not implement this.
     fn interpreter(&self) -> PathBuf {
         unimplemented!(
             "an interpreted backend must implement interpreter(); \
@@ -32,18 +21,12 @@ pub trait BackendUnderTest: Sync {
         )
     }
 
-    /// Run generated `source` with `args` and `stdin`, returning the raw
-    /// process `Output`. The default writes `source` to a temp file (keyed
-    /// by pid + counter so parallel test threads and concurrent `cargo test`
-    /// processes never collide) and execs `interpreter`.
+    /// Run generated `source` with `args` and `stdin`, returning the raw process `Output`. The default writes `source` to a temp file (keyed by pid + counter so parallel test threads and concurrent `cargo test` processes never collide) and execs `interpreter`.
     fn run(&self, source: &str, args: &[&str], stdin: &str) -> Output {
         self.run_bytes(source, args, stdin.as_bytes())
     }
 
-    /// Like `run`, but with raw-byte `stdin` (and a raw-byte stdout in the
-    /// returned `Output`). Needed by the binary-stdio app cases (minigzip),
-    /// whose input and output are not valid UTF-8 and so cannot travel
-    /// through the `&str`-typed `run`/`AppCase` path.
+    /// Like `run`, but with raw-byte `stdin` (and a raw-byte stdout in the returned `Output`). Needed by the binary-stdio app cases (minigzip), whose input and output are not valid UTF-8 and so cannot travel through the `&str`-typed `run`/`AppCase` path.
     fn run_bytes(&self, source: &str, args: &[&str], stdin: &[u8]) -> Output {
         run_script_bytes(
             &self.interpreter(),
@@ -54,24 +37,12 @@ pub trait BackendUnderTest: Sync {
         )
     }
 
-    /// Produce the runnable artifact for cached app `name` (bytes read from
-    /// the app cache) that the app/gzip suites then hand to `run`/`run_bytes`.
-    /// The default converts the wasm to backend source on a roomy stack
-    /// (`convert_on_big_stack`); an engine-under-test that runs the wasm
-    /// binary directly (e.g. wasmtime) overrides this to skip codegen and
-    /// return a path to the cached binary instead.
+    /// Produce the runnable artifact for cached app `name` (bytes read from the app cache) that the app/gzip suites then hand to `run`/`run_bytes`. The default converts the wasm to backend source on a roomy stack (`convert_on_big_stack`); an engine-under-test that runs the wasm binary directly (e.g. wasmtime) overrides this to skip codegen and return a path to the cached binary instead.
     fn convert_app(&self, bytes: &[u8], mode: Mode, name: &str) -> String {
         crate::convert_on_big_stack(self.backend(), bytes, mode, name)
     }
 
-    /// Prepare a *pty* run of standalone `source` with `args` (see
-    /// [`crate::run_under_pty`]). Returns the command to spawn on a pty. The
-    /// default — for interpreted backends — writes `source` to a temp script
-    /// and runs `interpreter <script> <args...>`, exactly mirroring
-    /// [`Self::run_bytes`]'s default but without capturing through pipes.
-    /// Compiled backends (Go, Java) override this to build `source` first and
-    /// return the resulting run command. A missing toolchain fails loud
-    /// (ADR-15).
+    /// Prepare a *pty* run of standalone `source` with `args` (see [`crate::run_under_pty`]). Returns the command to spawn on a pty. The default — for interpreted backends — writes `source` to a temp script and runs `interpreter <script> <args...>`, exactly mirroring [`Self::run_bytes`]'s default but without capturing through pipes. Compiled backends (Go, Java) override this to build `source` first and return the resulting run command. A missing toolchain fails loud (ADR-15).
     fn pty_command(&self, source: &str, args: &[&str]) -> PtyCommand {
         let script = write_temp_script(source, self.backend().file_extension());
         let mut argv = vec![script.to_string_lossy().into_owned()];
@@ -83,30 +54,13 @@ pub trait BackendUnderTest: Sync {
         }
     }
 
-    /// Compose several wat modules that share the backend's linkage model into
-    /// one runnable source (no driver appended). `modules` is `(wat filename in
-    /// examples/wat, class/type name)` pairs. `shared_runtime` selects the
-    /// linkage: `true` emits every module against ONE shared runtime (so an
-    /// imported table can cross modules — the `shared_table` case); `false`
-    /// emits independent self-contained (Embedded) runtimes that coexist
-    /// (the `embedded_coexist` case). Only backends wired into
-    /// `multi_module_e2e!` implement this, each using its own crate's
-    /// multi-module API (the test-helper crate cannot depend on a concrete
-    /// backend). See [`crate::run_multi_module_case`].
+    /// Compose several wat modules that share the backend's linkage model into one runnable source (no driver appended). `modules` is `(wat filename in examples/wat, class/type name)` pairs. `shared_runtime` selects the linkage: `true` emits every module against ONE shared runtime (so an imported table can cross modules — the `shared_table` case); `false` emits independent self-contained (Embedded) runtimes that coexist (the `embedded_coexist` case). Only backends wired into `multi_module_e2e!` implement this, each using its own crate's multi-module API (the test-helper crate cannot depend on a concrete backend). See [`crate::run_multi_module_case`].
     fn compose_modules(&self, modules: &[(&str, &str)], shared_runtime: bool) -> String {
         let _ = (modules, shared_runtime);
         unimplemented!("a multi-module backend must implement compose_modules()")
     }
 
-    /// Run library-mode `program` (from [`Self::convert_app`]) as a
-    /// filesystem app: append the already-filled instantiation `glue` (a named
-    /// backend const with its `{scratch}`/`{cache}` placeholders resolved by the
-    /// runner, ADR-27 revision), feed `stdin`, and return the process `Output`.
-    /// The default runs `program` + `glue` through `run_bytes`, so the static
-    /// `args`/`env`/`preopens` are written literally inside `glue` and ignored
-    /// here; an engine-under-test that runs the wasm binary directly (wasmtime)
-    /// overrides this to exec the binary (`program` is the wasm path) with those
-    /// host `args`/`env`/`preopens` and ignores `glue`.
+    /// Run library-mode `program` (from [`Self::convert_app`]) as a filesystem app: append the already-filled instantiation `glue` (a named backend const with its `{scratch}`/`{cache}` placeholders resolved by the runner, ADR-27 revision), feed `stdin`, and return the process `Output`. The default runs `program` + `glue` through `run_bytes`, so the static `args`/`env`/`preopens` are written literally inside `glue` and ignored here; an engine-under-test that runs the wasm binary directly (wasmtime) overrides this to exec the binary (`program` is the wasm path) with those host `args`/`env`/`preopens` and ignores `glue`.
     fn run_app_fs(
         &self,
         program: &str,
@@ -120,15 +74,7 @@ pub trait BackendUnderTest: Sync {
         self.run_bytes(&format!("{program}\n{glue}"), &[], stdin)
     }
 
-    /// Run a *standalone*-mode `program` through the standalone runtime
-    /// interface (ADR-31): the generated main parses a leading run of
-    /// `--dir HOST::GUEST` flags itself, then hands the rest to the guest as
-    /// `argv[1..]`. The default (every generated backend) execs the program with
-    /// those `--dir` flags followed by `args` — exactly what a user types — via
-    /// [`Self::run_bytes`] (compiled backends build first through their
-    /// `run_bytes` override). wasmtime overrides this: `--dir` is a *host*
-    /// runtime flag there, so it runs `wasmtime run --dir HOST::GUEST... <wasm>
-    /// args` instead. Same case feeds both, mirroring [`Self::run_app_fs`].
+    /// Run a *standalone*-mode `program` through the standalone runtime interface (ADR-31): the generated main parses a leading run of `--dir HOST::GUEST` flags itself, then hands the rest to the guest as `argv[1..]`. The default (every generated backend) execs the program with those `--dir` flags followed by `args` — exactly what a user types — via [`Self::run_bytes`] (compiled backends build first through their `run_bytes` override). wasmtime overrides this: `--dir` is a *host* runtime flag there, so it runs `wasmtime run --dir HOST::GUEST... <wasm> args` instead. Same case feeds both, mirroring [`Self::run_app_fs`].
     fn run_standalone_dir(
         &self,
         program: &str,
@@ -146,20 +92,9 @@ pub trait BackendUnderTest: Sync {
         self.run_bytes(program, &flag_refs, stdin)
     }
 
-    /// Run a *standalone*-mode `program` through the standalone interface
-    /// (ADR-31) like [`Self::run_standalone_dir`], but additionally set `env`
-    /// on the child process and return the full [`Output`] — the surface the
-    /// WASI-testsuite harness needs ([`crate::wasi_testsuite`]), which
-    /// [`Self::run_standalone_dir`] cannot give (it inherits the parent env and
-    /// its callers discard the exit code). `dirs` are `(guest, host)` preopens
-    /// rendered as the leading `--dir HOST::GUEST` flags the generated `main`
-    /// parses; `args` follow as guest `argv[1..]`.
+    /// Run a *standalone*-mode `program` through the standalone interface (ADR-31) like [`Self::run_standalone_dir`], but additionally set `env` on the child process and return the full [`Output`] — the surface the WASI-testsuite harness needs ([`crate::wasi_testsuite`]), which [`Self::run_standalone_dir`] cannot give (it inherits the parent env and its callers discard the exit code). `dirs` are `(guest, host)` preopens rendered as the leading `--dir HOST::GUEST` flags the generated `main` parses; `args` follow as guest `argv[1..]`.
     ///
-    /// The default reuses the backend's own launch recipe
-    /// ([`Self::pty_command`] — interpreter + temp script for the interpreted
-    /// backends, a freshly built binary for the compiled ones) so no
-    /// per-backend override is needed, then drives it through pipes with
-    /// exactly `env` as the child environment and `stdin` fed.
+    /// The default reuses the backend's own launch recipe ([`Self::pty_command`] — interpreter + temp script for the interpreted backends, a freshly built binary for the compiled ones) so no per-backend override is needed, then drives it through pipes with exactly `env` as the child environment and `stdin` fed.
     fn run_standalone_wasi(
         &self,
         program: &str,
@@ -176,13 +111,7 @@ pub trait BackendUnderTest: Sync {
         argv.extend(args.iter().map(|a| a.to_string()));
         let argv_refs: Vec<&str> = argv.iter().map(String::as_str).collect();
         let cmd = self.pty_command(program, &argv_refs);
-        // The guest must observe exactly the manifest env (upstream's wasmtime
-        // adapter passes only `--env k=v`, isolating the guest from the host
-        // environment); dewasm's ADR-31 programs pass the whole process env
-        // through, so the isolation has to happen here instead (ADR-40). With
-        // the child PATH gone, exec would fall back to the OS default path and
-        // pick the *system* interpreter (ruby 2.6 / bash 3.2 on macOS), so a
-        // bare program name is resolved against the parent PATH first.
+        // The guest must observe exactly the manifest env (upstream's wasmtime adapter passes only `--env k=v`, isolating the guest from the host environment); dewasm's ADR-31 programs pass the whole process env through, so the isolation has to happen here instead (ADR-40). With the child PATH gone, exec would fall back to the OS default path and pick the *system* interpreter (ruby 2.6 / bash 3.2 on macOS), so a bare program name is resolved against the parent PATH first.
         let resolved = resolve_in_parent_path(&cmd.program);
         let mut command = Command::new(resolved);
         command.args(&cmd.args);
@@ -197,10 +126,7 @@ pub trait BackendUnderTest: Sync {
     }
 }
 
-/// Resolve a bare program name to an absolute path using the *parent*
-/// process's PATH, so an `env_clear`ed child still runs the interpreter the
-/// test environment selected. Names already containing a separator pass
-/// through untouched.
+/// Resolve a bare program name to an absolute path using the *parent* process's PATH, so an `env_clear`ed child still runs the interpreter the test environment selected. Names already containing a separator pass through untouched.
 fn resolve_in_parent_path(program: &Path) -> PathBuf {
     if program.components().count() > 1 {
         return program.to_path_buf();
@@ -216,8 +142,7 @@ fn resolve_in_parent_path(program: &Path) -> PathBuf {
     program.to_path_buf()
 }
 
-/// Spawn `cmd` with `stdin` piped in and both output streams captured,
-/// returning the raw `Output`.
+/// Spawn `cmd` with `stdin` piped in and both output streams captured, returning the raw `Output`.
 pub fn run_command(cmd: &mut Command, stdin: &str) -> Output {
     run_command_bytes(cmd, stdin.as_bytes())
 }
@@ -235,10 +160,7 @@ pub fn run_command_bytes(cmd: &mut Command, stdin: &[u8]) -> Output {
     child.wait_with_output().expect("wait")
 }
 
-/// Write `script` to a temp file (extension `ext`) and run it under
-/// `interpreter`, returning the raw `Output`. The pid + counter pair keeps
-/// paths unique across both parallel test threads and concurrent `cargo
-/// test` processes.
+/// Write `script` to a temp file (extension `ext`) and run it under `interpreter`, returning the raw `Output`. The pid + counter pair keeps paths unique across both parallel test threads and concurrent `cargo test` processes.
 pub fn run_script(
     interpreter: &Path,
     script: &str,
@@ -261,9 +183,7 @@ pub fn run_script_bytes(
     run_command_bytes(Command::new(interpreter).arg(&path).args(args), stdin)
 }
 
-/// Write `script` to a fresh temp file with extension `ext` and return its
-/// path. The pid + counter pair keeps paths unique across both parallel test
-/// threads and concurrent `cargo test` processes.
+/// Write `script` to a fresh temp file with extension `ext` and return its path. The pid + counter pair keeps paths unique across both parallel test threads and concurrent `cargo test` processes.
 pub fn write_temp_script(script: &str, ext: &str) -> PathBuf {
     static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     let path = std::env::temp_dir().join(format!(

--- a/crates/dewasm-test-helper/src/fixtures.rs
+++ b/crates/dewasm-test-helper/src/fixtures.rs
@@ -1,7 +1,4 @@
-//! Fixture paths and the one conversion policy the e2e suites share. Paths
-//! resolve from the consuming crate via `CARGO_MANIFEST_DIR`; every crate
-//! that uses this helper sits at `crates/<x>/`, so `../../` still reaches the
-//! repo root (ADR-27).
+//! Fixture paths and the one conversion policy the e2e suites share. Paths resolve from the consuming crate via `CARGO_MANIFEST_DIR`; every crate that uses this helper sits at `crates/<x>/`, so `../../` still reaches the repo root (ADR-27).
 
 use std::path::{Path, PathBuf};
 
@@ -17,20 +14,17 @@ pub fn apps_cache_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("../../examples/apps/cache")
 }
 
-/// `examples/apps/fixtures/`, home of our own committed app-driver fixtures
-/// (the QuickJS `.js` scripts the Phase 5a filesystem app cases run).
+/// `examples/apps/fixtures/`, home of our own committed app-driver fixtures (the QuickJS `.js` scripts the Phase 5a filesystem app cases run).
 pub fn apps_fixtures_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("../../examples/apps/fixtures")
 }
 
-/// `examples/apps/golden/`, the checked-in golden outputs captured from
-/// `wasmtime` (ADR-15).
+/// `examples/apps/golden/`, the checked-in golden outputs captured from `wasmtime` (ADR-15).
 pub fn apps_golden_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("../../examples/apps/golden")
 }
 
-/// A fresh, empty scratch directory under the temp dir keyed by `name`, so
-/// cases running in parallel never share host state.
+/// A fresh, empty scratch directory under the temp dir keyed by `name`, so cases running in parallel never share host state.
 pub fn fresh_scratch_dir(name: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!("dewasm-app-{name}"));
     let _ = std::fs::remove_dir_all(&dir);
@@ -55,9 +49,7 @@ pub fn convert_bytes(backend: &dyn Backend, bytes: &[u8], mode: Mode, name: &str
         .expect("generate")
         .remove(0)
         .contents;
-    // The primary source is always UTF-8 (generated code); only the optional
-    // data sidecar is raw bytes, and this helper only ever asks for the
-    // primary file (`data_file: None`).
+    // The primary source is always UTF-8 (generated code); only the optional data sidecar is raw bytes, and this helper only ever asks for the primary file (`data_file: None`).
     String::from_utf8(source).expect("generated source is valid UTF-8")
 }
 
@@ -67,9 +59,7 @@ pub fn convert(backend: &dyn Backend, wat_path: &Path, mode: Mode, name: &str) -
     convert_bytes(backend, &bytes, mode, name)
 }
 
-/// Codegen recurses with the IR's control-flow nesting; SQLite's deepest
-/// functions exceed the 2 MiB test-thread default stack, so app conversion
-/// runs on a roomier stack.
+/// Codegen recurses with the IR's control-flow nesting; SQLite's deepest functions exceed the 2 MiB test-thread default stack, so app conversion runs on a roomier stack.
 pub fn convert_on_big_stack(
     backend: &(dyn Backend + Sync),
     bytes: &[u8],

--- a/crates/dewasm-test-helper/src/glue.rs
+++ b/crates/dewasm-test-helper/src/glue.rs
@@ -1,32 +1,14 @@
-//! The placeholder-substitution helper for direct-string test glue (ADR-27
-//! revision).
+//! The placeholder-substitution helper for direct-string test glue (ADR-27 revision).
 //!
-//! Per-language test glue — the host-language driver appended after a converted
-//! module to instantiate and exercise it — is written as a named `&str`
-//! constant in each backend crate and passed to a per-case macro as a plain
-//! argument (never a resolver function, a `match` on the case name, or a
-//! `(name, glue)` pair list). Everything a case needs statically — the class
-//! name, argv, env, preopen *guest* paths — is written out literally in the
-//! glue itself.
+//! Per-language test glue — the host-language driver appended after a converted module to instantiate and exercise it — is written as a named `&str` constant in each backend crate and passed to a per-case macro as a plain argument (never a resolver function, a `match` on the case name, or a `(name, glue)` pair list). Everything a case needs statically — the class name, argv, env, preopen *guest* paths — is written out literally in the glue itself.
 //!
 //! # Placeholders
 //!
-//! The one thing that cannot be a literal is a value the test runner computes
-//! at run time: the host path of a fresh scratch directory, the app-cache
-//! directory, or (for the WASI filesystem template) the preopen host/guest
-//! pair. Those are handled by a placeholder convention: [`fill`] substitutes
-//! `{name}` tokens with runtime-computed values. Each runner documents which
-//! placeholders it supplies; the full set in use is `{scratch}`, `{cache}`,
-//! `{host}`, and `{guest}`.
+//! The one thing that cannot be a literal is a value the test runner computes at run time: the host path of a fresh scratch directory, the app-cache directory, or (for the WASI filesystem template) the preopen host/guest pair. Those are handled by a placeholder convention: [`fill`] substitutes `{name}` tokens with runtime-computed values. Each runner documents which placeholders it supplies; the full set in use is `{scratch}`, `{cache}`, `{host}`, and `{guest}`.
 //!
-//! No escaping is performed or needed: glue authors control the surrounding
-//! string, and the substituted values are plain temporary/cache directory paths
-//! with no characters that would need quoting in the host languages.
+//! No escaping is performed or needed: glue authors control the surrounding string, and the substituted values are plain temporary/cache directory paths with no characters that would need quoting in the host languages.
 
-/// Substitute `{name}` placeholders in `template` with the given values, a plain
-/// literal replace of `{name}` for each `(name, value)` pair (no escaping — see
-/// the module docs). A placeholder absent from `template` is simply a no-op, so
-/// a runner can offer more placeholders than a given glue uses.
+/// Substitute `{name}` placeholders in `template` with the given values, a plain literal replace of `{name}` for each `(name, value)` pair (no escaping — see the module docs). A placeholder absent from `template` is simply a no-op, so a runner can offer more placeholders than a given glue uses.
 pub fn fill(template: &str, vars: &[(&str, &str)]) -> String {
     let mut out = template.to_string();
     for (name, value) in vars {

--- a/crates/dewasm-test-helper/src/lib.rs
+++ b/crates/dewasm-test-helper/src/lib.rs
@@ -1,9 +1,4 @@
-//! Shared test harness, case tables, and per-feature test macros for the
-//! dewasm backend crates (ADR-27). This crate depends only on `dewasm-core`
-//! and `dewasm-backend` — never on a concrete backend crate — and is taken as
-//! a dev-dependency by each backend crate, which supplies a
-//! [`BackendUnderTest`] (and, for the spec harness, a [`SpecBackend`]) and
-//! wires up the suites it participates in via the macros below.
+//! Shared test harness, case tables, and per-feature test macros for the dewasm backend crates (ADR-27). This crate depends only on `dewasm-core` and `dewasm-backend` — never on a concrete backend crate — and is taken as a dev-dependency by each backend crate, which supplies a [`BackendUnderTest`] (and, for the spec harness, a [`SpecBackend`]) and wires up the suites it participates in via the macros below.
 
 mod apps;
 mod apps_capi;
@@ -58,12 +53,7 @@ pub use wasi::{
 pub use wasi_testsuite::{wasi_testsuite_main, wasi_testsuite_trials, WasiTestsuiteBackend};
 pub use wasmtime_backend::Wasmtime;
 
-/// The `harness = false` `main` of a backend's spec integration test: builds
-/// one libtest-mimic trial per `.wast` file for `$lang` (a [`SpecBackend`]) and
-/// runs them with cargo's own test arguments (name filter,
-/// `--ignored`/`--include-ignored`, thread count). `$lang` must be a
-/// promotable-to-`'static` value — the backend `Spec` structs are unit structs,
-/// so `spec_suite!(RubySpec)` promotes `&RubySpec` to `&'static`.
+/// The `harness = false` `main` of a backend's spec integration test: builds one libtest-mimic trial per `.wast` file for `$lang` (a [`SpecBackend`]) and runs them with cargo's own test arguments (name filter, `--ignored`/`--include-ignored`, thread count). `$lang` must be a promotable-to-`'static` value — the backend `Spec` structs are unit structs, so `spec_suite!(RubySpec)` promotes `&RubySpec` to `&'static`.
 #[macro_export]
 macro_rules! spec_suite {
     ($lang:expr) => {
@@ -73,10 +63,7 @@ macro_rules! spec_suite {
     };
 }
 
-/// The `harness = false` `main` of a backend's WASI-testsuite integration test
-/// (ADR-36): builds one libtest-mimic trial per prebuilt `.wasm` for `$lang` (a
-/// [`WasiTestsuiteBackend`]) and runs them with cargo's own test arguments. Like
-/// [`spec_suite!`], `$lang` is a promotable-to-`'static` unit struct.
+/// The `harness = false` `main` of a backend's WASI-testsuite integration test (ADR-36): builds one libtest-mimic trial per prebuilt `.wasm` for `$lang` (a [`WasiTestsuiteBackend`]) and runs them with cargo's own test arguments. Like [`spec_suite!`], `$lang` is a promotable-to-`'static` unit struct.
 ///
 /// [`WasiTestsuiteBackend`]: crate::WasiTestsuiteBackend
 #[macro_export]
@@ -88,16 +75,10 @@ macro_rules! wasi_testsuite_suite {
     };
 }
 
-/// Internal: attach a two-tier `#[ignore]` gate to a generated `#[test]` item
-/// (ADR-48). The per-case app macros below delegate here so a callsite can pick
-/// the tier without duplicating the gate:
+/// Internal: attach a two-tier `#[ignore]` gate to a generated `#[test]` item (ADR-48). The per-case app macros below delegate here so a callsite can pick the tier without duplicating the gate:
 ///
-/// * `slow` — gated on the backend crate's `slow_test` feature (CI's main sweep
-///   tier). This is the default for every slow-case macro.
-/// * `ultra` — gated on `ultra_slow_test` (which implies `slow_test`), for a
-///   case measured at roughly a minute or more on a CI runner. These are kept
-///   out of CI and run only under `--features ultra_slow_test` or
-///   `-- --include-ignored`, in local pre-release verification.
+/// * `slow` — gated on the backend crate's `slow_test` feature (CI's main sweep tier). This is the default for every slow-case macro.
+/// * `ultra` — gated on `ultra_slow_test` (which implies `slow_test`), for a case measured at roughly a minute or more on a CI runner. These are kept out of CI and run only under `--features ultra_slow_test` or `-- --include-ignored`, in local pre-release verification.
 #[macro_export]
 macro_rules! slow_tier_test {
     (slow, $item:item) => {
@@ -116,11 +97,7 @@ macro_rules! slow_tier_test {
     };
 }
 
-/// Per-case library macros (ADR-27 revision): each expands to one
-/// `#[test] fn <case>()` running the named [`LibraryCase`] const for `$lang`
-/// with `$glue` (a named `&str` const in the backend crate). A backend declares
-/// participation by invoking the macro and drops it (with a REASON comment) for
-/// a capability it lacks.
+/// Per-case library macros (ADR-27 revision): each expands to one `#[test] fn <case>()` running the named [`LibraryCase`] const for `$lang` with `$glue` (a named `&str` const in the backend crate). A backend declares participation by invoking the macro and drops it (with a REASON comment) for a capability it lacks.
 ///
 /// [`LIBRARY_ADD`]: crate::LIBRARY_ADD
 #[macro_export]
@@ -177,12 +154,7 @@ macro_rules! stdio_capture_e2e {
     };
 }
 
-/// One `#[test]` running the WASI cases of a given feature kind for `$lang`.
-/// The no-glue form covers whole-program standalone kinds (`Stdio`, `ArgsEnv`,
-/// `ClockRandom`, `Poll`); the `Fs` form covers the filesystem cases
-/// (library-mode runs against a preopened host directory), taking a single
-/// per-backend glue **template** const whose `{guest}`/`{host}` placeholders the
-/// runner fills with each case's preopen pair (ADR-27 revision).
+/// One `#[test]` running the WASI cases of a given feature kind for `$lang`. The no-glue form covers whole-program standalone kinds (`Stdio`, `ArgsEnv`, `ClockRandom`, `Poll`); the `Fs` form covers the filesystem cases (library-mode runs against a preopened host directory), taking a single per-backend glue **template** const whose `{guest}`/`{host}` placeholders the runner fills with each case's preopen pair (ADR-27 revision).
 #[macro_export]
 macro_rules! wasi_suite {
     ($lang:expr, Stdio) => {
@@ -217,11 +189,7 @@ macro_rules! wasi_suite {
     };
 }
 
-/// One `#[test]` exercising the standalone `--dir` interface (ADR-31) for
-/// `$lang`: convert `wasi_standalone_dir.wat` standalone, run it with a `--dir`
-/// mount, and require the file round-trip to succeed. No glue — standalone needs
-/// none. Wired by every filesystem backend (and re-run under wasmtime as ground
-/// truth); Bash joined once its WASI filesystem landed (ADR-34).
+/// One `#[test]` exercising the standalone `--dir` interface (ADR-31) for `$lang`: convert `wasi_standalone_dir.wat` standalone, run it with a `--dir` mount, and require the file round-trip to succeed. No glue — standalone needs none. Wired by every filesystem backend (and re-run under wasmtime as ground truth); Bash joined once its WASI filesystem landed (ADR-34).
 #[macro_export]
 macro_rules! standalone_dir_e2e {
     ($lang:expr) => {
@@ -232,14 +200,7 @@ macro_rules! standalone_dir_e2e {
     };
 }
 
-/// One `#[test]` requiring the standalone entrypoint to survive deep-but-valid
-/// guest recursion for `$lang`: convert `deep_recursion.wat` (5000-frame
-/// recursion) standalone, run it, and require the guest's `proc_exit(42)` as
-/// the exit code — see [`run_deep_recursion`](crate::run_deep_recursion). No
-/// glue — this exercises the emitted entrypoint itself. Wired by Python, whose
-/// entrypoint applies ADR-28's mitigation (issue #31); each other backend's
-/// host recursion depth is its own concern — it invokes this once its
-/// entrypoint needs (and has) such a mitigation.
+/// One `#[test]` requiring the standalone entrypoint to survive deep-but-valid guest recursion for `$lang`: convert `deep_recursion.wat` (5000-frame recursion) standalone, run it, and require the guest's `proc_exit(42)` as the exit code — see [`run_deep_recursion`](crate::run_deep_recursion). No glue — this exercises the emitted entrypoint itself. Wired by Python, whose entrypoint applies ADR-28's mitigation (issue #31); each other backend's host recursion depth is its own concern — it invokes this once its entrypoint needs (and has) such a mitigation.
 #[macro_export]
 macro_rules! deep_recursion_e2e {
     ($lang:expr) => {
@@ -250,10 +211,7 @@ macro_rules! deep_recursion_e2e {
     };
 }
 
-/// One `#[test]` running the root-preopen containment probe for `$lang` with
-/// `$glue` (a named `&str` const that drives the WASI resolver directly). Split
-/// out of `wasi_suite!(Fs)` because it does not fit the shared preopen-and-run
-/// template — see [`run_wasi_containment`](crate::run_wasi_containment).
+/// One `#[test]` running the root-preopen containment probe for `$lang` with `$glue` (a named `&str` const that drives the WASI resolver directly). Split out of `wasi_suite!(Fs)` because it does not fit the shared preopen-and-run template — see [`run_wasi_containment`](crate::run_wasi_containment).
 #[macro_export]
 macro_rules! wasi_root_containment_e2e {
     ($lang:expr, $glue:expr) => {
@@ -264,15 +222,7 @@ macro_rules! wasi_root_containment_e2e {
     };
 }
 
-/// Per-case app macros (ADR-27 revision): each expands to one
-/// `#[test] fn <case>()` running the named [`AppCase`] const for `$lang` (a
-/// [`BackendUnderTest`]). No glue argument — these are standalone-mode
-/// stdin/args cases, so no host-language glue is needed. `cowsay_args_e2e!`
-/// and `cowsay_stdin_e2e!` always run; `qjs_eval_e2e!` and `sqlite3_shell_e2e!`
-/// are slow — their generated `#[test]` is `#[ignore]`d unless the expanding
-/// backend crate's `slow_test` feature is enabled (run with `--features slow_test`
-/// or `cargo test -- --include-ignored`). A callsite may pass a trailing tier
-/// token (`slow`, the default, or `ultra`); see [`slow_tier_test!`] (ADR-48).
+/// Per-case app macros (ADR-27 revision): each expands to one `#[test] fn <case>()` running the named [`AppCase`] const for `$lang` (a [`BackendUnderTest`]). No glue argument — these are standalone-mode stdin/args cases, so no host-language glue is needed. `cowsay_args_e2e!` and `cowsay_stdin_e2e!` always run; `qjs_eval_e2e!` and `sqlite3_shell_e2e!` are slow — their generated `#[test]` is `#[ignore]`d unless the expanding backend crate's `slow_test` feature is enabled (run with `--features slow_test` or `cargo test -- --include-ignored`). A callsite may pass a trailing tier token (`slow`, the default, or `ultra`); see [`slow_tier_test!`] (ADR-48).
 ///
 /// [`AppCase`]: crate::AppCase
 #[macro_export]
@@ -296,11 +246,7 @@ macro_rules! cowsay_stdin_e2e {
     };
 }
 
-/// See [`cowsay_args_e2e!`]. Runs the slow [`QJS_EVAL`](crate::QJS_EVAL) case.
-/// Slow: the generated `#[test]` is `#[ignore]`d unless the expanding
-/// backend crate's `slow_test` feature is enabled (ADR-27 revision) — run it with
-/// `--features slow_test` or `cargo test -- --include-ignored`. Pass a trailing
-/// `ultra` to promote it to the ultra tier ([`slow_tier_test!`], ADR-48).
+/// See [`cowsay_args_e2e!`]. Runs the slow [`QJS_EVAL`](crate::QJS_EVAL) case. Slow: the generated `#[test]` is `#[ignore]`d unless the expanding backend crate's `slow_test` feature is enabled (ADR-27 revision) — run it with `--features slow_test` or `cargo test -- --include-ignored`. Pass a trailing `ultra` to promote it to the ultra tier ([`slow_tier_test!`], ADR-48).
 #[macro_export]
 macro_rules! qjs_eval_e2e {
     ($lang:expr) => {
@@ -316,9 +262,7 @@ macro_rules! qjs_eval_e2e {
     };
 }
 
-/// See [`cowsay_args_e2e!`]. Runs the slow [`SQLITE3_SHELL`](crate::SQLITE3_SHELL)
-/// case. Slow: see [`qjs_eval_e2e!`] for the `#[ignore]`/`slow_test` feature gate
-/// and the trailing tier token.
+/// See [`cowsay_args_e2e!`]. Runs the slow [`SQLITE3_SHELL`](crate::SQLITE3_SHELL) case. Slow: see [`qjs_eval_e2e!`] for the `#[ignore]`/`slow_test` feature gate and the trailing tier token.
 #[macro_export]
 macro_rules! sqlite3_shell_e2e {
     ($lang:expr) => {
@@ -334,10 +278,7 @@ macro_rules! sqlite3_shell_e2e {
     };
 }
 
-/// One `#[test]` running the gzip byte-stdio stress cases (minigzip) for
-/// `$lang`. Separate from the app macros above because those cases carry
-/// binary stdin/stdout an `&str`/`include_str!` `AppCase` cannot represent
-/// (`run_gzip_cases`).
+/// One `#[test]` running the gzip byte-stdio stress cases (minigzip) for `$lang`. Separate from the app macros above because those cases carry binary stdin/stdout an `&str`/`include_str!` `AppCase` cannot represent (`run_gzip_cases`).
 #[macro_export]
 macro_rules! gzip_e2e {
     ($lang:expr) => {
@@ -348,10 +289,7 @@ macro_rules! gzip_e2e {
     };
 }
 
-/// One `#[test]` driving the bare QuickJS interactive REPL under a real pty for
-/// `$lang` and comparing the transcript byte-for-byte to the wasmtime golden
-/// (Fix 4). Slow: see [`qjs_eval_e2e!`] for the `#[ignore]`/`slow_test` feature
-/// gate and the trailing tier token.
+/// One `#[test]` driving the bare QuickJS interactive REPL under a real pty for `$lang` and comparing the transcript byte-for-byte to the wasmtime golden (Fix 4). Slow: see [`qjs_eval_e2e!`] for the `#[ignore]`/`slow_test` feature gate and the trailing tier token.
 #[macro_export]
 macro_rules! qjs_repl_pty_e2e {
     ($lang:expr) => {
@@ -367,14 +305,7 @@ macro_rules! qjs_repl_pty_e2e {
     };
 }
 
-/// Per-case filesystem-app macros (ADR-27 revision): each expands to one
-/// `#[test] fn <case>()` running the named [`FsAppCase`] const for `$lang` with
-/// `$glue` (a named `&str` const in the backend crate whose `{scratch}`/`{cache}`
-/// placeholders the runner fills). A backend declares participation by invoking
-/// the macro and drops it (with a REASON comment) for a case it cannot run.
-/// Slow: the generated `#[test]` is `#[ignore]`d unless the expanding backend
-/// crate's `slow_test` feature is enabled (see [`qjs_eval_e2e!`]); a trailing
-/// tier token after `$glue` promotes a case to the ultra tier ([`slow_tier_test!`]).
+/// Per-case filesystem-app macros (ADR-27 revision): each expands to one `#[test] fn <case>()` running the named [`FsAppCase`] const for `$lang` with `$glue` (a named `&str` const in the backend crate whose `{scratch}`/`{cache}` placeholders the runner fills). A backend declares participation by invoking the macro and drops it (with a REASON comment) for a case it cannot run. Slow: the generated `#[test]` is `#[ignore]`d unless the expanding backend crate's `slow_test` feature is enabled (see [`qjs_eval_e2e!`]); a trailing tier token after `$glue` promotes a case to the ultra tier ([`slow_tier_test!`]).
 ///
 /// [`FsAppCase`]: crate::FsAppCase
 #[macro_export]
@@ -472,14 +403,7 @@ macro_rules! cruby_hello_e2e {
     };
 }
 
-/// Per-case C-API macros (ADR-27 revision): each expands to one
-/// `#[test] fn <case>()` running the named [`CApiCase`] const for `$lang` with
-/// `$glue` (a named `&str` const in the backend crate; the file-backed case's
-/// `{scratch}` placeholder is filled by the runner). Which backends invoke
-/// these is the capability declaration (ADR-27): Ruby/Python/Go/Java, not Bash
-/// (ADR-12). Slow: the generated `#[test]` is `#[ignore]`d unless the
-/// expanding backend crate's `slow_test` feature is enabled (see
-/// [`qjs_eval_e2e!`]).
+/// Per-case C-API macros (ADR-27 revision): each expands to one `#[test] fn <case>()` running the named [`CApiCase`] const for `$lang` with `$glue` (a named `&str` const in the backend crate; the file-backed case's `{scratch}` placeholder is filled by the runner). Which backends invoke these is the capability declaration (ADR-27): Ruby/Python/Go/Java, not Bash (ADR-12). Slow: the generated `#[test]` is `#[ignore]`d unless the expanding backend crate's `slow_test` feature is enabled (see [`qjs_eval_e2e!`]).
 ///
 /// [`CApiCase`]: crate::CApiCase
 #[macro_export]
@@ -513,11 +437,7 @@ macro_rules! sqlite3_file_c_api_e2e {
     };
 }
 
-/// See [`libsqlite3_c_api_e2e!`]. Runs the libpcap BPF-compile case
-/// [`PCAP_COMPILE`](crate::PCAP_COMPILE): drives `compile_filter` on
-/// "tcp port 80" and prints the serialized BPF program. Slow (a ~2 MB
-/// reactor artifact reconverted per run), so gated like the sqlite C-API
-/// cases.
+/// See [`libsqlite3_c_api_e2e!`]. Runs the libpcap BPF-compile case [`PCAP_COMPILE`](crate::PCAP_COMPILE): drives `compile_filter` on "tcp port 80" and prints the serialized BPF program. Slow (a ~2 MB reactor artifact reconverted per run), so gated like the sqlite C-API cases.
 #[macro_export]
 macro_rules! pcap_compile_e2e {
     ($lang:expr, $glue:expr) => {
@@ -533,11 +453,7 @@ macro_rules! pcap_compile_e2e {
     };
 }
 
-/// See [`libsqlite3_c_api_e2e!`]. Runs the tree-sitter JSON-parse case
-/// [`TREESITTER_PARSE`](crate::TREESITTER_PARSE): drives `parse_source` on a
-/// fixed JSON snippet and prints the parse tree's S-expression. Slow (a
-/// ~1.5 MB reactor artifact reconverted per run), so gated like the sqlite
-/// C-API cases.
+/// See [`libsqlite3_c_api_e2e!`]. Runs the tree-sitter JSON-parse case [`TREESITTER_PARSE`](crate::TREESITTER_PARSE): drives `parse_source` on a fixed JSON snippet and prints the parse tree's S-expression. Slow (a ~1.5 MB reactor artifact reconverted per run), so gated like the sqlite C-API cases.
 #[macro_export]
 macro_rules! treesitter_parse_e2e {
     ($lang:expr, $glue:expr) => {
@@ -569,13 +485,7 @@ macro_rules! sqlite3_callback_binding_e2e {
     };
 }
 
-/// Per-case multi-module macros (ADR-27 revision): each expands to one
-/// `#[test] fn <case>()` running the named [`MultiModuleCase`] const for `$lang`
-/// with `$glue` (a named `&str` driver const in the backend crate). The backend
-/// must implement [`BackendUnderTest::compose_modules`]. Which backends invoke
-/// these is the capability declaration (ADR-27): the ImportedTables-capable
-/// backends for the shared-table case, and the nested-runtime backends for the
-/// coexistence case.
+/// Per-case multi-module macros (ADR-27 revision): each expands to one `#[test] fn <case>()` running the named [`MultiModuleCase`] const for `$lang` with `$glue` (a named `&str` driver const in the backend crate). The backend must implement [`BackendUnderTest::compose_modules`]. Which backends invoke these is the capability declaration (ADR-27): the ImportedTables-capable backends for the shared-table case, and the nested-runtime backends for the coexistence case.
 ///
 /// [`MultiModuleCase`]: crate::MultiModuleCase
 #[macro_export]

--- a/crates/dewasm-test-helper/src/library.rs
+++ b/crates/dewasm-test-helper/src/library.rs
@@ -1,17 +1,6 @@
-//! Library-mode scenarios over hand-written `.wat` fixtures
-//! (`examples/wat/`). These need per-language glue (Ruby method calls vs.
-//! Bash function calls against globals) — that can't be shared, so glue is
-//! *not* in the case data (ADR-27 revision); each backend crate passes a named
-//! glue constant to the per-case macro. Each glue is engineered to observe the
-//! same thing the same way (e.g. both intercept fd_write and print the literal
-//! bytes written), so one `expect` per scenario is pinned instead of one per
-//! language that could quietly drift apart.
+//! Library-mode scenarios over hand-written `.wat` fixtures (`examples/wat/`). These need per-language glue (Ruby method calls vs. Bash function calls against globals) — that can't be shared, so glue is *not* in the case data (ADR-27 revision); each backend crate passes a named glue constant to the per-case macro. Each glue is engineered to observe the same thing the same way (e.g. both intercept fd_write and print the literal bytes written), so one `expect` per scenario is pinned instead of one per language that could quietly drift apart.
 //!
-//! Each case is a `pub const` [`LibraryCase`] a per-case macro
-//! (`library_add_e2e!`, `wasi_import_override_e2e!`, ...) drives; a backend
-//! declares participation by invoking the macro, and drops it (with a REASON
-//! comment) for a capability it lacks — the ADR-27 replacement for the old
-//! per-case `exclude` ledger.
+//! Each case is a `pub const` [`LibraryCase`] a per-case macro (`library_add_e2e!`, `wasi_import_override_e2e!`, ...) drives; a backend declares participation by invoking the macro, and drops it (with a REASON comment) for a capability it lacks — the ADR-27 replacement for the old per-case `exclude` ledger.
 
 use dewasm_backend::Mode;
 
@@ -22,15 +11,11 @@ pub struct LibraryCase {
     pub name: &'static str,
     pub wat: &'static str,
     pub module_name: &'static str,
-    /// Both sides are engineered to produce this same string — the glue
-    /// captures and prints the actual bytes the wasm module wrote, rather
-    /// than a language-specific diagnostic, so there is exactly one
-    /// expectation per scenario.
+    /// Both sides are engineered to produce this same string — the glue captures and prints the actual bytes the wasm module wrote, rather than a language-specific diagnostic, so there is exactly one expectation per scenario.
     pub expect: &'static str,
 }
 
-/// `add.wat`: plain exported arithmetic (masked-unsigned overflow and a fib
-/// recursion). Every backend runs it (`library_add_e2e!`).
+/// `add.wat`: plain exported arithmetic (masked-unsigned overflow and a fib recursion). Every backend runs it (`library_add_e2e!`).
 pub const LIBRARY_ADD: LibraryCase = LibraryCase {
     name: "add",
     wat: "add.wat",
@@ -38,12 +23,7 @@ pub const LIBRARY_ADD: LibraryCase = LibraryCase {
     expect: "5\n0\n55\n",
 };
 
-/// The ADR-7 override/fallback semantics: an explicit import wins, an unhandled
-/// one falls back to the bundled WASI. Both glues intercept fd_write and print
-/// the actual bytes the module wrote (rather than a fd/len diagnostic) — the one
-/// observable both languages can produce identically. Both sides only touch
-/// fd_write/random_get (WASI core), so every backend runs it
-/// (`wasi_import_override_e2e!`).
+/// The ADR-7 override/fallback semantics: an explicit import wins, an unhandled one falls back to the bundled WASI. Both glues intercept fd_write and print the actual bytes the module wrote (rather than a fd/len diagnostic) — the one observable both languages can produce identically. Both sides only touch fd_write/random_get (WASI core), so every backend runs it (`wasi_import_override_e2e!`).
 pub const WASI_IMPORT_OVERRIDE: LibraryCase = LibraryCase {
     name: "wasi_import_override",
     wat: "wasi_imports.wat",
@@ -51,13 +31,7 @@ pub const WASI_IMPORT_OVERRIDE: LibraryCase = LibraryCase {
     expect: "ok\n",
 };
 
-/// A provider *object* (ADR-7) replaces the bundled WASI wholesale:
-/// `import`/`wasm_import` resolves every function, `attach` binds the memory,
-/// and — because every import is covered — the bundled WASI is never lazily
-/// constructed. The glue prints the intercepted bytes plus the "not constructed"
-/// observable. Only Ruby (duck-typed object) and Python
-/// (`wasm_import`/`attach` provider + lazy `_wasi`) invoke
-/// `custom_wasi_provider_e2e!`.
+/// A provider *object* (ADR-7) replaces the bundled WASI wholesale: `import`/`wasm_import` resolves every function, `attach` binds the memory, and — because every import is covered — the bundled WASI is never lazily constructed. The glue prints the intercepted bytes plus the "not constructed" observable. Only Ruby (duck-typed object) and Python (`wasm_import`/`attach` provider + lazy `_wasi`) invoke `custom_wasi_provider_e2e!`.
 pub const CUSTOM_WASI_PROVIDER: LibraryCase = LibraryCase {
     name: "custom_wasi_provider",
     wat: "wasi_imports.wat",
@@ -65,11 +39,7 @@ pub const CUSTOM_WASI_PROVIDER: LibraryCase = LibraryCase {
     expect: "ok\nbundled wasi constructed: false\n",
 };
 
-/// The `true` counterpart: a *partial* override (fd_write only) still lets the
-/// bundled WASI be lazily constructed for the one import it doesn't cover
-/// (random_get) — ADR-7's `@wasi ||= ...`. Same fallback the always-on
-/// `WASI_IMPORT_OVERRIDE` case proves, but here the glue additionally probes
-/// that the bundled WASI *was* built. Ruby/Python only (`partial_override_e2e!`).
+/// The `true` counterpart: a *partial* override (fd_write only) still lets the bundled WASI be lazily constructed for the one import it doesn't cover (random_get) — ADR-7's `@wasi ||= ...`. Same fallback the always-on `WASI_IMPORT_OVERRIDE` case proves, but here the glue additionally probes that the bundled WASI *was* built. Ruby/Python only (`partial_override_e2e!`).
 pub const PARTIAL_OVERRIDE: LibraryCase = LibraryCase {
     name: "partial_override_falls_back_to_bundled_wasi",
     wat: "wasi_imports.wat",
@@ -77,11 +47,7 @@ pub const PARTIAL_OVERRIDE: LibraryCase = LibraryCase {
     expect: "ok\nbundled wasi constructed: true\n",
 };
 
-/// Library-mode stdio redirected to an in-memory object: the embedder wires the
-/// module's stdout to a language-native in-memory sink (Ruby StringIO, Python
-/// BytesIO, Java ByteArrayOutputStream) and reads the guest output back. Ruby,
-/// Python, and Java invoke `stdio_capture_e2e!`; Go and Bash lack the injection
-/// point (see their non-invocation REASON comments).
+/// Library-mode stdio redirected to an in-memory object: the embedder wires the module's stdout to a language-native in-memory sink (Ruby StringIO, Python BytesIO, Java ByteArrayOutputStream) and reads the guest output back. Ruby, Python, and Java invoke `stdio_capture_e2e!`; Go and Bash lack the injection point (see their non-invocation REASON comments).
 pub const STDIO_CAPTURE: LibraryCase = LibraryCase {
     name: "wasi_stdio_capture",
     wat: "hello.wat",
@@ -89,9 +55,7 @@ pub const STDIO_CAPTURE: LibraryCase = LibraryCase {
     expect: "Hello, WASI!\n",
 };
 
-/// Convert `case` in library mode, append `lang`'s `glue` for it, run it, and
-/// check stdout against the case's fixed expectation. A non-zero exit is a
-/// failure regardless of stdout.
+/// Convert `case` in library mode, append `lang`'s `glue` for it, run it, and check stdout against the case's fixed expectation. A non-zero exit is a failure regardless of stdout.
 pub fn run_library_case(lang: &dyn BackendUnderTest, case: &LibraryCase, glue: &str) {
     let code = convert(
         lang.backend(),

--- a/crates/dewasm-test-helper/src/multimodule.rs
+++ b/crates/dewasm-test-helper/src/multimodule.rs
@@ -1,46 +1,21 @@
-//! Multi-module scenarios (ADR-27): two generated modules living in one
-//! process. The *composition* — how a backend emits several modules against
-//! one runtime, or as independent self-contained ones — is backend-specific and
-//! uses each backend's own crate API, which the test-helper crate cannot depend
-//! on; it is therefore supplied via [`BackendUnderTest::compose_modules`]. The
-//! *driver* (instantiate, link, assert) is per-language glue passed to the
-//! runner as a named const. What stays shared is the case content: which
-//! fixtures, the linkage model, and the one fixed expectation each backend's
-//! driver is engineered to produce (normalized so it is identical across
-//! languages).
+//! Multi-module scenarios (ADR-27): two generated modules living in one process. The *composition* — how a backend emits several modules against one runtime, or as independent self-contained ones — is backend-specific and uses each backend's own crate API, which the test-helper crate cannot depend on; it is therefore supplied via [`BackendUnderTest::compose_modules`]. The *driver* (instantiate, link, assert) is per-language glue passed to the runner as a named const. What stays shared is the case content: which fixtures, the linkage model, and the one fixed expectation each backend's driver is engineered to produce (normalized so it is identical across languages).
 //!
-//! Each case is a `pub const` [`MultiModuleCase`] driven by a per-case macro
-//! (`shared_table_e2e!`, `embedded_coexist_e2e!`); which backends invoke it is
-//! the capability declaration (ADR-27 revision), with a REASON comment at any
-//! non-invocation.
+//! Each case is a `pub const` [`MultiModuleCase`] driven by a per-case macro (`shared_table_e2e!`, `embedded_coexist_e2e!`); which backends invoke it is the capability declaration (ADR-27 revision), with a REASON comment at any non-invocation.
 
 use crate::backend::BackendUnderTest;
 
-/// A multi-module case: emit `modules` (`(wat filename, class/type name)`) with
-/// the chosen linkage, append the backend's driver glue, run, and require
-/// exactly `expect`.
+/// A multi-module case: emit `modules` (`(wat filename, class/type name)`) with the chosen linkage, append the backend's driver glue, run, and require exactly `expect`.
 pub struct MultiModuleCase {
     pub name: &'static str,
     /// `(wat filename in examples/wat, class/type name)` for each module.
     pub modules: &'static [(&'static str, &'static str)],
-    /// `true`: emit every module against ONE shared runtime, so an imported
-    /// table crosses modules (structural call_indirect typing, ADR-4/16).
-    /// `false`: emit independent self-contained (Embedded) runtimes that
-    /// coexist without colliding.
+    /// `true`: emit every module against ONE shared runtime, so an imported table crosses modules (structural call_indirect typing, ADR-4/16). `false`: emit independent self-contained (Embedded) runtimes that coexist without colliding.
     pub shared_runtime: bool,
-    /// The one fixed output every backend's driver is engineered to produce
-    /// (normalized: e.g. `distinct-rt`/`trapped` tokens rather than a
-    /// language-specific `true`/trap message).
+    /// The one fixed output every backend's driver is engineered to produce (normalized: e.g. `distinct-rt`/`trapped` tokens rather than a language-specific `true`/trap message).
     pub expect: &'static str,
 }
 
-/// A table shared across two modules whose type sections order the same
-/// structural type differently: the call_indirect check must compare types
-/// structurally (ADR-4/16), never via a module-local id. Cross-module linking
-/// runs on one shared runtime (Ruby's Alias linkage / Go's & Java's shared
-/// program bundle, as the spec harness's `register` path does). Wired on the
-/// four ImportedTables-capable backends via `shared_table_e2e!`; Bash rejects
-/// imported tables at conversion time (ADR-12), so it does not invoke it.
+/// A table shared across two modules whose type sections order the same structural type differently: the call_indirect check must compare types structurally (ADR-4/16), never via a module-local id. Cross-module linking runs on one shared runtime (Ruby's Alias linkage / Go's & Java's shared program bundle, as the spec harness's `register` path does). Wired on the four ImportedTables-capable backends via `shared_table_e2e!`; Bash rejects imported tables at conversion time (ADR-12), so it does not invoke it.
 pub const SHARED_TABLE: MultiModuleCase = MultiModuleCase {
     name: "shared_table_call_indirect",
     modules: &[
@@ -51,13 +26,7 @@ pub const SHARED_TABLE: MultiModuleCase = MultiModuleCase {
     expect: "42\n",
 };
 
-/// Two self-contained artifacts must coexist in one process, each carrying its
-/// own runtime, so runtime classes (and the trap type) never collide.
-/// Inherently a *nested*-runtime capability, and only Ruby nests: its Embedded
-/// output puts `module Rt` inside each class, so `Alpha::Rt` and `Beta::Rt` are
-/// distinct types. Only Ruby invokes `embedded_coexist_e2e!` (see the other
-/// backends' non-invocation REASON comments). The driver normalizes output to
-/// `distinct-rt`/`trapped`.
+/// Two self-contained artifacts must coexist in one process, each carrying its own runtime, so runtime classes (and the trap type) never collide. Inherently a *nested*-runtime capability, and only Ruby nests: its Embedded output puts `module Rt` inside each class, so `Alpha::Rt` and `Beta::Rt` are distinct types. Only Ruby invokes `embedded_coexist_e2e!` (see the other backends' non-invocation REASON comments). The driver normalizes output to `distinct-rt`/`trapped`.
 pub const EMBEDDED_COEXIST: MultiModuleCase = MultiModuleCase {
     name: "embedded_runtimes_coexist",
     modules: &[("div_trap.wat", "Alpha"), ("div_trap.wat", "Beta")],
@@ -65,8 +34,7 @@ pub const EMBEDDED_COEXIST: MultiModuleCase = MultiModuleCase {
     expect: "3\n4294967293\ndistinct-rt\ntrapped\n",
 };
 
-/// Compose `case`'s modules with the backend, append its driver `glue`, run, and
-/// check stdout against the case's fixed expectation.
+/// Compose `case`'s modules with the backend, append its driver `glue`, run, and check stdout against the case's fixed expectation.
 pub fn run_multi_module_case(lang: &dyn BackendUnderTest, case: &MultiModuleCase, glue: &str) {
     let modules = lang.compose_modules(case.modules, case.shared_runtime);
     let output = lang.run(&format!("{modules}\n{glue}"), &[], "");

--- a/crates/dewasm-test-helper/src/pty.rs
+++ b/crates/dewasm-test-helper/src/pty.rs
@@ -1,31 +1,12 @@
 //! Real-pty process driving for the interactive-REPL transcript tests (Fix 4).
 //!
-//! Some programs behave differently when their stdin is a terminal: the qjs
-//! REPL, for one, only enters its interactive line-editing path (banner,
-//! prompts, per-keystroke echo, result printing) when `fd_fdstat_get` on fd 0
-//! reports a character device. Proving a converted backend byte-identical to
-//! wasmtime on that path therefore needs a genuine pty pair, not the pipes the
-//! rest of the suite uses.
+//! Some programs behave differently when their stdin is a terminal: the qjs REPL, for one, only enters its interactive line-editing path (banner, prompts, per-keystroke echo, result printing) when `fd_fdstat_get` on fd 0 reports a character device. Proving a converted backend byte-identical to wasmtime on that path therefore needs a genuine pty pair, not the pipes the rest of the suite uses.
 //!
-//! [`run_under_pty`] spawns a command on a fixed-size (80x24) pty, feeds it a
-//! scripted input, reads the whole transcript until the child exits, and
-//! returns the raw bytes (ANSI escapes and all). Two pacing strategies exist:
+//! [`run_under_pty`] spawns a command on a fixed-size (80x24) pty, feeds it a scripted input, reads the whole transcript until the child exits, and returns the raw bytes (ANSI escapes and all). Two pacing strategies exist:
 //!
-//!   * *prompt-driven* (`prompt: Some(..)`) — before each input line, wait for
-//!     the prompt marker to appear in the output, then send the line. This
-//!     synchronizes input with the guest's readiness, so the transcript is
-//!     identical no matter how long the guest takes to start (a Ruby backend
-//!     parses a ~200 MB source before qjs even runs; a fixed time delay would
-//!     let the tty buffer every line into one before the guest read any of it).
-//!   * *time-paced* (`prompt: None`) — write each line with a small fixed
-//!     delay. Simpler, but only stable for fast-starting programs; kept as the
-//!     fallback the task asked to compare against.
+//! * *prompt-driven* (`prompt: Some(..)`) — before each input line, wait for the prompt marker to appear in the output, then send the line. This synchronizes input with the guest's readiness, so the transcript is identical no matter how long the guest takes to start (a Ruby backend parses a ~200 MB source before qjs even runs; a fixed time delay would let the tty buffer every line into one before the guest read any of it). * *time-paced* (`prompt: None`) — write each line with a small fixed delay. Simpler, but only stable for fast-starting programs; kept as the fallback the task asked to compare against.
 //!
-//! WASI p1 has no `winsize`/termios surface, so the guest cannot switch the pty
-//! out of canonical mode: input stays line-buffered and the driver echoes it.
-//! With the pty size fixed, `TERM` pinned, and prompt-driven pacing, the whole
-//! transcript is deterministic across engines — that is what makes the
-//! wasmtime-vs-backend byte comparison meaningful.
+//! WASI p1 has no `winsize`/termios surface, so the guest cannot switch the pty out of canonical mode: input stays line-buffered and the driver echoes it. With the pty size fixed, `TERM` pinned, and prompt-driven pacing, the whole transcript is deterministic across engines — that is what makes the wasmtime-vs-backend byte comparison meaningful.
 
 use std::io::{Read, Write};
 use std::path::PathBuf;
@@ -34,9 +15,7 @@ use std::time::{Duration, Instant};
 
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
 
-/// A command to run under a pty: the program path, its arguments (argv[1..]),
-/// and an optional working directory. Mirrors the `std::process::Command`
-/// surface the rest of the helper builds, but is spawned onto a pty slave.
+/// A command to run under a pty: the program path, its arguments (argv[1..]), and an optional working directory. Mirrors the `std::process::Command` surface the rest of the helper builds, but is spawned onto a pty slave.
 pub struct PtyCommand {
     pub program: PathBuf,
     pub args: Vec<String>,
@@ -46,14 +25,9 @@ pub struct PtyCommand {
 /// Per-line delay for the time-paced (`prompt: None`) strategy.
 const LINE_PACING: Duration = Duration::from_millis(120);
 
-/// Spawn `cmd` on a fresh 80x24 pty, feed it `input` (see the module docs for
-/// the two pacing strategies selected by `prompt`), read the full transcript
-/// until the child exits, and return the raw bytes.
+/// Spawn `cmd` on a fresh 80x24 pty, feed it `input` (see the module docs for the two pacing strategies selected by `prompt`), read the full transcript until the child exits, and return the raw bytes.
 ///
-/// The pty size is fixed and `TERM` is pinned to a constant so the transcript
-/// does not vary with the developer's terminal. A child that does not exit — or
-/// a prompt that never appears — within `timeout` is killed and the call panics
-/// (fail loud, ADR-15) rather than hanging the suite.
+/// The pty size is fixed and `TERM` is pinned to a constant so the transcript does not vary with the developer's terminal. A child that does not exit — or a prompt that never appears — within `timeout` is killed and the call panics (fail loud, ADR-15) rather than hanging the suite.
 pub fn run_under_pty(
     cmd: PtyCommand,
     input: &[u8],
@@ -72,20 +46,14 @@ pub fn run_under_pty(
     if let Some(cwd) = &cmd.cwd {
         builder.cwd(cwd);
     }
-    // Deterministic terminal: `CommandBuilder::new` already inherits the parent
-    // environment, so only pin the one variable a terminal type could vary the
-    // output by. wasmtime and every backend go through this same helper, so
-    // both sides see an identical TERM.
+    // Deterministic terminal: `CommandBuilder::new` already inherits the parent environment, so only pin the one variable a terminal type could vary the output by. wasmtime and every backend go through this same helper, so both sides see an identical TERM.
     builder.env("TERM", "xterm-256color");
 
     let mut child = pair.slave.spawn_command(builder).expect("spawn on pty");
-    // Drop our handle to the slave so that, once the child closes its own copy
-    // on exit, the master read returns EOF instead of blocking forever.
+    // Drop our handle to the slave so that, once the child closes its own copy on exit, the master read returns EOF instead of blocking forever.
     drop(pair.slave);
 
-    // Reader thread: pump every chunk over a channel so the driving loop can
-    // wait on output (for the prompt) with a timeout without blocking on a
-    // read that may never return.
+    // Reader thread: pump every chunk over a channel so the driving loop can wait on output (for the prompt) with a timeout without blocking on a read that may never return.
     let mut reader = pair.master.try_clone_reader().expect("clone pty reader");
     let (tx, rx) = mpsc::channel::<Vec<u8>>();
     let reader_handle = std::thread::spawn(move || {
@@ -98,8 +66,7 @@ pub fn run_under_pty(
                         break;
                     }
                 }
-                // A closed pty surfaces as an EIO read error on some platforms
-                // rather than a clean EOF; treat it as end-of-transcript.
+                // A closed pty surfaces as an EIO read error on some platforms rather than a clean EOF; treat it as end-of-transcript.
                 Err(_) => break,
             }
         }
@@ -113,8 +80,7 @@ pub fn run_under_pty(
     let mut search_from = 0usize;
     for line in lines {
         if let Some(marker) = prompt {
-            // Wait for the next prompt (strictly after the previous one) before
-            // sending, so slow-starting guests never miss buffered input.
+            // Wait for the next prompt (strictly after the previous one) before sending, so slow-starting guests never miss buffered input.
             match pump_until_marker(&mut transcript, &rx, marker, search_from, deadline) {
                 Some(pos) => search_from = pos + marker.len(),
                 None => {
@@ -162,8 +128,7 @@ pub fn run_under_pty(
         }
     }
 
-    // Child is gone; drop the master to guarantee the reader observes EOF, then
-    // collect whatever is left in flight.
+    // Child is gone; drop the master to guarantee the reader observes EOF, then collect whatever is left in flight.
     drop(writer);
     drop(pair.master);
     drain(&mut transcript, &rx, Duration::from_millis(500));
@@ -171,9 +136,7 @@ pub fn run_under_pty(
     transcript
 }
 
-/// Pump output from `rx` into `transcript` until `marker` appears at or after
-/// byte `from`, returning its absolute index, or `None` on timeout / the child
-/// closing its output before the marker showed up.
+/// Pump output from `rx` into `transcript` until `marker` appears at or after byte `from`, returning its absolute index, or `None` on timeout / the child closing its output before the marker showed up.
 fn pump_until_marker(
     transcript: &mut Vec<u8>,
     rx: &mpsc::Receiver<Vec<u8>>,
@@ -202,8 +165,7 @@ fn pump_until_marker(
     }
 }
 
-/// Drain any bytes still queued in `rx` into `transcript`, giving up after
-/// `quiet` elapses with nothing new (used once the child has exited).
+/// Drain any bytes still queued in `rx` into `transcript`, giving up after `quiet` elapses with nothing new (used once the child has exited).
 fn drain(transcript: &mut Vec<u8>, rx: &mpsc::Receiver<Vec<u8>>, quiet: Duration) {
     while let Ok(chunk) = rx.recv_timeout(quiet) {
         transcript.extend_from_slice(&chunk);
@@ -220,9 +182,7 @@ fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
         .position(|window| window == needle)
 }
 
-/// Split `input` into lines, keeping each line's terminating `\r` or `\n` (a
-/// bare CR is what a terminal sends on Enter). A trailing unterminated segment
-/// is yielded as its own line.
+/// Split `input` into lines, keeping each line's terminating `\r` or `\n` (a bare CR is what a terminal sends on Enter). A trailing unterminated segment is yielded as its own line.
 fn split_inclusive_newlines(input: &[u8]) -> Vec<&[u8]> {
     let mut lines = Vec::new();
     let mut start = 0;

--- a/crates/dewasm-test-helper/src/qjs_repl.rs
+++ b/crates/dewasm-test-helper/src/qjs_repl.rs
@@ -1,20 +1,8 @@
-//! The interactive-REPL transcript case (Fix 4): drive the *bare* QuickJS REPL
-//! (no script argument, so `_start` sees only argv[0] and QuickJS drops into
-//! its interactive loop) under a real pty and require the transcript to be
-//! byte-identical to the one wasmtime produces.
+//! The interactive-REPL transcript case (Fix 4): drive the *bare* QuickJS REPL (no script argument, so `_start` sees only argv[0] and QuickJS drops into its interactive loop) under a real pty and require the transcript to be byte-identical to the one wasmtime produces.
 //!
-//! The bare no-args invocation is the interactive REPL: a standalone backend
-//! runs `_start` with the host process's real argv, so spawning the converted
-//! program under the pty with no extra arguments is exactly `qjs` with an empty
-//! argument list — the same shape `wasmtime run qjs.wasm` (no trailing args)
-//! takes. The scripted session is fed with CR line endings because that is
-//! what a terminal sends on Enter; the pty driver's ICRNL then delivers NL to
-//! the guest, whose stdin reads a character device (matching wasmtime).
+//! The bare no-args invocation is the interactive REPL: a standalone backend runs `_start` with the host process's real argv, so spawning the converted program under the pty with no extra arguments is exactly `qjs` with an empty argument list — the same shape `wasmtime run qjs.wasm` (no trailing args) takes. The scripted session is fed with CR line endings because that is what a terminal sends on Enter; the pty driver's ICRNL then delivers NL to the guest, whose stdin reads a character device (matching wasmtime).
 //!
-//! The golden lives at `examples/apps/golden/qjs_repl_interactive.transcript`
-//! (raw bytes, ANSI escapes included) and is re-validated against a live
-//! wasmtime by the `wasmtime_test`-gated freshness test in
-//! `crates/dewasm-test-helper/tests/apps_wasmtime.rs`.
+//! The golden lives at `examples/apps/golden/qjs_repl_interactive.transcript` (raw bytes, ANSI escapes included) and is re-validated against a live wasmtime by the `wasmtime_test`-gated freshness test in `crates/dewasm-test-helper/tests/apps_wasmtime.rs`.
 
 use std::path::PathBuf;
 use std::time::Duration;
@@ -25,20 +13,13 @@ use crate::backend::BackendUnderTest;
 use crate::fixtures::{apps_cache_dir, apps_golden_dir};
 use crate::pty::run_under_pty;
 
-/// The scripted interactive session: three expressions and the `\q` quit
-/// command, each terminated by CR (what a tty sends on Enter — verified against
-/// wasmtime, whose guest sees the driver's CR->NL translation).
+/// The scripted interactive session: three expressions and the `\q` quit command, each terminated by CR (what a tty sends on Enter — verified against wasmtime, whose guest sees the driver's CR->NL translation).
 pub const QJS_REPL_SESSION: &[u8] = b"1+2\r[3,1,2].sort()\rMath.max(4,9)\r\\q\r";
 
-/// The QuickJS REPL prompt. The pty driver is prompt-driven off this: each
-/// scripted line is sent only after the prompt reappears, so the transcript is
-/// identical no matter how long a backend takes to start (see
-/// [`crate::run_under_pty`]).
+/// The QuickJS REPL prompt. The pty driver is prompt-driven off this: each scripted line is sent only after the prompt reappears, so the transcript is identical no matter how long a backend takes to start (see [`crate::run_under_pty`]).
 const QJS_PROMPT: &[u8] = b"qjs > ";
 
-/// Hard cap on the pty session (fail loud, ADR-15). Generous: the interactive
-/// loop is I/O-bound line editing, not the slow batch qjs cases, but the
-/// compiled backends may pay a one-time build inside `pty_command` first.
+/// Hard cap on the pty session (fail loud, ADR-15). Generous: the interactive loop is I/O-bound line editing, not the slow batch qjs cases, but the compiled backends may pay a one-time build inside `pty_command` first.
 const PTY_TIMEOUT: Duration = Duration::from_secs(180);
 
 /// Path to the checked-in golden transcript.
@@ -46,10 +27,7 @@ pub fn qjs_repl_golden_path() -> PathBuf {
     apps_golden_dir().join("qjs_repl_interactive.transcript")
 }
 
-/// Convert the cached `qjs.wasm` to a standalone program for `lang` and drive
-/// its interactive REPL under a pty with [`QJS_REPL_SESSION`], returning the
-/// raw transcript. Shared by the gated per-backend runner and the wasmtime
-/// golden capture/freshness path.
+/// Convert the cached `qjs.wasm` to a standalone program for `lang` and drive its interactive REPL under a pty with [`QJS_REPL_SESSION`], returning the raw transcript. Shared by the gated per-backend runner and the wasmtime golden capture/freshness path.
 pub fn capture_qjs_repl_transcript(lang: &dyn BackendUnderTest) -> Vec<u8> {
     let wasm = apps_cache_dir().join("qjs.wasm");
     assert!(
@@ -62,20 +40,14 @@ pub fn capture_qjs_repl_transcript(lang: &dyn BackendUnderTest) -> Vec<u8> {
     run_under_pty(cmd, QJS_REPL_SESSION, Some(QJS_PROMPT), PTY_TIMEOUT)
 }
 
-/// Capture the transcript via `lang` (the wasmtime engine-under-test) and write
-/// it to the golden path, returning the bytes. Used to (re)generate the golden.
+/// Capture the transcript via `lang` (the wasmtime engine-under-test) and write it to the golden path, returning the bytes. Used to (re)generate the golden.
 pub fn capture_qjs_repl_golden(lang: &dyn BackendUnderTest) -> Vec<u8> {
     let transcript = capture_qjs_repl_transcript(lang);
     std::fs::write(qjs_repl_golden_path(), &transcript).expect("write qjs repl golden");
     transcript
 }
 
-/// The per-backend runner: convert qjs to a standalone program for `lang`,
-/// drive its REPL under a pty, and require the transcript to be
-/// byte-identical to the wasmtime golden. The perf opt-out lives at the
-/// macro/feature level (`qjs_repl_pty_e2e!` expands its `#[test]` as
-/// `#[ignore]`d unless the `slow_test` feature is on), so this runner runs
-/// unconditionally.
+/// The per-backend runner: convert qjs to a standalone program for `lang`, drive its REPL under a pty, and require the transcript to be byte-identical to the wasmtime golden. The perf opt-out lives at the macro/feature level (`qjs_repl_pty_e2e!` expands its `#[test]` as `#[ignore]`d unless the `slow_test` feature is on), so this runner runs unconditionally.
 pub fn run_qjs_repl_pty(lang: &dyn BackendUnderTest) {
     let golden = std::fs::read(qjs_repl_golden_path()).unwrap_or_else(|e| {
         panic!(
@@ -93,9 +65,7 @@ pub fn run_qjs_repl_pty(lang: &dyn BackendUnderTest) {
     );
 }
 
-/// Byte-compare two transcripts, panicking with an escaped, human-readable dump
-/// (and the first differing offset) rather than the raw byte-array spew
-/// `assert_eq!` would produce for hundreds of bytes of ANSI escapes.
+/// Byte-compare two transcripts, panicking with an escaped, human-readable dump (and the first differing offset) rather than the raw byte-array spew `assert_eq!` would produce for hundreds of bytes of ANSI escapes.
 pub fn assert_transcript_eq(got: &[u8], want: &[u8], who: &str) {
     if got == want {
         return;

--- a/crates/dewasm-test-helper/src/spec.rs
+++ b/crates/dewasm-test-helper/src/spec.rs
@@ -1,19 +1,6 @@
-//! Spec test harness (ADR-3, skip policy revised by ADR-8): parses every
-//! .wast file of the testsuite submodule (tests/spec, tracking upstream
-//! latest), translates each module with a target-language backend, generates
-//! a script that runs all assertions, and executes it with the real
-//! interpreter for that language. The language-specific pieces live behind
-//! the `SpecBackend` trait (implemented in each backend crate); everything
-//! about directive iteration, skip attribution, and result accounting is
-//! shared here.
+//! Spec test harness (ADR-3, skip policy revised by ADR-8): parses every .wast file of the testsuite submodule (tests/spec, tracking upstream latest), translates each module with a target-language backend, generates a script that runs all assertions, and executes it with the real interpreter for that language. The language-specific pieces live behind the `SpecBackend` trait (implemented in each backend crate); everything about directive iteration, skip attribution, and result accounting is shared here.
 //!
-//! Skips must be *attributable*: a module that fails to convert carries an
-//! `UnsupportedError` naming the declared-unsupported features, and every
-//! directive skipped because of it is counted under those feature ids. A
-//! conversion failure without attribution is a dewasm bug and fails the
-//! suite. Validation failures beyond every proposal this toolchain knows are
-//! reported as `unknown-proposal` but tolerated (the converter refused
-//! cleanly, which is the ADR-0 contract).
+//! Skips must be *attributable*: a module that fails to convert carries an `UnsupportedError` naming the declared-unsupported features, and every directive skipped because of it is counted under those feature ids. A conversion failure without attribution is a dewasm bug and fails the suite. Validation failures beyond every proposal this toolchain knows are reported as `unknown-proposal` but tolerated (the converter refused cleanly, which is the ADR-0 contract).
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
@@ -27,40 +14,21 @@ use wast::{QuoteWat, Wast, WastArg, WastDirective, WastExecute, WastRet, Wat};
 
 use crate::backend::BackendUnderTest;
 
-/// The script-phrasing layer of a backend under test (ADR-27): how to convert
-/// a module, how to phrase each assertion in that language, and how to bundle
-/// the runtime. `name`/`backend`/`interpreter`/`run` come from the base
-/// [`BackendUnderTest`] trait. `emit_*` methods append to the script body;
-/// returning `Err(tag)` skips the directive under that attribution tag.
+/// The script-phrasing layer of a backend under test (ADR-27): how to convert a module, how to phrase each assertion in that language, and how to bundle the runtime. `name`/`backend`/`interpreter`/`run` come from the base [`BackendUnderTest`] trait. `emit_*` methods append to the script body; returning `Err(tag)` skips the directive under that attribution tag.
 pub trait SpecBackend: BackendUnderTest {
     /// Known assertion-level failures: (file, count, attribution tag).
     fn expected_failures(&self) -> &'static [(&'static str, u32, &'static str)];
-    /// The non-ignored set: files run by a plain `cargo test`. Every other
-    /// `.wast` file still becomes a trial, but marked `#[ignore]`d, so
-    /// `cargo test -- --ignored` / `--include-ignored` sweeps the whole
-    /// testsuite. `None` marks nothing ignored — the whole testsuite runs by
-    /// default (used by the fast interpreters).
+    /// The non-ignored set: files run by a plain `cargo test`. Every other `.wast` file still becomes a trial, but marked `#[ignore]`d, so `cargo test -- --ignored` / `--include-ignored` sweeps the whole testsuite. `None` marks nothing ignored — the whole testsuite runs by default (used by the fast interpreters).
     fn curated_files(&self) -> Option<&'static [&'static str]>;
     /// Units the harness helpers themselves use.
     fn seed_units(&self) -> &'static [&'static str];
-    /// Lower an IR module to source. Backend-level refusals (e.g. floats on an
-    /// integer-only backend) carry `UnsupportedError` in the chain.
+    /// Lower an IR module to source. Backend-level refusals (e.g. floats on an integer-only backend) carry `UnsupportedError` in the chain.
     fn generate(&self, module: &ir::Module, counter: u32) -> anyhow::Result<Converted>;
-    /// Whether `register`-directive linking is wired up for this language: a
-    /// `(register "Name" $id)`'d instance becomes resolvable as an import
-    /// source for later modules (`registered` below), and `assert_unlinkable`
-    /// is checked for real instead of always skipped.
+    /// Whether `register`-directive linking is wired up for this language: a `(register "Name" $id)`'d instance becomes resolvable as an import source for later modules (`registered` below), and `assert_unlinkable` is checked for real instead of always skipped.
     fn supports_registered_imports(&self) -> bool {
         false
     }
-    /// Emit the module source plus its instantiation; returns the variable (or
-    /// prefix) later invocations use to reach the instance. `registered` is
-    /// the (name, instance-expr) pairs of currently `register`ed modules with
-    /// a live instance, for languages that support them. `decls` is the
-    /// file-scoped declaration buffer: languages that must hoist a converted
-    /// module's definitions to package/class scope (Go, Java) push
-    /// `conv.source` there rather than into `script`. It is owned by the
-    /// per-file harness state, so parallel trials never share it.
+    /// Emit the module source plus its instantiation; returns the variable (or prefix) later invocations use to reach the instance. `registered` is the (name, instance-expr) pairs of currently `register`ed modules with a live instance, for languages that support them. `decls` is the file-scoped declaration buffer: languages that must hoist a converted module's definitions to package/class scope (Go, Java) push `conv.source` there rather than into `script`. It is owned by the per-file harness state, so parallel trials never share it.
     fn emit_instantiate(
         &self,
         script: &mut String,
@@ -69,9 +37,7 @@ pub trait SpecBackend: BackendUnderTest {
         var_id: u32,
         registered: &[(String, String)],
     ) -> String;
-    /// Emit the module source only, returning the call that performs the
-    /// (possibly trapping) instantiation, for assert_trap on a module. See
-    /// [`Self::emit_instantiate`] for `decls`.
+    /// Emit the module source only, returning the call that performs the (possibly trapping) instantiation, for assert_trap on a module. See [`Self::emit_instantiate`] for `decls`.
     fn instantiate_call(
         &self,
         script: &mut String,
@@ -90,9 +56,7 @@ pub trait SpecBackend: BackendUnderTest {
     ) -> Result<(), String>;
     fn emit_check_trap(&self, script: &mut String, desc: &str, call: &str, message: &str);
     fn emit_check_exhaust(&self, script: &mut String, desc: &str, call: &str);
-    /// Emit an `assert_exception` check: `call` must raise an (uncaught) wasm
-    /// exception. The default keeps the directive an attributed skip for
-    /// backends that don't declare exception handling supported.
+    /// Emit an `assert_exception` check: `call` must raise an (uncaught) wasm exception. The default keeps the directive an attributed skip for backends that don't declare exception handling supported.
     fn emit_check_exception(
         &self,
         script: &mut String,
@@ -103,23 +67,17 @@ pub trait SpecBackend: BackendUnderTest {
         Err("exception-handling".to_string())
     }
     fn emit_bare_invoke(&self, script: &mut String, desc: &str, call: &str);
-    /// Emit an `assert_unlinkable` check: `call` (the instantiation) must
-    /// raise/fail. Only invoked when `supports_registered_imports()` is true.
+    /// Emit an `assert_unlinkable` check: `call` (the instantiation) must raise/fail. Only invoked when `supports_registered_imports()` is true.
     fn emit_check_unlinkable(&self, script: &mut String, desc: &str, call: &str) {
         let _ = (script, desc, call);
         unreachable!("only called when supports_registered_imports() is true")
     }
-    /// Wrap the accumulated body into a runnable script: shared runtime for
-    /// `units`, harness helpers, hoisted `decls` (see
-    /// [`Self::emit_instantiate`]), body, result-line footer. Backends that
-    /// inline module definitions into `script` receive an empty `decls`.
+    /// Wrap the accumulated body into a runnable script: shared runtime for `units`, harness helpers, hoisted `decls` (see [`Self::emit_instantiate`]), body, result-line footer. Backends that inline module definitions into `script` receive an empty `decls`.
     fn assemble(&self, units: &BTreeSet<String>, decls: &str, body: &str)
         -> anyhow::Result<String>;
 }
 
-/// A converted module: its source text, the language-specific handle used to
-/// instantiate it (class name, function prefix, ...), and the runtime units it
-/// references.
+/// A converted module: its source text, the language-specific handle used to instantiate it (class name, function prefix, ...), and the runtime units it references.
 pub struct Converted {
     pub source: String,
     pub handle: String,
@@ -131,18 +89,9 @@ fn spec_dir() -> std::path::PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/spec")
 }
 
-/// Build one libtest-mimic [`Trial`] per `.wast` file of the testsuite for
-/// `lang` (the `spec_suite!` macro's entry point). File selection is now
-/// cargo's own: the trial name is the file stem, so `cargo test --test spec
-/// i32` runs the `i32`-named file(s) via the built-in name filter. Files
-/// outside the backend's [`SpecBackend::curated_files`] set become `#[ignore]`d
-/// trials, so a plain `cargo test` runs the curated set and `--include-ignored`
-/// (or `--ignored`) sweeps the whole testsuite. Trials run on libtest-mimic's
-/// thread pool; each owns its per-file state, so the sweep parallelizes.
+/// Build one libtest-mimic [`Trial`] per `.wast` file of the testsuite for `lang` (the `spec_suite!` macro's entry point). File selection is now cargo's own: the trial name is the file stem, so `cargo test --test spec i32` runs the `i32`-named file(s) via the built-in name filter. Files outside the backend's [`SpecBackend::curated_files`] set become `#[ignore]`d trials, so a plain `cargo test` runs the curated set and `--include-ignored` (or `--ignored`) sweeps the whole testsuite. Trials run on libtest-mimic's thread pool; each owns its per-file state, so the sweep parallelizes.
 ///
-/// `slow_tier` is the backend crate's `slow_test` feature (CI's main sweep tier,
-/// ADR-48): when on, nothing is marked ignored — the whole testsuite runs, the
-/// same set the old `--include-ignored` sweep covered.
+/// `slow_tier` is the backend crate's `slow_test` feature (CI's main sweep tier, ADR-48): when on, nothing is marked ignored — the whole testsuite runs, the same set the old `--include-ignored` sweep covered.
 pub fn spec_trials(lang: &'static dyn SpecBackend, slow_tier: bool) -> Vec<Trial> {
     let dir = spec_dir();
     assert!(
@@ -163,8 +112,7 @@ pub fn spec_trials(lang: &'static dyn SpecBackend, slow_tier: bool) -> Vec<Trial
         .collect();
     names.sort();
 
-    // The slow tier runs the whole testsuite (nothing curated => nothing
-    // ignored below), matching the old `--include-ignored` main sweep.
+    // The slow tier runs the whole testsuite (nothing curated => nothing ignored below), matching the old `--include-ignored` main sweep.
     let curated: Option<BTreeSet<&'static str>> = if slow_tier {
         None
     } else {
@@ -174,8 +122,7 @@ pub fn spec_trials(lang: &'static dyn SpecBackend, slow_tier: bool) -> Vec<Trial
     names
         .into_iter()
         .map(|name| {
-            // Nothing curated => nothing ignored (the whole suite is the
-            // default); otherwise files outside the curated set are ignored.
+            // Nothing curated => nothing ignored (the whole suite is the default); otherwise files outside the curated set are ignored.
             let ignored = curated
                 .as_ref()
                 .is_some_and(|set| !set.contains(name.as_str()));
@@ -186,21 +133,13 @@ pub fn spec_trials(lang: &'static dyn SpecBackend, slow_tier: bool) -> Vec<Trial
         .collect()
 }
 
-/// harness=false entry point: parse cargo's test arguments (name filter,
-/// `--ignored`/`--include-ignored`, thread count, ...) and run the trials.
+/// harness=false entry point: parse cargo's test arguments (name filter, `--ignored`/`--include-ignored`, thread count, ...) and run the trials.
 pub fn spec_main(lang: &'static dyn SpecBackend, slow_tier: bool) {
     let args = libtest_mimic::Arguments::from_args();
     libtest_mimic::run(&args, spec_trials(lang, slow_tier)).exit();
 }
 
-/// Run one `.wast` file and apply the per-file gates that the old aggregate
-/// suite applied globally: (a) the assertion-failure count must equal the
-/// backend's `EXPECTED_FAILURES` ledger entry (0 if absent); (b) an
-/// unattributed conversion failure is a dewasm bug; (c) a skip attributed to a
-/// feature the backend declares `Supported` is a declaration regression.
-/// Checks (a)/(c) are per-file here, equivalent to the old global check because
-/// the global sets are the union of the per-file sets. A passing trial stays
-/// quiet; failures carry the per-file summary and detail.
+/// Run one `.wast` file and apply the per-file gates that the old aggregate suite applied globally: (a) the assertion-failure count must equal the backend's `EXPECTED_FAILURES` ledger entry (0 if absent); (b) an unattributed conversion failure is a dewasm bug; (c) a skip attributed to a feature the backend declares `Supported` is a declaration regression. Checks (a)/(c) are per-file here, equivalent to the old global check because the global sets are the union of the per-file sets. A passing trial stays quiet; failures carry the per-file summary and detail.
 fn run_trial(lang: &dyn SpecBackend, name: &str, path: &Path) -> Result<(), Failed> {
     let stats = run_file(lang, name, path).map_err(|err| format!("{name}: {err:#}"))?;
 
@@ -220,9 +159,7 @@ fn run_trial(lang: &dyn SpecBackend, name: &str, path: &Path) -> Result<(), Fail
         failures.extend(stats.fail_lines.iter().cloned());
     }
 
-    // A skip is only legitimate while its feature is declared unsupported;
-    // once the backend flips a feature to Supported, remaining skips are
-    // regressions of the declaration.
+    // A skip is only legitimate while its feature is declared unsupported; once the backend flips a feature to Supported, remaining skips are regressions of the declaration.
     for (tag, count) in &stats.unsupported {
         let ids: Vec<&str> = tag.split('+').collect();
         let all_supported = ids.iter().all(|id| {
@@ -256,16 +193,14 @@ fn run_trial(lang: &dyn SpecBackend, name: &str, path: &Path) -> Result<(), Fail
 struct Stats {
     pass: u32,
     fail: u32,
-    /// Skipped directives, attributed to declared-unsupported feature ids
-    /// (plus harness-level tags like "linking" and "unknown-proposal").
+    /// Skipped directives, attributed to declared-unsupported feature ids (plus harness-level tags like "linking" and "unknown-proposal").
     unsupported: BTreeMap<String, u32>,
     /// Unattributed conversion errors: dewasm bugs, fail the suite.
     hard_errors: Vec<String>,
     /// assert_invalid / assert_malformed handled on the Rust side
     rust_pass: u32,
     rust_fail: u32,
-    /// `FAIL...` lines from the generated script's stdout, surfaced in the
-    /// trial's failure message (only when the file's count breaks the ledger).
+    /// `FAIL...` lines from the generated script's stdout, surfaced in the trial's failure message (only when the file's count breaks the ledger).
     fail_lines: Vec<String>,
 }
 
@@ -278,20 +213,15 @@ impl Stats {
 struct ScriptGen<'a> {
     lang: &'a dyn SpecBackend,
     script: String,
-    /// File-scoped declaration buffer hoisted ahead of `script` by `assemble`
-    /// (see [`SpecBackend::emit_instantiate`]). Owned per file, so parallel
-    /// trials never share it.
+    /// File-scoped declaration buffer hoisted ahead of `script` by `assemble` (see [`SpecBackend::emit_instantiate`]). Owned per file, so parallel trials never share it.
     decls: String,
     source: &'a str,
     file: &'a str,
-    /// Variable/prefix holding the most recent instance, or the attribution
-    /// tag when the most recent module failed to convert.
+    /// Variable/prefix holding the most recent instance, or the attribution tag when the most recent module failed to convert.
     current: Result<String, String>,
     /// Same, for named modules.
     named: std::collections::HashMap<String, Result<String, String>>,
-    /// Same, keyed by the *registered* name from `(register "Name" $id)` (a
-    /// different namespace from `named`'s wast `$id`s) — what a later module's
-    /// `(import "Name" ...)` actually resolves against.
+    /// Same, keyed by the *registered* name from `(register "Name" $id)` (a different namespace from `named`'s wast `$id`s) — what a later module's `(import "Name" ...)` actually resolves against.
     registered: std::collections::HashMap<String, Result<String, String>>,
     counter: u32,
     converted: u32,
@@ -321,9 +251,7 @@ impl<'a> ScriptGen<'a> {
         }
     }
 
-    /// Module names a fresh `convert()` may treat as import sources: always
-    /// `spectest`, plus every successfully-registered module when the language
-    /// supports it.
+    /// Module names a fresh `convert()` may treat as import sources: always `spectest`, plus every successfully-registered module when the language supports it.
     fn resolvable_modules(&self) -> std::collections::HashSet<String> {
         let mut set = std::collections::HashSet::new();
         set.insert("spectest".to_string());
@@ -349,10 +277,7 @@ impl<'a> ScriptGen<'a> {
             .collect()
     }
 
-    /// Encode `qw` and convert it, with the bookkeeping every conversion site
-    /// shares: the module counter, the converted count, the unit union, and
-    /// attribution (unknown-proposal mapping, hard errors). `Err` carries the
-    /// skip tag; emitting the instantiation is the caller's job.
+    /// Encode `qw` and convert it, with the bookkeeping every conversion site shares: the module counter, the converted count, the unit union, and attribution (unknown-proposal mapping, hard errors). `Err` carries the skip tag; emitting the instantiation is the caller's job.
     fn convert_quote_wat(&mut self, mut qw: QuoteWat<'_>, desc: &str) -> Result<Converted, String> {
         let resolvable = self.resolvable_modules();
         self.counter += 1;
@@ -410,8 +335,7 @@ enum Attribution {
     Bug(String),
 }
 
-/// Map a conversion error to its attribution: `UnsupportedError` anywhere in
-/// the chain names the responsible features; anything else is a bug.
+/// Map a conversion error to its attribution: `UnsupportedError` anywhere in the chain names the responsible features; anything else is a bug.
 fn attribute(err: &anyhow::Error) -> Attribution {
     match err
         .chain()
@@ -435,9 +359,7 @@ fn convert(
     resolvable: &std::collections::HashSet<String>,
 ) -> Result<Converted, Attribution> {
     let module = dewasm_core::build_module(bytes).map_err(|err| attribute(&err))?;
-    // The harness only provides the spectest host module plus whatever is
-    // currently `register`ed and resolvable (ScriptGen::resolvable_modules);
-    // anything else needs cross-module linking this harness doesn't track.
+    // The harness only provides the spectest host module plus whatever is currently `register`ed and resolvable (ScriptGen::resolvable_modules); anything else needs cross-module linking this harness doesn't track.
     let unresolved = |m: &str| !resolvable.contains(m);
     let needs_linking = module.imported_funcs.iter().any(|f| unresolved(&f.module))
         || module
@@ -461,8 +383,7 @@ fn convert(
 
 fn run_file(lang: &dyn SpecBackend, name: &str, path: &Path) -> anyhow::Result<Stats> {
     let source = std::fs::read_to_string(path)?;
-    // A text-format construct newer than the wast crate is not our bug; report
-    // it like an unknown proposal.
+    // A text-format construct newer than the wast crate is not our bug; report it like an unknown proposal.
     let unparsable = |err: &dyn std::fmt::Display| {
         eprintln!("{name}.wast does not parse ({err}); counted as unknown-proposal");
         let mut stats = Stats::default();
@@ -555,8 +476,7 @@ fn run_directives(
             | WastDirective::AssertMalformed { mut module, .. }
             | WastDirective::AssertInvalidCustom { mut module, .. }
             | WastDirective::AssertMalformedCustom { mut module, .. } => {
-                // Handled on the Rust side: the module must fail to decode,
-                // validate, or convert.
+                // Handled on the Rust side: the module must fail to decode, validate, or convert.
                 match module.encode() {
                     Ok(bytes) => match dewasm_core::build_module(&bytes) {
                         Err(_) => gen.stats.rust_pass += 1,
@@ -587,8 +507,7 @@ fn run_directives(
                                 &conv,
                                 &registered,
                             );
-                            // Upstream wording never matches ours; only the
-                            // Rt::LinkError class is checked.
+                            // Upstream wording never matches ours; only the Rt::LinkError class is checked.
                             let _ = message;
                             lang.emit_check_unlinkable(&mut gen.script, &desc, &call);
                         }
@@ -619,8 +538,7 @@ fn run_directives(
         return Ok(gen.stats);
     }
 
-    // One shared runtime bundle for the whole file, kept minimal so that
-    // undeclared unit dependencies surface as missing-method errors.
+    // One shared runtime bundle for the whole file, kept minimal so that undeclared unit dependencies surface as missing-method errors.
     let script = lang
         .assemble(&gen.units, &gen.decls, &gen.script)
         .map_err(|e| anyhow::anyhow!("assembling script: {e:#}"))?;

--- a/crates/dewasm-test-helper/src/wasi.rs
+++ b/crates/dewasm-test-helper/src/wasi.rs
@@ -1,21 +1,6 @@
-//! The project's own WASI preview-1 conformance suite (ADR-27): WASI has no
-//! official testsuite, so the WASI-exercising fixtures are grouped by feature
-//! unit — stdio, args/env, clock/random, filesystem. Each backend crate wires
-//! up exactly the kinds it supports via `wasi_suite!`.
+//! The project's own WASI preview-1 conformance suite (ADR-27): WASI has no official testsuite, so the WASI-exercising fixtures are grouped by feature unit — stdio, args/env, clock/random, filesystem. Each backend crate wires up exactly the kinds it supports via `wasi_suite!`.
 //!
-//! Two execution shapes share one table:
-//!   * `WasiCheck::Standalone` — a whole-program standalone run checked by
-//!     stdout + exit code (stdio, args/env, clock/random). No glue; every
-//!     backend runs these.
-//!   * `WasiCheck::Fs` — a library-mode run against a preopened host scratch
-//!     directory, with host-side setup before and assertions after. Needs
-//!     per-backend instantiation glue: a single template string per backend
-//!     (`wasi_suite!(Lang, Fs, TEMPLATE)`) whose `{guest}`/`{host}`
-//!     placeholders the runner fills with the preopen pair (ADR-27 revision).
-//!     The one case that does not fit the template — the root-preopen
-//!     containment probe, which calls the WASI resolver directly rather than
-//!     running a guest — is dissolved into its own `wasi_root_containment_e2e!`
-//!     macro with its own glue const.
+//! Two execution shapes share one table: * `WasiCheck::Standalone` — a whole-program standalone run checked by stdout + exit code (stdio, args/env, clock/random). No glue; every backend runs these. * `WasiCheck::Fs` — a library-mode run against a preopened host scratch directory, with host-side setup before and assertions after. Needs per-backend instantiation glue: a single template string per backend (`wasi_suite!(Lang, Fs, TEMPLATE)`) whose `{guest}`/`{host}` placeholders the runner fills with the preopen pair (ADR-27 revision). The one case that does not fit the template — the root-preopen containment probe, which calls the WASI resolver directly rather than running a guest — is dissolved into its own `wasi_root_containment_e2e!` macro with its own glue const.
 
 use std::path::Path;
 
@@ -25,17 +10,13 @@ use crate::backend::BackendUnderTest;
 use crate::fixtures::{convert, examples_dir};
 use crate::glue::fill;
 
-/// The WASI p1 feature units a fixture exercises. Public API of the helper
-/// crate, so unused variants are not dead code — a backend selects the kinds
-/// it supports at `wasi_suite!` sites.
+/// The WASI p1 feature units a fixture exercises. Public API of the helper crate, so unused variants are not dead code — a backend selects the kinds it supports at `wasi_suite!` sites.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum WasiKind {
     Stdio,
     ArgsEnv,
     ClockRandom,
-    /// poll_oneoff. A whole-program standalone kind like the others, but split
-    /// out because bash resolves poll_oneoff to ENOSYS (ADR-12/ADR-14) and so
-    /// does not wire this kind; the four backends that implement it do.
+    /// poll_oneoff. A whole-program standalone kind like the others, but split out because bash resolves poll_oneoff to ENOSYS (ADR-12/ADR-14) and so does not wire this kind; the four backends that implement it do.
     Poll,
     Fs,
 }
@@ -54,28 +35,20 @@ pub enum WasiCheck {
     Standalone { stdout: &'static str, code: i32 },
     /// Library-mode filesystem run against a preopened scratch directory.
     Fs {
-        /// Preopen a subdirectory of the scratch root instead of the root
-        /// itself, so a canary can sit *outside* the sandbox (the escape
-        /// test). `setup`/`assert_host`/glue all receive the preopened dir;
-        /// its `.parent()` reaches the scratch root.
+        /// Preopen a subdirectory of the scratch root instead of the root itself, so a canary can sit *outside* the sandbox (the escape test). `setup`/`assert_host`/glue all receive the preopened dir; its `.parent()` reaches the scratch root.
         preopen_subdir: Option<&'static str>,
-        /// Prepare the scratch layout before the run (create a symlink, drop
-        /// a canary file, ...). Receives the preopened dir.
+        /// Prepare the scratch layout before the run (create a symlink, drop a canary file, ...). Receives the preopened dir.
         setup: fn(&Path),
-        /// Check the run's captured stdout (exact match vs. `contains` is the
-        /// closure's own business — the exact original assertion).
+        /// Check the run's captured stdout (exact match vs. `contains` is the closure's own business — the exact original assertion).
         check_stdout: fn(&str),
-        /// Assert host filesystem state after the run. Receives the
-        /// preopened dir.
+        /// Assert host filesystem state after the run. Receives the preopened dir.
         assert_host: fn(&Path),
-        /// Restrict to unix (the symlink fixture); skipped elsewhere the way
-        /// `#[cfg(unix)]` used to compile it out.
+        /// Restrict to unix (the symlink fixture); skipped elsewhere the way `#[cfg(unix)]` used to compile it out.
         unix_only: bool,
     },
 }
 
-/// A fresh, empty scratch directory keyed by `name`, so cases running in
-/// parallel never share host state.
+/// A fresh, empty scratch directory keyed by `name`, so cases running in parallel never share host state.
 fn scratch_dir(name: &str) -> std::path::PathBuf {
     let dir = std::env::temp_dir().join(format!("dewasm-wasi-{name}"));
     let _ = std::fs::remove_dir_all(&dir);
@@ -96,8 +69,7 @@ pub const WASI_CASES: &[WasiCase] = &[
             code: 0,
         },
     },
-    // Args/env: argc (program name + arguments) becomes the exit code via
-    // args_sizes_get + proc_exit.
+    // Args/env: argc (program name + arguments) becomes the exit code via args_sizes_get + proc_exit.
     WasiCase {
         name: "argc",
         wat: "args_proc_exit.wat",
@@ -109,10 +81,7 @@ pub const WASI_CASES: &[WasiCase] = &[
             code: 3,
         },
     },
-    // poll_oneoff: a clock subscription (relative 1 ms) plus an fd_write
-    // readiness subscription on stdout. stdout is always ready, so the call
-    // reports at least one event with error 0 and the module prints its
-    // success line without blocking on the timer.
+    // poll_oneoff: a clock subscription (relative 1 ms) plus an fd_write readiness subscription on stdout. stdout is always ready, so the call reports at least one event with error 0 and the module prints its success line without blocking on the timer.
     WasiCase {
         name: "poll_oneoff",
         wat: "wasi_poll_oneoff.wat",
@@ -124,8 +93,7 @@ pub const WASI_CASES: &[WasiCase] = &[
             code: 0,
         },
     },
-    // Filesystem (ADR-14). path_open (create+write, then reopen+read)
-    // round-trips real file content through a preopened host directory.
+    // Filesystem (ADR-14). path_open (create+write, then reopen+read) round-trips real file content through a preopened host directory.
     WasiCase {
         name: "fs_path_open_roundtrip",
         wat: "wasi_path_open_roundtrip.wat",
@@ -145,9 +113,7 @@ pub const WASI_CASES: &[WasiCase] = &[
             unix_only: false,
         },
     },
-    // path_create_directory + fd_readdir + path_unlink_file /
-    // path_remove_directory, verified from both sides: the dirent listing the
-    // guest saw, and the host filesystem after cleanup.
+    // path_create_directory + fd_readdir + path_unlink_file / path_remove_directory, verified from both sides: the dirent listing the guest saw, and the host filesystem after cleanup.
     WasiCase {
         name: "fs_mkdir_readdir_unlink",
         wat: "wasi_mkdir_readdir_unlink.wat",
@@ -167,10 +133,7 @@ pub const WASI_CASES: &[WasiCase] = &[
             unix_only: false,
         },
     },
-    // fd_readdir with a dircookie whose high bit is set (u64 2^63): the
-    // cookie is an unsigned position past any snapshot's end, so the call
-    // succeeds with bufused 0 (matching wasmtime). Runtimes holding the
-    // cookie in a signed type must not index negatively (issue #27).
+    // fd_readdir with a dircookie whose high bit is set (u64 2^63): the cookie is an unsigned position past any snapshot's end, so the call succeeds with bufused 0 (matching wasmtime). Runtimes holding the cookie in a signed type must not index negatively (issue #27).
     WasiCase {
         name: "fs_readdir_high_cookie",
         wat: "wasi_readdir_high_cookie.wat",
@@ -185,9 +148,7 @@ pub const WASI_CASES: &[WasiCase] = &[
             unix_only: false,
         },
     },
-    // path_open with oflags::DIRECTORY on a missing path is ENOENT (44), not
-    // ENOTDIR (54) — guests (e.g. wasi-libc's opendir) branch on the
-    // difference. The fixture exits with the errno.
+    // path_open with oflags::DIRECTORY on a missing path is ENOENT (44), not ENOTDIR (54) — guests (e.g. wasi-libc's opendir) branch on the difference. The fixture exits with the errno.
     WasiCase {
         name: "fs_dir_open_missing",
         wat: "wasi_dir_open_missing.wat",
@@ -202,9 +163,7 @@ pub const WASI_CASES: &[WasiCase] = &[
             unix_only: false,
         },
     },
-    // path_filestat_get without SYMLINK_FOLLOW stats the symlink itself
-    // (filetype 7), not its target: resolution must not follow the final
-    // component. The fixture exits with the reported filetype.
+    // path_filestat_get without SYMLINK_FOLLOW stats the symlink itself (filetype 7), not its target: resolution must not follow the final component. The fixture exits with the reported filetype.
     WasiCase {
         name: "fs_filestat_nofollow_symlink",
         wat: "wasi_filestat_nofollow.wat",
@@ -227,10 +186,7 @@ pub const WASI_CASES: &[WasiCase] = &[
             unix_only: true,
         },
     },
-    // A `..`-escaping guest path must be rejected (ERRNO_NOTCAPABLE, not a
-    // host filesystem escape): a canary file sitting just outside the
-    // preopened directory must stay unreadable and untouched. The scratch
-    // dir is a `sandbox` subdir; the canary sits beside it.
+    // A `..`-escaping guest path must be rejected (ERRNO_NOTCAPABLE, not a host filesystem escape): a canary file sitting just outside the preopened directory must stay unreadable and untouched. The scratch dir is a `sandbox` subdir; the canary sits beside it.
     WasiCase {
         name: "fs_escape_rejected",
         wat: "wasi_escape_rejected.wat",
@@ -256,10 +212,7 @@ pub const WASI_CASES: &[WasiCase] = &[
             unix_only: false,
         },
     },
-    // Trailing-slash shapes (issue #42): pinned to wasmtime 47 on both hosts
-    // (ADR-49). Probe k is wasmtime's own host split, asserted per host; the
-    // fixture header lists the unpinned shapes. The bash-only PR #41 pins
-    // live in crates/dewasm-backend-bash/tests/wasi_fs_regressions.rs.
+    // Trailing-slash shapes (issue #42): pinned to wasmtime 47 on both hosts (ADR-49). Probe k is wasmtime's own host split, asserted per host; the fixture header lists the unpinned shapes. The bash-only PR #41 pins live in crates/dewasm-backend-bash/tests/wasi_fs_regressions.rs.
     WasiCase {
         name: "fs_trailing_slash",
         wat: "wasi_trailing_slash.wat",
@@ -287,8 +240,7 @@ pub const WASI_CASES: &[WasiCase] = &[
                 )
             },
             assert_host: |dir| {
-                // The failing probes must have left the filesystem alone; the
-                // succeeding ones (j, m, p) must have taken effect.
+                // The failing probes must have left the filesystem alone; the succeeding ones (j, m, p) must have taken effect.
                 assert_eq!(
                     std::fs::read_to_string(dir.join("file")).unwrap(),
                     "keep me"
@@ -308,9 +260,7 @@ pub const WASI_CASES: &[WasiCase] = &[
             unix_only: false,
         },
     },
-    // The symlink side (ADR-49): readlink through a slash follows to the
-    // target; a slash-suffixed symlink destination errs by what sits behind
-    // the slash.
+    // The symlink side (ADR-49): readlink through a slash follows to the target; a slash-suffixed symlink destination errs by what sits behind the slash.
     WasiCase {
         name: "fs_trailing_slash_symlink",
         wat: "wasi_trailing_slash_symlink.wat",
@@ -343,12 +293,7 @@ pub const WASI_CASES: &[WasiCase] = &[
             unix_only: true,
         },
     },
-    // Per-fd rights enforcement (ADR-40). A fd narrowed by
-    // fd_fdstat_set_rights must refuse fd_pread/fd_pwrite (NOTCAPABLE, like
-    // fd_read/fd_write); a dirfd stripped of PATH_FILESTAT_SET_SIZE must
-    // refuse an O_TRUNC open without touching the file; and one stripped of
-    // PATH_OPEN must refuse any open. The fixture prints "<tag><errno>" per
-    // probe (76 = NOTCAPABLE), so the expected stdout pins every gate.
+    // Per-fd rights enforcement (ADR-40). A fd narrowed by fd_fdstat_set_rights must refuse fd_pread/fd_pwrite (NOTCAPABLE, like fd_read/fd_write); a dirfd stripped of PATH_FILESTAT_SET_SIZE must refuse an O_TRUNC open without touching the file; and one stripped of PATH_OPEN must refuse any open. The fixture prints "<tag><errno>" per probe (76 = NOTCAPABLE), so the expected stdout pins every gate.
     WasiCase {
         name: "fs_rights_notcapable",
         wat: "wasi_rights_notcapable.wat",
@@ -371,9 +316,7 @@ pub const WASI_CASES: &[WasiCase] = &[
     },
 ];
 
-/// Run the `WasiCheck::Standalone` cases of `kind` (stdio, args/env,
-/// clock/random): convert standalone, run, check stdout + exit code. Works
-/// for every backend; no glue.
+/// Run the `WasiCheck::Standalone` cases of `kind` (stdio, args/env, clock/random): convert standalone, run, check stdout + exit code. Works for every backend; no glue.
 pub fn run_wasi_standalone(lang: &dyn BackendUnderTest, kind: WasiKind) {
     for case in WASI_CASES.iter().filter(|c| c.kind == kind) {
         let WasiCheck::Standalone { stdout, code } = case.check else {
@@ -406,13 +349,7 @@ pub fn run_wasi_standalone(lang: &dyn BackendUnderTest, kind: WasiKind) {
     }
 }
 
-/// Run the `WasiCheck::Fs` cases: create a scratch dir, run the host-side
-/// setup, convert in library mode, append `template` with its `{guest}`/`{host}`
-/// placeholders filled (guest `/`, host the preopened dir), run, then apply the
-/// case's stdout check and host-state assertions. Every non-containment Fs case
-/// shares the one template (preopen the host dir at `/`, run `_start`, surface a
-/// `proc_exit` code as a trailing decimal line); the containment probe is a
-/// separate case (see [`run_wasi_containment`]).
+/// Run the `WasiCheck::Fs` cases: create a scratch dir, run the host-side setup, convert in library mode, append `template` with its `{guest}`/`{host}` placeholders filled (guest `/`, host the preopened dir), run, then apply the case's stdout check and host-state assertions. Every non-containment Fs case shares the one template (preopen the host dir at `/`, run `_start`, surface a `proc_exit` code as a trailing decimal line); the containment probe is a separate case (see [`run_wasi_containment`]).
 pub fn run_wasi_fs(lang: &dyn BackendUnderTest, template: &str) {
     for case in WASI_CASES.iter().filter(|c| c.kind == WasiKind::Fs) {
         let WasiCheck::Fs {
@@ -462,13 +399,7 @@ pub fn run_wasi_fs(lang: &dyn BackendUnderTest, template: &str) {
     }
 }
 
-/// Exercise the standalone runtime interface's `--dir` end to end (ADR-31):
-/// convert `wasi_standalone_dir.wat` in *standalone* mode, run it with a
-/// `--dir HOST::GUEST` mount of a fresh scratch dir at guest `/`, and require
-/// the guest to round-trip a file through it — the echoed stdout and the host
-/// file the guest wrote must both be correct. Shared by the four filesystem
-/// backends and re-run under wasmtime as ground truth (its `run_standalone_dir`
-/// override consumes `--dir` as a host flag). No glue: standalone needs none.
+/// Exercise the standalone runtime interface's `--dir` end to end (ADR-31): convert `wasi_standalone_dir.wat` in *standalone* mode, run it with a `--dir HOST::GUEST` mount of a fresh scratch dir at guest `/`, and require the guest to round-trip a file through it — the echoed stdout and the host file the guest wrote must both be correct. Shared by the four filesystem backends and re-run under wasmtime as ground truth (its `run_standalone_dir` override consumes `--dir` as a host flag). No glue: standalone needs none.
 pub fn run_standalone_dir(lang: &dyn BackendUnderTest) {
     let scratch = scratch_dir(&format!("standalone-dir-{}", lang.name()));
     let bytes = wat::parse_file(examples_dir().join("wasi_standalone_dir.wat")).expect("parse wat");
@@ -499,14 +430,7 @@ pub fn run_standalone_dir(lang: &dyn BackendUnderTest) {
     );
 }
 
-/// Run the deep-recursion standalone case (`deep_recursion_e2e!`): convert
-/// `deep_recursion.wat` — whose `_start` recurses 5000 wasm frames, far past
-/// e.g. CPython's default ~1000-frame recursion limit — in *standalone* mode
-/// and run it with no arguments. The generated entrypoint must survive the
-/// recursion (Python: ADR-28's raised recursion limit plus a big-stack guest
-/// thread) and still surface the guest's `proc_exit(42)` as the process exit
-/// code (ADR-31). Like `run_standalone_dir`, this exercises the emitted
-/// entrypoint itself, so no glue.
+/// Run the deep-recursion standalone case (`deep_recursion_e2e!`): convert `deep_recursion.wat` — whose `_start` recurses 5000 wasm frames, far past e.g. CPython's default ~1000-frame recursion limit — in *standalone* mode and run it with no arguments. The generated entrypoint must survive the recursion (Python: ADR-28's raised recursion limit plus a big-stack guest thread) and still surface the guest's `proc_exit(42)` as the process exit code (ADR-31). Like `run_standalone_dir`, this exercises the emitted entrypoint itself, so no glue.
 pub fn run_deep_recursion(lang: &dyn BackendUnderTest) {
     let src = convert(
         lang.backend(),
@@ -530,16 +454,7 @@ pub fn run_deep_recursion(lang: &dyn BackendUnderTest) {
     );
 }
 
-/// Run the root-preopen containment probe (`wasi_root_containment_e2e!`): a
-/// preopen whose realpath is the filesystem root must not reject every path
-/// (the containment check would otherwise build the prefix "//" and never
-/// match). This exercises a WASI-model *internal* (the path-resolution helper)
-/// rather than a guest fixture — no host files are touched — so `glue` probes
-/// the resolver directly with a `"/" => "/"` preopen instead of running the
-/// converted module's `_start`. `wasi_path_open_roundtrip.wat` is converted only
-/// to bring the runtime's WASI class into scope; `glue` normalizes the outcome
-/// to `contained`. Unix-only: a realpath of `/` is a unix notion, so it is a
-/// no-op elsewhere (the way `#[cfg(unix)]` used to compile it out).
+/// Run the root-preopen containment probe (`wasi_root_containment_e2e!`): a preopen whose realpath is the filesystem root must not reject every path (the containment check would otherwise build the prefix "//" and never match). This exercises a WASI-model *internal* (the path-resolution helper) rather than a guest fixture — no host files are touched — so `glue` probes the resolver directly with a `"/" => "/"` preopen instead of running the converted module's `_start`. `wasi_path_open_roundtrip.wat` is converted only to bring the runtime's WASI class into scope; `glue` normalizes the outcome to `contained`. Unix-only: a realpath of `/` is a unix notion, so it is a no-op elsewhere (the way `#[cfg(unix)]` used to compile it out).
 pub fn run_wasi_containment(lang: &dyn BackendUnderTest, glue: &str) {
     if !cfg!(unix) {
         return;

--- a/crates/dewasm-test-helper/src/wasi_testsuite.rs
+++ b/crates/dewasm-test-helper/src/wasi_testsuite.rs
@@ -1,33 +1,12 @@
-//! Official WASI preview-1 conformance harness (ADR-36): drives the prebuilt
-//! `WebAssembly/wasi-testsuite` modules (submodule `tests/wasi-testsuite`,
-//! branch `prod/testsuite-base`) through the ADR-31 standalone interface. This
-//! mirrors `spec.rs`'s structure — one libtest-mimic [`Trial`] per `.wasm`, a
-//! fail-loud assert when the submodule is missing, and an
-//! `EXPECTED_FAILURES` ledger checked *both ways* (an unexpectedly-passing
-//! ledgered test is a hard failure, exactly like the spec harness).
+//! Official WASI preview-1 conformance harness (ADR-36): drives the prebuilt `WebAssembly/wasi-testsuite` modules (submodule `tests/wasi-testsuite`, branch `prod/testsuite-base`) through the ADR-31 standalone interface. This mirrors `spec.rs`'s structure — one libtest-mimic [`Trial`] per `.wasm`, a fail-loud assert when the submodule is missing, and an `EXPECTED_FAILURES` ledger checked *both ways* (an unexpectedly-passing ledgered test is a hard failure, exactly like the spec harness).
 //!
-//! Each `<name>.wasm` may carry a co-located `<name>.json` manifest (the
-//! upstream v0 schema: `args`, `env`, `root`, `exit_code`, `stdout`,
-//! `stderr`). The runner converts the module in [`Mode::Standalone`], mounts
-//! the manifest's `root` fixture at guest `/` (via a fresh temp copy so trials
-//! stay hermetic), sets `env`/`args`, then asserts the process exit code and —
-//! when the manifest pins it — stdout/stderr. The `root`→`/` mapping mirrors
-//! upstream's own wasmtime adapter (`--dir {root}::/`).
+//! Each `<name>.wasm` may carry a co-located `<name>.json` manifest (the upstream v0 schema: `args`, `env`, `root`, `exit_code`, `stdout`, `stderr`). The runner converts the module in [`Mode::Standalone`], mounts the manifest's `root` fixture at guest `/` (via a fresh temp copy so trials stay hermetic), sets `env`/`args`, then asserts the process exit code and — when the manifest pins it — stdout/stderr. The `root`→`/` mapping mirrors upstream's own wasmtime adapter (`--dir {root}::/`).
 //!
-//! A conversion refusal attributed to a declared-unsupported feature, a wrong
-//! exit code, or a stdout mismatch is a *failure*; the ledger (ADR-8) then
-//! decides whether it is expected. Every ledger entry names the WASI function
-//! or interface behaviour responsible.
+//! A conversion refusal attributed to a declared-unsupported feature, a wrong exit code, or a stdout mismatch is a *failure*; the ledger (ADR-8) then decides whether it is expected. Every ledger entry names the WASI function or interface behaviour responsible.
 //!
-//! The Rust suite runs with the host-matched strict errno mode injected
-//! (ADR-49); see [`evaluate`].
+//! The Rust suite runs with the host-matched strict errno mode injected (ADR-49); see [`evaluate`].
 //!
-//! A ledger entry may be *host-scoped*: some failures depend on the host libc
-//! or interpreter (e.g. macOS CoreFoundation injecting `__CF_USER_TEXT_ENCODING`,
-//! or a Linux JDK truncating symlink times to microseconds). A backend declares
-//! those via `expected_failures_macos()`/`expected_failures_linux()`; the runner
-//! merges the host-matching list into the base ledger, so an entry that only
-//! trips on one host is not flagged as an unexpected pass on the other.
+//! A ledger entry may be *host-scoped*: some failures depend on the host libc or interpreter (e.g. macOS CoreFoundation injecting `__CF_USER_TEXT_ENCODING`, or a Linux JDK truncating symlink times to microseconds). A backend declares those via `expected_failures_macos()`/`expected_failures_linux()`; the runner merges the host-matching list into the base ledger, so an entry that only trips on one host is not flagged as an unexpected pass on the other.
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -39,39 +18,23 @@ use serde::Deserialize;
 
 use crate::backend::BackendUnderTest;
 
-/// A backend wired into the WASI-testsuite harness: the base
-/// [`BackendUnderTest`] plus its known-failure ledger.
+/// A backend wired into the WASI-testsuite harness: the base [`BackendUnderTest`] plus its known-failure ledger.
 pub trait WasiTestsuiteBackend: BackendUnderTest {
-    /// Known trial failures: `(trial name, attribution tag)`. The trial name
-    /// is `"<suite>/<stem>"` (e.g. `"rust/path_link"`); the tag names the WASI
-    /// function or interface behaviour that causes the failure (a declared
-    /// ENOSYS gap, or an ADR-31 interface choice). A ledgered trial that
-    /// *passes* is a hard failure — remove it (same both-ways discipline as
-    /// `spec.rs`).
+    /// Known trial failures: `(trial name, attribution tag)`. The trial name is `"<suite>/<stem>"` (e.g. `"rust/path_link"`); the tag names the WASI function or interface behaviour that causes the failure (a declared ENOSYS gap, or an ADR-31 interface choice). A ledgered trial that *passes* is a hard failure — remove it (same both-ways discipline as `spec.rs`).
     fn expected_failures(&self) -> &'static [(&'static str, &'static str)];
 
-    /// Host-scoped ledger entries that only fail on a **macOS** host (host libc
-    /// or interpreter behaviour, e.g. CoreFoundation injecting
-    /// `__CF_USER_TEXT_ENCODING`). Merged into [`expected_failures`] only when
-    /// the harness runs on macOS; ignored on other hosts, so the both-ways
-    /// discipline still flags a genuine unexpected pass there.
+    /// Host-scoped ledger entries that only fail on a **macOS** host (host libc or interpreter behaviour, e.g. CoreFoundation injecting `__CF_USER_TEXT_ENCODING`). Merged into [`expected_failures`] only when the harness runs on macOS; ignored on other hosts, so the both-ways discipline still flags a genuine unexpected pass there.
     fn expected_failures_macos(&self) -> &'static [(&'static str, &'static str)] {
         &[]
     }
 
-    /// Host-scoped ledger entries that only fail on a **Linux** host (host libc
-    /// or interpreter behaviour, e.g. a JDK routing NOFOLLOW symlink times
-    /// through microsecond `lutimes`). Merged into [`expected_failures`] only
-    /// when the harness runs on Linux.
+    /// Host-scoped ledger entries that only fail on a **Linux** host (host libc or interpreter behaviour, e.g. a JDK routing NOFOLLOW symlink times through microsecond `lutimes`). Merged into [`expected_failures`] only when the harness runs on Linux.
     fn expected_failures_linux(&self) -> &'static [(&'static str, &'static str)] {
         &[]
     }
 }
 
-/// The three prebuilt suites we drive, all `wasm32-wasip1` (the standard goal
-/// for a dewasm backend: wasm 1.0 + full WASI p1). The Rust suite's
-/// `wasm32-wasip3` tree is deliberately excluded — preview 3 is component-model
-/// territory, rejected outright (ADR-24).
+/// The three prebuilt suites we drive, all `wasm32-wasip1` (the standard goal for a dewasm backend: wasm 1.0 + full WASI p1). The Rust suite's `wasm32-wasip3` tree is deliberately excluded — preview 3 is component-model territory, rejected outright (ADR-24).
 const SUITES: &[&str] = &["c", "rust", "assemblyscript"];
 
 /// The `tests/wasi-testsuite` submodule directory.
@@ -79,18 +42,13 @@ fn testsuite_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/wasi-testsuite")
 }
 
-/// A parsed test manifest (the upstream v0 legacy schema). Every field is
-/// optional (`#[serde(default)]`); an absent `.json` means "all defaults" (a
-/// still-valid test). Unknown keys (the v1 `operations`/`proposals` schema, the
-/// suite-level `manifest.json`) are ignored rather than rejected — serde's
-/// default without `deny_unknown_fields`.
+/// A parsed test manifest (the upstream v0 legacy schema). Every field is optional (`#[serde(default)]`); an absent `.json` means "all defaults" (a still-valid test). Unknown keys (the v1 `operations`/`proposals` schema, the suite-level `manifest.json`) are ignored rather than rejected — serde's default without `deny_unknown_fields`.
 #[derive(Default, Deserialize)]
 #[serde(default)]
 struct Manifest {
     args: Vec<String>,
     env: BTreeMap<String, String>,
-    /// The preopen directory fixture (relative to the manifest), mounted at
-    /// guest `/`.
+    /// The preopen directory fixture (relative to the manifest), mounted at guest `/`.
     root: Option<String>,
     exit_code: i32,
     stdout: Option<String>,
@@ -110,9 +68,7 @@ struct Case {
     manifest: Manifest,
 }
 
-/// Enumerate every `.wasm` under each suite's `wasm32-wasip1` directory (the
-/// suite-level `manifest.json` has no `.wasm`, so it is never a case), pairing
-/// it with its optional `<stem>.json`.
+/// Enumerate every `.wasm` under each suite's `wasm32-wasip1` directory (the suite-level `manifest.json` has no `.wasm`, so it is never a case), pairing it with its optional `<stem>.json`.
 fn enumerate() -> anyhow::Result<Vec<Case>> {
     let root = testsuite_dir();
     assert!(
@@ -158,16 +114,10 @@ fn enumerate() -> anyhow::Result<Vec<Case>> {
     Ok(cases)
 }
 
-/// Build one libtest-mimic [`Trial`] per prebuilt module (the
-/// `wasi_testsuite_suite!` macro's entry point). The trial name is
-/// `"<suite>/<stem>"`, so `cargo test --test wasi_testsuite rust` filters by
-/// suite and `-- --exact rust/path_link` selects one module.
+/// Build one libtest-mimic [`Trial`] per prebuilt module (the `wasi_testsuite_suite!` macro's entry point). The trial name is `"<suite>/<stem>"`, so `cargo test --test wasi_testsuite rust` filters by suite and `-- --exact rust/path_link` selects one module.
 pub fn wasi_testsuite_trials(lang: &'static dyn WasiTestsuiteBackend) -> Vec<Trial> {
     let cases = enumerate().expect("enumerate wasi-testsuite");
-    // Merge the base ledger with the host-matching scoped entries, so a failure
-    // that only trips on this host is expected while its counterpart on the
-    // other host is still flagged as a genuine unexpected pass. Leaked to
-    // `'static` because trials outlive this function.
+    // Merge the base ledger with the host-matching scoped entries, so a failure that only trips on this host is expected while its counterpart on the other host is still flagged as a genuine unexpected pass. Leaked to `'static` because trials outlive this function.
     let mut ledger: Vec<(&'static str, &'static str)> = lang.expected_failures().to_vec();
     if cfg!(target_os = "macos") {
         ledger.extend_from_slice(lang.expected_failures_macos());
@@ -185,8 +135,7 @@ pub fn wasi_testsuite_trials(lang: &'static dyn WasiTestsuiteBackend) -> Vec<Tri
         .collect()
 }
 
-/// `harness = false` entry point: parse cargo's test arguments and run every
-/// trial.
+/// `harness = false` entry point: parse cargo's test arguments and run every trial.
 pub fn wasi_testsuite_main(lang: &'static dyn WasiTestsuiteBackend) {
     let args = libtest_mimic::Arguments::from_args();
     libtest_mimic::run(&args, wasi_testsuite_trials(lang)).exit();
@@ -220,9 +169,7 @@ fn run_trial(
     }
 }
 
-/// Convert, run, and check one case against its manifest. Any deviation
-/// (conversion refusal, wrong exit code, wrong stdout/stderr) is a
-/// [`Outcome::Fail`]; the ledger in [`run_trial`] decides if it is expected.
+/// Convert, run, and check one case against its manifest. Any deviation (conversion refusal, wrong exit code, wrong stdout/stderr) is a [`Outcome::Fail`]; the ledger in [`run_trial`] decides if it is expected.
 fn evaluate(lang: &dyn WasiTestsuiteBackend, case: &Case) -> Outcome {
     let bytes = match std::fs::read(&case.wasm) {
         Ok(b) => b,
@@ -239,9 +186,7 @@ fn evaluate(lang: &dyn WasiTestsuiteBackend, case: &Case) -> Outcome {
         }
     };
 
-    // Mount the `root` fixture at guest `/` from a fresh temp copy, so a test
-    // that creates/removes files never mutates the committed submodule and
-    // re-runs cleanly.
+    // Mount the `root` fixture at guest `/` from a fresh temp copy, so a test that creates/removes files never mutates the committed submodule and re-runs cleanly.
     let m = &case.manifest;
     let _scratch = match &m.root {
         Some(root) => match stage_root(&case.wasm, root) {
@@ -261,11 +206,7 @@ fn evaluate(lang: &dyn WasiTestsuiteBackend, case: &Case) -> Outcome {
         .iter()
         .map(|(k, v)| (k.as_str(), v.as_str()))
         .collect();
-    // Pin the Rust suite's errno assertions to the host flavor (ADR-49):
-    // unset, upstream's TestConfig is Permissive — the union of its per-OS
-    // arms. Deliberate deviation from the manifest-only-env rule (commit
-    // 02c5ef5), scoped to Rust: the C/assemblyscript suites assert exact
-    // environ contents.
+    // Pin the Rust suite's errno assertions to the host flavor (ADR-49): unset, upstream's TestConfig is Permissive — the union of its per-OS arms. Deliberate deviation from the manifest-only-env rule (commit 02c5ef5), scoped to Rust: the C/assemblyscript suites assert exact environ contents.
     if case.trial_name.starts_with("rust/") {
         env.push((
             if std::env::consts::OS == "macos" {
@@ -316,15 +257,13 @@ fn truncate(s: &str) -> String {
     }
 }
 
-/// A conversion refusal, split like `spec.rs`: attributable (a declared gap) or
-/// an unattributed dewasm bug.
+/// A conversion refusal, split like `spec.rs`: attributable (a declared gap) or an unattributed dewasm bug.
 enum Attribution {
     Tag(String),
     Bug(String),
 }
 
-/// Map a conversion error to its attribution: an [`UnsupportedError`] anywhere
-/// in the chain names the responsible feature(s); anything else is a bug.
+/// Map a conversion error to its attribution: an [`UnsupportedError`] anywhere in the chain names the responsible feature(s); anything else is a bug.
 fn attribute(err: &anyhow::Error) -> Attribution {
     match err
         .chain()
@@ -341,8 +280,7 @@ fn attribute(err: &anyhow::Error) -> Attribution {
     }
 }
 
-/// Convert `bytes` to a standalone program with `backend`, returning the source
-/// text or an attributed refusal.
+/// Convert `bytes` to a standalone program with `backend`, returning the source text or an attributed refusal.
 fn convert_standalone(backend: &(dyn Backend + Sync), bytes: &[u8]) -> Result<String, Attribution> {
     let module = dewasm_core::build_module(bytes).map_err(|e| attribute(&e))?;
     let mut units = backend
@@ -357,8 +295,7 @@ fn convert_standalone(backend: &(dyn Backend + Sync), bytes: &[u8]) -> Result<St
             },
         )
         .map_err(|e| attribute(&e))?;
-    // The primary source is always UTF-8 (generated code); only the optional
-    // data sidecar is raw bytes, and this runner never requests one.
+    // The primary source is always UTF-8 (generated code); only the optional data sidecar is raw bytes, and this runner never requests one.
     Ok(String::from_utf8(units.remove(0).contents).expect("generated source is valid UTF-8"))
 }
 
@@ -379,8 +316,7 @@ impl Drop for Scratch {
     }
 }
 
-/// Copy the `root` fixture (relative to the module) into a fresh, uniquely
-/// named temp directory so parallel trials never share host state.
+/// Copy the `root` fixture (relative to the module) into a fresh, uniquely named temp directory so parallel trials never share host state.
 fn stage_root(wasm: &Path, root: &str) -> std::io::Result<Scratch> {
     static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     let src = wasm.parent().unwrap().join(root);

--- a/crates/dewasm-test-helper/src/wasmtime_backend.rs
+++ b/crates/dewasm-test-helper/src/wasmtime_backend.rs
@@ -1,14 +1,6 @@
-//! wasmtime as a [`BackendUnderTest`] (ADR-27): the golden-vs-wasmtime
-//! freshness checks run through the *same* shared app/gzip runners every real
-//! backend uses, rather than a hand-written per-case loop. wasmtime does not
-//! generate source — it runs the cached `.wasm` binary directly — so its
-//! `convert_app` returns the path to the exact cache binary the goldens were
-//! captured from, and its `run`/`run_bytes` exec `wasmtime run <path>`.
+//! wasmtime as a [`BackendUnderTest`] (ADR-27): the golden-vs-wasmtime freshness checks run through the *same* shared app/gzip runners every real backend uses, rather than a hand-written per-case loop. wasmtime does not generate source — it runs the cached `.wasm` binary directly — so its `convert_app` returns the path to the exact cache binary the goldens were captured from, and its `run`/`run_bytes` exec `wasmtime run <path>`.
 //!
-//! Public (not gated behind the `wasmtime_test` feature, which only gates the
-//! *tests* in `tests/apps_wasmtime.rs`) so that both that test file and
-//! `cargo xtask update-repl-golden` can drive the same wasmtime-backed
-//! [`BackendUnderTest`] to (re)capture the interactive-REPL golden.
+//! Public (not gated behind the `wasmtime_test` feature, which only gates the *tests* in `tests/apps_wasmtime.rs`) so that both that test file and `cargo xtask update-repl-golden` can drive the same wasmtime-backed [`BackendUnderTest`] to (re)capture the interactive-REPL golden.
 
 use std::path::Path;
 use std::process::{Command, Output};
@@ -19,9 +11,7 @@ use dewasm_core::ir;
 use crate::backend::{run_command_bytes, BackendUnderTest};
 use crate::pty::PtyCommand;
 
-/// A [`Backend`] that only exists to satisfy `BackendUnderTest::backend()`.
-/// wasmtime runs the cached binary directly, so codegen is never reached; if
-/// anything routes into `generate()` it is a wiring bug, not a supported path.
+/// A [`Backend`] that only exists to satisfy `BackendUnderTest::backend()`. wasmtime runs the cached binary directly, so codegen is never reached; if anything routes into `generate()` it is a wiring bug, not a supported path.
 struct NeverBackend;
 
 impl Backend for NeverBackend {
@@ -42,9 +32,7 @@ impl Backend for NeverBackend {
     }
 }
 
-/// The wasmtime engine wired into the shared app/gzip runners. `convert_app`
-/// hands back the cache-binary path (no codegen); `run_bytes` execs
-/// `wasmtime run <path> <args...>` on that exact binary.
+/// The wasmtime engine wired into the shared app/gzip runners. `convert_app` hands back the cache-binary path (no codegen); `run_bytes` execs `wasmtime run <path> <args...>` on that exact binary.
 pub struct Wasmtime;
 
 impl BackendUnderTest for Wasmtime {
@@ -56,13 +44,7 @@ impl BackendUnderTest for Wasmtime {
         &NeverBackend
     }
 
-    /// Skip codegen entirely: write the exact bytes the shared runner read from
-    /// the cache to a temp `.wasm` (keyed by content hash so identical apps
-    /// share one file) and return that path, which the runner then feeds to
-    /// `run`/`run_app_fs`. Writing the bytes rather than rebuilding the cache
-    /// path from `name` keeps this independent of the conversion module name,
-    /// which no longer always equals the cache stem (e.g. CRuby: cache
-    /// `ruby.wasm`, class `Cruby`).
+    /// Skip codegen entirely: write the exact bytes the shared runner read from the cache to a temp `.wasm` (keyed by content hash so identical apps share one file) and return that path, which the runner then feeds to `run`/`run_app_fs`. Writing the bytes rather than rebuilding the cache path from `name` keeps this independent of the conversion module name, which no longer always equals the cache stem (e.g. CRuby: cache `ruby.wasm`, class `Cruby`).
     fn convert_app(&self, bytes: &[u8], _mode: Mode, _name: &str) -> String {
         use std::hash::{Hash, Hasher};
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
@@ -75,9 +57,7 @@ impl BackendUnderTest for Wasmtime {
         path.to_string_lossy().into_owned()
     }
 
-    /// `source` is a cache-binary path (from `convert_app`), not generated
-    /// code: exec `wasmtime run <path> <args...>` with `stdin` piped in. Per
-    /// ADR-15 a missing `wasmtime` fails loud, never skips.
+    /// `source` is a cache-binary path (from `convert_app`), not generated code: exec `wasmtime run <path> <args...>` with `stdin` piped in. Per ADR-15 a missing `wasmtime` fails loud, never skips.
     fn run_bytes(&self, source: &str, args: &[&str], stdin: &[u8]) -> Output {
         assert!(
             Command::new("wasmtime").arg("--version").output().is_ok(),
@@ -96,11 +76,7 @@ impl BackendUnderTest for Wasmtime {
         )
     }
 
-    /// Run the filesystem app directly on the cache binary: `program` is the
-    /// wasm path (from `convert_app`), so ignore the appended `glue` the default
-    /// composes and instead exec `wasmtime run --dir <host>::<guest>...
-    /// --env K=V... <wasm> <args[1..]>` (wasmtime injects argv0 itself). Per
-    /// ADR-15 a missing `wasmtime` fails loud, never skips.
+    /// Run the filesystem app directly on the cache binary: `program` is the wasm path (from `convert_app`), so ignore the appended `glue` the default composes and instead exec `wasmtime run --dir <host>::<guest>... --env K=V... <wasm> <args[1..]>` (wasmtime injects argv0 itself). Per ADR-15 a missing `wasmtime` fails loud, never skips.
     fn run_app_fs(
         &self,
         program: &str,
@@ -128,11 +104,7 @@ impl BackendUnderTest for Wasmtime {
         run_command_bytes(&mut cmd, stdin)
     }
 
-    /// Standalone `--dir` ground truth (ADR-31): `program` is the wasm path
-    /// (from `convert_app`), and `--dir` is a wasmtime host flag, so run
-    /// `wasmtime run --dir HOST::GUEST... <wasm> args`. This is what the
-    /// generated backends' own `--dir` parsing must reproduce. Per ADR-15 a
-    /// missing `wasmtime` fails loud, never skips.
+    /// Standalone `--dir` ground truth (ADR-31): `program` is the wasm path (from `convert_app`), and `--dir` is a wasmtime host flag, so run `wasmtime run --dir HOST::GUEST... <wasm> args`. This is what the generated backends' own `--dir` parsing must reproduce. Per ADR-15 a missing `wasmtime` fails loud, never skips.
     fn run_standalone_dir(
         &self,
         program: &str,
@@ -155,11 +127,7 @@ impl BackendUnderTest for Wasmtime {
         run_command_bytes(&mut cmd, stdin)
     }
 
-    /// Drive the cached wasm binary directly under a pty: `source` is the wasm
-    /// path (from `convert_app`), so the command is `wasmtime run <path>
-    /// <args...>` — the ground-truth interactive session the backends must
-    /// match. wasmtime injects argv0, so a bare no-args call is the interactive
-    /// REPL invocation.
+    /// Drive the cached wasm binary directly under a pty: `source` is the wasm path (from `convert_app`), so the command is `wasmtime run <path> <args...>` — the ground-truth interactive session the backends must match. wasmtime injects argv0, so a bare no-args call is the interactive REPL invocation.
     fn pty_command(&self, source: &str, args: &[&str]) -> PtyCommand {
         assert!(
             Command::new("wasmtime").arg("--version").output().is_ok(),

--- a/crates/dewasm-test-helper/tests/apps_wasmtime.rs
+++ b/crates/dewasm-test-helper/tests/apps_wasmtime.rs
@@ -1,18 +1,6 @@
-//! wasmtime as a [`BackendUnderTest`] (ADR-27): the golden-vs-wasmtime
-//! freshness check run through the *same* shared app/gzip runners every real
-//! backend uses, rather than a hand-written per-case loop. wasmtime does not
-//! generate source — it runs the cached `.wasm` binary directly — so its
-//! `convert_app` returns the path to the exact cache binary the goldens were
-//! captured from, and its `run`/`run_bytes` exec `wasmtime run <path>`. The
-//! per-backend `apps`/`gzip` suites cover the other half (generated output vs.
-//! golden); this suite re-validates the goldens themselves against a live
-//! engine.
+//! wasmtime as a [`BackendUnderTest`] (ADR-27): the golden-vs-wasmtime freshness check run through the *same* shared app/gzip runners every real backend uses, rather than a hand-written per-case loop. wasmtime does not generate source — it runs the cached `.wasm` binary directly — so its `convert_app` returns the path to the exact cache binary the goldens were captured from, and its `run`/`run_bytes` exec `wasmtime run <path>`. The per-backend `apps`/`gzip` suites cover the other half (generated output vs. golden); this suite re-validates the goldens themselves against a live engine.
 //!
-//! Named `apps_wasmtime` for the family: a future engine-under-test (wasmer,
-//! wasmedge) would join here the same way. Gated behind the `wasmtime_test`
-//! feature and `#[ignore]`d otherwise, because `wasmtime` is deliberately not
-//! one of the default suite's required tools (ADR-15) — this suite exists to
-//! check the checker, not to run on every `cargo test`.
+//! Named `apps_wasmtime` for the family: a future engine-under-test (wasmer, wasmedge) would join here the same way. Gated behind the `wasmtime_test` feature and `#[ignore]`d otherwise, because `wasmtime` is deliberately not one of the default suite's required tools (ADR-15) — this suite exists to check the checker, not to run on every `cargo test`.
 //!
 //! Run it with:
 //!
@@ -27,20 +15,9 @@ use dewasm_test_helper::{
     SQLITE3_SHELL, SQLITE3_SHELL_DBFILE,
 };
 
-// The wasmtime-backed `BackendUnderTest` (`Wasmtime`, plus the `NeverBackend`
-// stand-in it uses to satisfy `BackendUnderTest::backend()`) lives in
-// `dewasm_test_helper::wasmtime_backend` so `cargo xtask update-repl-golden`
-// can drive it too; see that module for the implementation.
+// The wasmtime-backed `BackendUnderTest` (`Wasmtime`, plus the `NeverBackend` stand-in it uses to satisfy `BackendUnderTest::backend()`) lives in `dewasm_test_helper::wasmtime_backend` so `cargo xtask update-repl-golden` can drive it too; see that module for the implementation.
 
-// Hand-written `#[test]` fns rather than the per-case `*_e2e!` macros: those
-// macros take a bare `$lang:expr` and forwarding an optional leading attribute
-// onto the generated fn is a local macro-parsing ambiguity (`#` can begin an
-// expr fragment). Calling the shared runners directly is the simplest honest
-// way to attach the `wasmtime_test` ignore gate while still routing through
-// the exact same runners the real backends use. The runners themselves are
-// ungated (the slow per-case macros carry their own `slow_test`-feature
-// `#[ignore]` instead, ADR-27 revision), so `wasmtime_test` alone gates every
-// test in this file.
+// Hand-written `#[test]` fns rather than the per-case `*_e2e!` macros: those macros take a bare `$lang:expr` and forwarding an optional leading attribute onto the generated fn is a local macro-parsing ambiguity (`#` can begin an expr fragment). Calling the shared runners directly is the simplest honest way to attach the `wasmtime_test` ignore gate while still routing through the exact same runners the real backends use. The runners themselves are ungated (the slow per-case macros carry their own `slow_test`-feature `#[ignore]` instead, ADR-27 revision), so `wasmtime_test` alone gates every test in this file.
 
 #[cfg_attr(not(feature = "wasmtime_test"), ignore)]
 #[test]
@@ -72,12 +49,7 @@ fn gzip() {
     run_gzip_cases(&Wasmtime);
 }
 
-// The filesystem app cases: the `wasmtime_test` feature is already the opt-in,
-// and `run_fs_app_case` is ungated, so wasmtime runs the full set with no
-// per-case exclusion; its `run_app_fs` override ignores the glue, so each case
-// is driven with an empty glue string. Hand-written rather than via the per-case
-// `*_e2e!` macros because those cannot carry the `wasmtime_test` ignore gate
-// (the same reason `apps`/`gzip` above are hand-written).
+// The filesystem app cases: the `wasmtime_test` feature is already the opt-in, and `run_fs_app_case` is ungated, so wasmtime runs the full set with no per-case exclusion; its `run_app_fs` override ignores the glue, so each case is driven with an empty glue string. Hand-written rather than via the per-case `*_e2e!` macros because those cannot carry the `wasmtime_test` ignore gate (the same reason `apps`/`gzip` above are hand-written).
 #[cfg_attr(not(feature = "wasmtime_test"), ignore)]
 #[test]
 fn fs_apps() {
@@ -89,22 +61,14 @@ fn fs_apps() {
     run_fs_app_case(&Wasmtime, &CRUBY_HELLO, "");
 }
 
-// The standalone `--dir` interface (ADR-31) run against wasmtime as ground
-// truth: `run_standalone_dir`'s wasmtime path consumes `--dir` as a host flag
-// (`wasmtime run --dir HOST::GUEST <wasm>`), the exact behavior the generated
-// backends' own `--dir` parsing must reproduce. Uses no cached app, only the
-// committed `wasi_standalone_dir.wat`, so it needs only wasmtime on PATH.
+// The standalone `--dir` interface (ADR-31) run against wasmtime as ground truth: `run_standalone_dir`'s wasmtime path consumes `--dir` as a host flag (`wasmtime run --dir HOST::GUEST <wasm>`), the exact behavior the generated backends' own `--dir` parsing must reproduce. Uses no cached app, only the committed `wasi_standalone_dir.wat`, so it needs only wasmtime on PATH.
 #[cfg_attr(not(feature = "wasmtime_test"), ignore)]
 #[test]
 fn standalone_dir() {
     run_standalone_dir(&Wasmtime);
 }
 
-// Golden freshness for the interactive-REPL transcript (Fix 4): re-capture the
-// bare qjs REPL under a real pty from a live wasmtime and require it to equal
-// the checked-in `qjs_repl_interactive.transcript`. Compare-only; regenerate
-// with `cargo xtask update-repl-golden` when the pinned qjs binary or the
-// scripted session changes.
+// Golden freshness for the interactive-REPL transcript (Fix 4): re-capture the bare qjs REPL under a real pty from a live wasmtime and require it to equal the checked-in `qjs_repl_interactive.transcript`. Compare-only; regenerate with `cargo xtask update-repl-golden` when the pinned qjs binary or the scripted session changes.
 #[cfg_attr(not(feature = "wasmtime_test"), ignore)]
 #[test]
 fn qjs_repl_interactive_golden() {
@@ -116,12 +80,7 @@ fn qjs_repl_interactive_golden() {
         )
     });
     let got = capture_qjs_repl_transcript(&Wasmtime);
-    // Linux wasmtime emits one extra trailing CRLF on pty teardown that
-    // macOS wasmtime (which captured the golden) does not; the converted
-    // backends match the golden byte-for-byte on both hosts, so the
-    // difference is wasmtime's own exit behavior, outside the transcript's
-    // meaningful content (it ends at the `\q` echo). Compare modulo trailing
-    // CRLFs here only — the per-backend comparison stays exact (issue #33).
+    // Linux wasmtime emits one extra trailing CRLF on pty teardown that macOS wasmtime (which captured the golden) does not; the converted backends match the golden byte-for-byte on both hosts, so the difference is wasmtime's own exit behavior, outside the transcript's meaningful content (it ends at the `\q` echo). Compare modulo trailing CRLFs here only — the per-backend comparison stays exact (issue #33).
     assert_transcript_eq(
         trim_trailing_crlfs(&got),
         trim_trailing_crlfs(&golden),

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1,8 +1,4 @@
-//! Developer-facing workspace tasks, run as `cargo xtask <command>` (aliased
-//! in `.cargo/config.toml`). Replaces the former golden-regeneration env-var
-//! toggles on the `support_docs` and `apps_wasmtime` tests with explicit
-//! subcommands: those tests are now compare-only and point here when they
-//! fail.
+//! Developer-facing workspace tasks, run as `cargo xtask <command>` (aliased in `.cargo/config.toml`). Replaces the former golden-regeneration env-var toggles on the `support_docs` and `apps_wasmtime` tests with explicit subcommands: those tests are now compare-only and point here when they fail.
 //!
 //! No `clap` dependency: two subcommands and a help message do not need one.
 
@@ -48,10 +44,7 @@ fn main() -> Result<()> {
     }
 }
 
-/// Render `docs/support.md` from the backends' own declarations and write it
-/// to disk (ADR-8). The corresponding test (`crates/dewasm-cli/tests/
-/// support_docs.rs`) is compare-only and names this command in its failure
-/// message.
+/// Render `docs/support.md` from the backends' own declarations and write it to disk (ADR-8). The corresponding test (`crates/dewasm-cli/tests/ support_docs.rs`) is compare-only and names this command in its failure message.
 fn update_support_docs() -> Result<()> {
     let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../docs/support.md");
     let rendered = render_support_docs();
@@ -60,11 +53,7 @@ fn update_support_docs() -> Result<()> {
     Ok(())
 }
 
-/// Recapture the interactive QuickJS REPL transcript against a live wasmtime
-/// under a pty and write it to the checked-in golden path (Fix 4,
-/// `crates/dewasm-test-helper/src/qjs_repl.rs`). The corresponding freshness
-/// test (`crates/dewasm-test-helper/tests/apps_wasmtime.rs`) is compare-only
-/// and names this command in its failure message.
+/// Recapture the interactive QuickJS REPL transcript against a live wasmtime under a pty and write it to the checked-in golden path (Fix 4, `crates/dewasm-test-helper/src/qjs_repl.rs`). The corresponding freshness test (`crates/dewasm-test-helper/tests/apps_wasmtime.rs`) is compare-only and names this command in its failure message.
 fn update_repl_golden() -> Result<()> {
     let bytes = capture_qjs_repl_golden(&Wasmtime);
     println!(

--- a/docs/adr/0-foundation.md
+++ b/docs/adr/0-foundation.md
@@ -1,67 +1,28 @@
 # ADR-0 — Foundation and Core Architecture
 
-Status: **Accepted, 2026-07-23.** Backfilled; the decision was made during
-initial planning and implementation. The core pipeline, the Ruby backend,
-and the spec harness are implemented; other backends are planned.
-Amended by [ADR-10](10-csharp-target.md): C# joins the target list,
-paired with Java.
+Status: **Accepted, 2026-07-23.** Backfilled; the decision was made during initial planning and implementation. The core pipeline, the Ruby backend, and the spec harness are implemented; other backends are planned. Amended by [ADR-10](10-csharp-target.md): C# joins the target list, paired with Java.
 
 ## Context
 
-Programs compiled to WebAssembly (from C, C++, Rust, ...) normally need a
-wasm runtime to execute. Existing source-to-source translators remove that
-requirement but each targets exactly one language — wasm2c / w2c2 (C),
-wasm2js (JavaScript), wasm2go (Go), unwasm (PHP), wasm2lua (Lua) — and no
-tool covers multiple target languages from one codebase. dewasmify's goal
-is to translate wasm binaries into source code of *many* languages, so a
-tool built once (e.g. in Rust) can run anywhere the target language runs —
-including places with no wasm runtime at all, such as a plain Bash
-environment.
+Programs compiled to WebAssembly (from C, C++, Rust, ...) normally need a wasm runtime to execute. Existing source-to-source translators remove that requirement but each targets exactly one language — wasm2c / w2c2 (C), wasm2js (JavaScript), wasm2go (Go), unwasm (PHP), wasm2lua (Lua) — and no tool covers multiple target languages from one codebase. dewasmify's goal is to translate wasm binaries into source code of *many* languages, so a tool built once (e.g. in Rust) can run anywhere the target language runs — including places with no wasm runtime at all, such as a plain Bash environment.
 
 ## Decision
 
-- **One shared IR, pluggable language backends.** The core decodes,
-  validates, and builds a language-neutral IR (ADR-1); each backend is a
-  lowering of that IR plus an embedded lightweight runtime written in the
-  target language (`runtime/<lang>/`). Adding a language must not require
-  touching the core.
-- **Implementation language: Rust**, using the Bytecode Alliance crates
-  (`wasmparser` for decoding/validation, `wast`/`wat` for the test
-  pipeline). Rust also keeps the self-hosting demo possible: dewasmify
-  itself compiled to wasm, then translated by itself.
-- **First-release input scope: Wasm core 1.0 plus the extensions
-  C/Rust toolchains enable by default** (mutable globals, sign-extension,
-  saturating float-to-int, multi-value, bulk memory), and **WASI
-  preview 1**. Reference types, SIMD, threads, GC, multiple
-  memories/tables, and cross-module linking are out of scope and must be
-  rejected with a clear error.
-- **Two output modes**: *library* (a class/module instantiated with an
-  imports object, exports exposed to the host language) and *standalone*
-  (WASI wired up, `_start` invoked, exit code mapped).
-- **Target language priority: Ruby → Bash → Java → Go → Python → PHP.**
-  Bash is the flagship demonstration (running C/Rust tools with no
-  hardware-specific binary at all); Ruby went first to validate the
-  pipeline (implemented). JavaScript is deliberately absent.
-- **Name: `dewasmify`** — the tool strips ("de-") the wasm out of a
-  program. Crate, CLI, and repository share the name. *Amended by
-  [ADR-26](26-rename-dewasm.md) (2026-07-25): renamed to `dewasm`.*
+- **One shared IR, pluggable language backends.** The core decodes, validates, and builds a language-neutral IR (ADR-1); each backend is a lowering of that IR plus an embedded lightweight runtime written in the target language (`runtime/<lang>/`). Adding a language must not require touching the core.
+- **Implementation language: Rust**, using the Bytecode Alliance crates (`wasmparser` for decoding/validation, `wast`/`wat` for the test pipeline). Rust also keeps the self-hosting demo possible: dewasmify itself compiled to wasm, then translated by itself.
+- **First-release input scope: Wasm core 1.0 plus the extensions C/Rust toolchains enable by default** (mutable globals, sign-extension, saturating float-to-int, multi-value, bulk memory), and **WASI preview 1**. Reference types, SIMD, threads, GC, multiple memories/tables, and cross-module linking are out of scope and must be rejected with a clear error.
+- **Two output modes**: *library* (a class/module instantiated with an imports object, exports exposed to the host language) and *standalone* (WASI wired up, `_start` invoked, exit code mapped).
+- **Target language priority: Ruby → Bash → Java → Go → Python → PHP.** Bash is the flagship demonstration (running C/Rust tools with no hardware-specific binary at all); Ruby went first to validate the pipeline (implemented). JavaScript is deliberately absent.
+- **Name: `dewasmify`** — the tool strips ("de-") the wasm out of a program. Crate, CLI, and repository share the name. *Amended by [ADR-26](26-rename-dewasm.md) (2026-07-25): renamed to `dewasm`.*
 
 ## Rejected alternatives
 
-- **Contributing to / forking the single-language translators** — six
-  divergent codebases with different IRs and test rigs; the shared-IR
-  economics are the point of this project.
-- **JavaScript as an early target** — wasm2js exists and every JS runtime
-  ships a wasm engine; little value added. May be revisited later.
-- **Naming the project `wasmify`** — reads as "convert *to* wasm" and
-  collides with an existing npm package.
+- **Contributing to / forking the single-language translators** — six divergent codebases with different IRs and test rigs; the shared-IR economics are the point of this project.
+- **JavaScript as an early target** — wasm2js exists and every JS runtime ships a wasm engine; little value added. May be revisited later.
+- **Naming the project `wasmify`** — reads as "convert *to* wasm" and collides with an existing npm package.
 
 ## Consequences
 
-- Positive: each backend is "lowering table + runtime + pass the shared
-  harness" (ADR-3); semantics knowledge concentrates in the IR and the
-  per-language numeric strategy (ADR-2).
-- Negative: unsupported-feature errors are part of the UX until Wasm 2.0+
-  features land; modules using them fail at conversion time, not runtime.
-- The milestone plan (M0 core → M1 Ruby → M2 WASI → M3 Bash → M4 Java/Go
-  → M5 Python/PHP → M6 release/self-hosting) follows this priority order.
+- Positive: each backend is "lowering table + runtime + pass the shared harness" (ADR-3); semantics knowledge concentrates in the IR and the per-language numeric strategy (ADR-2).
+- Negative: unsupported-feature errors are part of the UX until Wasm 2.0+ features land; modules using them fail at conversion time, not runtime.
+- The milestone plan (M0 core → M1 Ruby → M2 WASI → M3 Bash → M4 Java/Go → M5 Python/PHP → M6 release/self-hosting) follows this priority order.

--- a/docs/adr/1-ir-design.md
+++ b/docs/adr/1-ir-design.md
@@ -1,58 +1,26 @@
 # ADR-1 — IR Design: Structured Control Flow + Stack-Slot Temps
 
-Status: **Accepted, 2026-07-23.** Backfilled; implemented in
-`crates/dewasm-core/src/ir.rs` and `func.rs`. The expression-folding
-readability pass remains future work.
+Status: **Accepted, 2026-07-23.** Backfilled; implemented in `crates/dewasm-core/src/ir.rs` and `func.rs`. The expression-folding readability pass remains future work.
 
 ## Context
 
-Backends emit source code in languages without `goto`, so the IR shape
-decides how hard every backend's control-flow and evaluation-order story
-is. Wasm 1.0 bodies are stack-machine code, but their control flow is
-already structured (`block` / `loop` / `if` / `br` / `br_table` — branches
-only jump to enclosing labels).
+Backends emit source code in languages without `goto`, so the IR shape decides how hard every backend's control-flow and evaluation-order story is. Wasm 1.0 bodies are stack-machine code, but their control flow is already structured (`block` / `loop` / `if` / `br` / `br_table` — branches only jump to enclosing labels).
 
 ## Decision
 
-- **Keep wasm's structured control flow as-is.** The IR statement tree
-  mirrors block/loop/if with resolved branch targets; no CFG, no relooper.
-  Every structured target language can express "exit block N" / "continue
-  loop N" one way or another (ADR-4 for Ruby's), so re-deriving structure
-  from a CFG would be pure waste. Labels carry a `referenced` flag so
-  backends emit no machinery for branch-free blocks.
-- **Flatten the value stack into temps keyed by (depth, type)**, the
-  wasm2c approach, using the type information tracked during translation.
-  The same slot is one target-language variable.
-- **Materialize every pushed value into a temp immediately.** The
-  criterion: *evaluation order and trap points must be provably identical
-  to wasm's without any effect analysis.* A `drop` of a loaded value still
-  traps on out-of-bounds; call/store ordering needs no reasoning. The cost
-  is verbose output; folding single-use pure temps back into expressions
-  is a planned, separate pass that must not change semantics.
-- **Dead code after an unconditional branch is skipped tracking only
-  block nesting** — no type tracking in unreachable code. Runtime-safe
-  because the skipped region is never entered.
-- Branch moves (`br` operands → target result/param slots) are computed
-  during translation and stored on the branch (`BrTarget::Label.assigns`),
-  with self-assignments already filtered; backends just print them.
+- **Keep wasm's structured control flow as-is.** The IR statement tree mirrors block/loop/if with resolved branch targets; no CFG, no relooper. Every structured target language can express "exit block N" / "continue loop N" one way or another (ADR-4 for Ruby's), so re-deriving structure from a CFG would be pure waste. Labels carry a `referenced` flag so backends emit no machinery for branch-free blocks.
+- **Flatten the value stack into temps keyed by (depth, type)**, the wasm2c approach, using the type information tracked during translation. The same slot is one target-language variable.
+- **Materialize every pushed value into a temp immediately.** The criterion: *evaluation order and trap points must be provably identical to wasm's without any effect analysis.* A `drop` of a loaded value still traps on out-of-bounds; call/store ordering needs no reasoning. The cost is verbose output; folding single-use pure temps back into expressions is a planned, separate pass that must not change semantics.
+- **Dead code after an unconditional branch is skipped tracking only block nesting** — no type tracking in unreachable code. Runtime-safe because the skipped region is never entered.
+- Branch moves (`br` operands → target result/param slots) are computed during translation and stored on the branch (`BrTarget::Label.assigns`), with self-assignments already filtered; backends just print them.
 
 ## Rejected alternatives
 
-- **Expression-tree reconstruction from the start** — better-looking
-  output, but correctness (side-effect ordering, trap points) becomes an
-  analysis problem in every backend. Ordered as: correct first, pretty
-  later.
-- **CFG + relooper** — needed only for input that has arbitrary jumps;
-  wasm 1.0 does not.
+- **Expression-tree reconstruction from the start** — better-looking output, but correctness (side-effect ordering, trap points) becomes an analysis problem in every backend. Ordered as: correct first, pretty later.
+- **CFG + relooper** — needed only for input that has arbitrary jumps; wasm 1.0 does not.
 
 ## Consequences
 
-- Positive: backends are lowering tables, not compilers; the spec harness
-  (ADR-3) passed on the first backend with only lowering bugs, no IR
-  redesign.
-- Negative: generated code reads like register transfers (`s0 = l0`;
-  `s0 = (s0 + s1) & 0xffffffff`) until the folding pass exists; output
-  size is larger than hand-written style.
-- Multi-value blocks/returns are representable for free (result slots are
-  just consecutive temps), so the multi-value feature costs backends
-  almost nothing.
+- Positive: backends are lowering tables, not compilers; the spec harness (ADR-3) passed on the first backend with only lowering bugs, no IR redesign.
+- Negative: generated code reads like register transfers (`s0 = l0`; `s0 = (s0 + s1) & 0xffffffff`) until the folding pass exists; output size is larger than hand-written style.
+- Multi-value blocks/returns are representable for free (result slots are just consecutive temps), so the multi-value feature costs backends almost nothing.

--- a/docs/adr/10-csharp-target.md
+++ b/docs/adr/10-csharp-target.md
@@ -1,42 +1,21 @@
 # ADR-10 — Add C# to the Target Languages, Paired with Java
 
-Status: **Accepted, 2026-07-23.** Amends ADR-0's target list; no backend
-work has started. Planned order: Ruby → Bash → Java → C# → Go → Python →
-PHP, with Java and C# designed as one "managed static languages" pair.
-*Revised by [ADR-24](24-01-scope-reset.md) (2026-07-25): the 0.1 backends
-are Python, Go, and Java; C# moves to the future list (the Java/C#
-pairing argument below still applies when C# is picked up).*
+Status: **Accepted, 2026-07-23.** Amends ADR-0's target list; no backend work has started. Planned order: Ruby → Bash → Java → C# → Go → Python → PHP, with Java and C# designed as one "managed static languages" pair. *Revised by [ADR-24](24-01-scope-reset.md) (2026-07-25): the 0.1 backends are Python, Go, and Java; C# moves to the future list (the Java/C# pairing argument below still applies when C# is picked up).*
 
 ## Context
 
-C# was simply missing from the original target list (user call-out). It
-fits the ADR-0 criterion — a mainstream language whose ecosystem does
-not ship a wasm runtime by default in the places dewasmify targets — and
-no wasm→C# *source* translator exists.
+C# was simply missing from the original target list (user call-out). It fits the ADR-0 criterion — a mainstream language whose ecosystem does not ship a wasm runtime by default in the places dewasmify targets — and no wasm→C# *source* translator exists.
 
 ## Decision
 
-Add C#, scheduled together with Java: the two backends share almost all
-design decisions (class-shaped module, byte-array linear memory,
-exceptions for traps), so the marginal cost of the second one is small.
-Where they differ, C# is the easier half: native unsigned integers
-(`uint`/`ulong`, so ADR-2's masked-unsigned strategy is bypassed
-entirely), `goto` for multi-level `br`, `Span<byte>`/`BinaryPrimitives`
-for little-endian memory access, and no hard method-size limit like the
-JVM's 64 KB (Java keeps its function-splitting task). A shared
-lowering-conventions ADR for the pair is expected when that milestone
-starts.
+Add C#, scheduled together with Java: the two backends share almost all design decisions (class-shaped module, byte-array linear memory, exceptions for traps), so the marginal cost of the second one is small. Where they differ, C# is the easier half: native unsigned integers (`uint`/`ulong`, so ADR-2's masked-unsigned strategy is bypassed entirely), `goto` for multi-level `br`, `Span<byte>`/`BinaryPrimitives` for little-endian memory access, and no hard method-size limit like the JVM's 64 KB (Java keeps its function-splitting task). A shared lowering-conventions ADR for the pair is expected when that milestone starts.
 
 ## Rejected alternatives
 
 - **Not adding it** — the omission was an oversight, not a decision.
-- **Revisiting JavaScript on the same grounds** — unchanged from ADR-0:
-  wasm2js exists and every JS runtime ships a wasm engine.
+- **Revisiting JavaScript on the same grounds** — unchanged from ADR-0: wasm2js exists and every JS runtime ships a wasm engine.
 
 ## Consequences
 
-- README target table and roadmap gain C#; the support matrix
-  (docs/support.md) grows a column when the backend lands.
-- The Java/C# milestone produces one design, two emitters — a first test
-  of how much backend machinery (ADR-6 units, lowering tables) is
-  reusable across similar languages.
+- README target table and roadmap gain C#; the support matrix (docs/support.md) grows a column when the backend lands.
+- The Java/C# milestone produces one design, two emitters — a first test of how much backend machinery (ADR-6 units, lowering tables) is reusable across similar languages.

--- a/docs/adr/11-bash-backend-lowering.md
+++ b/docs/adr/11-bash-backend-lowering.md
@@ -1,107 +1,32 @@
 # ADR-11 — Bash Backend Lowering Conventions (Integer Subset)
 
-Status: **Accepted, 2026-07-23.** Implemented in
-`crates/dewasm-backend-bash/src/lib.rs` + `runtime/bash/units/`. Covers
-the integer subset; WASI and standalone mode landed the same day under
-[ADR-12](12-bash-wasi.md), and the ADR-5 softfloat (conventions in
-[ADR-13](13-bash-softfloat-conventions.md)) later removed the float
-conversion-time gate this ADR originally imposed. Cross-module linking
-conventions (imported globals, the PROVIDERS provider protocol, status-135
-link errors) are extended by [ADR-35](35-bash-cross-module-linking.md).
-Requires bash >= 5 (namerefs, associative arrays); macOS system bash is 3.2
-and is out of scope.
+Status: **Accepted, 2026-07-23.** Implemented in `crates/dewasm-backend-bash/src/lib.rs` + `runtime/bash/units/`. Covers the integer subset; WASI and standalone mode landed the same day under [ADR-12](12-bash-wasi.md), and the ADR-5 softfloat (conventions in [ADR-13](13-bash-softfloat-conventions.md)) later removed the float conversion-time gate this ADR originally imposed. Cross-module linking conventions (imported globals, the PROVIDERS provider protocol, status-135 link errors) are extended by [ADR-35](35-bash-cross-module-linking.md). Requires bash >= 5 (namerefs, associative arrays); macOS system bash is 3.2 and is out of scope.
 
 ## Context
 
-Bash arithmetic (`$(( ))`) is signed 64-bit only, `(( x = 0 ))` returns
-exit status 1, there are no exceptions, no binary-safe strings, and
-`break N`/`continue N` count only enclosing loops. Exceeding `FUNCNEST`
-kills the whole shell, not just the call. Every convention below exists to
-fit wasm semantics into those facts with zero external commands (the ADR-5
-dependency criterion, applied backend-wide).
+Bash arithmetic (`$(( ))`) is signed 64-bit only, `(( x = 0 ))` returns exit status 1, there are no exceptions, no binary-safe strings, and `break N`/`continue N` count only enclosing loops. Exceeding `FUNCNEST` kills the whole shell, not just the call. Every convention below exists to fit wasm semantics into those facts with zero external commands (the ADR-5 dependency criterion, applied backend-wide).
 
 ## Decision
 
-- **i32 is masked-unsigned (ADR-2); i64 is the signed-64 two's-complement
-  bit pattern.** i32 fits bash's signed-64 range, so unsigned compare,
-  `shr_u`, and `div_u` are native. i64 cannot be stored unsigned; unsigned
-  views are derived per-op: compares flip the sign bit
-  (`(a ^ 1<<63) < (b ^ 1<<63)`), `shr_u` masks the dragged-in sign bits
-  (special-casing shift 0 — bash takes shift counts mod 64), and
-  `div_u`/`rem_u` use the Hacker's-Delight halving trick
-  (`runtime/bash/units/rt/i64_div_u.sh`). The discriminating rule: an op
-  whose unsigned semantics are free on the chosen representation lowers
-  inline; anything needing a trap check or a loop becomes a runtime unit.
-- **Structured control flow maps to `while :; do ...; break; done`
-  wrappers; `br` is `break N`/`continue N`.** `if` adds no loop level in
-  bash, so the generator's label→depth stack stays exact. Unreferenced
-  labels emit no wrapper (ADR-1's `referenced` flag); `br_table` is a
-  `case` (also level-neutral).
-- **Traps are a status cascade, not subshells.** `rt_trap` sets
-  `TRAP_MSG` (ADR-2's exact message strings) and returns 134; every
-  trap-capable statement is a command with `|| return $?` appended, and
-  every generated/runtime function ends with an explicit `return 0`
-  because a trailing arithmetic statement leaks status 1 (the units lint
-  enforces this). Assertions therefore run in the parent shell and
-  side effects of checked calls persist, matching Ruby's exceptions.
-  Only `assert_exhaustion` runs in a subshell: FUNCNEST overflow kills the
-  shell it happens in.
-- **Values flow through globals `R0, R1, ...`;** locals/temps/params are
-  `local` (dynamic scoping handles recursion). Statements split by shape:
-  pure arithmetic lowers into one `(( dst = expr ))`, helper-backed ops
-  and loads emit a command then `(( dst = R0 ))`; nested command results
-  are copied to `__t<n>` scratch locals so a later helper cannot clobber
-  them. Operand/destination aliasing is real: `memory.grow` must update
-  pages before deriving the old size because the delta may live in the
-  destination temp.
-- **Linear memory is a sparse indexed array, one byte per element**, read
-  as `__m[a]` inside arithmetic (unset elements are 0, so zero-init and
-  `memory.grow` are free). Loads/stores are nameref units
-  (`runtime/bash/units/mem/`); bounds checks compare against
-  `pages * 65536`. Tables, globals, and data segments are plain per-prefix
-  variables emitted inline; `call_indirect` checks the canonicalized type
-  index (ADR-4's structural canonicalization, ported).
-- **One instance per generation-time prefix** (`m1_f0`, `m1_g0`,
-  `m1_init`, `m1_invoke`, `m1_EXPORTS`); the spec harness passes a fresh
-  prefix per module directive, which is how one script hosts many
-  modules. Imports resolve from the caller's `IMPORTS` associative array
-  (`[module.name]=function`); `RuntimeLinkage::Embedded` prepends the
-  unit bundle, `Alias` emits nothing because bash names are global.
+- **i32 is masked-unsigned (ADR-2); i64 is the signed-64 two's-complement bit pattern.** i32 fits bash's signed-64 range, so unsigned compare, `shr_u`, and `div_u` are native. i64 cannot be stored unsigned; unsigned views are derived per-op: compares flip the sign bit (`(a ^ 1<<63) < (b ^ 1<<63)`), `shr_u` masks the dragged-in sign bits (special-casing shift 0 — bash takes shift counts mod 64), and `div_u`/`rem_u` use the Hacker's-Delight halving trick (`runtime/bash/units/rt/i64_div_u.sh`). The discriminating rule: an op whose unsigned semantics are free on the chosen representation lowers inline; anything needing a trap check or a loop becomes a runtime unit.
+- **Structured control flow maps to `while :; do ...; break; done` wrappers; `br` is `break N`/`continue N`.** `if` adds no loop level in bash, so the generator's label→depth stack stays exact. Unreferenced labels emit no wrapper (ADR-1's `referenced` flag); `br_table` is a `case` (also level-neutral).
+- **Traps are a status cascade, not subshells.** `rt_trap` sets `TRAP_MSG` (ADR-2's exact message strings) and returns 134; every trap-capable statement is a command with `|| return $?` appended, and every generated/runtime function ends with an explicit `return 0` because a trailing arithmetic statement leaks status 1 (the units lint enforces this). Assertions therefore run in the parent shell and side effects of checked calls persist, matching Ruby's exceptions. Only `assert_exhaustion` runs in a subshell: FUNCNEST overflow kills the shell it happens in.
+- **Values flow through globals `R0, R1, ...`;** locals/temps/params are `local` (dynamic scoping handles recursion). Statements split by shape: pure arithmetic lowers into one `(( dst = expr ))`, helper-backed ops and loads emit a command then `(( dst = R0 ))`; nested command results are copied to `__t<n>` scratch locals so a later helper cannot clobber them. Operand/destination aliasing is real: `memory.grow` must update pages before deriving the old size because the delta may live in the destination temp.
+- **Linear memory is a sparse indexed array, one byte per element**, read as `__m[a]` inside arithmetic (unset elements are 0, so zero-init and `memory.grow` are free). Loads/stores are nameref units (`runtime/bash/units/mem/`); bounds checks compare against `pages * 65536`. Tables, globals, and data segments are plain per-prefix variables emitted inline; `call_indirect` checks the canonicalized type index (ADR-4's structural canonicalization, ported).
+- **One instance per generation-time prefix** (`m1_f0`, `m1_g0`, `m1_init`, `m1_invoke`, `m1_EXPORTS`); the spec harness passes a fresh prefix per module directive, which is how one script hosts many modules. Imports resolve from the caller's `IMPORTS` associative array (`[module.name]=function`); `RuntimeLinkage::Embedded` prepends the unit bundle, `Alias` emits nothing because bash names are global.
 
-Measured on the spec harness (ADR-3): the curated CI subset passes
-1,455 assertions in ~1 s; the full-testsuite sweep passes 9,923 with only
-the Ruby ledger's five linking-attributed failure groups, in ~39 s
-(Ruby: ~13 s). The feared fork cost never materialized because the
-cascade design forks only for exhaustion checks.
+Measured on the spec harness (ADR-3): the curated CI subset passes 1,455 assertions in ~1 s; the full-testsuite sweep passes 9,923 with only the Ruby ledger's five linking-attributed failure groups, in ~39 s (Ruby: ~13 s). The feared fork cost never materialized because the cascade design forks only for exhaustion checks.
 
 ## Rejected alternatives
 
-- **Dispatch variable for multi-level `br`** (set a level flag, re-test
-  after every block) — costs a test per block exit and obscures the code;
-  `break N` maps 1:1 once `if`'s level-neutrality is established.
-- **Subshell per assertion for trap isolation** — loses the side effects
-  of checked invokes (`set_x` then a getter is common in the testsuite)
-  and pays a fork per assertion; the status cascade isolates nothing
-  because it never needs to.
-- **Word-packed memory (8 bytes/element)** — less RAM and faster bulk
-  ops, but every load/store pays shift/mask reassembly. Byte-per-element
-  with sparse reads is simpler and measured fast enough for the spec
-  suite; revisit when MB-class app memories (QuickJS/SQLite) become the
-  target.
-- **External commands (`od`, `awk`, `bc`) for bit work** — rejected by
-  ADR-5's criterion: the dependency set must be exactly a Bash
-  interpreter.
+- **Dispatch variable for multi-level `br`** (set a level flag, re-test after every block) — costs a test per block exit and obscures the code; `break N` maps 1:1 once `if`'s level-neutrality is established.
+- **Subshell per assertion for trap isolation** — loses the side effects of checked invokes (`set_x` then a getter is common in the testsuite) and pays a fork per assertion; the status cascade isolates nothing because it never needs to.
+- **Word-packed memory (8 bytes/element)** — less RAM and faster bulk ops, but every load/store pays shift/mask reassembly. Byte-per-element with sparse reads is simpler and measured fast enough for the spec suite; revisit when MB-class app memories (QuickJS/SQLite) become the target.
+- **External commands (`od`, `awk`, `bc`) for bit work** — rejected by ADR-5's criterion: the dependency set must be exactly a Bash interpreter.
 
 ## Consequences
 
-- Positive: the shared `Backend`/`RuntimeBundler`/spec-harness machinery
-  (ADR-6, ADR-3) carried over unchanged except for per-language harness
-  emitters — the multi-language design is validated. Runtime speed is a
-  non-issue at spec scale.
-- Negative (resolved): float-using modules were refused (attributed
-  `floats`, ADR-8) until the ADR-5 softfloat landed under ADR-13; the
-  classic control-flow files and the pure-float suite are green since.
-- Deep recursion without `FUNCNEST` segfaults bash around 10–20k frames;
-  exhaustion checks must stay inside `( FUNCNEST=...; ... )` subshells.
-- Bulk memory ops loop per byte; large `memory.copy`/`fill` will need
-  batching before real apps run under bash.
+- Positive: the shared `Backend`/`RuntimeBundler`/spec-harness machinery (ADR-6, ADR-3) carried over unchanged except for per-language harness emitters — the multi-language design is validated. Runtime speed is a non-issue at spec scale.
+- Negative (resolved): float-using modules were refused (attributed `floats`, ADR-8) until the ADR-5 softfloat landed under ADR-13; the classic control-flow files and the pure-float suite are green since.
+- Deep recursion without `FUNCNEST` segfaults bash around 10–20k frames; exhaustion checks must stay inside `( FUNCNEST=...; ... )` subshells.
+- Bulk memory ops loop per byte; large `memory.copy`/`fill` will need batching before real apps run under bash.

--- a/docs/adr/12-bash-wasi.md
+++ b/docs/adr/12-bash-wasi.md
@@ -1,72 +1,29 @@
 # ADR-12 — Bash WASI Conventions
 
-Status: **Accepted, 2026-07-23.** Implemented in `runtime/bash/units/wasi/`
-(the same 16-syscall surface as Ruby, plus the `write_string_list` helper)
-and the standalone emitter in `crates/dewasm-backend-bash/src/lib.rs`.
-Filesystem syscalls remain ENOSYS, as on Ruby.
-The filesystem scope excluded here is superseded by
-[ADR-34](34-bash-wasi-filesystem.md).
+Status: **Accepted, 2026-07-23.** Implemented in `runtime/bash/units/wasi/` (the same 16-syscall surface as Ruby, plus the `write_string_list` helper) and the standalone emitter in `crates/dewasm-backend-bash/src/lib.rs`. Filesystem syscalls remain ENOSYS, as on Ruby. The filesystem scope excluded here is superseded by [ADR-34](34-bash-wasi-filesystem.md).
 
 ## Context
 
-WASI needs three things bash does not natively offer: a non-local exit
-(`proc_exit`), binary-safe stdio, and an entropy/clock source — all under
-ADR-5's dependency criterion (exactly a Bash interpreter, no external
-commands) and ADR-11's status-cascade protocol. WASI units also need the
-per-module state prefix, but imports are bound as bare command names.
+WASI needs three things bash does not natively offer: a non-local exit (`proc_exit`), binary-safe stdio, and an entropy/clock source — all under ADR-5's dependency criterion (exactly a Bash interpreter, no external commands) and ADR-11's status-cascade protocol. WASI units also need the per-module state prefix, but imports are bound as bare command names.
 
 ## Decision
 
-- **`proc_exit` is a second status cascade**: `rt_exit` sets `EXIT_CODE`
-  and returns 133 (`runtime/bash/units/rt/exit.sh`), the sibling of
-  `rt_trap`'s 134. The standalone main maps 133 to
-  `exit $(( EXIT_CODE & 0xff ))`; a sourced library surfaces it as
-  `invoke`'s return status. The reusable rule: any non-local wasm exit is
-  a reserved status code riding the existing `|| return $?` chains, never
-  a bash `exit`.
-- **Binary-safe stdio is byte-wise through builtins.** Writes collect
-  memory bytes into an every-byte `'\\x%02x'` printf format (NUL/%/`\`
-  safe; the format must stay single-quoted). Reads use
-  `IFS= LC_ALL=C read -r -d '' -n 1`, where `''` with success is a NUL
-  byte and failure is EOF. `random_get` reads `/dev/urandom` the same way
-  — a device file via the `read` builtin is within ADR-5's criterion.
-- **Clocks come from `$EPOCHREALTIME`** (microsecond granularity, so
-  `clock_res_get` reports 1000 ns); clock ids 1–3 fall back to realtime
-  because pure bash has no monotonic source — an accepted, documented
-  deviation.
-- **Imports bind through per-module wrapper functions**:
-  `<p>wasi_<name>() { wasi_<name> <p> "$@"; }` bakes the state prefix into
-  the bare command name the import table expects. Resolution order is
-  ADR-7's: `IMPORTS` entry → bundled unit wrapper → `rt_enosys`. State is
-  per-prefix (`<p>wargs`, `<p>wenv`, `<p>wfds`, `<p>wtell`); callers set
-  the `WASI_ARGS`/`WASI_ENV` arrays before `<p>init` (the standalone main
-  fills them from `$0`/`$@` and `compgen -e`).
-- **The fd model is stdio-only**: fds 0/1/2 preopened, `fd_seek` answers
-  ESPIPE, `fd_tell` reports the byte counters `fd_read`/`fd_write` track,
-  `fd_prestat_get` answers EBADF to stop libc preopen scans.
+- **`proc_exit` is a second status cascade**: `rt_exit` sets `EXIT_CODE` and returns 133 (`runtime/bash/units/rt/exit.sh`), the sibling of `rt_trap`'s 134. The standalone main maps 133 to `exit $(( EXIT_CODE & 0xff ))`; a sourced library surfaces it as `invoke`'s return status. The reusable rule: any non-local wasm exit is a reserved status code riding the existing `|| return $?` chains, never a bash `exit`.
+- **Binary-safe stdio is byte-wise through builtins.** Writes collect memory bytes into an every-byte `'\\x%02x'` printf format (NUL/%/`\` safe; the format must stay single-quoted). Reads use `IFS= LC_ALL=C read -r -d '' -n 1`, where `''` with success is a NUL byte and failure is EOF. `random_get` reads `/dev/urandom` the same way — a device file via the `read` builtin is within ADR-5's criterion.
+- **Clocks come from `$EPOCHREALTIME`** (microsecond granularity, so `clock_res_get` reports 1000 ns); clock ids 1–3 fall back to realtime because pure bash has no monotonic source — an accepted, documented deviation.
+- **Imports bind through per-module wrapper functions**: `<p>wasi_<name>() { wasi_<name> <p> "$@"; }` bakes the state prefix into the bare command name the import table expects. Resolution order is ADR-7's: `IMPORTS` entry → bundled unit wrapper → `rt_enosys`. State is per-prefix (`<p>wargs`, `<p>wenv`, `<p>wfds`, `<p>wtell`); callers set the `WASI_ARGS`/`WASI_ENV` arrays before `<p>init` (the standalone main fills them from `$0`/`$@` and `compgen -e`).
+- **The fd model is stdio-only**: fds 0/1/2 preopened, `fd_seek` answers ESPIPE, `fd_tell` reports the byte counters `fd_read`/`fd_write` track, `fd_prestat_get` answers EBADF to stop libc preopen scans.
 
 ## Rejected alternatives
 
-- **`exit` inside `proc_exit`** — kills the caller's shell when the
-  module is sourced as a library, and cannot be intercepted by the spec
-  harness or an embedder.
-- **`$SRANDOM` / `$RANDOM` for random_get** — SRANDOM needs bash 5.1
-  (the floor is 5.0); RANDOM is 15-bit and unseedable-weak.
-- **`od`/`dd`/`head` for binary I/O** — external commands, rejected by
-  ADR-5's criterion.
-- **A global current-instance variable instead of prefix wrappers** —
-  breaks the moment two instances interleave calls; the wrapper costs one
-  function definition per bundled syscall.
+- **`exit` inside `proc_exit`** — kills the caller's shell when the module is sourced as a library, and cannot be intercepted by the spec harness or an embedder.
+- **`$SRANDOM` / `$RANDOM` for random_get** — SRANDOM needs bash 5.1 (the floor is 5.0); RANDOM is 15-bit and unseedable-weak.
+- **`od`/`dd`/`head` for binary I/O** — external commands, rejected by ADR-5's criterion.
+- **A global current-instance variable instead of prefix wrappers** — breaks the moment two instances interleave calls; the wrapper costs one function definition per bundled syscall.
 
 ## Consequences
 
-- Positive: `hello.wat` runs standalone under bash with the same stdout
-  and exit code as Ruby; the ADR-7 override/fallback semantics carry over
-  (`crates/dewasm-backend-bash/tests/e2e.rs`).
-- Negative: byte-wise stdio is slow for large payloads; batching rides on
-  ADR-11's bulk-memory scaling work when real apps (post-softfloat, ADR-5)
-  demand it.
-- Time from ids 1–3 can go backwards with the realtime fallback; programs
-  timing themselves may misbehave.
-- `wasi_unstable` (snapshot 0) shares the implemented ABI except
-  fd_seek's whence encoding, which is moot while fd_seek is ESPIPE-only.
+- Positive: `hello.wat` runs standalone under bash with the same stdout and exit code as Ruby; the ADR-7 override/fallback semantics carry over (`crates/dewasm-backend-bash/tests/e2e.rs`).
+- Negative: byte-wise stdio is slow for large payloads; batching rides on ADR-11's bulk-memory scaling work when real apps (post-softfloat, ADR-5) demand it.
+- Time from ids 1–3 can go backwards with the realtime fallback; programs timing themselves may misbehave.
+- `wasi_unstable` (snapshot 0) shares the implemented ABI except fd_seek's whence encoding, which is moot while fd_seek is ESPIPE-only.

--- a/docs/adr/13-bash-softfloat-conventions.md
+++ b/docs/adr/13-bash-softfloat-conventions.md
@@ -1,90 +1,30 @@
 # ADR-13 — Bash Softfloat Conventions
 
-Status: **Accepted, 2026-07-23.** Implements ADR-5. ~60 units under
-`runtime/bash/units/rt/` (round-pack cores, f64 arithmetic, pattern ops,
-conversions, f32 wrappers) plus the lowering tables in
-`crates/dewasm-backend-bash/src/lib.rs`. `Feature::Floats` is flipped
-to Supported; the full-testsuite sweep now matches the Ruby backend's
-totals exactly (pass 24,338 / the same five linking-attributed failure
-groups), and cowsay/QuickJS run standalone under bash
-(`crates/dewasm-test-helper/src/apps.rs`).
+Status: **Accepted, 2026-07-23.** Implements ADR-5. ~60 units under `runtime/bash/units/rt/` (round-pack cores, f64 arithmetic, pattern ops, conversions, f32 wrappers) plus the lowering tables in `crates/dewasm-backend-bash/src/lib.rs`. `Feature::Floats` is flipped to Supported; the full-testsuite sweep now matches the Ruby backend's totals exactly (pass 24,338 / the same five linking-attributed failure groups), and cowsay/QuickJS run standalone under bash (`crates/dewasm-test-helper/src/apps.rs`).
 
 ## Context
 
-ADR-5 decided *that* floats would be a pure-Bash IEEE-754 softfloat; this
-ADR records *how*. Bash offers only signed 64-bit integer arithmetic with
-mod-64 shift counts and wrapping multiplication, and the harness compares
-results bit-exactly including NaN patterns (ADR-8/ADR-3).
+ADR-5 decided *that* floats would be a pure-Bash IEEE-754 softfloat; this ADR records *how*. Bash offers only signed 64-bit integer arithmetic with mod-64 shift counts and wrapping multiplication, and the harness compares results bit-exactly including NaN patterns (ADR-8/ADR-3).
 
 ## Decision
 
-- **Floats are stored as their bit patterns** — f64 as the signed-64
-  pattern, f32 as a u32 — and every operation is integer arithmetic on
-  those patterns. No host float exists anywhere, so NaN bit-exactness
-  holds by construction (the Ruby backend's `pack`-canonicalization
-  fixups, ADR-2, have no analogue here). Reinterprets are the identity
-  and float loads/stores reuse the integer memory units, so a float-free
-  module's bundle is unchanged (ADR-6).
-- **f64 is the core; f32 arithmetic is promote → f64 op → demote.**
-  Promote is exact and 53 ≥ 2·24+2 makes the double rounding innocuous
-  for add/sub/mul/div/sqrt (the same theorem the Ruby backend rests on,
-  spec-suite-proven). Everything that needs no rounding theorem —
-  comparisons, min/max, the ceil/floor/trunc/nearest family, int→f32 —
-  operates directly on u32 patterns; int→f32 rounds once from the full
-  64-bit integer, eliminating Ruby's round-to-odd pre-step.
-- **All rounding funnels through one shared core**,
-  `rt_f64_round_pack s e m sk` (`rt_f32_round_pack` sibling): value =
-  (−1)^s·m·2^(e−53) with a sticky flag, RNE, gradual underflow, and
-  overflow to ±Inf. Its contract — m < 2^63, and never a left
-  normalization with sticky pending — is what each caller's
-  pre-normalization exists to satisfy. The reusable rule: any operation
-  producing a rounded float reduces itself to (sign, exponent,
-  ≥54-bit mantissa, sticky) and delegates.
-- **Wide arithmetic avoids 64-bit overflow by construction**: mul splits
-  mantissas 26/27 bits so every partial stays < 2^55; div is chunked long
-  division (9 bits × 6 steps, remainder < 2^53); sqrt is a 55-iteration
-  restoring root whose remainder stays < 2^59. Variable shifts are
-  proven ≤ 63 or clamped (bash takes shift counts mod 64) and
-  `-INT64_MIN` is special-cased in the i64 converts (negation is a
-  wrapping no-op).
-- **Arithmetic NaN results are always the canonical quiet NaN**
-  (0x7ff8…0 / 0x7fc00000; demote keeps the sign). The spec's
-  canonical/arithmetic NaN masks are satisfied by canonical always;
-  abs/neg/copysign stay payload-preserving bit ops in the codegen.
-- **A Rust-oracle test harness is the development net**
-  (`crates/dewasm-backend-bash/tests/softfloat.rs`): ~100k edge and
-  seeded-random vectors per run, expected values from host IEEE-754
-  adjusted to wasm semantics (wasm min/max, canonical NaNs, the Ruby
-  trunc trap table). The spec harness remains the bar (ADR-3); the
-  oracle exists to pinpoint the exact op and operands on a regression.
+- **Floats are stored as their bit patterns** — f64 as the signed-64 pattern, f32 as a u32 — and every operation is integer arithmetic on those patterns. No host float exists anywhere, so NaN bit-exactness holds by construction (the Ruby backend's `pack`-canonicalization fixups, ADR-2, have no analogue here). Reinterprets are the identity and float loads/stores reuse the integer memory units, so a float-free module's bundle is unchanged (ADR-6).
+- **f64 is the core; f32 arithmetic is promote → f64 op → demote.** Promote is exact and 53 ≥ 2·24+2 makes the double rounding innocuous for add/sub/mul/div/sqrt (the same theorem the Ruby backend rests on, spec-suite-proven). Everything that needs no rounding theorem — comparisons, min/max, the ceil/floor/trunc/nearest family, int→f32 — operates directly on u32 patterns; int→f32 rounds once from the full 64-bit integer, eliminating Ruby's round-to-odd pre-step.
+- **All rounding funnels through one shared core**, `rt_f64_round_pack s e m sk` (`rt_f32_round_pack` sibling): value = (−1)^s·m·2^(e−53) with a sticky flag, RNE, gradual underflow, and overflow to ±Inf. Its contract — m < 2^63, and never a left normalization with sticky pending — is what each caller's pre-normalization exists to satisfy. The reusable rule: any operation producing a rounded float reduces itself to (sign, exponent, ≥54-bit mantissa, sticky) and delegates.
+- **Wide arithmetic avoids 64-bit overflow by construction**: mul splits mantissas 26/27 bits so every partial stays < 2^55; div is chunked long division (9 bits × 6 steps, remainder < 2^53); sqrt is a 55-iteration restoring root whose remainder stays < 2^59. Variable shifts are proven ≤ 63 or clamped (bash takes shift counts mod 64) and `-INT64_MIN` is special-cased in the i64 converts (negation is a wrapping no-op).
+- **Arithmetic NaN results are always the canonical quiet NaN** (0x7ff8…0 / 0x7fc00000; demote keeps the sign). The spec's canonical/arithmetic NaN masks are satisfied by canonical always; abs/neg/copysign stay payload-preserving bit ops in the codegen.
+- **A Rust-oracle test harness is the development net** (`crates/dewasm-backend-bash/tests/softfloat.rs`): ~100k edge and seeded-random vectors per run, expected values from host IEEE-754 adjusted to wasm semantics (wasm min/max, canonical NaNs, the Ruby trunc trap table). The spec harness remains the bar (ADR-3); the oracle exists to pinpoint the exact op and operands on a regression.
 
 ## Rejected alternatives
 
-- **Host-float emulation à la Ruby** (compute in some host numeric type,
-  fix up NaNs) — bash has no float type at all; there is nothing to fix
-  up from.
-- **Native 24-bit f32 arithmetic** — duplicates every algorithm for a
-  second precision; the promote/op/demote route reuses the f64 core and
-  is covered by the double-rounding theorem plus ~40k oracle vectors
-  biased at the 24-bit boundary.
-- **32-bit halves for the mantissa product** — partials reach ~2^64 and
-  wrap (verified); the 26-bit split keeps everything provably in range.
-- **128-bit hi/lo arithmetic for sqrt** — unnecessary: the radicand's
-  low half is all zeros, so a 2-bits-per-step restoring loop never
-  exceeds 2^59.
-- **Payload-propagating NaNs** — the spec only ever checks quiet-bit
-  masks for arithmetic results; propagating payloads would complicate
-  every special-value path for zero observable benefit.
+- **Host-float emulation à la Ruby** (compute in some host numeric type, fix up NaNs) — bash has no float type at all; there is nothing to fix up from.
+- **Native 24-bit f32 arithmetic** — duplicates every algorithm for a second precision; the promote/op/demote route reuses the f64 core and is covered by the double-rounding theorem plus ~40k oracle vectors biased at the 24-bit boundary.
+- **32-bit halves for the mantissa product** — partials reach ~2^64 and wrap (verified); the 26-bit split keeps everything provably in range.
+- **128-bit hi/lo arithmetic for sqrt** — unnecessary: the radicand's low half is all zeros, so a 2-bits-per-step restoring loop never exceeds 2^59.
+- **Payload-propagating NaNs** — the spec only ever checks quiet-bit masks for arithmetic results; propagating payloads would complicate every special-value path for zero observable benefit.
 
 ## Consequences
 
-- Positive: the Bash backend reaches full parity with Ruby on the spec
-  testsuite; real binaries (cowsay byte-identical to wasmtime in ~2 s,
-  QuickJS `console.log` in ~23 s) run under plain bash — the ADR-0
-  flagship demo exists. The feared data-segment scaling wall did not
-  materialize at cowsay/QuickJS size.
-- Negative: softfloat ops cost 40–300 µs each; float-heavy hot loops are
-  orders of magnitude slower than Ruby's host floats. The curated spec
-  suite grew from ~1 s to ~5 s and the full sweep from ~39 s to ~58 s.
-- The `floats` skip tag is dead: `Feature::Floats` Supported means any
-  float-related skip is now a hard harness failure (ADR-8's ratchet).
+- Positive: the Bash backend reaches full parity with Ruby on the spec testsuite; real binaries (cowsay byte-identical to wasmtime in ~2 s, QuickJS `console.log` in ~23 s) run under plain bash — the ADR-0 flagship demo exists. The feared data-segment scaling wall did not materialize at cowsay/QuickJS size.
+- Negative: softfloat ops cost 40–300 µs each; float-heavy hot loops are orders of magnitude slower than Ruby's host floats. The curated spec suite grew from ~1 s to ~5 s and the full sweep from ~39 s to ~58 s.
+- The `floats` skip tag is dead: `Feature::Floats` Supported means any float-related skip is now a hard harness failure (ADR-8's ratchet).

--- a/docs/adr/14-ruby-wasi-filesystem.md
+++ b/docs/adr/14-ruby-wasi-filesystem.md
@@ -1,145 +1,34 @@
 # ADR-14 — Ruby WASI Filesystem Support
 
-Status: **Accepted, 2026-07-23.** Implemented in `runtime/ruby/units/wasi/`
-(`path_open`, `fd_pread`/`fd_pwrite`, `fd_filestat_get`,
-`path_filestat_get`, `fd_readdir`, `path_create_directory`,
-`path_remove_directory`, `path_unlink_file`, `path_rename`, `fd_sync`,
-`fd_datasync`, `fd_filestat_set_size`, `fd_prestat_dir_name`) and the
-`preopens:` provider kwarg in `crates/dewasm-backend-ruby/src/lib.rs`.
-Symlink and rights-narrowing syscalls remain ENOSYS.
+Status: **Accepted, 2026-07-23.** Implemented in `runtime/ruby/units/wasi/` (`path_open`, `fd_pread`/`fd_pwrite`, `fd_filestat_get`, `path_filestat_get`, `fd_readdir`, `path_create_directory`, `path_remove_directory`, `path_unlink_file`, `path_rename`, `fd_sync`, `fd_datasync`, `fd_filestat_set_size`, `fd_prestat_dir_name`) and the `preopens:` provider kwarg in `crates/dewasm-backend-ruby/src/lib.rs`. Symlink and rights-narrowing syscalls remain ENOSYS.
 
-**Revision, 2026-07-27:** `poll_oneoff` is no longer a deliberate ENOSYS gap.
-It is implemented for the Ruby, Python, Go, and Java backends
-(`runtime/<lang>/units/wasi/poll_oneoff.*`); Bash stays ENOSYS for now
-(deferred; the Bash filesystem design, including `poll_oneoff`, is
-[ADR-34](34-bash-wasi-filesystem.md)). The motivation is event-loop guests such as the QuickJS REPL,
-which after printing each prompt blocks in `poll_oneoff` on an fd_read
-subscription over stdin — an ENOSYS return there collapses the loop and the
-program exits immediately. Only fd_read on stdin actually blocks (via
-`IO.select`/`select.select`/`syscall.Select`; Java approximates it by polling
-`InputStream.available()`, a documented limitation); regular files,
-stdout/stderr, and every fd_write are treated as immediately ready, and clock
-subscriptions set the wait deadline. Symlink and rights-narrowing syscalls
-still remain ENOSYS.
+**Revision, 2026-07-27:** `poll_oneoff` is no longer a deliberate ENOSYS gap. It is implemented for the Ruby, Python, Go, and Java backends (`runtime/<lang>/units/wasi/poll_oneoff.*`); Bash stays ENOSYS for now (deferred; the Bash filesystem design, including `poll_oneoff`, is [ADR-34](34-bash-wasi-filesystem.md)). The motivation is event-loop guests such as the QuickJS REPL, which after printing each prompt blocks in `poll_oneoff` on an fd_read subscription over stdin — an ENOSYS return there collapses the loop and the program exits immediately. Only fd_read on stdin actually blocks (via `IO.select`/`select.select`/`syscall.Select`; Java approximates it by polling `InputStream.available()`, a documented limitation); regular files, stdout/stderr, and every fd_write are treated as immediately ready, and clock subscriptions set the wait deadline. Symlink and rights-narrowing syscalls still remain ENOSYS.
 
-**Revision, 2026-07-28 ([ADR-40](40-wasi-p1-completion.md)):** the symlink
-family (`path_symlink`/`path_readlink`/`path_link`) and the rights syscalls
-are now implemented on every backend, superseding this ADR's two deferral
-paragraphs: containment is enforced at follow time by the existing
-`resolve_path` check (creating a link no longer waits on a posture it cannot
-close), and rights are tracked *and enforced* per fd, answering the
-"narrowing without enforcement misleads" objection by enforcing. The TOCTOU
-check-then-open caveat itself is unchanged.
+**Revision, 2026-07-28 ([ADR-40](40-wasi-p1-completion.md)):** the symlink family (`path_symlink`/`path_readlink`/`path_link`) and the rights syscalls are now implemented on every backend, superseding this ADR's two deferral paragraphs: containment is enforced at follow time by the existing `resolve_path` check (creating a link no longer waits on a posture it cannot close), and rights are tracked *and enforced* per fd, answering the "narrowing without enforcement misleads" objection by enforcing. The TOCTOU check-then-open caveat itself is unchanged.
 
 ## Context
 
-`Rt::WASI` (ADR-7) covered stdio, args/env, clock, and random, but every
-`path_*` call and filesystem-only `fd_*` call resolved to the ENOSYS stub
-— blocking the project's north star (running Rails on a pure-Ruby SQLite
-driver, which needs a real main-DB-plus-journal/WAL file lifecycle:
-create, read/write at arbitrary offsets, sync, delete, rename). Adding
-real file I/O means answering two questions the stdio-only design never
-had to: what a directory descriptor *is*, and how a guest-supplied path
-gets confined to a directory the embedder explicitly authorized (a WASI
-preopen), since ambient authority to the whole host filesystem is not
-acceptable even in a demo runtime.
+`Rt::WASI` (ADR-7) covered stdio, args/env, clock, and random, but every `path_*` call and filesystem-only `fd_*` call resolved to the ENOSYS stub — blocking the project's north star (running Rails on a pure-Ruby SQLite driver, which needs a real main-DB-plus-journal/WAL file lifecycle: create, read/write at arbitrary offsets, sync, delete, rename). Adding real file I/O means answering two questions the stdio-only design never had to: what a directory descriptor *is*, and how a guest-supplied path gets confined to a directory the embedder explicitly authorized (a WASI preopen), since ambient authority to the whole host filesystem is not acceptable even in a demo runtime.
 
 ## Decision
 
-- **Preopens are a provider kwarg, not a new provider shape.**
-  `Rt::WASI.new(preopens: { guest_path => host_path })` extends the
-  existing `args:`/`env:` kwargs (ADR-7); `wasi_bundled`'s generated
-  `initialize` gained `preopens: {}` alongside them, so the fallback
-  construction stays `@wasi ||= Rt::WASI.new(args:, env:, preopens:)`
-  with no change to the provider protocol itself. Standalone mode reads
-  a `DEWASM_PREOPEN` env var (`guest=host,...`) into the same kwarg,
-  kept separate from `ARGV` because `ARGV` already mirrors the guest's
-  own argv one-to-one.
-- **One fd table, two kinds of entry.** `@fds` keeps mapping fd → Ruby
-  `IO` for files and stdio (unchanged — `File` already answers every
-  method the stdio-only units called). Directories, whether a true
-  preopen or one the guest opened itself via `path_open`'s
-  `oflags::DIRECTORY`, are a `WasiDir = Struct.new(:host_path,
-  :preopen_name, :entries)`. `preopen_name` is set only for entries that
-  came from `preopens:`, which is exactly what `fd_prestat_get`/
-  `fd_prestat_dir_name` must be able to tell apart from a directory the
-  guest opened for its own traversal. `entries` is the `fd_readdir`
-  listing cache. Fds are never reused after `fd_close` — simpler than
-  tracking reuse safety, and irrelevant at the scale this runtime targets.
-  Criterion: reuse the existing IO-shaped path for files (every stdio
-  unit keeps working unmodified against `File`) and add exactly one new
-  shape for the one thing IO cannot represent (a directory), rather than
-  wrapping every fd in a new envelope type.
-- **Sandboxing is `File.realpath` plus prefix-containment, checked fresh
-  on every path resolution against that specific directory fd's own
-  (already-realpath'd) root** — `resolve_path` in
-  `runtime/ruby/units/wasi/_class.rb`. Re-deriving the containment check
-  locally per dirfd, rather than once against a single global root, means
-  a directory fd opened three levels deep still gets the same check as a
-  preopen: nesting can't launder an escape one level cheaper. This is a
-  check-then-open, not an atomic `openat(2)`-beneath resolution: a
-  symlink planted inside the sandbox between the realpath check and the
-  actual `File.open`/`Dir.mkdir`/etc. call could in principle be used to
-  escape (TOCTOU). Accepted for a single-process research/demo runtime
-  embedding a trusted or semi-trusted guest, not a multi-tenant sandbox
-  host — the alternative (a component-by-component `openat`-style walk
-  rejecting symlinks one path segment at a time, `cap-std`'s approach) is
-  real defense-in-depth but a much larger implementation for a project
-  whose correctness bar (ADR-3) is the wasm spec testsuite, not a
-  security-hardened sandbox.
-- **Rights (`fs_rights_base`/`fs_rights_inheriting`) are read only to pick
-  a `File.open` mode (read/write/both) in `path_open`, never stored or
-  checked again.** Access control in this design is entirely "which
-  directories did the embedder preopen", not capability narrowing within
-  that access. Consequently `fd_fdstat_set_flags`/`fd_fdstat_set_rights`
-  stay ENOSYS: implementing them to *appear* to narrow rights while
-  nothing enforces the narrowed rights afterward would be misleading
-  rather than merely incomplete.
-- **Symlink syscalls (`path_symlink`, `path_link`, `path_readlink`) stay
-  ENOSYS.** A symlink written by the guest is precisely the escape vector
-  the sandboxing caveat above already accepts passively (a *preexisting*
-  host symlink); letting the guest *create* new ones on demand widens
-  that surface actively, so it is deferred rather than half-solved.
-  `fd_renumber`, `fd_advise`, `fd_allocate`, and
-  `path_filestat_set_times` stay ENOSYS as lower-value gaps, not
-  security-motivated ones.
-- **`fd_readdir`'s cookie is a 1-based index into a listing snapshot
-  cached on `WasiDir#entries` at the first call for that fd**, not a
-  live cursor coherent under concurrent directory mutation. Matches the
-  spec's "cookie is an opaque resume point" contract without needing a
-  stable-under-mutation iteration order, which POSIX `readdir` itself
-  does not guarantee either.
+- **Preopens are a provider kwarg, not a new provider shape.** `Rt::WASI.new(preopens: { guest_path => host_path })` extends the existing `args:`/`env:` kwargs (ADR-7); `wasi_bundled`'s generated `initialize` gained `preopens: {}` alongside them, so the fallback construction stays `@wasi ||= Rt::WASI.new(args:, env:, preopens:)` with no change to the provider protocol itself. Standalone mode reads a `DEWASM_PREOPEN` env var (`guest=host,...`) into the same kwarg, kept separate from `ARGV` because `ARGV` already mirrors the guest's own argv one-to-one.
+- **One fd table, two kinds of entry.** `@fds` keeps mapping fd → Ruby `IO` for files and stdio (unchanged — `File` already answers every method the stdio-only units called). Directories, whether a true preopen or one the guest opened itself via `path_open`'s `oflags::DIRECTORY`, are a `WasiDir = Struct.new(:host_path, :preopen_name, :entries)`. `preopen_name` is set only for entries that came from `preopens:`, which is exactly what `fd_prestat_get`/ `fd_prestat_dir_name` must be able to tell apart from a directory the guest opened for its own traversal. `entries` is the `fd_readdir` listing cache. Fds are never reused after `fd_close` — simpler than tracking reuse safety, and irrelevant at the scale this runtime targets. Criterion: reuse the existing IO-shaped path for files (every stdio unit keeps working unmodified against `File`) and add exactly one new shape for the one thing IO cannot represent (a directory), rather than wrapping every fd in a new envelope type.
+- **Sandboxing is `File.realpath` plus prefix-containment, checked fresh on every path resolution against that specific directory fd's own (already-realpath'd) root** — `resolve_path` in `runtime/ruby/units/wasi/_class.rb`. Re-deriving the containment check locally per dirfd, rather than once against a single global root, means a directory fd opened three levels deep still gets the same check as a preopen: nesting can't launder an escape one level cheaper. This is a check-then-open, not an atomic `openat(2)`-beneath resolution: a symlink planted inside the sandbox between the realpath check and the actual `File.open`/`Dir.mkdir`/etc. call could in principle be used to escape (TOCTOU). Accepted for a single-process research/demo runtime embedding a trusted or semi-trusted guest, not a multi-tenant sandbox host — the alternative (a component-by-component `openat`-style walk rejecting symlinks one path segment at a time, `cap-std`'s approach) is real defense-in-depth but a much larger implementation for a project whose correctness bar (ADR-3) is the wasm spec testsuite, not a security-hardened sandbox.
+- **Rights (`fs_rights_base`/`fs_rights_inheriting`) are read only to pick a `File.open` mode (read/write/both) in `path_open`, never stored or checked again.** Access control in this design is entirely "which directories did the embedder preopen", not capability narrowing within that access. Consequently `fd_fdstat_set_flags`/`fd_fdstat_set_rights` stay ENOSYS: implementing them to *appear* to narrow rights while nothing enforces the narrowed rights afterward would be misleading rather than merely incomplete.
+- **Symlink syscalls (`path_symlink`, `path_link`, `path_readlink`) stay ENOSYS.** A symlink written by the guest is precisely the escape vector the sandboxing caveat above already accepts passively (a *preexisting* host symlink); letting the guest *create* new ones on demand widens that surface actively, so it is deferred rather than half-solved. `fd_renumber`, `fd_advise`, `fd_allocate`, and `path_filestat_set_times` stay ENOSYS as lower-value gaps, not security-motivated ones.
+- **`fd_readdir`'s cookie is a 1-based index into a listing snapshot cached on `WasiDir#entries` at the first call for that fd**, not a live cursor coherent under concurrent directory mutation. Matches the spec's "cookie is an opaque resume point" contract without needing a stable-under-mutation iteration order, which POSIX `readdir` itself does not guarantee either.
 
 ## Rejected alternatives
 
-- **Per-component `openat`-beneath path resolution** — closes the TOCTOU
-  gap properly but requires walking and re-validating every path segment
-  against the live filesystem, well past what a single-process demo
-  runtime needs; revisit if dewasmify ever targets untrusted-guest
-  multi-tenancy.
-- **A capability object per fd carrying its granted rights, checked on
-  every subsequent call** — the honest version of rights support, but
-  pointless without also being asked for by a real target program; adding
-  the bookkeeping now would be speculative.
-- **Reusing fd numbers after `fd_close`** — saves nothing at this scale
-  and reopens fd-confusion bug classes for no benefit.
-- **A separate `@dirs` hash instead of folding directories into `@fds`**
-  — considered so `fd_read`/`fd_write` wouldn't need an `is_a?(IO)`
-  guard, but every WASI syscall that takes an `fd` (close, fdstat,
-  prestat) has to look in exactly one table regardless; one table with a
-  type-tagged value is simpler than keeping two tables in sync.
+- **Per-component `openat`-beneath path resolution** — closes the TOCTOU gap properly but requires walking and re-validating every path segment against the live filesystem, well past what a single-process demo runtime needs; revisit if dewasmify ever targets untrusted-guest multi-tenancy.
+- **A capability object per fd carrying its granted rights, checked on every subsequent call** — the honest version of rights support, but pointless without also being asked for by a real target program; adding the bookkeeping now would be speculative.
+- **Reusing fd numbers after `fd_close`** — saves nothing at this scale and reopens fd-confusion bug classes for no benefit.
+- **A separate `@dirs` hash instead of folding directories into `@fds`** — considered so `fd_read`/`fd_write` wouldn't need an `is_a?(IO)` guard, but every WASI syscall that takes an `fd` (close, fdstat, prestat) has to look in exactly one table regardless; one table with a type-tagged value is simpler than keeping two tables in sync.
 
 ## Consequences
 
-- Positive: SQLite's file-backed VFS lifecycle (create, random-access
-  read/write, sync, delete journal/WAL, rename) is implementable against
-  this syscall set entirely in library mode via `preopens:`, without
-  CLI changes.
-- Negative / accepted: the sandboxing TOCTOU/symlink-escape gap above is
-  a standing caveat, not a bug to fix under this ADR — anyone embedding
-  this runtime for genuinely untrusted guests needs to know that.
-- Carry-over: rights enforcement, symlink support, and `fd_renumber` are
-  explicit future work if a target program needs them, not oversights.
-- The provider surface (`preopens:`) is Ruby-specific for now; a Bash
-  filesystem backend would need its own ADR (ADR-12 explicitly scoped
-  filesystem syscalls out).
+- Positive: SQLite's file-backed VFS lifecycle (create, random-access read/write, sync, delete journal/WAL, rename) is implementable against this syscall set entirely in library mode via `preopens:`, without CLI changes.
+- Negative / accepted: the sandboxing TOCTOU/symlink-escape gap above is a standing caveat, not a bug to fix under this ADR — anyone embedding this runtime for genuinely untrusted guests needs to know that.
+- Carry-over: rights enforcement, symlink support, and `fd_renumber` are explicit future work if a target program needs them, not oversights.
+- The provider surface (`preopens:`) is Ruby-specific for now; a Bash filesystem backend would need its own ADR (ADR-12 explicitly scoped filesystem syscalls out).

--- a/docs/adr/15-tests-fail-not-skip.md
+++ b/docs/adr/15-tests-fail-not-skip.md
@@ -1,113 +1,30 @@
 # ADR-15 — Tests Fail Loud on Missing Environment, Never Skip
 
-Status: **Accepted, 2026-07-23.** Implemented across
-`crates/dewasm-cli/tests/{e2e,spec}/`, `crates/dewasm-backend-bash/tests/softfloat.rs`,
-and `docs/testing.md` (the setup reference these failures point to). The
-`apps` e2e cases (`crates/dewasm-test-helper/src/apps.rs`) additionally
-dropped their `wasmtime` dependency entirely, in favor of golden files
-captured once and checked into `examples/apps/golden/`, with an opt-in
-`apps_golden_matches_wasmtime` test (the `wasmtime_test` Cargo feature
-on `dewasm-cli`, `#[ignore]`d otherwise) to re-validate those golden
-files against a live `wasmtime` on demand.
+Status: **Accepted, 2026-07-23.** Implemented across `crates/dewasm-cli/tests/{e2e,spec}/`, `crates/dewasm-backend-bash/tests/softfloat.rs`, and `docs/testing.md` (the setup reference these failures point to). The `apps` e2e cases (`crates/dewasm-test-helper/src/apps.rs`) additionally dropped their `wasmtime` dependency entirely, in favor of golden files captured once and checked into `examples/apps/golden/`, with an opt-in `apps_golden_matches_wasmtime` test (the `wasmtime_test` Cargo feature on `dewasm-cli`, `#[ignore]`d otherwise) to re-validate those golden files against a live `wasmtime` on demand.
 
 ## Context
 
-Every test needing `ruby`, `bash >= 5`, or `wasmtime` self-skipped when
-the tool was missing — `if find_ruby().is_none() { eprintln!("..."); return; }`,
-repeated at nearly every call site. `AGENTS.md` already flagged the
-consequence in its own words: "a green run without it proves less than
-it looks." That is the problem in one sentence: a contributor (or CI
-runner) with a broken or incomplete environment sees `cargo test` pass
-and reasonably concludes the code works, when in fact nothing ran. A
-missing interpreter is not a legitimate reason for a wasm-to-source
-transpiler's tests to report success — it is exactly the environment
-those tests exist to exercise.
+Every test needing `ruby`, `bash >= 5`, or `wasmtime` self-skipped when the tool was missing — `if find_ruby().is_none() { eprintln!("..."); return; }`, repeated at nearly every call site. `AGENTS.md` already flagged the consequence in its own words: "a green run without it proves less than it looks." That is the problem in one sentence: a contributor (or CI runner) with a broken or incomplete environment sees `cargo test` pass and reasonably concludes the code works, when in fact nothing ran. A missing interpreter is not a legitimate reason for a wasm-to-source transpiler's tests to report success — it is exactly the environment those tests exist to exercise.
 
 ## Decision
 
-**A missing required tool fails the test it's required by; it does not
-skip it.** `find_ruby()`/`find_bash5()` (the backend-crate detection
-functions, ADR-14's `find_ruby` mirroring the pre-existing `find_bash5`)
-keep returning `Option<PathBuf>` — that contract is still useful to
-non-test callers — but every test call site now does
-`find_ruby().expect("ruby not found on PATH — see docs/testing.md")`
-instead of checking `is_none()` and returning early. The spec harness's
-`SpecLang::interpreter()` changed shape to match: it returns `PathBuf`
-directly (not `Option<PathBuf>`), panicking internally, since
-`run_suite` has no legitimate "interpreter absent" path left to handle.
-The `tests/spec` submodule check follows the same rule (`assert!` instead
-of an `eprintln!` + return). `docs/testing.md` is the single place that
-documents what a full `cargo test` run actually requires, so every
-panic message has one canonical place to point to instead of restating
-setup instructions inline.
+**A missing required tool fails the test it's required by; it does not skip it.** `find_ruby()`/`find_bash5()` (the backend-crate detection functions, ADR-14's `find_ruby` mirroring the pre-existing `find_bash5`) keep returning `Option<PathBuf>` — that contract is still useful to non-test callers — but every test call site now does `find_ruby().expect("ruby not found on PATH — see docs/testing.md")` instead of checking `is_none()` and returning early. The spec harness's `SpecLang::interpreter()` changed shape to match: it returns `PathBuf` directly (not `Option<PathBuf>`), panicking internally, since `run_suite` has no legitimate "interpreter absent" path left to handle. The `tests/spec` submodule check follows the same rule (`assert!` instead of an `eprintln!` + return). `docs/testing.md` is the single place that documents what a full `cargo test` run actually requires, so every panic message has one canonical place to point to instead of restating setup instructions inline.
 
-**The `apps` cases stop depending on `wasmtime` altogether**, rather than
-adding it to the now-mandatory tool list. Their historical role for
-`wasmtime` was purely as a comparison oracle — run the same wasm binary
-both ways, diff stdout and exit code. That comparison's *result* doesn't
-change from run to run for a pinned binary and fixed input, so it can be
-captured once and checked in: `examples/apps/golden/<case>.stdout`,
-generated by an actual `wasmtime run` (documented in `docs/testing.md`
-for whoever needs to regenerate one after re-pinning an app version) and
-compared with `include_str!` at compile time. This is strictly better
-than adding `wasmtime` to the required-tools list: one fewer install
-requirement, and the tests still catch the exact regressions they did
-before (generated-language output silently diverging from the real
-runtime's).
+**The `apps` cases stop depending on `wasmtime` altogether**, rather than adding it to the now-mandatory tool list. Their historical role for `wasmtime` was purely as a comparison oracle — run the same wasm binary both ways, diff stdout and exit code. That comparison's *result* doesn't change from run to run for a pinned binary and fixed input, so it can be captured once and checked in: `examples/apps/golden/<case>.stdout`, generated by an actual `wasmtime run` (documented in `docs/testing.md` for whoever needs to regenerate one after re-pinning an app version) and compared with `include_str!` at compile time. This is strictly better than adding `wasmtime` to the required-tools list: one fewer install requirement, and the tests still catch the exact regressions they did before (generated-language output silently diverging from the real runtime's).
 
-Populating `examples/apps/cache/` (via `examples/apps/fetch.sh`, ADR-9)
-remains a required, fail-loud precondition for the `apps` cases — that
-one is a real, currently-necessary setup step (the binaries are real,
-copyrighted, third-party artifacts ADR-9 deliberately keeps out of git),
-not a convenience this ADR is trying to remove.
+Populating `examples/apps/cache/` (via `examples/apps/fetch.sh`, ADR-9) remains a required, fail-loud precondition for the `apps` cases — that one is a real, currently-necessary setup step (the binaries are real, copyrighted, third-party artifacts ADR-9 deliberately keeps out of git), not a convenience this ADR is trying to remove.
 
-**A golden file can itself go stale**, so there is one more test:
-`apps_golden_matches_wasmtime` runs every case through a live
-`wasmtime run` and diffs it against the checked-in golden file —
-independent of, and a check *on*, the golden files the always-on tests
-trust. This one genuinely is optional (it audits the fixtures, it
-doesn't gate dewasmify's own correctness), so it's the one place
-`#[ignore]` is the *right* tool rather than the rejected one above:
-`#[cfg_attr(not(feature = "wasmtime_test"), ignore)]` keeps it out of a
-plain `cargo test` (no new required tool) while making it a normal,
-non-ignored test the moment `--features wasmtime_test` is passed — no
-`--include-ignored` needed, and no separate skip-detection branch to
-keep in sync with the rest of this ADR's policy.
+**A golden file can itself go stale**, so there is one more test: `apps_golden_matches_wasmtime` runs every case through a live `wasmtime run` and diffs it against the checked-in golden file — independent of, and a check *on*, the golden files the always-on tests trust. This one genuinely is optional (it audits the fixtures, it doesn't gate dewasmify's own correctness), so it's the one place `#[ignore]` is the *right* tool rather than the rejected one above: `#[cfg_attr(not(feature = "wasmtime_test"), ignore)]` keeps it out of a plain `cargo test` (no new required tool) while making it a normal, non-ignored test the moment `--features wasmtime_test` is passed — no `--include-ignored` needed, and no separate skip-detection branch to keep in sync with the rest of this ADR's policy.
 
 ## Rejected alternatives
 
-- **Keep skipping, but print more loudly** — doesn't fix the actual
-  problem (a green `cargo test` that ran nothing), only makes the log
-  noisier.
-- **`#[ignore = "reason"]`** for the *required*-tool tests — Rust's
-  built-in "don't run this by default" mechanism, visible as `ignored`
-  rather than `ok`. Closer to honest than silent-pass-via-skip, but
-  still reports overall success without running the test — wrong for
-  `ruby`/`bash`/the apps cache, which this ADR treats as genuinely
-  required. (It's the *right* tool for the wasmtime golden-file check
-  below, precisely because that one is genuinely optional.)
-- **Keep `wasmtime` but add it to the required-tools list** — considered
-  as the straightforward way to make `apps` consistent with the new
-  policy, but it adds a real install requirement for a role (comparison
-  oracle) that a checked-in golden file fills just as well, so removing
-  the dependency outright is strictly better than requiring it.
+- **Keep skipping, but print more loudly** — doesn't fix the actual problem (a green `cargo test` that ran nothing), only makes the log noisier.
+- **`#[ignore = "reason"]`** for the *required*-tool tests — Rust's built-in "don't run this by default" mechanism, visible as `ignored` rather than `ok`. Closer to honest than silent-pass-via-skip, but still reports overall success without running the test — wrong for `ruby`/`bash`/the apps cache, which this ADR treats as genuinely required. (It's the *right* tool for the wasmtime golden-file check below, precisely because that one is genuinely optional.)
+- **Keep `wasmtime` but add it to the required-tools list** — considered as the straightforward way to make `apps` consistent with the new policy, but it adds a real install requirement for a role (comparison oracle) that a checked-in golden file fills just as well, so removing the dependency outright is strictly better than requiring it.
 
 ## Consequences
 
-- Positive: a passing `cargo test` now means what it says. CI or a
-  contributor missing `ruby`/`bash >= 5`/the spec submodule/the apps
-  cache gets an immediate, actionable failure instead of a quietly
-  empty pass.
-- Positive: the `apps` e2e cases no longer need `wasmtime` installed at
-  all, only for maintainers regenerating a golden file.
-- Negative / carry-over: golden files can go stale relative to a
-  re-pinned app version (a new `fetch.sh` URL bump needs a matching
-  golden-file regeneration, documented in `docs/testing.md`) — the old
-  live-diff design couldn't go stale this way, since it always compared
-  against whatever binary was currently cached. Mitigated, not
-  eliminated: `apps_golden_matches_wasmtime` (`--features wasmtime_test`)
-  catches it on demand, but nothing runs that check automatically on
-  every `fetch.sh` pin bump.
-- This ADR is a policy every *future* test must also follow: a new test
-  needing an external tool fails loud (`.expect(...)`) rather than
-  adding another silent-skip call site.
+- Positive: a passing `cargo test` now means what it says. CI or a contributor missing `ruby`/`bash >= 5`/the spec submodule/the apps cache gets an immediate, actionable failure instead of a quietly empty pass.
+- Positive: the `apps` e2e cases no longer need `wasmtime` installed at all, only for maintainers regenerating a golden file.
+- Negative / carry-over: golden files can go stale relative to a re-pinned app version (a new `fetch.sh` URL bump needs a matching golden-file regeneration, documented in `docs/testing.md`) — the old live-diff design couldn't go stale this way, since it always compared against whatever binary was currently cached. Mitigated, not eliminated: `apps_golden_matches_wasmtime` (`--features wasmtime_test`) catches it on demand, but nothing runs that check automatically on every `fetch.sh` pin bump.
+- This ADR is a policy every *future* test must also follow: a new test needing an external tool fails loud (`.expect(...)`) rather than adding another silent-skip call site.

--- a/docs/adr/16-ruby-wasm1-completion.md
+++ b/docs/adr/16-ruby-wasm1-completion.md
@@ -1,128 +1,31 @@
 # ADR-16 — Completing Wasm 1.0 for Ruby: Non-Function Imports, Multiple Tables, Table Bulk Ops, Linking
 
-Status: **Accepted, 2026-07-24.** Implemented: `crates/dewasm-core/src/{ir,module,func}.rs`,
-`crates/dewasm-backend/src/lib.rs`, `crates/dewasm-backend-ruby/src/lib.rs`,
-`runtime/ruby/units/{global,table,rt}/*.rb`, and the spec harness
-(`crates/dewasm-test-helper/src/spec.rs` plus the per-backend
-`crates/dewasm-backend-{ruby,bash}/tests/spec.rs`).
+Status: **Accepted, 2026-07-24.** Implemented: `crates/dewasm-core/src/{ir,module,func}.rs`, `crates/dewasm-backend/src/lib.rs`, `crates/dewasm-backend-ruby/src/lib.rs`, `runtime/ruby/units/{global,table,rt}/*.rb`, and the spec harness (`crates/dewasm-test-helper/src/spec.rs` plus the per-backend `crates/dewasm-backend-{ruby,bash}/tests/spec.rs`).
 
 ## Context
 
-`docs/support.md` listed five wasm-1.0-scoped gaps for every backend (ADR-8's "declared debt"):
-imported globals, imported memories, imported tables, multiple tables, and the table half of bulk
-memory (passive/declared element segments, `table.init`/`table.copy`/`elem.drop`). The core IR
-builder rejected all five universally, so no backend had ever needed to think about them. Closing
-them for Ruby only, while leaving Bash exactly as unsupported as before, required decisions about
-representation (globals, tables) and about a mechanism the core builder no longer provides for
-free (per-backend gating).
+`docs/support.md` listed five wasm-1.0-scoped gaps for every backend (ADR-8's "declared debt"): imported globals, imported memories, imported tables, multiple tables, and the table half of bulk memory (passive/declared element segments, `table.init`/`table.copy`/`elem.drop`). The core IR builder rejected all five universally, so no backend had ever needed to think about them. Closing them for Ruby only, while leaving Bash exactly as unsupported as before, required decisions about representation (globals, tables) and about a mechanism the core builder no longer provides for free (per-backend gating).
 
 ## Decision
 
-- **Every wasm global is a boxed `Rt::Global`** (`value` accessor,
-  `runtime/ruby/units/global/_class.rb`), not a plain ivar holding the value. `Expr::GlobalGet`
-  lowers to `@g{idx}.value`, `Stmt::GlobalSet` to `@g{idx}.value = ...`, uniformly for local and
-  imported globals. **Criterion:** a global that crosses an instantiation boundary (imported, or
-  exported and later imported by another instance) must be a shared mutable cell, not a copied
-  value — `Memory`/`Table` are already always objects for the same reason, so making `Global`
-  follow suit keeps one representation instead of two paths through every place a global is read,
-  written, or exported. **Superseded for performance:** only globals that actually cross a
-  boundary (imported, or `ExportKind::Global`) are boxed now; the criterion above is unchanged; see
-  the "Rejected alternatives" entry below, now adopted.
-- **Imports beyond functions reuse ADR-7's mechanism as-is.** `Rt.resolve_import(imports, mod,
-  name)` already returns whatever object the embedder supplied; nothing about it was
-  function-specific. Imported memory/table/global codegen calls it exactly like imported functions
-  do (`crates/dewasm-backend-ruby/src/lib.rs`'s `resolve_import_string`), just assigning into
-  `@memory`, `@t{N}`, or `@g{N}` instead of `@if{N}`.
-- **A present-but-wrong-*kind* import is now a link error.** `Rt.check_import_kind(value, kind,
-  mod, name)` (`runtime/ruby/units/rt/check_import_kind.rb`) checks a resolved import before
-  accepting it: functions must be a `Method`/`Proc`; `Global`/`Table`/`Memory` self-report via a
-  `wasm_kind` reader each class now implements. A `nil` (missing) import still falls through to
-  the caller's `||` fallback (WASI/ENOSYS/raise); a present wrong-kind one raises immediately, never
-  silently substitutes. **Accepted narrower gap:** only the *kind* is checked, not the full wasm
-  type — function param/result types, global mutability, and table/memory min/max limits against
-  the import site's declared bounds are not compared. This surfaces as the `import-limits`-tagged
-  entries in `crates/dewasm-backend-ruby/tests/spec.rs`'s `EXPECTED_FAILURES`; implementing it fully
-  would mean carrying `FuncType`/limit metadata into generated code purely for a check with no
-  runtime-correctness payoff beyond `assert_unlinkable` conformance.
-- **Table index space is `imported_tables ++ tables`**, matching how functions already worked
-  (`ir::Module`). Ruby gives each table a fixed `@t{N}` ivar (`N` is always a compile-time
-  constant — wasm 1.0 encodes `call_indirect`/element-segment table indices as immediates, never
-  computed), the same shape as `@g{N}`/`@if{N}`.
-- **Element segments are retained at instantiation**, mirroring how active data segments are
-  already kept as `@data{i}` hex strings for `memory.init`/`data.drop`. `ir::ElemSegment` gained
-  `kind: Active{table_index,offset} | Passive | Declared` and `items: Vec<Option<u32>>` (`None` =
-  a `ref.null` item). Every segment becomes `@elem{i}` (an array of `[type_idx, func_ref]` pairs or
-  `nil`); active ones eagerly populate their table via the new `Rt::Table#init` and then mark
-  themselves already-dropped (`@elem{i} = []`), exactly like active data segments do. New IR
-  `Stmt::TableInit`/`TableCopy`/`ElemDrop`; new units `table/init.rb`, `table/copy.rb`,
-  `table/slice.rb`. Cross-table `table.copy` needs another `Rt::Table`'s raw arrays, exposed via a
-  small `slice(offset, len)` — `Array#[]` always returns a fresh array, so self-copy overlap is
-  safe automatically, the same trick `memory/copy.rb` already plays with `String#byteslice`.
-  `table.get`/`set`/`grow`/`size`/`fill` stay rejected under `Feature::ReferenceTypes`: confirmed
-  these were never part of wasm 1.0's MVP instruction set — they, table.get/set in particular,
-  shipped later alongside reference types — so this is scope, not a partial implementation.
-- **A shared `check_module_support(backend, module)`** (`crates/dewasm-backend/src/lib.rs`)
-  replaces the gating the core builder used to do unconditionally. Because the core IR is now
-  backend-agnostic about all five constructs, each backend must refuse what it hasn't implemented
-  itself, at conversion time (ADR-0's contract), with the same `UnsupportedError` attribution the
-  core used to produce. Called first thing in both `dewasm-backend-ruby::generate_class_inner`
-  and `dewasm-backend-bash::generate_module_inner` — this is the entire reason Bash's declared
-  support didn't have to move.
-- **Generated classes are their own ADR-7 import providers.** Every class gets a public
-  `import(name)` (checks `@exports`, then `GLOBAL_EXPORTS`, `TABLE_EXPORTS`, `MEMORY_EXPORTS`) so
-  one instance is directly usable as another's import source (`imports["M"] = other_instance`) —
-  applying ADR-7 symmetrically, not a new mechanism. This is what let the spec harness implement
-  the wast testsuite's `(register "Name" $id)` directive for real:
-  `crates/dewasm-test-helper/src/spec.rs`'s `ScriptGen` tracks registered-name → live instance,
-  `convert()` takes the set of module names it may treat as import sources, and `assert_unlinkable`
-  is checked for real (any raised error during instantiation counts — upstream's exact wording
-  never matches ours) instead of always skipped. `SpecLang::supports_registered_imports()` gates
-  all of this per language (Ruby: true; Bash: false — its ambient global `IMPORTS` associative
-  array has no per-instance import object to extend this way). **This is harness-only wiring using
-  the pre-existing imports-Hash mechanism a real embedder would also use; dewasmify itself still
-  converts exactly one wasm module into one class. ADR-0's "cross-module linking is out of scope
-  for the tool" is unchanged** — what changed is that the test harness can now exercise import
-  resolution the same way a Ruby embedder linking two generated classes by hand already could.
+- **Every wasm global is a boxed `Rt::Global`** (`value` accessor, `runtime/ruby/units/global/_class.rb`), not a plain ivar holding the value. `Expr::GlobalGet` lowers to `@g{idx}.value`, `Stmt::GlobalSet` to `@g{idx}.value = ...`, uniformly for local and imported globals. **Criterion:** a global that crosses an instantiation boundary (imported, or exported and later imported by another instance) must be a shared mutable cell, not a copied value — `Memory`/`Table` are already always objects for the same reason, so making `Global` follow suit keeps one representation instead of two paths through every place a global is read, written, or exported. **Superseded for performance:** only globals that actually cross a boundary (imported, or `ExportKind::Global`) are boxed now; the criterion above is unchanged; see the "Rejected alternatives" entry below, now adopted.
+- **Imports beyond functions reuse ADR-7's mechanism as-is.** `Rt.resolve_import(imports, mod, name)` already returns whatever object the embedder supplied; nothing about it was function-specific. Imported memory/table/global codegen calls it exactly like imported functions do (`crates/dewasm-backend-ruby/src/lib.rs`'s `resolve_import_string`), just assigning into `@memory`, `@t{N}`, or `@g{N}` instead of `@if{N}`.
+- **A present-but-wrong-*kind* import is now a link error.** `Rt.check_import_kind(value, kind, mod, name)` (`runtime/ruby/units/rt/check_import_kind.rb`) checks a resolved import before accepting it: functions must be a `Method`/`Proc`; `Global`/`Table`/`Memory` self-report via a `wasm_kind` reader each class now implements. A `nil` (missing) import still falls through to the caller's `||` fallback (WASI/ENOSYS/raise); a present wrong-kind one raises immediately, never silently substitutes. **Accepted narrower gap:** only the *kind* is checked, not the full wasm type — function param/result types, global mutability, and table/memory min/max limits against the import site's declared bounds are not compared. This surfaces as the `import-limits`-tagged entries in `crates/dewasm-backend-ruby/tests/spec.rs`'s `EXPECTED_FAILURES`; implementing it fully would mean carrying `FuncType`/limit metadata into generated code purely for a check with no runtime-correctness payoff beyond `assert_unlinkable` conformance.
+- **Table index space is `imported_tables ++ tables`**, matching how functions already worked (`ir::Module`). Ruby gives each table a fixed `@t{N}` ivar (`N` is always a compile-time constant — wasm 1.0 encodes `call_indirect`/element-segment table indices as immediates, never computed), the same shape as `@g{N}`/`@if{N}`.
+- **Element segments are retained at instantiation**, mirroring how active data segments are already kept as `@data{i}` hex strings for `memory.init`/`data.drop`. `ir::ElemSegment` gained `kind: Active{table_index,offset} | Passive | Declared` and `items: Vec<Option<u32>>` (`None` = a `ref.null` item). Every segment becomes `@elem{i}` (an array of `[type_idx, func_ref]` pairs or `nil`); active ones eagerly populate their table via the new `Rt::Table#init` and then mark themselves already-dropped (`@elem{i} = []`), exactly like active data segments do. New IR `Stmt::TableInit`/`TableCopy`/`ElemDrop`; new units `table/init.rb`, `table/copy.rb`, `table/slice.rb`. Cross-table `table.copy` needs another `Rt::Table`'s raw arrays, exposed via a small `slice(offset, len)` — `Array#[]` always returns a fresh array, so self-copy overlap is safe automatically, the same trick `memory/copy.rb` already plays with `String#byteslice`. `table.get`/`set`/`grow`/`size`/`fill` stay rejected under `Feature::ReferenceTypes`: confirmed these were never part of wasm 1.0's MVP instruction set — they, table.get/set in particular, shipped later alongside reference types — so this is scope, not a partial implementation.
+- **A shared `check_module_support(backend, module)`** (`crates/dewasm-backend/src/lib.rs`) replaces the gating the core builder used to do unconditionally. Because the core IR is now backend-agnostic about all five constructs, each backend must refuse what it hasn't implemented itself, at conversion time (ADR-0's contract), with the same `UnsupportedError` attribution the core used to produce. Called first thing in both `dewasm-backend-ruby::generate_class_inner` and `dewasm-backend-bash::generate_module_inner` — this is the entire reason Bash's declared support didn't have to move.
+- **Generated classes are their own ADR-7 import providers.** Every class gets a public `import(name)` (checks `@exports`, then `GLOBAL_EXPORTS`, `TABLE_EXPORTS`, `MEMORY_EXPORTS`) so one instance is directly usable as another's import source (`imports["M"] = other_instance`) — applying ADR-7 symmetrically, not a new mechanism. This is what let the spec harness implement the wast testsuite's `(register "Name" $id)` directive for real: `crates/dewasm-test-helper/src/spec.rs`'s `ScriptGen` tracks registered-name → live instance, `convert()` takes the set of module names it may treat as import sources, and `assert_unlinkable` is checked for real (any raised error during instantiation counts — upstream's exact wording never matches ours) instead of always skipped. `SpecLang::supports_registered_imports()` gates all of this per language (Ruby: true; Bash: false — its ambient global `IMPORTS` associative array has no per-instance import object to extend this way). **This is harness-only wiring using the pre-existing imports-Hash mechanism a real embedder would also use; dewasmify itself still converts exactly one wasm module into one class. ADR-0's "cross-module linking is out of scope for the tool" is unchanged** — what changed is that the test harness can now exercise import resolution the same way a Ruby embedder linking two generated classes by hand already could.
 
 ## Rejected alternatives
 
-- **Box only imported/exported-mutable globals, keep plain ivars for purely-local ones** — saves
-  an allocation and a `.value` indirection on the common case, at the cost of two codegen paths for
-  every global read/write/export site and a runtime decision (is this global ever imported
-  elsewhere?) that the generator can't always know locally. Rejected at the time for the
-  `Memory`/`Table` precedent and for keeping `GlobalGet`/`GlobalSet` lowering a single rule.
-  **Adopted later** (the two-path cost was overstated: the decision is knowable statically —
-  `boxed_globals = imported ∪ ExportKind::Global` computed once per module, since wasm 1.0's
-  export/import sets are fixed at conversion time, not runtime — and a `global_ref` helper keeps
-  `GlobalGet`/`GlobalSet`/`ElemItem::Global` at one call site each). The boundary criterion above
-  (crosses an instantiation boundary ⇒ needs the box) is exactly what `boxed_globals` computes;
-  only the plain-ivar-for-everything-else half of this alternative was actually implemented.
-- **Full wasm-type import validation (signatures, mutability, limits)** — real correctness value
-  only for `assert_unlinkable` conformance; no embedder-visible behavior changes for a
-  correctly-typed import, which is the only case that matters outside the spec harness. Deferred as
-  documented debt (`import-limits` ledger entries) rather than implemented speculatively.
-- **Keep the core builder rejecting these constructs per-backend (a `Backend` parameter threaded
-  into `build_module`)** — would leak backend concerns into the shared, backend-agnostic IR builder
-  (ADR-0's "adding a language must not require touching the core"). A post-hoc gate in the shared
-  backend-trait crate keeps `dewasm-core` untouched and gives every future backend the same
-  free gating Bash uses here.
+- **Box only imported/exported-mutable globals, keep plain ivars for purely-local ones** — saves an allocation and a `.value` indirection on the common case, at the cost of two codegen paths for every global read/write/export site and a runtime decision (is this global ever imported elsewhere?) that the generator can't always know locally. Rejected at the time for the `Memory`/`Table` precedent and for keeping `GlobalGet`/`GlobalSet` lowering a single rule. **Adopted later** (the two-path cost was overstated: the decision is knowable statically — `boxed_globals = imported ∪ ExportKind::Global` computed once per module, since wasm 1.0's export/import sets are fixed at conversion time, not runtime — and a `global_ref` helper keeps `GlobalGet`/`GlobalSet`/`ElemItem::Global` at one call site each). The boundary criterion above (crosses an instantiation boundary ⇒ needs the box) is exactly what `boxed_globals` computes; only the plain-ivar-for-everything-else half of this alternative was actually implemented.
+- **Full wasm-type import validation (signatures, mutability, limits)** — real correctness value only for `assert_unlinkable` conformance; no embedder-visible behavior changes for a correctly-typed import, which is the only case that matters outside the spec harness. Deferred as documented debt (`import-limits` ledger entries) rather than implemented speculatively.
+- **Keep the core builder rejecting these constructs per-backend (a `Backend` parameter threaded into `build_module`)** — would leak backend concerns into the shared, backend-agnostic IR builder (ADR-0's "adding a language must not require touching the core"). A post-hoc gate in the shared backend-trait crate keeps `dewasm-core` untouched and gives every future backend the same free gating Bash uses here.
 
 ## Consequences
 
-- Positive: `docs/support.md` shows ✅ for Ruby on all five rows; full spec-suite sweep pass count
-  24,338 → 29,233, `fail` count 23 → 40 with every one of the 17 new failures re-attributed to the
-  two narrow, documented gaps above (verified file by file, none are regressions). Bash's sweep is
-  byte-identical to the pre-milestone baseline (pass=24,338, fail=23) — `check_module_support`
-  contained the blast radius entirely.
-- Positive: the `import(name)` provider method is a real capability for any Ruby embedder linking
-  two dewasm-generated classes by hand, not just the spec harness.
-- Negative / carry-over: `import-limits` stays open debt until (if ever) function/global/table/
-  memory type metadata is worth carrying at runtime purely for stricter unlinkable detection.
-  Bash gaining any of these five features later is a separate, symmetric milestone — its own
-  `check_module_support` call means it costs nothing until then.
+- Positive: `docs/support.md` shows ✅ for Ruby on all five rows; full spec-suite sweep pass count 24,338 → 29,233, `fail` count 23 → 40 with every one of the 17 new failures re-attributed to the two narrow, documented gaps above (verified file by file, none are regressions). Bash's sweep is byte-identical to the pre-milestone baseline (pass=24,338, fail=23) — `check_module_support` contained the blast radius entirely.
+- Positive: the `import(name)` provider method is a real capability for any Ruby embedder linking two dewasm-generated classes by hand, not just the spec harness.
+- Negative / carry-over: `import-limits` stays open debt until (if ever) function/global/table/ memory type metadata is worth carrying at runtime purely for stricter unlinkable detection. Bash gaining any of these five features later is a separate, symmetric milestone — its own `check_module_support` call means it costs nothing until then.
 
-See also: [ADR-0](0-foundation.md) (scope, cross-module linking), [ADR-1](1-ir-design.md) (IR
-design), [ADR-4](4-ruby-backend-lowering.md) (Ruby lowering conventions this extends),
-[ADR-6](6-runtime-units.md) (runtime units), [ADR-7](7-import-providers.md) (the import provider
-protocol this generalizes), [ADR-8](8-latest-testsuite-support-matrix.md) (the support matrix and
-skip-attribution policy this fulfills).
+See also: [ADR-0](0-foundation.md) (scope, cross-module linking), [ADR-1](1-ir-design.md) (IR design), [ADR-4](4-ruby-backend-lowering.md) (Ruby lowering conventions this extends), [ADR-6](6-runtime-units.md) (runtime units), [ADR-7](7-import-providers.md) (the import provider protocol this generalizes), [ADR-8](8-latest-testsuite-support-matrix.md) (the support matrix and skip-attribution policy this fulfills).

--- a/docs/adr/17-ruby-reference-types.md
+++ b/docs/adr/17-ruby-reference-types.md
@@ -2,90 +2,33 @@
 
 Status: **Superseded by [ADR-24](24-01-scope-reset.md), 2026-07-26.** Kept as a design record for a future restoration of this support; git history plus this ADR make the work cheap to revive. The original acceptance note and implementation pointers below are retained as history.
 
-Originally accepted 2026-07-24. Implemented: `crates/dewasm-core/src/{ir,module,func}.rs`,
-`crates/dewasm-backend/src/lib.rs`, `crates/dewasm-backend-ruby/src/lib.rs`,
-`runtime/ruby/units/table/*.rb`, and the spec harness's ref-valued arguments/results
-(`crates/dewasm-backend-ruby/tests/spec.rs`).
+Originally accepted 2026-07-24. Implemented: `crates/dewasm-core/src/{ir,module,func}.rs`, `crates/dewasm-backend/src/lib.rs`, `crates/dewasm-backend-ruby/src/lib.rs`, `runtime/ruby/units/table/*.rb`, and the spec harness's ref-valued arguments/results (`crates/dewasm-backend-ruby/tests/spec.rs`).
 
 ## Context
 
-Reference types is the first post-1.0 proposal to land (the opening move of the wasm 2.0+ /
-component-model roadmap), and the first to put non-numeric values on the wasm stack: `funcref`
-and `externref` flow through locals, block results, `select`, globals, and the new table
-instructions (`table.get/set/grow/size/fill`, `ref.null/ref.func/ref.is_null`). The IR's
-`ValType` had exactly four numeric variants, and `Rt::Table` stored elements as parallel
-`@types`/`@funcs` arrays that nothing else could produce or consume. A representation had to be
-chosen for both reference kinds in Ruby, and the ADR-16 gate had to keep Bash rejecting every
-new construct at conversion time.
+Reference types is the first post-1.0 proposal to land (the opening move of the wasm 2.0+ / component-model roadmap), and the first to put non-numeric values on the wasm stack: `funcref` and `externref` flow through locals, block results, `select`, globals, and the new table instructions (`table.get/set/grow/size/fill`, `ref.null/ref.func/ref.is_null`). The IR's `ValType` had exactly four numeric variants, and `Rt::Table` stored elements as parallel `@types`/`@funcs` arrays that nothing else could produce or consume. A representation had to be chosen for both reference kinds in Ruby, and the ADR-16 gate had to keep Bash rejecting every new construct at conversion time.
 
 ## Decision
 
-- **A funcref value *is* the table slot: the `[type_symbol, callable]` pair** that element
-  segments already built for `Rt::Table` (ADR-16). `ref.func` emits the same pair
-  (`Gen::func_pair`, `crates/dewasm-backend-ruby/src/lib.rs`), so `ref.func` → `table.set` →
-  `call_indirect` round-trips with no conversion anywhere. **Criterion: one representation per
-  wasm value type, chosen so the most semantics-critical consumer (`call_indirect`'s structural
-  type check, ADR-4) needs no adaptation.** The callable alone was rejected because the type
-  symbol would have to be recomputed from a `Method` object, which is impossible across module
-  boundaries (the symbol is interned from the *type shape*, not derivable from a Ruby callable).
-- **An externref value is the raw host object; null is `nil` for both kinds.** No wrapper.
-  Accepted degeneracy: a host passing Ruby `nil` as a "non-null" externref is indistinguishable
-  from `ref.null extern` — wasm's null is whatever the host's null is, the same equation every
-  JS embedding uses.
-- **`Rt::Table` stores one `@slots` array** (`runtime/ruby/units/table/_class.rb`) instead of
-  parallel `@types`/`@funcs`: since a funcref is the pair, slots are representation-agnostic and
-  `get`/`set`/`grow`/`fill`/`copy`/`init` move values without inspecting them; only `call`
-  destructures. Tables now carry their `max` (new `Table.new(min, max)`) because `table.grow`
-  must refuse growth past it (`table/grow.rb`, returns `0xffffffff`).
-- **`ValType` gains flat `FuncRef`/`ExternRef` variants**, not a structured `Ref(RefType)`.
-  Typed function references/GC will force the structured form eventually; until then the flat
-  variants keep every backend match one arm per type, and `ValType::is_ref()` +
-  `default_value` funnel the spots that will need migrating.
-- **Element items became a proper enum** (`ir::ElemItem::Func | Null | Global`): the testsuite's
-  `elem.wast` initializes a table slot from an imported funcref global (`global.get` item),
-  which `Option<u32>` could not express. Ruby renders `Global(i)` as `@g{i}.value`.
-- **Gating: `check_module_support` grew a `ReferenceTypes` require backed by the first
-  exhaustive `Expr` walk** (`module_uses_reference_types`,
-  `crates/dewasm-backend/src/lib.rs`) — ref-typed values anywhere (signatures, globals,
-  locals, temps), externref tables (funcref tables are MVP and must *not* trigger it), and the
-  new instructions. Like `stmts_use_table_bulk_ops`, both walks are exhaustive on purpose so a
-  future `Stmt`/`Expr` variant is a compile error, not a silent mis-lowering. Bash's only
-  change is `unreachable!` match arms.
-- **The harness expresses ref-valued directives in the same representation**
-  (`crates/dewasm-backend-ruby/tests/spec.rs`): `(ref.extern n)` args/results are the Integer
-  `n`, nulls are `nil`, `(ref.func)` results check for the pair shape. This had to land in the
-  same change as the `Supported` flip — the harness's anti-regression check
-  (`crates/dewasm-test-helper/src/spec.rs`) turns any leftover `reference-types`-tagged skip into a suite failure.
+- **A funcref value *is* the table slot: the `[type_symbol, callable]` pair** that element segments already built for `Rt::Table` (ADR-16). `ref.func` emits the same pair (`Gen::func_pair`, `crates/dewasm-backend-ruby/src/lib.rs`), so `ref.func` → `table.set` → `call_indirect` round-trips with no conversion anywhere. **Criterion: one representation per wasm value type, chosen so the most semantics-critical consumer (`call_indirect`'s structural type check, ADR-4) needs no adaptation.** The callable alone was rejected because the type symbol would have to be recomputed from a `Method` object, which is impossible across module boundaries (the symbol is interned from the *type shape*, not derivable from a Ruby callable).
+- **An externref value is the raw host object; null is `nil` for both kinds.** No wrapper. Accepted degeneracy: a host passing Ruby `nil` as a "non-null" externref is indistinguishable from `ref.null extern` — wasm's null is whatever the host's null is, the same equation every JS embedding uses.
+- **`Rt::Table` stores one `@slots` array** (`runtime/ruby/units/table/_class.rb`) instead of parallel `@types`/`@funcs`: since a funcref is the pair, slots are representation-agnostic and `get`/`set`/`grow`/`fill`/`copy`/`init` move values without inspecting them; only `call` destructures. Tables now carry their `max` (new `Table.new(min, max)`) because `table.grow` must refuse growth past it (`table/grow.rb`, returns `0xffffffff`).
+- **`ValType` gains flat `FuncRef`/`ExternRef` variants**, not a structured `Ref(RefType)`. Typed function references/GC will force the structured form eventually; until then the flat variants keep every backend match one arm per type, and `ValType::is_ref()` + `default_value` funnel the spots that will need migrating.
+- **Element items became a proper enum** (`ir::ElemItem::Func | Null | Global`): the testsuite's `elem.wast` initializes a table slot from an imported funcref global (`global.get` item), which `Option<u32>` could not express. Ruby renders `Global(i)` as `@g{i}.value`.
+- **Gating: `check_module_support` grew a `ReferenceTypes` require backed by the first exhaustive `Expr` walk** (`module_uses_reference_types`, `crates/dewasm-backend/src/lib.rs`) — ref-typed values anywhere (signatures, globals, locals, temps), externref tables (funcref tables are MVP and must *not* trigger it), and the new instructions. Like `stmts_use_table_bulk_ops`, both walks are exhaustive on purpose so a future `Stmt`/`Expr` variant is a compile error, not a silent mis-lowering. Bash's only change is `unreachable!` match arms.
+- **The harness expresses ref-valued directives in the same representation** (`crates/dewasm-backend-ruby/tests/spec.rs`): `(ref.extern n)` args/results are the Integer `n`, nulls are `nil`, `(ref.func)` results check for the pair shape. This had to land in the same change as the `Supported` flip — the harness's anti-regression check (`crates/dewasm-test-helper/src/spec.rs`) turns any leftover `reference-types`-tagged skip into a suite failure.
 
 ## Rejected alternatives
 
-- **funcref = bare callable, type symbol looked up at call time** — needs a side table from
-  callable to type symbol; breaks for callables imported from another module instance where no
-  such table exists. The pair costs one array per reference and buys structural identity that
-  travels with the value.
-- **A `Rt::FuncRef` wrapper class** — same information as the pair with an extra class,
-  allocation, and accessor per touch; the pair is already the established table wire format.
-- **Wrapping externref so host `nil` ≠ wasm null** — a wrapper on every host↔wasm crossing to
-  preserve a distinction no realistic embedder relies on; rejected for the same "raw host
-  value" reasoning as ADR-14's use of plain `IO` objects.
-- **`ValType::Ref(RefType)` now** — structurally future-proof but forces nested matching on all
-  backends for two inhabitants; the flat variants plus `is_ref()` keep today simple and mark
-  the migration points for GC.
+- **funcref = bare callable, type symbol looked up at call time** — needs a side table from callable to type symbol; breaks for callables imported from another module instance where no such table exists. The pair costs one array per reference and buys structural identity that travels with the value.
+- **A `Rt::FuncRef` wrapper class** — same information as the pair with an extra class, allocation, and accessor per touch; the pair is already the established table wire format.
+- **Wrapping externref so host `nil` ≠ wasm null** — a wrapper on every host↔wasm crossing to preserve a distinction no realistic embedder relies on; rejected for the same "raw host value" reasoning as ADR-14's use of plain `IO` objects.
+- **`ValType::Ref(RefType)` now** — structurally future-proof but forces nested matching on all backends for two inhabitants; the flat variants plus `is_ref()` keep today simple and mark the migration points for GC.
 
 ## Consequences
 
-- Positive: full Ruby sweep pass 29,233 → 29,516; `reference-types` disappeared from the skip
-  histogram; fail count stays 40 with the ADR-16 `import-limits` ledger byte-identical. Bash's
-  totals are unchanged — the gate contained the blast radius exactly as designed.
-- Positive: funcref tables, `ref.func` globals, and cross-module table sharing all speak one
-  format, so tail calls (a third pair element or sibling) and the component model's funcref
-  shim tables build on this without another representation decision.
-- Negative / carry-over: the externref `nil` degeneracy is permanent by construction. The flat
-  `ValType` variants are a known migration debt for typed function references/GC. `table_grow.rb`
-  shares one init object across new slots (correct — references are values — but worth knowing
-  when reading dumps).
+- Positive: full Ruby sweep pass 29,233 → 29,516; `reference-types` disappeared from the skip histogram; fail count stays 40 with the ADR-16 `import-limits` ledger byte-identical. Bash's totals are unchanged — the gate contained the blast radius exactly as designed.
+- Positive: funcref tables, `ref.func` globals, and cross-module table sharing all speak one format, so tail calls (a third pair element or sibling) and the component model's funcref shim tables build on this without another representation decision.
+- Negative / carry-over: the externref `nil` degeneracy is permanent by construction. The flat `ValType` variants are a known migration debt for typed function references/GC. `table_grow.rb` shares one init object across new slots (correct — references are values — but worth knowing when reading dumps).
 
-See also: [ADR-4](4-ruby-backend-lowering.md) (the `type_symbol` mechanism this reuses),
-[ADR-16](16-ruby-wasm1-completion.md) (the table machinery and gating mechanism this extends),
-[ADR-8](8-latest-testsuite-support-matrix.md) (skip attribution that forced the harness work to
-be atomic with the flip).
+See also: [ADR-4](4-ruby-backend-lowering.md) (the `type_symbol` mechanism this reuses), [ADR-16](16-ruby-wasm1-completion.md) (the table machinery and gating mechanism this extends), [ADR-8](8-latest-testsuite-support-matrix.md) (skip attribution that forced the harness work to be atomic with the flip).

--- a/docs/adr/18-ruby-tail-calls.md
+++ b/docs/adr/18-ruby-tail-calls.md
@@ -2,77 +2,31 @@
 
 Status: **Superseded by [ADR-24](24-01-scope-reset.md), 2026-07-26.** Kept as a design record for a future restoration of this support; git history plus this ADR make the work cheap to revive. The original acceptance note and implementation pointers below are retained as history.
 
-Originally accepted 2026-07-24. Implemented: `crates/dewasm-core/src/{ir,func,module}.rs`,
-`crates/dewasm-backend/src/lib.rs` (`stmts_use_tail_calls`),
-`crates/dewasm-backend-ruby/src/lib.rs`, `runtime/ruby/units/rt/tail_call.rb`,
-`runtime/ruby/units/table/tail_ref.rb`.
+Originally accepted 2026-07-24. Implemented: `crates/dewasm-core/src/{ir,func,module}.rs`, `crates/dewasm-backend/src/lib.rs` (`stmts_use_tail_calls`), `crates/dewasm-backend-ruby/src/lib.rs`, `runtime/ruby/units/rt/tail_call.rb`, `runtime/ruby/units/table/tail_ref.rb`.
 
 ## Context
 
-`return_call`/`return_call_indirect` require tail-call chains to run in constant stack space:
-`return_call.wast` drives 1,000,000-deep *mutual* recursion (`even`/`odd`), far past MRI's
-~10⁴-frame limit. Ruby has no dependable tail-call elimination, so the lowering itself must
-keep chains flat.
+`return_call`/`return_call_indirect` require tail-call chains to run in constant stack space: `return_call.wast` drives 1,000,000-deep *mutual* recursion (`even`/`odd`), far past MRI's ~10⁴-frame limit. Ruby has no dependable tail-call elimination, so the lowering itself must keep chains flat.
 
 ## Decision
 
 A trampoline, shaped so that no per-hop stack frame survives:
 
-- Every defined function that **contains** a tail call (computed by the shared, exhaustive
-  `stmts_use_tail_calls` walk) is split: `_fN_body` holds the real code, and the public `_fN`
-  is `Rt.trampoline(_fN_body(...))`. `Rt::TailCall` is a `Struct(:target, :args)`;
-  `Rt.trampoline` re-dispatches while the result is one
-  (`runtime/ruby/units/rt/tail_call.rb`). All existing call sites (exports, `Stmt::Call`,
-  tables, `start`) keep using `_fN`, so the split is invisible outside.
-- **Every `return_call` produces a thunk — never a plain call.** To a tail-calling callee the
-  thunk targets the *body* (`method(:_fM_body)`), so mutual chains bounce in the one outermost
-  trampoline with zero intermediate frames; to anything else (imports, plain functions) it
-  targets the ordinary callable, costing one completing frame per such hop. **Criterion: the
-  callee must run after the caller's frame — including its `rescue` blocks — is gone.** A
-  "plain call for non-tail-calling callees" shortcut passed every stack-depth test but was
-  observably wrong under exception handling: `try_table.wast`'s `return-call-in-try-catch`
-  requires an exception thrown by the tail-called function to *escape* the caller's
-  `try_table`, and a direct call keeps that `rescue` wrapped around the callee (ADR-19). The
-  thunk is unwrapped outside the body's `begin/rescue`, giving the frame-replacement semantics
-  for free.
-- `return_call_indirect` resolves through the table at the instruction's execution point:
-  `Rt::TailCall.new(@tK.tail_ref(i, type_sym), [...])`. ADR-17's slot pair carries an optional
-  **third element** — the body method — added by `Gen::func_pair` for tail-calling functions;
-  `tail_ref` performs `call`'s exact trap sequence (undefined element, uninitialized, type
-  mismatch — raised inside the caller's body, i.e. at the right point in execution order) and
-  returns `slot[2] || slot[1]`. A pair from a non-tail-caller, or from another module
-  instance, falls back to its public entry: that entry runs its *own* trampoline to
-  completion, costing one frame per module switch, which the criterion permits.
+- Every defined function that **contains** a tail call (computed by the shared, exhaustive `stmts_use_tail_calls` walk) is split: `_fN_body` holds the real code, and the public `_fN` is `Rt.trampoline(_fN_body(...))`. `Rt::TailCall` is a `Struct(:target, :args)`; `Rt.trampoline` re-dispatches while the result is one (`runtime/ruby/units/rt/tail_call.rb`). All existing call sites (exports, `Stmt::Call`, tables, `start`) keep using `_fN`, so the split is invisible outside.
+- **Every `return_call` produces a thunk — never a plain call.** To a tail-calling callee the thunk targets the *body* (`method(:_fM_body)`), so mutual chains bounce in the one outermost trampoline with zero intermediate frames; to anything else (imports, plain functions) it targets the ordinary callable, costing one completing frame per such hop. **Criterion: the callee must run after the caller's frame — including its `rescue` blocks — is gone.** A "plain call for non-tail-calling callees" shortcut passed every stack-depth test but was observably wrong under exception handling: `try_table.wast`'s `return-call-in-try-catch` requires an exception thrown by the tail-called function to *escape* the caller's `try_table`, and a direct call keeps that `rescue` wrapped around the callee (ADR-19). The thunk is unwrapped outside the body's `begin/rescue`, giving the frame-replacement semantics for free.
+- `return_call_indirect` resolves through the table at the instruction's execution point: `Rt::TailCall.new(@tK.tail_ref(i, type_sym), [...])`. ADR-17's slot pair carries an optional **third element** — the body method — added by `Gen::func_pair` for tail-calling functions; `tail_ref` performs `call`'s exact trap sequence (undefined element, uninitialized, type mismatch — raised inside the caller's body, i.e. at the right point in execution order) and returns `slot[2] || slot[1]`. A pair from a non-tail-caller, or from another module instance, falls back to its public entry: that entry runs its *own* trampoline to completion, costing one frame per module switch, which the criterion permits.
 
 ## Rejected alternatives
 
-- **Plain call + `return`** — correct results, wrong space: dies by stack overflow around 10⁴
-  frames against the suite's 10⁶ chains.
-- **Self-tail-call → loop rewrite in the IR** — only covers direct self-recursion; `even`/`odd`
-  mutual recursion still overflows. Viable later as a readability/speed optimization layered
-  on top (it would simply shrink the tail-caller set), never as the mechanism.
-- **Thunks holding the public `_fM` entry (no body split)** — each hop enters a fresh
-  trampoline one frame deeper; 10⁶ hops = 10⁶ frames. The body split is precisely what makes
-  the chain flat.
-- **`RubyVM::InstructionSequence.compile_option = {tailcall_optimization: true}`** — MRI-only,
-  requires routing generated code through explicit iseq compilation, and silently absent on
-  JRuby/TruffleRuby; generated code must not depend on an interpreter flag for correctness.
+- **Plain call + `return`** — correct results, wrong space: dies by stack overflow around 10⁴ frames against the suite's 10⁶ chains.
+- **Self-tail-call → loop rewrite in the IR** — only covers direct self-recursion; `even`/`odd` mutual recursion still overflows. Viable later as a readability/speed optimization layered on top (it would simply shrink the tail-caller set), never as the mechanism.
+- **Thunks holding the public `_fM` entry (no body split)** — each hop enters a fresh trampoline one frame deeper; 10⁶ hops = 10⁶ frames. The body split is precisely what makes the chain flat.
+- **`RubyVM::InstructionSequence.compile_option = {tailcall_optimization: true}`** — MRI-only, requires routing generated code through explicit iseq compilation, and silently absent on JRuby/TruffleRuby; generated code must not depend on an interpreter flag for correctness.
 
 ## Consequences
 
-- Positive: `return_call.wast` (33) + `return_call_indirect.wast` (82 total with the former)
-  pass in ~2 s including the 10⁶-deep chains; full Ruby sweep pass 29,516 → 29,598, fail
-  stays 40; Bash unchanged (gated by `check_module_support`, `tail-call` skips re-appear in
-  its histogram unchanged).
-- Positive: `stmts_use_tail_calls` lives in `dewasm-backend` because gating needs it anyway
-  — a future backend implementing tail calls (C#'s real `tail.` prefix, Java trampolines)
-  reuses the same tail-caller analysis.
-- Negative / carry-over: tail-calling functions allocate one `Rt::TailCall` per hop, and every
-  tail-caller pays the extra wrapper frame even when called normally. A host externref that is
-  itself an `Rt::TailCall` instance would confuse a trampoline only if a wasm function could
-  *return* it from a body — it cannot (bodies only produce thunks at `return_call` sites), so
-  this is theoretical. `return_call_ref` stays rejected under `function-references`.
+- Positive: `return_call.wast` (33) + `return_call_indirect.wast` (82 total with the former) pass in ~2 s including the 10⁶-deep chains; full Ruby sweep pass 29,516 → 29,598, fail stays 40; Bash unchanged (gated by `check_module_support`, `tail-call` skips re-appear in its histogram unchanged).
+- Positive: `stmts_use_tail_calls` lives in `dewasm-backend` because gating needs it anyway — a future backend implementing tail calls (C#'s real `tail.` prefix, Java trampolines) reuses the same tail-caller analysis.
+- Negative / carry-over: tail-calling functions allocate one `Rt::TailCall` per hop, and every tail-caller pays the extra wrapper frame even when called normally. A host externref that is itself an `Rt::TailCall` instance would confuse a trampoline only if a wasm function could *return* it from a body — it cannot (bodies only produce thunks at `return_call` sites), so this is theoretical. `return_call_ref` stays rejected under `function-references`.
 
-See also: [ADR-17](17-ruby-reference-types.md) (the table slot format the third element
-extends), [ADR-4](4-ruby-backend-lowering.md) (lowering conventions),
-[ADR-16](16-ruby-wasm1-completion.md) (`check_module_support`).
+See also: [ADR-17](17-ruby-reference-types.md) (the table slot format the third element extends), [ADR-4](4-ruby-backend-lowering.md) (lowering conventions), [ADR-16](16-ruby-wasm1-completion.md) (`check_module_support`).

--- a/docs/adr/19-ruby-exception-handling.md
+++ b/docs/adr/19-ruby-exception-handling.md
@@ -2,83 +2,31 @@
 
 Status: **Superseded by [ADR-24](24-01-scope-reset.md), 2026-07-26.** Kept as a design record for a future restoration of this support; git history plus this ADR make the work cheap to revive. The original acceptance note and implementation pointers below are retained as history.
 
-Originally accepted 2026-07-24. Implemented: `crates/dewasm-core/src/{ir,module,func}.rs`,
-`crates/dewasm-backend/src/lib.rs`, `crates/dewasm-backend-ruby/src/lib.rs`,
-`runtime/ruby/units/rt/{tag,wasm_exception,throw_ref}.rb`, and the spec harness's
-`assert_exception` support (`crates/dewasm-test-helper/src/spec.rs` plus
-`crates/dewasm-backend-ruby/tests/spec.rs`).
+Originally accepted 2026-07-24. Implemented: `crates/dewasm-core/src/{ir,module,func}.rs`, `crates/dewasm-backend/src/lib.rs`, `crates/dewasm-backend-ruby/src/lib.rs`, `runtime/ruby/units/rt/{tag,wasm_exception,throw_ref}.rb`, and the spec harness's `assert_exception` support (`crates/dewasm-test-helper/src/spec.rs` plus `crates/dewasm-backend-ruby/tests/spec.rs`).
 
 ## Context
 
-Wasm 3.0 exception handling (`try_table`/`throw`/`throw_ref`, tags, `exnref`) is the third
-roadmap phase. The pinned testsuite contains only the final `try_table` design — no legacy
-`try`/`catch`/`rethrow`/`delegate` anywhere — so full `Supported` was reachable without a
-`Partial` carve-out. The design questions: what a tag is at runtime (imported tags must match
-their origin across `register`ed instances), what an `exnref` value is, and how catch-clause
-payloads — which arrive dynamically, not from stack slots — fit an IR whose branches move
-values between statically-known temps.
+Wasm 3.0 exception handling (`try_table`/`throw`/`throw_ref`, tags, `exnref`) is the third roadmap phase. The pinned testsuite contains only the final `try_table` design — no legacy `try`/`catch`/`rethrow`/`delegate` anywhere — so full `Supported` was reachable without a `Partial` carve-out. The design questions: what a tag is at runtime (imported tags must match their origin across `register`ed instances), what an `exnref` value is, and how catch-clause payloads — which arrive dynamically, not from stack slots — fit an IR whose branches move values between statically-known temps.
 
 ## Decision
 
-- **A tag is an empty identity object, `Rt::Tag`;** catch clauses compare `.equal?`.
-  **Criterion: wasm tag equality is instance identity, never structure** — two `(tag)`
-  definitions are distinct, while one tag imported twice matches itself — which is exactly
-  Ruby object identity, so sharing the object through the ADR-7 provider protocol
-  (`TAG_EXPORTS`, `tag_export`, an `import(name)` arm, `check_import_kind :tag` via
-  `wasm_kind`) is the entire cross-instance story. Tag *types* are not carried: the
-  kind-not-type gap of ADR-16 extends to tags (see Consequences).
-- **A thrown exception is `raise Rt::WasmException.new(@tagK, [values])`, and the exception
-  object itself is the exnref value.** `throw_ref` re-raises it (`Rt.throw_ref`, trapping
-  `"null exception reference"` on `nil`); `ValType::ExnRef` joins the flat ref variants with
-  `nil` as null. `Rt::WasmException` is deliberately unrelated to `Rt::Trap`: `try_table`'s
-  `rescue Rt::WasmException` structurally cannot catch traps, exhaustion, or `Rt::Exit`
-  (`unreachable-not-caught`/`trap-in-callee` in `try_table.wast` pin this down).
-- **`Stmt::TryTable` lowers to the body wrapped in `begin … rescue Rt::WasmException => __e`**,
-  clauses checked in order (first match wins, per `duplicated-catches`), ending in a bare
-  `raise` for the no-match case. A catchless `try_table` is folded to a plain block in the
-  builder — it is one.
-- **Catch payloads land directly in the target frame's slots.** `ir::CatchClause` carries
-  `value_temps` (computed with `branch_target`'s arithmetic — target base + index — but
-  sourced from `__e.values[i]`/`__e` instead of the stack) plus a `target: BrTarget` with
-  empty assigns. Catch labels resolve against the context *enclosing* the `try_table` (the
-  spec validates clauses under `C`, before the block's own label is pushed).
-- **`return_call` interacts correctly by construction** — and forced an ADR-18 correction: a
-  thunk returned out of the body leaves the `begin/rescue` before the callee runs, so an
-  exception thrown by a tail-called function escapes the caller's `try_table` as required.
-  The "plain call for non-tail-calling callees" shortcut ADR-18 originally allowed was
-  observably wrong here and was removed (every `return_call` now thunks).
+- **A tag is an empty identity object, `Rt::Tag`;** catch clauses compare `.equal?`. **Criterion: wasm tag equality is instance identity, never structure** — two `(tag)` definitions are distinct, while one tag imported twice matches itself — which is exactly Ruby object identity, so sharing the object through the ADR-7 provider protocol (`TAG_EXPORTS`, `tag_export`, an `import(name)` arm, `check_import_kind :tag` via `wasm_kind`) is the entire cross-instance story. Tag *types* are not carried: the kind-not-type gap of ADR-16 extends to tags (see Consequences).
+- **A thrown exception is `raise Rt::WasmException.new(@tagK, [values])`, and the exception object itself is the exnref value.** `throw_ref` re-raises it (`Rt.throw_ref`, trapping `"null exception reference"` on `nil`); `ValType::ExnRef` joins the flat ref variants with `nil` as null. `Rt::WasmException` is deliberately unrelated to `Rt::Trap`: `try_table`'s `rescue Rt::WasmException` structurally cannot catch traps, exhaustion, or `Rt::Exit` (`unreachable-not-caught`/`trap-in-callee` in `try_table.wast` pin this down).
+- **`Stmt::TryTable` lowers to the body wrapped in `begin … rescue Rt::WasmException => __e`**, clauses checked in order (first match wins, per `duplicated-catches`), ending in a bare `raise` for the no-match case. A catchless `try_table` is folded to a plain block in the builder — it is one.
+- **Catch payloads land directly in the target frame's slots.** `ir::CatchClause` carries `value_temps` (computed with `branch_target`'s arithmetic — target base + index — but sourced from `__e.values[i]`/`__e` instead of the stack) plus a `target: BrTarget` with empty assigns. Catch labels resolve against the context *enclosing* the `try_table` (the spec validates clauses under `C`, before the block's own label is pushed).
+- **`return_call` interacts correctly by construction** — and forced an ADR-18 correction: a thunk returned out of the body leaves the `begin/rescue` before the callee runs, so an exception thrown by a tail-called function escapes the caller's `try_table` as required. The "plain call for non-tail-calling callees" shortcut ADR-18 originally allowed was observably wrong here and was removed (every `return_call` now thunks).
 
 ## Rejected alternatives
 
-- **Tag = symbol/index keyed by module** — breaks imported-tag identity across instances
-  (`catch-imported` in `try_table.wast`); an interned structural key (the `type_symbol` trick)
-  is wrong by design here because tag equality is *not* structural.
-- **`exnref` as a separate wrapper around (tag, values)** — the exception object already *is*
-  that tuple; a second object would need converting at every catch_ref/throw_ref boundary.
-- **Routing traps and exceptions through one class hierarchy** — a `rescue` of a common
-  superclass would make it too easy for generated code to catch traps; two unrelated classes
-  make the "traps are uncatchable" property structural rather than disciplined.
-- **`Partial("try_table only")`** — unnecessary: the pinned suite has no legacy-EH constructs
-  (verified by grep before implementation); legacy binaries fail validation (the
-  `LEGACY_EXCEPTIONS` validator feature stays off) and surface as clean `unknown-proposal`
-  refusals.
+- **Tag = symbol/index keyed by module** — breaks imported-tag identity across instances (`catch-imported` in `try_table.wast`); an interned structural key (the `type_symbol` trick) is wrong by design here because tag equality is *not* structural.
+- **`exnref` as a separate wrapper around (tag, values)** — the exception object already *is* that tuple; a second object would need converting at every catch_ref/throw_ref boundary.
+- **Routing traps and exceptions through one class hierarchy** — a `rescue` of a common superclass would make it too easy for generated code to catch traps; two unrelated classes make the "traps are uncatchable" property structural rather than disciplined.
+- **`Partial("try_table only")`** — unnecessary: the pinned suite has no legacy-EH constructs (verified by grep before implementation); legacy binaries fail validation (the `LEGACY_EXCEPTIONS` validator feature stays off) and surface as clean `unknown-proposal` refusals.
 
 ## Consequences
 
-- Positive: `try_table` (44), `throw` (9), `throw_ref` (12), `tag` (1 + skips attributed to
-  gc-era constructs) all pass; full Ruby sweep pass 29,598 → 29,679. `assert_exception` is now
-  a real check (`SpecLang::emit_check_exception`; the default keeps it an attributed skip for
-  Bash).
-- **Ledger change (ADR-8): `imports.wast` expected failures 28 → 59**, same `import-limits`
-  tag. Its "test" fixture module exports tags, so it never converted before this ADR; now that
-  it does, the downstream `assert_unlinkable` cases checking function signatures, global
-  types, and tag parameter types run — all instances of the ADR-16 kind-not-type gap, no new
-  mechanism. Every other ledger entry (imports2 2, linking 4, linking0 1, load1 5) is
-  byte-identical, and Bash's sweep is unchanged.
-- Negative / carry-over: tag parameter types join the `import-limits` debt. An uncaught wasm
-  exception in `--mode standalone` surfaces as a raw Ruby backtrace (no dedicated exit path
-  like `Rt::Trap`'s 134) — acceptable until a real p2/component consumer defines better.
+- Positive: `try_table` (44), `throw` (9), `throw_ref` (12), `tag` (1 + skips attributed to gc-era constructs) all pass; full Ruby sweep pass 29,598 → 29,679. `assert_exception` is now a real check (`SpecLang::emit_check_exception`; the default keeps it an attributed skip for Bash).
+- **Ledger change (ADR-8): `imports.wast` expected failures 28 → 59**, same `import-limits` tag. Its "test" fixture module exports tags, so it never converted before this ADR; now that it does, the downstream `assert_unlinkable` cases checking function signatures, global types, and tag parameter types run — all instances of the ADR-16 kind-not-type gap, no new mechanism. Every other ledger entry (imports2 2, linking 4, linking0 1, load1 5) is byte-identical, and Bash's sweep is unchanged.
+- Negative / carry-over: tag parameter types join the `import-limits` debt. An uncaught wasm exception in `--mode standalone` surfaces as a raw Ruby backtrace (no dedicated exit path like `Rt::Trap`'s 134) — acceptable until a real p2/component consumer defines better.
 
-See also: [ADR-16](16-ruby-wasm1-completion.md) (provider protocol, kind-not-type gap),
-[ADR-17](17-ruby-reference-types.md) (flat ref `ValType` variants),
-[ADR-18](18-ruby-tail-calls.md) (the trampoline this corrected).
+See also: [ADR-16](16-ruby-wasm1-completion.md) (provider protocol, kind-not-type gap), [ADR-17](17-ruby-reference-types.md) (flat ref `ValType` variants), [ADR-18](18-ruby-tail-calls.md) (the trampoline this corrected).

--- a/docs/adr/2-numeric-semantics.md
+++ b/docs/adr/2-numeric-semantics.md
@@ -1,61 +1,25 @@
 # ADR-2 — Numeric Semantics Strategy for Dynamically-Typed Targets
 
-Status: **Accepted, 2026-07-23.** Backfilled; implemented for Ruby in
-`runtime/ruby/runtime.rb`. The conventions below bind every backend whose
-language lacks fixed-width/unsigned integers or 32-bit floats (Ruby,
-Python, PHP, Bash); Java/Go map to native types instead.
+Status: **Accepted, 2026-07-23.** Backfilled; implemented for Ruby in `runtime/ruby/runtime.rb`. The conventions below bind every backend whose language lacks fixed-width/unsigned integers or 32-bit floats (Ruby, Python, PHP, Bash); Java/Go map to native types instead.
 
 ## Context
 
-Wasm requires bit-exact numerics: wrapping two's-complement i32/i64 with
-signed *and* unsigned views, IEEE 754 f32/f64 including NaN bit patterns,
-and precise trap conditions. Ruby/Python have arbitrary-precision
-integers and only doubles; the spec testsuite (ADR-3) checks all of it,
-including NaN payloads through `reinterpret` and memory.
+Wasm requires bit-exact numerics: wrapping two's-complement i32/i64 with signed *and* unsigned views, IEEE 754 f32/f64 including NaN bit patterns, and precise trap conditions. Ruby/Python have arbitrary-precision integers and only doubles; the spec testsuite (ADR-3) checks all of it, including NaN payloads through `reinterpret` and memory.
 
 ## Decision
 
-- **Integers are stored as masked unsigned values** (`x & 0xffffffff` /
-  `& 0xffff...`), the signed view derived only where an instruction needs
-  it (`div_s`, `lt_s`, `shr_s`, ...) via `s32`/`s64` helpers. Criterion:
-  the *storage* representation should make the more mechanical operation
-  free — masking after add/sub/mul is unavoidable either way, while
-  unsigned compare/div/shift come for free on non-negative integers and
-  memory stores need no sign fix-up. This convention is shared by all
-  bignum-style backends so lowering tables stay parallel.
-- **f32/f64 are host doubles; every f32 operation result is re-rounded
-  to single precision.** Sound for add/sub/mul/div/sqrt because
-  53 ≥ 2·24 + 2 (double rounding is innocuous at that precision gap).
-  Integer→f32 conversions of values above 2^53 pre-round to odd before
-  the double→single step for the same reason.
-- **NaN bit-exactness is achieved with software bit conversions exactly
-  where the host rounds through a lossy path.** Measured on MRI: `pack("e")`
-  canonicalizes NaN sign and payload, and overflows straight to infinity
-  instead of rounding near f32-max. So f32 bit extraction/injection takes
-  a software path for NaNs, f32 memory traffic goes through those helpers,
-  and the overflow boundary (2^128 − 2^103) is handled explicitly.
-  Operations required by the spec to *quiet* NaNs (floor/ceil/trunc/
-  nearest/sqrt/promote) set the quiet bit via bit manipulation.
-- **Trap conditions are explicit checks in helpers** (`div` by zero,
-  `INT_MIN / −1`, out-of-range `trunc`, memory bounds), with the spec
-  interpreter's trap message strings, which the harness matches.
+- **Integers are stored as masked unsigned values** (`x & 0xffffffff` / `& 0xffff...`), the signed view derived only where an instruction needs it (`div_s`, `lt_s`, `shr_s`, ...) via `s32`/`s64` helpers. Criterion: the *storage* representation should make the more mechanical operation free — masking after add/sub/mul is unavoidable either way, while unsigned compare/div/shift come for free on non-negative integers and memory stores need no sign fix-up. This convention is shared by all bignum-style backends so lowering tables stay parallel.
+- **f32/f64 are host doubles; every f32 operation result is re-rounded to single precision.** Sound for add/sub/mul/div/sqrt because 53 ≥ 2·24 + 2 (double rounding is innocuous at that precision gap). Integer→f32 conversions of values above 2^53 pre-round to odd before the double→single step for the same reason.
+- **NaN bit-exactness is achieved with software bit conversions exactly where the host rounds through a lossy path.** Measured on MRI: `pack("e")` canonicalizes NaN sign and payload, and overflows straight to infinity instead of rounding near f32-max. So f32 bit extraction/injection takes a software path for NaNs, f32 memory traffic goes through those helpers, and the overflow boundary (2^128 − 2^103) is handled explicitly. Operations required by the spec to *quiet* NaNs (floor/ceil/trunc/ nearest/sqrt/promote) set the quiet bit via bit manipulation.
+- **Trap conditions are explicit checks in helpers** (`div` by zero, `INT_MIN / −1`, out-of-range `trunc`, memory bounds), with the spec interpreter's trap message strings, which the harness matches.
 
 ## Rejected alternatives
 
-- **Representing floats as bit-pattern integers everywhere** — makes every
-  arithmetic op a pack/unpack round-trip; only needed at the (few) lossy
-  conversion points.
-- **Signed storage representation** — every memory store, unsigned compare,
-  and unsigned div/shift would need fix-ups; the testsuite is dominated by
-  unsigned-view operations.
+- **Representing floats as bit-pattern integers everywhere** — makes every arithmetic op a pack/unpack round-trip; only needed at the (few) lossy conversion points.
+- **Signed storage representation** — every memory store, unsigned compare, and unsigned div/shift would need fix-ups; the testsuite is dominated by unsigned-view operations.
 
 ## Consequences
 
-- Positive: f32/f64/f32_bitwise/float_memory/conversions spec files pass
-  on Ruby, including NaN sign/payload assertions.
-- Known limitation: a *signaling* NaN can be quieted by hardware
-  float↔double conversion on paths we do not intercept; no spec test
-  currently catches this on the Ruby backend, but it is a standing caveat
-  for future backends.
-- Exported function results are unsigned integers by ABI; embedders
-  wanting signed views apply `s32`/`s64` themselves.
+- Positive: f32/f64/f32_bitwise/float_memory/conversions spec files pass on Ruby, including NaN sign/payload assertions.
+- Known limitation: a *signaling* NaN can be quieted by hardware float↔double conversion on paths we do not intercept; no spec test currently catches this on the Ruby backend, but it is a standing caveat for future backends.
+- Exported function results are unsigned integers by ABI; embedders wanting signed views apply `s32`/`s64` themselves.

--- a/docs/adr/20-component-model-core-ir-adapters.md
+++ b/docs/adr/20-component-model-core-ir-adapters.md
@@ -2,91 +2,31 @@
 
 Status: **Superseded by [ADR-24](24-01-scope-reset.md), 2026-07-26.** Kept as a design record for a future restoration of this support; git history plus this ADR make the work cheap to revive. The original acceptance note and implementation pointers below are retained as history.
 
-Originally accepted 2026-07-24. Implemented for the Ruby backend:
-`crates/dewasm-core/src/{component,canon}.rs`,
-`crates/dewasm-backend-ruby/src/lib.rs` (`generate_component`), CLI auto-detection, and the
-component e2e fixtures (`examples/wat/component_*.wat`). Remaining: a real
-`wasm32-wasip2`-binary e2e (its fetch/build sourcing is an open ADR-15 question) and the Bash
-side, which stays rejected.
+Originally accepted 2026-07-24. Implemented for the Ruby backend: `crates/dewasm-core/src/{component,canon}.rs`, `crates/dewasm-backend-ruby/src/lib.rs` (`generate_component`), CLI auto-detection, and the component e2e fixtures (`examples/wat/component_*.wat`). Remaining: a real `wasm32-wasip2`-binary e2e (its fetch/build sourcing is an open ADR-15 question) and the Bash side, which stays rejected.
 
 ## Context
 
-WASI preview 2 binaries are components (layer-1 wrappers): N core modules, an instantiation
-graph, and `canon lift`/`canon lower` adapters translating between WIT values and core
-values via linear memory. dewasmify targets many languages (ADR-0), so the load-bearing
-question was where the canonical ABI lives: implemented once per backend (jco-style host
-glue), or once centrally. A D0 probe of a real Rust `wasm32-wasip2` binary fixed the required
-shape: 17 versioned `wasi:*` instance imports, a shim module whose funcref `$imports` table is
-fixed up post-instantiation, 26 lowers/1 lift, and — decisively — a trivial *nested component*
-wrapping the lifted `run` into an instance export, plus core-level import names whose versions
-(`@0.2.0`) differ from the component-level ones (`@0.2.9`).
+WASI preview 2 binaries are components (layer-1 wrappers): N core modules, an instantiation graph, and `canon lift`/`canon lower` adapters translating between WIT values and core values via linear memory. dewasmify targets many languages (ADR-0), so the load-bearing question was where the canonical ABI lives: implemented once per backend (jco-style host glue), or once centrally. A D0 probe of a real Rust `wasm32-wasip2` binary fixed the required shape: 17 versioned `wasi:*` instance imports, a shim module whose funcref `$imports` table is fixed up post-instantiation, 26 lowers/1 lift, and — decisively — a trivial *nested component* wrapping the lifted `run` into an instance export, plus core-level import names whose versions (`@0.2.0`) differ from the component-level ones (`@0.2.9`).
 
 ## Decision
 
-- **The canonical ABI is compiled away in `dewasm-core`, not interpreted per backend.**
-  `component.rs` parses the binary into core modules (via the ordinary `build_module`), typed
-  interface imports, an ordered instantiation plan, and lift/lower definitions; `canon.rs`
-  synthesizes each adapter as a function of a **regular `ir::Module`** whose body does all
-  layout walking with ordinary loads/stores/calls. **Criterion: a backend must be able to
-  support components without knowing the canonical ABI exists** — a backend's entire
-  component cost is (a) the host-boundary vocabulary below, (b) per-language host units
-  (ADR-21), and (c) a wrapper emitter executing the plan.
-- **The host boundary is a fixed IR vocabulary**: `ValType::Host` (opaque host value) plus
-  ~25 `Expr::Host*`/2 `Stmt::Host*` ops (string/bytes lift-store, list new/get/len/push,
-  record/tuple construction and field access, variant `[case, payload]` pairs, enum symbols,
-  bool/char/option bridges, sign/mask integer bridges). Host *calls* need no new op: host
-  functions are imported funcs with Host-typed signatures, so `Stmt::Call` carries them, and
-  the ADR-7 provider protocol resolves them (`host.<interface>#<func>`).
-- **Adapter modules use conventional import names** — `canon.memory`, `canon.realloc`,
-  `host.<iface>#<func>`, `core.<instance>:<export>` — and index conventions (j-th `Lower`
-  in plan order = lowers module's j-th defined func; `lifted[i]` = lifts module's i-th). The
-  generated wrapper class executes the plan in the component's own section order (which is
-  what makes the shim/fixups cycle-free), constructing the Lowers adapter instance with
-  placeholder canon imports and rebinding memory/realloc the moment their providing instance
-  exists — scalar-only lowers, the only ones callable earlier, never touch memory.
-- **The accepted subset is what `wit-component` command components need**, everything else
-  refused at conversion time with `UnsupportedError(ComponentModel)` (ADR-0): instance-kind
-  imports, utf8 strings, the wrapper-shaped nested component, `resource.drop` (handles are
-  plain i32 end-to-end; drops become host calls). Flat-position variants *with payloads* are
-  refused (they do not occur in CLI-world signatures; memory-position variants are fully
-  general). The Ruby declaration is deliberately **`Partial`, never `Supported`** — the spec
-  harness's component-model-tagged directive skips must stay legitimate (ADR-8's
-  anti-regression turns a `Supported` flip into hard failures for the unexecuted `.wast`
-  component directives).
-- **Wiring follows instantiation arguments, never name matching** (the version-mismatch
-  finding makes name matching wrong by construction).
+- **The canonical ABI is compiled away in `dewasm-core`, not interpreted per backend.** `component.rs` parses the binary into core modules (via the ordinary `build_module`), typed interface imports, an ordered instantiation plan, and lift/lower definitions; `canon.rs` synthesizes each adapter as a function of a **regular `ir::Module`** whose body does all layout walking with ordinary loads/stores/calls. **Criterion: a backend must be able to support components without knowing the canonical ABI exists** — a backend's entire component cost is (a) the host-boundary vocabulary below, (b) per-language host units (ADR-21), and (c) a wrapper emitter executing the plan.
+- **The host boundary is a fixed IR vocabulary**: `ValType::Host` (opaque host value) plus ~25 `Expr::Host*`/2 `Stmt::Host*` ops (string/bytes lift-store, list new/get/len/push, record/tuple construction and field access, variant `[case, payload]` pairs, enum symbols, bool/char/option bridges, sign/mask integer bridges). Host *calls* need no new op: host functions are imported funcs with Host-typed signatures, so `Stmt::Call` carries them, and the ADR-7 provider protocol resolves them (`host.<interface>#<func>`).
+- **Adapter modules use conventional import names** — `canon.memory`, `canon.realloc`, `host.<iface>#<func>`, `core.<instance>:<export>` — and index conventions (j-th `Lower` in plan order = lowers module's j-th defined func; `lifted[i]` = lifts module's i-th). The generated wrapper class executes the plan in the component's own section order (which is what makes the shim/fixups cycle-free), constructing the Lowers adapter instance with placeholder canon imports and rebinding memory/realloc the moment their providing instance exists — scalar-only lowers, the only ones callable earlier, never touch memory.
+- **The accepted subset is what `wit-component` command components need**, everything else refused at conversion time with `UnsupportedError(ComponentModel)` (ADR-0): instance-kind imports, utf8 strings, the wrapper-shaped nested component, `resource.drop` (handles are plain i32 end-to-end; drops become host calls). Flat-position variants *with payloads* are refused (they do not occur in CLI-world signatures; memory-position variants are fully general). The Ruby declaration is deliberately **`Partial`, never `Supported`** — the spec harness's component-model-tagged directive skips must stay legitimate (ADR-8's anti-regression turns a `Supported` flip into hard failures for the unexecuted `.wast` component directives).
+- **Wiring follows instantiation arguments, never name matching** (the version-mismatch finding makes name matching wrong by construction).
 
 ## Rejected alternatives
 
-- **Per-backend canonical-ABI runtime glue (jco / wit-bindgen-host style)** — each backend
-  reimplements lift/lower, exactly the N-times cost ADR-0 exists to avoid; also unverifiable
-  except end-to-end per language. Rejected by the user at planning time.
-- **A host-side canonical-ABI interpreter driven by type descriptors** — one runtime
-  implementation per language again, just data-driven; same multi-backend bill, plus
-  interpretation overhead on every boundary crossing.
-- **External preprocessing (`wasm-tools` demote/compose)** — breaks the single-tool
-  conversion contract (ADR-0) and still leaves the host boundary unsolved.
-- **Rejecting nested components outright** — would reject every Rust wasip2 binary; instead
-  the one observed wrapper shape (function imports re-exported, possibly as an instance) is
-  modelled, all else refused.
+- **Per-backend canonical-ABI runtime glue (jco / wit-bindgen-host style)** — each backend reimplements lift/lower, exactly the N-times cost ADR-0 exists to avoid; also unverifiable except end-to-end per language. Rejected by the user at planning time.
+- **A host-side canonical-ABI interpreter driven by type descriptors** — one runtime implementation per language again, just data-driven; same multi-backend bill, plus interpretation overhead on every boundary crossing.
+- **External preprocessing (`wasm-tools` demote/compose)** — breaks the single-tool conversion contract (ADR-0) and still leaves the host boundary unsolved.
+- **Rejecting nested components outright** — would reject every Rust wasip2 binary; instead the one observed wrapper shape (function imports re-exported, possibly as an instance) is modelled, all else refused.
 
 ## Consequences
 
-- Positive: a real Rust `wasm32-wasip2` binary (103 KB, 3 core modules, 26 lowers) converts
-  to ~1 MB of Ruby and runs byte-identically to wasmtime (stdout, stdin, env, preopened file
-  I/O, exit semantics) with zero canonical-ABI knowledge in the Ruby backend. The committed
-  `.wat` component fixtures give interpreter-level e2e without binary artifacts.
-- Positive: a future backend (ADR-10's C#/Java) gets components by implementing the Host
-  vocabulary (bounded, enumerable) + host units + a wrapper emitter; `ValType::Host` maps to
-  `Object`, and no vocabulary op mixes host and core types in one slot, so static typing
-  stays clean.
-- Negative / carry-over: Bash rejection of Host constructs relies on components only being
-  routed to Ruby (CLI-level check), not on `check_module_support` — acceptable while the
-  component path is single-backend, to revisit when a second backend lands. Flat variants
-  with payloads, non-utf8 encodings, `wasi:sockets/http`, and WASI 0.3 async remain out of
-  scope. The `run` result is `result<(),()>`: nonzero guest exit codes collapse to 1 (a WASI
-  0.2 limitation, not ours).
+- Positive: a real Rust `wasm32-wasip2` binary (103 KB, 3 core modules, 26 lowers) converts to ~1 MB of Ruby and runs byte-identically to wasmtime (stdout, stdin, env, preopened file I/O, exit semantics) with zero canonical-ABI knowledge in the Ruby backend. The committed `.wat` component fixtures give interpreter-level e2e without binary artifacts.
+- Positive: a future backend (ADR-10's C#/Java) gets components by implementing the Host vocabulary (bounded, enumerable) + host units + a wrapper emitter; `ValType::Host` maps to `Object`, and no vocabulary op mixes host and core types in one slot, so static typing stays clean.
+- Negative / carry-over: Bash rejection of Host constructs relies on components only being routed to Ruby (CLI-level check), not on `check_module_support` — acceptable while the component path is single-backend, to revisit when a second backend lands. Flat variants with payloads, non-utf8 encodings, `wasi:sockets/http`, and WASI 0.3 async remain out of scope. The `run` result is `result<(),()>`: nonzero guest exit codes collapse to 1 (a WASI 0.2 limitation, not ours).
 
-See also: [ADR-7](7-import-providers.md) (the provider protocol the wiring reuses),
-[ADR-16](16-ruby-wasm1-completion.md) (imported memories/tables the adapters lean on),
-[ADR-21](21-ruby-wasi-preview2.md) (the host side).
+See also: [ADR-7](7-import-providers.md) (the provider protocol the wiring reuses), [ADR-16](16-ruby-wasm1-completion.md) (imported memories/tables the adapters lean on), [ADR-21](21-ruby-wasi-preview2.md) (the host side).

--- a/docs/adr/21-ruby-wasi-preview2.md
+++ b/docs/adr/21-ruby-wasi-preview2.md
@@ -2,57 +2,28 @@
 
 Status: **Superseded by [ADR-24](24-01-scope-reset.md), 2026-07-26.** Kept as a design record for a future restoration of this support; git history plus this ADR make the work cheap to revive. The original acceptance note and implementation pointers below are retained as history.
 
-Originally accepted 2026-07-24. Implemented: `runtime/ruby/units/wasi_p2/` (`Rt::WASIP2`),
-bundled by `generate_component` when `default_wasi` is on; the function list is rendered into
-`docs/support.md` from the units.
+Originally accepted 2026-07-24. Implemented: `runtime/ruby/units/wasi_p2/` (`Rt::WASIP2`), bundled by `generate_component` when `default_wasi` is on; the function list is rendered into `docs/support.md` from the units.
 
 ## Context
 
-ADR-20's adapters deliver host calls *post-lift*: `Rt::WASIP2` receives Ruby Strings, Arrays,
-Hashes, and `[:case, payload]` variants, and returns the same — no pointers, no layout. The
-scope is the `wasi:cli` command world (io/streams, cli/*, filesystem, clocks, random), enough
-to run real `wasm32-wasip2` binaries; sockets/http and 0.3 async are out.
+ADR-20's adapters deliver host calls *post-lift*: `Rt::WASIP2` receives Ruby Strings, Arrays, Hashes, and `[:case, payload]` variants, and returns the same — no pointers, no layout. The scope is the `wasi:cli` command world (io/streams, cli/*, filesystem, clocks, random), enough to run real `wasm32-wasip2` binaries; sockets/http and 0.3 async are out.
 
 ## Decision
 
-- **One resource table** (`@res`, integer handles) holds streams, descriptors, and pollables;
-  `resource_drop(id, handle)` (called by the wrapper's `canon resource.drop` lambdas) closes
-  IOs the host opened and never the process stdio. **Filesystem descriptors hold a host
-  path, not an open IO** — each `*-via-stream` call opens its own handle, so stream offsets
-  never interfere and drop order cannot double-close.
-- **Name resolution is the ADR-7 provider protocol over versioned p2 names**:
-  `import("wasi:cli/stdout@0.2.9#get-stdout")` strips the version and resolves to
-  `p2_cli_stdout_get_stdout` by mechanical mangling — one runtime unit per function, so the
-  support matrix derives from `has_unit` exactly like preview 1. **An unimplemented `wasi:*`
-  function binds to a lambda that traps at call time**, not a link error: adapter modules
-  import every function a binary *references*, and real binaries reference far more than they
-  call (terminal-*, metadata-hash).
-- **A synchronous host is always "ready"**: `pollable.block` returns immediately, `poll`
-  reports every pollable ready, and the blocking stream variants stand in for the
-  non-blocking ones — the guest's poll loops terminate either way.
-- Sandboxing reuses ADR-14's realpath-plus-containment model (with its accepted TOCTOU
-  caveat); `exit` maps `result<(),()>` to `Rt::Exit` 0/1.
+- **One resource table** (`@res`, integer handles) holds streams, descriptors, and pollables; `resource_drop(id, handle)` (called by the wrapper's `canon resource.drop` lambdas) closes IOs the host opened and never the process stdio. **Filesystem descriptors hold a host path, not an open IO** — each `*-via-stream` call opens its own handle, so stream offsets never interfere and drop order cannot double-close.
+- **Name resolution is the ADR-7 provider protocol over versioned p2 names**: `import("wasi:cli/stdout@0.2.9#get-stdout")` strips the version and resolves to `p2_cli_stdout_get_stdout` by mechanical mangling — one runtime unit per function, so the support matrix derives from `has_unit` exactly like preview 1. **An unimplemented `wasi:*` function binds to a lambda that traps at call time**, not a link error: adapter modules import every function a binary *references*, and real binaries reference far more than they call (terminal-*, metadata-hash).
+- **A synchronous host is always "ready"**: `pollable.block` returns immediately, `poll` reports every pollable ready, and the blocking stream variants stand in for the non-blocking ones — the guest's poll loops terminate either way.
+- Sandboxing reuses ADR-14's realpath-plus-containment model (with its accepted TOCTOU caveat); `exit` maps `result<(),()>` to `Rt::Exit` 0/1.
 
 ## Rejected alternatives
 
-- **Link-time failure for unimplemented functions** — would refuse every real binary over
-  functions it never calls; the trap-at-call lambda keeps ADR-0's "fail loud" at the first
-  observable moment instead.
-- **Sharing `Rt::WASI` (preview 1) internals** — p1 units do pointer arithmetic against guest
-  memory; p2 units never see memory. The fd-table *model* is shared as a pattern, not code.
-- **Real non-blocking I/O + pollable wiring** — needed only for guests that genuinely
-  multiplex; CLI-world binaries poll in write/read loops that the always-ready answer
-  satisfies. Revisit if a real consumer misbehaves.
+- **Link-time failure for unimplemented functions** — would refuse every real binary over functions it never calls; the trap-at-call lambda keeps ADR-0's "fail loud" at the first observable moment instead.
+- **Sharing `Rt::WASI` (preview 1) internals** — p1 units do pointer arithmetic against guest memory; p2 units never see memory. The fd-table *model* is shared as a pattern, not code.
+- **Real non-blocking I/O + pollable wiring** — needed only for guests that genuinely multiplex; CLI-world binaries poll in write/read loops that the always-ready answer satisfies. Revisit if a real consumer misbehaves.
 
 ## Consequences
 
-- Positive: the D0 probe binary's full surface (stdout/stderr/stdin streams, environment,
-  arguments, exit, preopens, open-at/stat/via-stream file I/O, clocks, random) runs against
-  wasmtime-identical behavior; a user host object can replace `Rt::WASIP2` wholesale by
-  implementing `import(name)` + `resource_drop`.
-- Negative / carry-over: rights/permissions are not modelled at all (beyond the sandbox
-  containment); timestamps in `stat` are `none`; `metadata-hash` is ino/dev, not a real hash;
-  Bash has no p2 story (and per ADR-20 would need the host vocabulary first).
+- Positive: the D0 probe binary's full surface (stdout/stderr/stdin streams, environment, arguments, exit, preopens, open-at/stat/via-stream file I/O, clocks, random) runs against wasmtime-identical behavior; a user host object can replace `Rt::WASIP2` wholesale by implementing `import(name)` + `resource_drop`.
+- Negative / carry-over: rights/permissions are not modelled at all (beyond the sandbox containment); timestamps in `stat` are `none`; `metadata-hash` is ino/dev, not a real hash; Bash has no p2 story (and per ADR-20 would need the host vocabulary first).
 
-See also: [ADR-20](20-component-model-core-ir-adapters.md), [ADR-14](14-ruby-wasi-filesystem.md),
-[ADR-7](7-import-providers.md).
+See also: [ADR-20](20-component-model-core-ir-adapters.md), [ADR-14](14-ruby-wasi-filesystem.md), [ADR-7](7-import-providers.md).

--- a/docs/adr/22-sqlite3-built-from-source.md
+++ b/docs/adr/22-sqlite3-built-from-source.md
@@ -2,64 +2,27 @@
 
 Status: **Accepted, 2026-07-24.** Implemented: `examples/apps/fetch.sh` (amalgamation download
 + two `zig cc` builds), `crates/dewasm-test-helper/src/apps.rs` (`sqlite3-shell` case,
-`libsqlite3_c_api_ruby`), `examples/apps/golden/sqlite3_shell.stdout`. Extended (Phase 5a,
-2026-07-26) with a third `zig cc` build, `sqlite3-binding.wasm`, compiled from the same pinned
-source plus our own `examples/apps/src/sqlite3_binding.c` (an exported `run_query` that calls
-`sqlite3_exec` with a C callback forwarding each row to an imported `env.host_row`), which
-exercises the guest→host `sqlite3_exec` function-pointer callback the two original artifacts
-left untested — driven from Ruby's `sqlite3_callback_binding_ruby`.
+`libsqlite3_c_api_ruby`), `examples/apps/golden/sqlite3_shell.stdout`. Extended (Phase 5a, 2026-07-26) with a third `zig cc` build, `sqlite3-binding.wasm`, compiled from the same pinned source plus our own `examples/apps/src/sqlite3_binding.c` (an exported `run_query` that calls `sqlite3_exec` with a C callback forwarding each row to an imported `env.host_row`), which exercises the guest→host `sqlite3_exec` function-pointer callback the two original artifacts left untested — driven from Ruby's `sqlite3_callback_binding_ruby`.
 
 ## Context
 
-The apps e2e's SQLite was a wasmer-CDN binary of SQLite 3.26.0 (2018) — a CLI shell with no
-C API exported, which is why the sqlite3-gem-shim milestone (the Rails north star) was blocked
-on "obtain a wasm32-wasi libsqlite3 that exports the C API". No upstream distributes one.
-`zig cc -target wasm32-wasi` compiles the current amalgamation directly, and with
-`-mexec-model=reactor` plus `-Wl,--export=...` produces exactly that missing artifact.
+The apps e2e's SQLite was a wasmer-CDN binary of SQLite 3.26.0 (2018) — a CLI shell with no C API exported, which is why the sqlite3-gem-shim milestone (the Rails north star) was blocked on "obtain a wasm32-wasi libsqlite3 that exports the C API". No upstream distributes one. `zig cc -target wasm32-wasi` compiles the current amalgamation directly, and with `-mexec-model=reactor` plus `-Wl,--export=...` produces exactly that missing artifact.
 
 ## Decision
 
-`fetch.sh` downloads the version-pinned, checksum-verified amalgamation source zip
-(3.53.3) and builds **two artifacts from the one source**: `sqlite3-shell.wasm` (the CLI
-shell, `_start` + stdio; replaces the wasmer binary in the golden-diffed standalone cases)
-and `libsqlite3.wasm` (a reactor exporting the sqlite3 C API; driven from Ruby in
-`libsqlite3_c_api_ruby`, exercising `_initialize`, guest-memory pointer plumbing through
-`sqlite3_malloc`/`Rt::Memory`, and the prepare/step/column flow the future gem shim will
-use). **Criterion: what is pinned is the upstream *source*, not the build product** — the
-ADR-9 rule ("version-pinned, checksum-verified, never committed") is unchanged, with the
-stamp recording the source checksum; only the producing step moved from "extract" to
-"compile". The library test's expectation is a fixed string rather than a wasmtime golden:
-the wasmtime CLI cannot drive a C API whose results live in guest memory, and every expected
-value is determined by the pinned source version.
+`fetch.sh` downloads the version-pinned, checksum-verified amalgamation source zip (3.53.3) and builds **two artifacts from the one source**: `sqlite3-shell.wasm` (the CLI shell, `_start` + stdio; replaces the wasmer binary in the golden-diffed standalone cases) and `libsqlite3.wasm` (a reactor exporting the sqlite3 C API; driven from Ruby in `libsqlite3_c_api_ruby`, exercising `_initialize`, guest-memory pointer plumbing through `sqlite3_malloc`/`Rt::Memory`, and the prepare/step/column flow the future gem shim will use). **Criterion: what is pinned is the upstream *source*, not the build product** — the ADR-9 rule ("version-pinned, checksum-verified, never committed") is unchanged, with the stamp recording the source checksum; only the producing step moved from "extract" to "compile". The library test's expectation is a fixed string rather than a wasmtime golden: the wasmtime CLI cannot drive a C API whose results live in guest memory, and every expected value is determined by the pinned source version.
 
-Cost accepted: `fetch.sh` (and only `fetch.sh` — never `cargo test` with a warm cache) now
-requires `zig` and `unzip`, failing loudly per ADR-15 when absent. Build output bytes vary
-across zig versions; that is fine because nothing pins the *artifact* — the goldens compare
-program behavior, which the pinned source fixes.
+Cost accepted: `fetch.sh` (and only `fetch.sh` — never `cargo test` with a warm cache) now requires `zig` and `unzip`, failing loudly per ADR-15 when absent. Build output bytes vary across zig versions; that is fine because nothing pins the *artifact* — the goldens compare program behavior, which the pinned source fixes.
 
 ## Rejected alternatives
 
-- **Keep the wasmer-CDN binary and add a library build beside it** — two SQLites of two
-  vintages (3.26 vs 3.53) doubles the shell coverage without adding any, and keeps a CDN
-  dependency the source zip on sqlite.org makes unnecessary.
-- **Commit the built `.wasm` artifacts** — violates ADR-9, and at ~11 MB would bloat the
-  repository for something reproducible in seconds.
-- **wasi-sdk/clang instead of zig** — works, but wasi-sdk is a versioned SDK tarball to
-  install and point at, while zig is a single brew-installable binary with the wasi
-  sysroot built in; zig also matches how the artifact was first validated.
+- **Keep the wasmer-CDN binary and add a library build beside it** — two SQLites of two vintages (3.26 vs 3.53) doubles the shell coverage without adding any, and keeps a CDN dependency the source zip on sqlite.org makes unnecessary.
+- **Commit the built `.wasm` artifacts** — violates ADR-9, and at ~11 MB would bloat the repository for something reproducible in seconds.
+- **wasi-sdk/clang instead of zig** — works, but wasi-sdk is a versioned SDK tarball to install and point at, while zig is a single brew-installable binary with the wasi sysroot built in; zig also matches how the artifact was first validated.
 
 ## Consequences
 
-- Positive: the north star's last technical unknown is gone — the C API round-trip
-  (open/exec/prepare/step/column_text/finalize/close, in-memory DB) runs in pure Ruby in the
-  always-on gate (~3 s). SQLite is current (3.53.3) and its build flags are ours to change
-  (e.g. `SQLITE_OMIT_LOAD_EXTENSION`, future VFS experiments).
-- Negative / carry-over: one more tool in `fetch.sh`'s requirements; the golden for the shell
-  changed shape (batch-mode output — the 3.26 wasmer build printed interactive prompts).
-  `sqlite3_exec`-style function-pointer callbacks were unexercised by the two original
-  artifacts (the prepare/step flow avoids them); the Phase 5a `sqlite3-binding.wasm` artifact
-  now covers exactly that guest→host callback path.
+- Positive: the north star's last technical unknown is gone — the C API round-trip (open/exec/prepare/step/column_text/finalize/close, in-memory DB) runs in pure Ruby in the always-on gate (~3 s). SQLite is current (3.53.3) and its build flags are ours to change (e.g. `SQLITE_OMIT_LOAD_EXTENSION`, future VFS experiments).
+- Negative / carry-over: one more tool in `fetch.sh`'s requirements; the golden for the shell changed shape (batch-mode output — the 3.26 wasmer build printed interactive prompts). `sqlite3_exec`-style function-pointer callbacks were unexercised by the two original artifacts (the prepare/step flow avoids them); the Phase 5a `sqlite3-binding.wasm` artifact now covers exactly that guest→host callback path.
 
-See also: [ADR-9](9-example-apps-from-registry.md) (the fetch policy this extends),
-[ADR-15](15-tests-fail-not-skip.md) (fail-loud tooling), [ADR-16](16-ruby-wasm1-completion.md)
-(the `invoke`/`memory` surface the C API glue drives).
+See also: [ADR-9](9-example-apps-from-registry.md) (the fetch policy this extends), [ADR-15](15-tests-fail-not-skip.md) (fail-loud tooling), [ADR-16](16-ruby-wasm1-completion.md) (the `invoke`/`memory` surface the C API glue drives).

--- a/docs/adr/23-backend-support-tiers.md
+++ b/docs/adr/23-backend-support-tiers.md
@@ -1,132 +1,40 @@
 # ADR-23 — Backend Support Tiers, Specialized to Wasm 1.0 + WASI Preview 1
 
-Status: **Superseded by [ADR-25](25-retire-support-tiers.md), 2026-07-26.**
-Originally accepted 2026-07-24 and implemented as described below; kept
-here as history of the tier ladder's design and rationale. ADR-25 removes
-`Tier` and everything derived from it.
+Status: **Superseded by [ADR-25](25-retire-support-tiers.md), 2026-07-26.** Originally accepted 2026-07-24 and implemented as described below; kept here as history of the tier ladder's design and rationale. ADR-25 removes `Tier` and everything derived from it.
 
 ## Context
 
-`Feature` (ADR-8) is a flat matrix: 20 rows, each `Supported`/`Partial`/
-`Unsupported` per backend. It has no vocabulary for "how far along is
-this backend overall" — Ruby and Bash's actual standing had to be
-reconstructed by eyeballing the table. As more backends are added (Java+C#
-per ADR-10, then Go/Python/PHP), each needs a stated goal a reviewer can
-check against, in the way Zig's platform support tiers
-(https://ziglang.org/learn/platform-support/) let a target's status be
-read off a ladder instead of a feature-by-feature diff.
+`Feature` (ADR-8) is a flat matrix: 20 rows, each `Supported`/`Partial`/ `Unsupported` per backend. It has no vocabulary for "how far along is this backend overall" — Ruby and Bash's actual standing had to be reconstructed by eyeballing the table. As more backends are added (Java+C# per ADR-10, then Go/Python/PHP), each needs a stated goal a reviewer can check against, in the way Zig's platform support tiers (https://ziglang.org/learn/platform-support/) let a target's status be read off a ladder instead of a feature-by-feature diff.
 
-The natural single-number ladder only holds together if it covers a scope
-every wasm binary can be measured against. Wasm 2.0+ proposals (reference
-types, tail calls, GC, SIMD, threads, ...) and the component model /
-WASI preview 2 do not qualify: adoption is concentrated in the Bytecode
-Alliance ecosystem and still churning (WASI 0.3 is next), while the
-common case — what Zig, Go, and most existing wasm binaries actually
-emit — is wasm 1.0 plus WASI preview 1, a frozen ABI. A ladder built to
-include CM would either force every future backend toward a
-speculative target or make Tier 1 a moving one.
+The natural single-number ladder only holds together if it covers a scope every wasm binary can be measured against. Wasm 2.0+ proposals (reference types, tail calls, GC, SIMD, threads, ...) and the component model / WASI preview 2 do not qualify: adoption is concentrated in the Bytecode Alliance ecosystem and still churning (WASI 0.3 is next), while the common case — what Zig, Go, and most existing wasm binaries actually emit — is wasm 1.0 plus WASI preview 1, a frozen ABI. A ladder built to include CM would either force every future backend toward a speculative target or make Tier 1 a moving one.
 
 ## Decision
 
-**The tier ladder covers wasm 1.0 + WASI p1 only**, best-first
-(`Tier::ALL`, `crates/dewasm-backend/src/tier.rs`):
+**The tier ladder covers wasm 1.0 + WASI p1 only**, best-first (`Tier::ALL`, `crates/dewasm-backend/src/tier.rs`):
 
-- **Tier 1 (Full)** — wasm 1.0 handled completely (imported
-  globals/memories/tables + floats all `Supported`) and WASI p1 handled
-  completely short of the out-of-scope surface: `sock_accept/recv/send/
-  shutdown` and `proc_raise` (wasmtime itself leaves these
-  unimplemented; no toolchain output exercises them). Also requires the
-  spec harness's `EXPECTED_FAILURES` ledger to hold no wasm-1.0-
-  attributable entries (`Backend::wasm10_ledger_clean`; e.g. Ruby's
-  `import-limits` tag, ADR-16, blocks Tier 1 today).
-- **Tier 2 (Production)** — wasm 1.0 imports complete, plus the WASI p1
-  filesystem functions (`path_open` and friends, 14 total). The standard
-  goal for new backends (`Backend::target_tier`'s default): the scope a
-  major toolchain's typical CLI/library output needs.
-- **Tier 3 (Core)** — a single wasm 1.0 module with function-only
-  imports, plus the 16-function WASI p1 core (args/environ/clock/fd
-  read-write-seek-close/proc_exit/random/sched_yield). Self-contained CLI
-  tools live here.
-- **Tier 4 (Experimental)** — wired into the spec harness
-  (`SpecLang`/`achieved_tier` observes pass/fail/skip) but outside the
-  default gate. The starting point for a new backend.
+- **Tier 1 (Full)** — wasm 1.0 handled completely (imported globals/memories/tables + floats all `Supported`) and WASI p1 handled completely short of the out-of-scope surface: `sock_accept/recv/send/ shutdown` and `proc_raise` (wasmtime itself leaves these unimplemented; no toolchain output exercises them). Also requires the spec harness's `EXPECTED_FAILURES` ledger to hold no wasm-1.0- attributable entries (`Backend::wasm10_ledger_clean`; e.g. Ruby's `import-limits` tag, ADR-16, blocks Tier 1 today).
+- **Tier 2 (Production)** — wasm 1.0 imports complete, plus the WASI p1 filesystem functions (`path_open` and friends, 14 total). The standard goal for new backends (`Backend::target_tier`'s default): the scope a major toolchain's typical CLI/library output needs.
+- **Tier 3 (Core)** — a single wasm 1.0 module with function-only imports, plus the 16-function WASI p1 core (args/environ/clock/fd read-write-seek-close/proc_exit/random/sched_yield). Self-contained CLI tools live here.
+- **Tier 4 (Experimental)** — wired into the spec harness (`SpecLang`/`achieved_tier` observes pass/fail/skip) but outside the default gate. The starting point for a new backend.
 
-Requirements are cumulative (Tier 2 implies Tier 3, etc.). Each
-`Feature`/WASI function names the tier whose requirements include it
-(`feature_tier`, and the `Option<Tier>` second element of
-`WASI_PREVIEW1_FUNCTIONS`); this mapping, not a restated table, is the
-source of truth — `docs/support.md`'s `## Tiers` and per-row `Tier`
-columns are generated from it.
+Requirements are cumulative (Tier 2 implies Tier 3, etc.). Each `Feature`/WASI function names the tier whose requirements include it (`feature_tier`, and the `Option<Tier>` second element of `WASI_PREVIEW1_FUNCTIONS`); this mapping, not a restated table, is the source of truth — `docs/support.md`'s `## Tiers` and per-row `Tier` columns are generated from it.
 
-**Everything outside wasm 1.0 + WASI p1 is an orthogonal extension
-badge**: the existing `Feature` rows for post-1.0 proposals and the
-component model (`is_extension`) stay exactly as ADR-8 defined them —
-per-backend opt-in, never affecting a tier. `MultipleTables`/
-`TableBulkOps` are wasm-2.0-adjacent bulk-memory-proposal features and
-sit on the badge side too, even though `ImportedGlobals/Memories/Tables`
-(true wasm 1.0) are tier-gated.
+**Everything outside wasm 1.0 + WASI p1 is an orthogonal extension badge**: the existing `Feature` rows for post-1.0 proposals and the component model (`is_extension`) stay exactly as ADR-8 defined them — per-backend opt-in, never affecting a tier. `MultipleTables`/ `TableBulkOps` are wasm-2.0-adjacent bulk-memory-proposal features and sit on the badge side too, even though `ImportedGlobals/Memories/Tables` (true wasm 1.0) are tier-gated.
 
-`tier_gaps`/`achieved_tier` only check what's statically knowable from a
-backend's own declarations (feature status, `has_wasi_p1`, the ledger
-flag); the dynamic half — the spec sweep actually passing, e2e cases
-actually passing — is enforced by the test suite itself, the same split
-ADR-8 already draws between declaration and enforcement. `target_tier`
-is a second, independent declaration (what the backend *aims* for, not
-what it has reached) so the generated docs can show both.
+`tier_gaps`/`achieved_tier` only check what's statically knowable from a backend's own declarations (feature status, `has_wasi_p1`, the ledger flag); the dynamic half — the spec sweep actually passing, e2e cases actually passing — is enforced by the test suite itself, the same split ADR-8 already draws between declaration and enforcement. `target_tier` is a second, independent declaration (what the backend *aims* for, not what it has reached) so the generated docs can show both.
 
-The shared e2e case tables (`StandaloneCase`/`LibraryCase`/`AppCase`)
-carry a `tier` field; a case only runs for a language whose
-`achieved_tier` meets it (`tier_ok`), printing a skip line rather than
-failing — a declared-tier gap, not an ADR-15 missing-tool failure. Every
-case in the suite today only needs Tier 3, confirmed by re-running each
-under Bash before assigning tiers (including `sqlite3-shell`, which
-looked filesystem-heavy but uses no db-file argument). Component-model
-e2e is gated on the `ComponentModel` badge directly
-(`require_component_model_badge` in `component.rs`), not a tier — the
-precedent for badge-gated cases once one exists.
+The shared e2e case tables (`StandaloneCase`/`LibraryCase`/`AppCase`) carry a `tier` field; a case only runs for a language whose `achieved_tier` meets it (`tier_ok`), printing a skip line rather than failing — a declared-tier gap, not an ADR-15 missing-tool failure. Every case in the suite today only needs Tier 3, confirmed by re-running each under Bash before assigning tiers (including `sqlite3-shell`, which looked filesystem-heavy but uses no db-file argument). Component-model e2e is gated on the `ComponentModel` badge directly (`require_component_model_badge` in `component.rs`), not a tier — the precedent for badge-gated cases once one exists.
 
 ## Rejected alternatives
 
-- **Include wasm 2.0+/CM in the ladder** (e.g. Tier 1 = "every feature
-  dewasmify tracks, including CM"). Rejected: ties Tier 1 to WASI 0.3
-  churn and to proposals with genuinely uncertain adoption outside the
-  Bytecode Alliance ecosystem, and would implicitly commit every future
-  backend to a CM port to reach the top tier.
-- **A second, orthogonal WASI-support axis** instead of folding WASI p1
-  into the same ladder as wasm-core features. Rejected: a backend's wasm-
-  core completeness and its WASI completeness move together in practice
-  (Ruby's ADR-16 work touched both), and two axes would need a
-  combination rule to answer "what tier is this backend" anyway — one
-  ladder with WASI folded in is more direct and matches ADR-8's existing
-  practice of listing WASI p1 alongside the `Feature` rows.
-- **Ascending, cumulative-milestone numbering** (Tier N ⊇ Tier N-1, 1 =
-  weakest) instead of Zig's descending best-first convention. Rejected
-  per explicit user preference for the Zig framing users may already
-  recognize.
+- **Include wasm 2.0+/CM in the ladder** (e.g. Tier 1 = "every feature dewasmify tracks, including CM"). Rejected: ties Tier 1 to WASI 0.3 churn and to proposals with genuinely uncertain adoption outside the Bytecode Alliance ecosystem, and would implicitly commit every future backend to a CM port to reach the top tier.
+- **A second, orthogonal WASI-support axis** instead of folding WASI p1 into the same ladder as wasm-core features. Rejected: a backend's wasm- core completeness and its WASI completeness move together in practice (Ruby's ADR-16 work touched both), and two axes would need a combination rule to answer "what tier is this backend" anyway — one ladder with WASI folded in is more direct and matches ADR-8's existing practice of listing WASI p1 alongside the `Feature` rows.
+- **Ascending, cumulative-milestone numbering** (Tier N ⊇ Tier N-1, 1 = weakest) instead of Zig's descending best-first convention. Rejected per explicit user preference for the Zig framing users may already recognize.
 
 ## Consequences
 
-- Positive: `achieved_tier(backend)` and `target_tier(backend)` give a
-  one-line answer to "how far along is this backend" (currently ruby =
-  Tier 2 targeting Tier 1; bash = Tier 3, its settled target — the
-  north-star use case, running self-contained C/Rust CLI tools, is met
-  there). New backends have a concrete, checkable Tier 2 checklist
-  instead of copying Ruby's full feature set.
-- Positive: e2e cases self-describe their requirement instead of being
-  hand-gated per language; a future language automatically inherits every
-  case its tier covers.
-- Negative / caveats: `wasm10_ledger_clean` is a second place (besides
-  the harness's `EXPECTED_FAILURES`) that must be updated when a ledger
-  entry is cleared — it can drift stale (falsely `false`, which only
-  under-states a tier, never over-states one, so the failure mode is
-  safe but requires remembering to flip it). Tier 1 for Ruby remains
-  unreached: 12 WASI p1 functions (`fd_advise`/`allocate`/`fdstat_set_*`/
-  `renumber`, `poll_oneoff`, `path_link`/`readlink`/`symlink`,
-  `fd_filestat_set_times`/`path_filestat_set_times`) and the
-  `import-limits` ledger are the remaining gap.
+- Positive: `achieved_tier(backend)` and `target_tier(backend)` give a one-line answer to "how far along is this backend" (currently ruby = Tier 2 targeting Tier 1; bash = Tier 3, its settled target — the north-star use case, running self-contained C/Rust CLI tools, is met there). New backends have a concrete, checkable Tier 2 checklist instead of copying Ruby's full feature set.
+- Positive: e2e cases self-describe their requirement instead of being hand-gated per language; a future language automatically inherits every case its tier covers.
+- Negative / caveats: `wasm10_ledger_clean` is a second place (besides the harness's `EXPECTED_FAILURES`) that must be updated when a ledger entry is cleared — it can drift stale (falsely `false`, which only under-states a tier, never over-states one, so the failure mode is safe but requires remembering to flip it). Tier 1 for Ruby remains unreached: 12 WASI p1 functions (`fd_advise`/`allocate`/`fdstat_set_*`/ `renumber`, `poll_oneoff`, `path_link`/`readlink`/`symlink`, `fd_filestat_set_times`/`path_filestat_set_times`) and the `import-limits` ledger are the remaining gap.
 
-See also: [ADR-8](8-latest-testsuite-support-matrix.md) (the `Feature`
-matrix and attribution this builds on), [ADR-15](15-tests-fail-not-skip.md)
-(the fail-loud policy tier skips deliberately don't fall under),
-[ADR-16](16-ruby-wasm1-completion.md) (the `import-limits` ledger gap
-blocking Ruby's Tier 1).
+See also: [ADR-8](8-latest-testsuite-support-matrix.md) (the `Feature` matrix and attribution this builds on), [ADR-15](15-tests-fail-not-skip.md) (the fail-loud policy tier skips deliberately don't fall under), [ADR-16](16-ruby-wasm1-completion.md) (the `import-limits` ledger gap blocking Ruby's Tier 1).

--- a/docs/adr/24-01-scope-reset.md
+++ b/docs/adr/24-01-scope-reset.md
@@ -1,105 +1,34 @@
 # ADR-24 — 0.1 Scope Reset: Wasm 1.0 + WASI Preview 1 Only, App-Driven Goals
 
-Status: **Accepted, 2026-07-25.** The feature-audit tool
-(`crates/dewasm-core/src/bin/feature-audit.rs`) and the excision have
-landed: reference types, tail calls, exception handling, the component
-model, and WASI preview 2 are removed from the IR, backends, runtime
-units, harness, and docs, and their inputs are rejected at conversion time
-with attributed errors. The tier ladder's retirement and the rename land
-next ([ADR-25](25-retire-support-tiers.md)). Supersedes
-[ADR-17](17-ruby-reference-types.md), [ADR-18](18-ruby-tail-calls.md),
-[ADR-19](19-ruby-exception-handling.md),
-[ADR-20](20-component-model-core-ir-adapters.md),
-[ADR-21](21-ruby-wasi-preview2.md); revises the target-language plan of
-[ADR-10](10-csharp-target.md).
+Status: **Accepted, 2026-07-25.** The feature-audit tool (`crates/dewasm-core/src/bin/feature-audit.rs`) and the excision have landed: reference types, tail calls, exception handling, the component model, and WASI preview 2 are removed from the IR, backends, runtime units, harness, and docs, and their inputs are rejected at conversion time with attributed errors. The tier ladder's retirement and the rename land next ([ADR-25](25-retire-support-tiers.md)). Supersedes [ADR-17](17-ruby-reference-types.md), [ADR-18](18-ruby-tail-calls.md), [ADR-19](19-ruby-exception-handling.md), [ADR-20](20-component-model-core-ir-adapters.md), [ADR-21](21-ruby-wasi-preview2.md); revises the target-language plan of [ADR-10](10-csharp-target.md).
 
 ## Context
 
-Right after completing wasm 1.0 for Ruby (ADR-16), the project extended
-the Ruby backend to reference types, tail calls, exception handling
-(ADRs 17–19) and the component model + WASI preview 2 (ADRs 20–21) in a
-single sprint. A retrospective found the project harder to see whole:
-the input surface had grown faster than the number of backends able to
-carry it, goals were phrased as spec coverage rather than as programs
-users can convert, and every IR construct added is a construct all
-future backends must either lower or reject. Meanwhile the planned 0.1
-apps and backends (below) need none of the post-1.0 features.
+Right after completing wasm 1.0 for Ruby (ADR-16), the project extended the Ruby backend to reference types, tail calls, exception handling (ADRs 17–19) and the component model + WASI preview 2 (ADRs 20–21) in a single sprint. A retrospective found the project harder to see whole: the input surface had grown faster than the number of backends able to carry it, goals were phrased as spec coverage rather than as programs users can convert, and every IR construct added is a construct all future backends must either lower or reject. Meanwhile the planned 0.1 apps and backends (below) need none of the post-1.0 features.
 
 ## Decision
 
-For the 0.1 release, the accepted input is **wasm 1.0 + WASI preview 1**,
-where "wasm 1.0" means the MVP plus the universally-emitted baseline
-(sign extension, saturating float-to-int, multi-value, bulk memory,
-mutable globals) and the ADR-16 completion set (non-function imports,
-multiple tables, table bulk ops). Everything else — reference types,
-tail calls, exception handling, the component model, WASI preview 2,
-and all unimplemented proposals — is **removed from the code**, not
-frozen: IR variants, lowering, feature gates, runtime units, harness
-support, and docs rows all go. Unsupported input keeps failing at
-conversion time with a clear error (ADR-0).
+For the 0.1 release, the accepted input is **wasm 1.0 + WASI preview 1**, where "wasm 1.0" means the MVP plus the universally-emitted baseline (sign extension, saturating float-to-int, multi-value, bulk memory, mutable globals) and the ADR-16 completion set (non-function imports, multiple tables, table bulk ops). Everything else — reference types, tail calls, exception handling, the component model, WASI preview 2, and all unimplemented proposals — is **removed from the code**, not frozen: IR variants, lowering, feature gates, runtime units, harness support, and docs rows all go. Unsupported input keeps failing at conversion time with a clear error (ADR-0).
 
-One validator-level nuance, found by the app audit
-(`docs/apps-audit.md`): LLVM-based toolchains encode `call_indirect`
-immediates as overlong LEBs when the reference-types *target feature*
-is on (their default), so real wasip1 binaries — including the already
-shipping qjs and sqlite3 — only validate with the reference-types
-feature bit enabled. The bit therefore stays on in
-`dewasm-core::module::features()` as a pure **encoding relaxation**;
-every actual reference-types construct (externref, table instructions,
-`ref.*`, non-zero table indices) is rejected during IR building with
-the usual attributed error.
+One validator-level nuance, found by the app audit (`docs/apps-audit.md`): LLVM-based toolchains encode `call_indirect` immediates as overlong LEBs when the reference-types *target feature* is on (their default), so real wasip1 binaries — including the already shipping qjs and sqlite3 — only validate with the reference-types feature bit enabled. The bit therefore stays on in `dewasm-core::module::features()` as a pure **encoding relaxation**; every actual reference-types construct (externref, table instructions, `ref.*`, non-zero table indices) is rejected during IR building with the usual attributed error.
 
-The discriminating criterion: **a feature stays only if a pinned target
-app needs it or every 0.1 backend is expected to implement it.** Code
-kept "just in case" is code paid for in every exhaustive match, every
-new backend, and every reader; git history plus ADRs 17–21 (kept as
-design records) make restoration cheap if the need returns.
+The discriminating criterion: **a feature stays only if a pinned target app needs it or every 0.1 backend is expected to implement it.** Code kept "just in case" is code paid for in every exhaustive match, every new backend, and every reader; git history plus ADRs 17–21 (kept as design records) make restoration cheap if the need returns.
 
-Goals are stated app-first; the spec testsuite remains the correctness
-gate (ADR-3), not the goal. 0.1 targets: cowsay (backend bring-up),
-quickjs-ng (one-shot, script with file I/O, REPL), sqlite3 (shell and
-C-API library, DB files on disk, callback binding), ripgrep, a CPython
-or CRuby runtime binary, and a compression CLI. A **feature audit**
-(conversion-time feature report over each pinned binary) runs before
-the excision; an app that needs a dropped feature is deferred with a
-written note in `docs/apps-audit.md` — it does not block the excision.
-pandoc.wasm is the expected first deferral (GHC's wasm backend is
-believed to emit tail calls; to be confirmed by the audit).
+Goals are stated app-first; the spec testsuite remains the correctness gate (ADR-3), not the goal. 0.1 targets: cowsay (backend bring-up), quickjs-ng (one-shot, script with file I/O, REPL), sqlite3 (shell and C-API library, DB files on disk, callback binding), ripgrep, a CPython or CRuby runtime binary, and a compression CLI. A **feature audit** (conversion-time feature report over each pinned binary) runs before the excision; an app that needs a dropped feature is deferred with a written note in `docs/apps-audit.md` — it does not block the excision. pandoc.wasm is the expected first deferral (GHC's wasm backend is believed to emit tail calls; to be confirmed by the audit).
 
-0.1 backends: Ruby and Bash (existing) plus **Python, Go, Java**. Each
-new backend's first milestone is "cowsay runs"; its 0.1 bar is
-spec-green plus full WASI p1 including the filesystem. If the schedule
-demands, the release may relax to "Python at the full bar; Go/Java at
-the cowsay milestone" — that call is made at release time, not now.
+0.1 backends: Ruby and Bash (existing) plus **Python, Go, Java**. Each new backend's first milestone is "cowsay runs"; its 0.1 bar is spec-green plus full WASI p1 including the filesystem. If the schedule demands, the release may relax to "Python at the full bar; Go/Java at the cowsay milestone" — that call is made at release time, not now.
 
-Future work recorded, deliberately out of 0.1 scope: restoring wasm
-2.0+ support, wasix and partial emscripten-runtime import surfaces as
-possible additional input dialects, and Haskell/OCaml (and C#, per the
-ADR-10 revision) as later target languages.
+Future work recorded, deliberately out of 0.1 scope: restoring wasm 2.0+ support, wasix and partial emscripten-runtime import surfaces as possible additional input dialects, and Haskell/OCaml (and C#, per the ADR-10 revision) as later target languages.
 
 ## Rejected alternatives
 
-- **Freeze instead of delete** (keep the code, restrict new work to 1.0)
-  — dormant variants still appear in every exhaustive match, every
-  harness tag, and the support matrix; the visible surface is what made
-  the project hard to see. Deletion is the only option that shrinks it.
-- **Keep Ruby's 2.0+ support as badges** — it is tested, working code,
-  and removing it costs real churn. Lost to the criterion above: no
-  pinned app needs it, no other 0.1 backend will implement it, and a
-  five-backend project whose backends accept different inputs
-  reintroduces exactly the asymmetry ADR-23 tried to manage.
-- **Spec-coverage goals** — coverage numbers do not answer "what can I
-  convert?"; apps do, and each app pins an exact WASI surface to
-  implement. The spec suite stays as the gate underneath.
+- **Freeze instead of delete** (keep the code, restrict new work to 1.0) — dormant variants still appear in every exhaustive match, every harness tag, and the support matrix; the visible surface is what made the project hard to see. Deletion is the only option that shrinks it.
+- **Keep Ruby's 2.0+ support as badges** — it is tested, working code, and removing it costs real churn. Lost to the criterion above: no pinned app needs it, no other 0.1 backend will implement it, and a five-backend project whose backends accept different inputs reintroduces exactly the asymmetry ADR-23 tried to manage.
+- **Spec-coverage goals** — coverage numbers do not answer "what can I convert?"; apps do, and each app pins an exact WASI surface to implement. The spec suite stays as the gate underneath.
 
 ## Consequences
 
-- Positive: one input dialect shared by all five 0.1 backends; the IR
-  a new backend must lower shrinks; goals become demos a user can run.
-- Negative: working, spec-green Ruby code for ADRs 17–21 is deleted
-  (~4k LOC + 37 runtime units); pandoc is likely deferred; users with
-  2.0+ binaries are turned away at conversion time.
-- Carry-over: ADRs 17–21 stay in the tree as Superseded design records
-  for a future restoration; the excision commit flips their statuses.
-- The tier ladder loses its reason to exist once every backend targets
-  the same bar — retired separately in [ADR-25](25-retire-support-tiers.md).
+- Positive: one input dialect shared by all five 0.1 backends; the IR a new backend must lower shrinks; goals become demos a user can run.
+- Negative: working, spec-green Ruby code for ADRs 17–21 is deleted (~4k LOC + 37 runtime units); pandoc is likely deferred; users with 2.0+ binaries are turned away at conversion time.
+- Carry-over: ADRs 17–21 stay in the tree as Superseded design records for a future restoration; the excision commit flips their statuses.
+- The tier ladder loses its reason to exist once every backend targets the same bar — retired separately in [ADR-25](25-retire-support-tiers.md).

--- a/docs/adr/25-retire-support-tiers.md
+++ b/docs/adr/25-retire-support-tiers.md
@@ -1,54 +1,24 @@
 # ADR-25 — Retire the Support-Tier Ladder for Plain Capability Declarations
 
-Status: **Accepted, 2026-07-25.** The removal of `Tier` and its
-derivation functions (`crates/dewasm-backend/src/tier.rs`),
-`Backend::target_tier`, and tier gating on the e2e case tables has
-landed; `docs/support.md` now renders a flat `## Features` table (the
-in-scope subset) plus the `## WASI preview 1` table. Supersedes
-[ADR-23](23-backend-support-tiers.md).
+Status: **Accepted, 2026-07-25.** The removal of `Tier` and its derivation functions (`crates/dewasm-backend/src/tier.rs`), `Backend::target_tier`, and tier gating on the e2e case tables has landed; `docs/support.md` now renders a flat `## Features` table (the in-scope subset) plus the `## WASI preview 1` table. Supersedes [ADR-23](23-backend-support-tiers.md).
 
 ## Context
 
-ADR-23 introduced a Zig-style Tier 1–4 ladder over wasm 1.0 + WASI p1,
-one day before ADR-24 cut the input scope to exactly that surface and
-set the same bar — spec-green + full WASI p1 — for every 0.1 backend.
-With the 2.0+/CM badges gone and all backends aiming at one bar, the
-ladder degenerates: Tiers 1–2 differ only by a ledger flag and twelve
-WASI functions, and Tier 3 is just "filesystem not done yet".
+ADR-23 introduced a Zig-style Tier 1–4 ladder over wasm 1.0 + WASI p1, one day before ADR-24 cut the input scope to exactly that surface and set the same bar — spec-green + full WASI p1 — for every 0.1 backend. With the 2.0+/CM badges gone and all backends aiming at one bar, the ladder degenerates: Tiers 1–2 differ only by a ledger flag and twelve WASI functions, and Tier 3 is just "filesystem not done yet".
 
 ## Decision
 
-Retire the ladder. Backends declare capabilities directly — feature
-support (`Backend::feature_status`) and per-function WASI p1 coverage
-(`Backend::has_wasi_p1`, derived from runtime units) — and
-`docs/support.md` renders those declarations flat (features table +
-WASI p1 table, keeping the in-scope/out-of-scope distinction for the
-socket surface). E2e coverage is expressed by which suites a backend
-crate wires up (ADR-27), not by comparing tier numbers. `Tier`,
-`target_tier`, `achieved_tier`, and the tier gating in the e2e case
-tables are deleted.
+Retire the ladder. Backends declare capabilities directly — feature support (`Backend::feature_status`) and per-function WASI p1 coverage (`Backend::has_wasi_p1`, derived from runtime units) — and `docs/support.md` renders those declarations flat (features table + WASI p1 table, keeping the in-scope/out-of-scope distinction for the socket surface). E2e coverage is expressed by which suites a backend crate wires up (ADR-27), not by comparing tier numbers. `Tier`, `target_tier`, `achieved_tier`, and the tier gating in the e2e case tables are deleted.
 
-Criterion: **a ranking earns its keep only while it discriminates.**
-When every backend targets the same bar, "which capabilities are done"
-is the whole truth and a scalar summary of it is noise. Whether some
-summary scale is worth reintroducing is explicitly deferred until the
-Python/Go/Java backends exist and show what actually varies.
+Criterion: **a ranking earns its keep only while it discriminates.** When every backend targets the same bar, "which capabilities are done" is the whole truth and a scalar summary of it is noise. Whether some summary scale is worth reintroducing is explicitly deferred until the Python/Go/Java backends exist and show what actually varies.
 
 ## Rejected alternatives
 
-- **Keep the ladder** — collapses as described; also forces every new
-  test case to be tier-classified, which ADR-23's own experience showed
-  goes wrong when done by guesswork instead of execution.
-- **A numeric coverage score** (e.g. "38/42 WASI functions") — false
-  precision; the per-function table already says exactly this without
-  pretending the functions are fungible.
+- **Keep the ladder** — collapses as described; also forces every new test case to be tier-classified, which ADR-23's own experience showed goes wrong when done by guesswork instead of execution.
+- **A numeric coverage score** (e.g. "38/42 WASI functions") — false precision; the per-function table already says exactly this without pretending the functions are fungible.
 
 ## Consequences
 
-- Positive: one less taxonomy to keep truthful; new-backend authors
-  read a checklist, not a ladder spec.
-- Negative: README/support.md lose a one-glance maturity summary;
-  "production-ready?" now takes reading two tables.
-- Carry-over: the ADR-23 lesson that support claims must be verified by
-  execution before being declared survives in the support.md golden
-  gate and the harness.
+- Positive: one less taxonomy to keep truthful; new-backend authors read a checklist, not a ladder spec.
+- Negative: README/support.md lose a one-glance maturity summary; "production-ready?" now takes reading two tables.
+- Carry-over: the ADR-23 lesson that support claims must be verified by execution before being declared survives in the support.md golden gate and the harness.

--- a/docs/adr/26-rename-dewasm.md
+++ b/docs/adr/26-rename-dewasm.md
@@ -1,51 +1,26 @@
 # ADR-26 — Rename the Project: dewasmify → dewasm
 
-Status: **Accepted, 2026-07-25; fully landed 2026-07-28.** Landed
-2026-07-26: crates are `dewasm-*`, the binary is `dewasm`, env vars are
-`DEWASM_*`, and docs are swept (superseded ADR bodies keep the
-historical name). The GitHub repository itself now lives at
-`github.com/dewasm/dewasm` (commit ae2b430). Amends the naming note in
-[ADR-0](0-foundation.md).
+Status: **Accepted, 2026-07-25; fully landed 2026-07-28.** Landed 2026-07-26: crates are `dewasm-*`, the binary is `dewasm`, env vars are `DEWASM_*`, and docs are swept (superseded ADR bodies keep the historical name). The GitHub repository itself now lives at `github.com/dewasm/dewasm` (commit ae2b430). Amends the naming note in [ADR-0](0-foundation.md).
 
 ## Context
 
-ADR-0 named the project `dewasmify` ("strips the wasm out"). In use,
-the name is four syllables and awkward to say; the `-ify` suffix adds
-no meaning that `de-` doesn't already carry. A rename only gets more
-expensive: after 0.1 the name is in release artifacts, user scripts,
-and (potentially) crates.io.
+ADR-0 named the project `dewasmify` ("strips the wasm out"). In use, the name is four syllables and awkward to say; the `-ify` suffix adds no meaning that `de-` doesn't already carry. A rename only gets more expensive: after 0.1 the name is in release artifacts, user scripts, and (potentially) crates.io.
 
-Availability was checked on 2026-07-25: no `dewasm` crate exists on
-crates.io (the API returns 404), and a GitHub repository search finds
-no project of that name (only unrelated personal accounts).
+Availability was checked on 2026-07-25: no `dewasm` crate exists on crates.io (the API returns 404), and a GitHub repository search finds no project of that name (only unrelated personal accounts).
 
 ## Decision
 
-Rename to **`dewasm`** everywhere at once, before 0.1: repository,
-crate names (`dewasm-core`, `dewasm-backend`, `dewasm-backend-<lang>`,
-`dewasm-cli`), the binary (`dewasm`), and the env-var prefix
-(`DEWASM_*` for `DEWASM_SPEC`, `DEWASM_SPEC_ALL`, `DEWASM_APPS_ALL`,
-`DEWASM_UPDATE_DOCS`, `DEWASM_BASH`). Criterion: **the last cheap
-moment to rename is before the first release**; a name that will be
-typed for years should be short and pronounceable, and this one is
-verified free.
+Rename to **`dewasm`** everywhere at once, before 0.1: repository, crate names (`dewasm-core`, `dewasm-backend`, `dewasm-backend-<lang>`, `dewasm-cli`), the binary (`dewasm`), and the env-var prefix (`DEWASM_*` for `DEWASM_SPEC`, `DEWASM_SPEC_ALL`, `DEWASM_APPS_ALL`, `DEWASM_UPDATE_DOCS`, `DEWASM_BASH`). Criterion: **the last cheap moment to rename is before the first release**; a name that will be typed for years should be short and pronounceable, and this one is verified free.
 
-Reserving the crates.io name with an early publish is recommended at
-release time (the 0.1 checklist owns that call).
+Reserving the crates.io name with an early publish is recommended at release time (the 0.1 checklist owns that call).
 
 ## Rejected alternatives
 
-- **Keep `dewasmify`** — avoids one churn commit, but the friction is
-  paid on every future mention of the project.
-- **Rename after 0.1** — strictly more expensive: released artifacts,
-  tags, and external references would then also need aliases.
+- **Keep `dewasmify`** — avoids one churn commit, but the friction is paid on every future mention of the project.
+- **Rename after 0.1** — strictly more expensive: released artifacts, tags, and external references would then also need aliases.
 
 ## Consequences
 
-- Positive: shorter name, free on crates.io, single flag-day commit
-  while there are no external users.
-- Negative: one wide, though purely mechanical, diff; historical ADR
-  prose refers to the old name until the rename commit sweeps it
-  (superseded ADRs keep reading coherently — same project).
-- The rename commit must contain no behavior changes so it reviews as
-  a pure diff of names.
+- Positive: shorter name, free on crates.io, single flag-day commit while there are no external users.
+- Negative: one wide, though purely mechanical, diff; historical ADR prose refers to the old name until the rename commit sweeps it (superseded ADRs keep reading coherently — same project).
+- The rename commit must contain no behavior changes so it reviews as a pure diff of names.

--- a/docs/adr/27-test-helper-crate.md
+++ b/docs/adr/27-test-helper-crate.md
@@ -1,254 +1,72 @@
 # ADR-27 — Shared Test-Helper Crate with Per-Feature Test Macros
 
-Status: **Accepted, 2026-07-25; landed 2026-07-26.** The
-`dewasm-test-helper` crate and the two-layer `BackendUnderTest` /
-`SpecBackend` traits, shared case tables, and per-feature macros
-(`spec_suite!`, `standalone_e2e!`, `library_e2e!`, `wasi_suite!`,
-`apps_e2e!`, `gzip_e2e!`, `fs_apps_e2e!`) are in place; each backend crate
-owns its spec and e2e suites, `dewasm-cli` keeps only the `support_docs`
-cross-backend gate, and wasmtime is itself wired as a `BackendUnderTest`
-(`apps_wasmtime`) running the `apps`/`gzip`/`fs_apps` golden-freshness
-checks through the same shared runners. Builds on
-[ADR-3](3-testing-strategy.md) (the spec harness binds),
-[ADR-8](8-latest-testsuite-support-matrix.md) (skip attribution and
-per-file failure ledgers), and [ADR-15](15-tests-fail-not-skip.md).
+Status: **Accepted, 2026-07-25; landed 2026-07-26.** The `dewasm-test-helper` crate and the two-layer `BackendUnderTest` / `SpecBackend` traits, shared case tables, and per-feature macros (`spec_suite!`, `standalone_e2e!`, `library_e2e!`, `wasi_suite!`, `apps_e2e!`, `gzip_e2e!`, `fs_apps_e2e!`) are in place; each backend crate owns its spec and e2e suites, `dewasm-cli` keeps only the `support_docs` cross-backend gate, and wasmtime is itself wired as a `BackendUnderTest` (`apps_wasmtime`) running the `apps`/`gzip`/`fs_apps` golden-freshness checks through the same shared runners. Builds on [ADR-3](3-testing-strategy.md) (the spec harness binds), [ADR-8](8-latest-testsuite-support-matrix.md) (skip attribution and per-file failure ledgers), and [ADR-15](15-tests-fail-not-skip.md).
 
 ## Context
 
-Nearly all tests live in the CLI crate — spec harness, e2e suites, app
-golden tests — because it is the one crate that depends on every
-backend. That placement means a backend's conformance suite is not in
-the backend's crate, adding a backend means editing the CLI's test
-tree, and the two ad-hoc abstractions that grew there (`SpecLang` with
-its script-phrasing `emit_*` surface; the thinner `E2eLang`) overlap
-without composing. With three more backends planned, the shape must be
-fixed first.
+Nearly all tests live in the CLI crate — spec harness, e2e suites, app golden tests — because it is the one crate that depends on every backend. That placement means a backend's conformance suite is not in the backend's crate, adding a backend means editing the CLI's test tree, and the two ad-hoc abstractions that grew there (`SpecLang` with its script-phrasing `emit_*` surface; the thinner `E2eLang`) overlap without composing. With three more backends planned, the shape must be fixed first.
 
 ## Decision
 
-Create **`dewasm-test-helper`**: a crate depending only on
-`dewasm-core` + `dewasm-backend` (never on concrete backend crates),
-used by each backend crate as a dev-dependency. It provides:
+Create **`dewasm-test-helper`**: a crate depending only on `dewasm-core` + `dewasm-backend` (never on concrete backend crates), used by each backend crate as a dev-dependency. It provides:
 
-- **A two-layer backend-under-test abstraction.** The base trait
-  (`BackendUnderTest`) is `name` / `backend` / `run(source, args,
-  stdin)`; `run`'s default implementation writes a temp file and execs
-  an interpreter, and compiled targets (Go, Java) override `run`
-  itself. The spec layer (`SpecBackend: BackendUnderTest`) carries the
-  script-phrasing surface, the per-file failure ledger, and the
-  curated-file list. Criterion for the split: **a backend must be able
-  to run app/e2e suites before it can phrase spec assertions** — the
-  "cowsay first" bring-up path of ADR-24 implements the base layer
-  only.
-- **Shared case tables without glue** (standalone, library, WASI,
-  apps). WASI cases are grouped per feature unit — stdio, args/env,
-  clock/random, filesystem — forming the project's own WASI p1
-  conformance suite, which matters because WASI has no official one.
-  Language-specific glue stays in the backend crate and is passed to
-  the runners.
-- **Per-feature test macros** (`spec_suite!`, `standalone_e2e!`,
-  `library_e2e!`, `wasi_suite!`, `apps_e2e!`) that expand to `#[test]`
-  functions iterating the shared tables, so a backend crate's
-  `tests/` declares exactly which suites it participates in — this
-  wiring replaces the retired tier gating (ADR-25).
+- **A two-layer backend-under-test abstraction.** The base trait (`BackendUnderTest`) is `name` / `backend` / `run(source, args, stdin)`; `run`'s default implementation writes a temp file and execs an interpreter, and compiled targets (Go, Java) override `run` itself. The spec layer (`SpecBackend: BackendUnderTest`) carries the script-phrasing surface, the per-file failure ledger, and the curated-file list. Criterion for the split: **a backend must be able to run app/e2e suites before it can phrase spec assertions** — the "cowsay first" bring-up path of ADR-24 implements the base layer only.
+- **Shared case tables without glue** (standalone, library, WASI, apps). WASI cases are grouped per feature unit — stdio, args/env, clock/random, filesystem — forming the project's own WASI p1 conformance suite, which matters because WASI has no official one. Language-specific glue stays in the backend crate and is passed to the runners.
+- **Per-feature test macros** (`spec_suite!`, `standalone_e2e!`, `library_e2e!`, `wasi_suite!`, `apps_e2e!`) that expand to `#[test]` functions iterating the shared tables, so a backend crate's `tests/` declares exactly which suites it participates in — this wiring replaces the retired tier gating (ADR-25).
 
-Backend-specific tests (units lint, softfloat oracle, Ruby-only
-scenarios) live in their backend crate as today. Tests that inherently
-need every backend — the `docs/support.md` golden gate and the
-golden-vs-wasmtime app check — stay in the CLI crate, which already
-depends on all backends. Rule: **a test lives with the one backend it
-exercises; only a test that needs every backend may live centrally.**
+Backend-specific tests (units lint, softfloat oracle, Ruby-only scenarios) live in their backend crate as today. Tests that inherently need every backend — the `docs/support.md` golden gate and the golden-vs-wasmtime app check — stay in the CLI crate, which already depends on all backends. Rule: **a test lives with the one backend it exercises; only a test that needs every backend may live centrally.**
 
 ## Rejected alternatives
 
-- **Keep tests in the CLI crate** — a new backend's conformance would
-  again be someone else's test tree; the CLI crate is a 100-line
-  binary, not the project's test host.
-- **One flat trait** — forces a pre-spec backend to stub a dozen
-  `emit_*` methods before its first cowsay run.
-- **test-helper depends on the backend crates** — inverts the
-  dependency so backends could no longer dev-depend on the helper.
-- **A dedicated conformance crate for the cross-backend tests** — an
-  extra crate for two tests; noted as the escape hatch if a third
-  appears.
+- **Keep tests in the CLI crate** — a new backend's conformance would again be someone else's test tree; the CLI crate is a 100-line binary, not the project's test host.
+- **One flat trait** — forces a pre-spec backend to stub a dozen `emit_*` methods before its first cowsay run.
+- **test-helper depends on the backend crates** — inverts the dependency so backends could no longer dev-depend on the helper.
+- **A dedicated conformance crate for the cross-backend tests** — an extra crate for two tests; noted as the escape hatch if a third appears.
 
 ## Consequences
 
-- Positive: backend bring-up is "implement the base trait, invoke
-  macros"; suites stay byte-identical across backends by construction.
-- Negative: macro indirection makes individual test names less
-  greppable; fixture paths must resolve from each consuming crate
-  (same `crates/<x>/` depth keeps `../../` valid).
-- The ADR-8 ledgers and attribution tags move with each backend's
-  `SpecBackend` impl — their natural home — and keep their semantics.
+- Positive: backend bring-up is "implement the base trait, invoke macros"; suites stay byte-identical across backends by construction.
+- Negative: macro indirection makes individual test names less greppable; fixture paths must resolve from each consuming crate (same `crates/<x>/` depth keeps `../../` valid).
+- The ADR-8 ledgers and attribution tags move with each backend's `SpecBackend` impl — their natural home — and keep their semantics.
 
 ## Revision (2026-07-27): backend e2e is impl + glue + macros only
 
-The original decision let "Ruby-only scenarios" (provider objects, embedded
-coexistence, cross-module table sharing, the sqlite3 C-API drive, WASI-model
-internals, and the CPython/CRuby runtime demos) stay as hand-written `#[test]`
-functions in the Ruby crate. That carve-out is **withdrawn**. The rule is now
-uniform:
+The original decision let "Ruby-only scenarios" (provider objects, embedded coexistence, cross-module table sharing, the sqlite3 C-API drive, WASI-model internals, and the CPython/CRuby runtime demos) stay as hand-written `#[test]` functions in the Ruby crate. That carve-out is **withdrawn**. The rule is now uniform:
 
-- **A backend crate's `tests/e2e.rs` contains only** the `BackendUnderTest`
-  impl, glue strings / glue-producing functions, and macro invocations. No
-  backend-specific `#[test]` function exists.
-- **Case content is always shared.** Every scenario's fixtures, expectations,
-  and run/assert logic live in a `dewasm-test-helper` table + runner. What a
-  backend supplies is per-language glue (and, for multi-module cases, a
-  `BackendUnderTest::compose_modules` implementation using its own crate's API —
-  the helper crate still may not depend on a concrete backend, so composition
-  is a trait hook, not shared code).
-- **Capability is declared by which macros a backend invokes**, refined by
-  **explicit data-level exclusions with reasons** where a macro is invoked but a
-  particular case is not expressible or not practical. Each shared table carries
-  an `exclude: &[(lang, reason)]` (or, for the fixed-shape multi-module/library
-  cases, a per-case exclusion list) that the runner prints and honors, instead
-  of a bespoke skipped test. Examples now in the tables: Go/Java/Bash excluded
-  from the provider-object and lazy-`@wasi` cases (eager WASI, no provider
-  object); Go/Bash excluded from in-memory stdio capture (no injectable stream);
-  the CPython/CRuby runtime demos excluded on Java (a generated method overflows
-  the JVM 64 KB bytecode limit — `code too large`) and CRuby also on Go (its
-  ~242 MB Go source exceeds the ADR-24 ~5-minute `go build` bar). These are
-  measured, not guessed (docs/apps-audit.md records the numbers).
+- **A backend crate's `tests/e2e.rs` contains only** the `BackendUnderTest` impl, glue strings / glue-producing functions, and macro invocations. No backend-specific `#[test]` function exists.
+- **Case content is always shared.** Every scenario's fixtures, expectations, and run/assert logic live in a `dewasm-test-helper` table + runner. What a backend supplies is per-language glue (and, for multi-module cases, a `BackendUnderTest::compose_modules` implementation using its own crate's API — the helper crate still may not depend on a concrete backend, so composition is a trait hook, not shared code).
+- **Capability is declared by which macros a backend invokes**, refined by **explicit data-level exclusions with reasons** where a macro is invoked but a particular case is not expressible or not practical. Each shared table carries an `exclude: &[(lang, reason)]` (or, for the fixed-shape multi-module/library cases, a per-case exclusion list) that the runner prints and honors, instead of a bespoke skipped test. Examples now in the tables: Go/Java/Bash excluded from the provider-object and lazy-`@wasi` cases (eager WASI, no provider object); Go/Bash excluded from in-memory stdio capture (no injectable stream); the CPython/CRuby runtime demos excluded on Java (a generated method overflows the JVM 64 KB bytecode limit — `code too large`) and CRuby also on Go (its ~242 MB Go source exceeds the ADR-24 ~5-minute `go build` bar). These are measured, not guessed (docs/apps-audit.md records the numbers).
 
-New shared tables/macros this introduced: `capi_apps_e2e!` (`CAPI_CASES`, the
-sqlite3 C-API drives — no wasmtime golden is possible, so each pins a fixed
-string), `multi_module_e2e!` (`MULTI_MODULE_CASES`, the shared-table and
-embedded-coexistence scenarios, via `compose_modules`), plus new rows in
-`LIBRARY_CASES` (provider/override/stdio), `WASI_CASES` (root-preopen
-containment), and `FS_APP_CASES` (the cache-preopened CPython/CRuby demos, a new
-`cache_preopens` field mounting stdlib trees straight from the app cache instead
-of copying them). The consequence is that a scenario added for one backend is by
-construction offered to every backend, green where the capability holds and
-documented where it does not.
+New shared tables/macros this introduced: `capi_apps_e2e!` (`CAPI_CASES`, the sqlite3 C-API drives — no wasmtime golden is possible, so each pins a fixed string), `multi_module_e2e!` (`MULTI_MODULE_CASES`, the shared-table and embedded-coexistence scenarios, via `compose_modules`), plus new rows in `LIBRARY_CASES` (provider/override/stdio), `WASI_CASES` (root-preopen containment), and `FS_APP_CASES` (the cache-preopened CPython/CRuby demos, a new `cache_preopens` field mounting stdlib trees straight from the app cache instead of copying them). The consequence is that a scenario added for one backend is by construction offered to every backend, green where the capability holds and documented where it does not.
 
 ## Revision (2026-07-27): glue is a named const, one per-case macro per case
 
-The *delivery* of per-language glue set up by the previous revision — glue
-resolver functions that `match` on the case name, and later `(case name, glue)`
-pair lists iterated by one macro — is **withdrawn** as unreadable and of no
-value: the case name appeared twice (in the table and in the match/pair), the
-resolver's `panic!("no glue")` re-encoded what a missing invocation already
-says, and one macro fanning out over a table hid which cases a backend actually
-ran. The final shape:
+The *delivery* of per-language glue set up by the previous revision — glue resolver functions that `match` on the case name, and later `(case name, glue)` pair lists iterated by one macro — is **withdrawn** as unreadable and of no value: the case name appeared twice (in the table and in the match/pair), the resolver's `panic!("no glue")` re-encoded what a missing invocation already says, and one macro fanning out over a table hid which cases a backend actually ran. The final shape:
 
-- **Glue is a named `&str` constant** in each backend's `tests/e2e.rs` (e.g.
-  `const RUBY_QJS_FILE_IO_GLUE: &str = r#"..."#;`), passed as a plain macro
-  argument. No `(name, glue)` pair lists, no glue-returning functions, no
-  `match` on a case name anywhere.
-- **One macro per case, at most one glue argument each.** Every multi-case table
-  that was iterated by a single macro is dissolved into a `pub const` case in
-  `dewasm-test-helper` plus a per-case macro expanding to its own
-  `#[test] fn <case>()` that calls a shared per-case runner: the filesystem apps
-  (`qjs_file_io_e2e!` … `cruby_hello_e2e!` over `QJS_FILE_IO` … `CRUBY_HELLO`),
-  the C-API drives (`libsqlite3_c_api_e2e!` …), the multi-module cases
-  (`shared_table_e2e!`, `embedded_coexist_e2e!`), and the library cases
-  (`library_add_e2e!`, `wasi_import_override_e2e!`, `custom_wasi_provider_e2e!`,
-  `partial_override_e2e!`, `stdio_capture_e2e!`). The root-preopen containment
-  probe, which does not fit the WASI filesystem template, becomes its own
-  `wasi_root_containment_e2e!`. Zero-glue aggregate macros stay as they were
-  (`apps_e2e!`, `gzip_e2e!`, `standalone_e2e!`, `spec_suite!`,
-  `wasi_suite!(Stdio/ArgsEnv/ClockRandom/Poll)`); `wasi_suite!(Lang, Fs, …)`
-  keeps its single-template-string shape, the template now a named per-backend
-  const with `{guest}`/`{host}` placeholders.
-- **Static values are literals; only runtime paths are placeholders.** The class
-  name, argv, env, and preopen *guest* paths are written out literally inside
-  each glue const. The only values a glue cannot know statically — the host path
-  of a fresh scratch dir and the app-cache root — arrive through a tiny
-  documented substitution helper (`glue::fill`) that replaces `{scratch}`,
-  `{cache}`, `{guest}`, and `{host}`.
-- **Exclusions dissolve into non-invocation.** A backend that cannot run a case
-  simply does not invoke that case's macro; the reason lives as a short comment
-  at the (absent) callsite, with the measured numbers still in
-  `docs/apps-audit.md`. The per-case `exclude` fields and the `NO_LAZY_WASI`
-  ledger are removed from the shared case data.
-- **`BackendUnderTest::app_glue` is deleted** — glue arrives as data, not from a
-  trait hook. `run_app_fs` keeps its hook role but now takes the already-filled
-  glue string (and still carries `args`/`env`/`preopens` for the wasmtime
-  override, which execs the cache binary and ignores the glue). The other
-  infrastructure hooks (`convert_app`, `run`/`run_bytes`, `compose_modules`,
-  `pty_command`, `run_heavy_apps`) are unchanged.
-- **wasmtime** invokes the same per-case runners through hand-written
-  `#[test]` functions rather than the `*_e2e!` macros, because those cannot
-  carry the `wasmtime_test` `#[ignore]` gate (the same reason its `apps`/`gzip`
-  tests were already hand-written); it passes an empty glue, which its
-  `run_app_fs` override ignores.
+- **Glue is a named `&str` constant** in each backend's `tests/e2e.rs` (e.g. `const RUBY_QJS_FILE_IO_GLUE: &str = r#"..."#;`), passed as a plain macro argument. No `(name, glue)` pair lists, no glue-returning functions, no `match` on a case name anywhere.
+- **One macro per case, at most one glue argument each.** Every multi-case table that was iterated by a single macro is dissolved into a `pub const` case in `dewasm-test-helper` plus a per-case macro expanding to its own `#[test] fn <case>()` that calls a shared per-case runner: the filesystem apps (`qjs_file_io_e2e!` … `cruby_hello_e2e!` over `QJS_FILE_IO` … `CRUBY_HELLO`), the C-API drives (`libsqlite3_c_api_e2e!` …), the multi-module cases (`shared_table_e2e!`, `embedded_coexist_e2e!`), and the library cases (`library_add_e2e!`, `wasi_import_override_e2e!`, `custom_wasi_provider_e2e!`, `partial_override_e2e!`, `stdio_capture_e2e!`). The root-preopen containment probe, which does not fit the WASI filesystem template, becomes its own `wasi_root_containment_e2e!`. Zero-glue aggregate macros stay as they were (`apps_e2e!`, `gzip_e2e!`, `standalone_e2e!`, `spec_suite!`, `wasi_suite!(Stdio/ArgsEnv/ClockRandom/Poll)`); `wasi_suite!(Lang, Fs, …)` keeps its single-template-string shape, the template now a named per-backend const with `{guest}`/`{host}` placeholders.
+- **Static values are literals; only runtime paths are placeholders.** The class name, argv, env, and preopen *guest* paths are written out literally inside each glue const. The only values a glue cannot know statically — the host path of a fresh scratch dir and the app-cache root — arrive through a tiny documented substitution helper (`glue::fill`) that replaces `{scratch}`, `{cache}`, `{guest}`, and `{host}`.
+- **Exclusions dissolve into non-invocation.** A backend that cannot run a case simply does not invoke that case's macro; the reason lives as a short comment at the (absent) callsite, with the measured numbers still in `docs/apps-audit.md`. The per-case `exclude` fields and the `NO_LAZY_WASI` ledger are removed from the shared case data.
+- **`BackendUnderTest::app_glue` is deleted** — glue arrives as data, not from a trait hook. `run_app_fs` keeps its hook role but now takes the already-filled glue string (and still carries `args`/`env`/`preopens` for the wasmtime override, which execs the cache binary and ignores the glue). The other infrastructure hooks (`convert_app`, `run`/`run_bytes`, `compose_modules`, `pty_command`, `run_heavy_apps`) are unchanged.
+- **wasmtime** invokes the same per-case runners through hand-written `#[test]` functions rather than the `*_e2e!` macros, because those cannot carry the `wasmtime_test` `#[ignore]` gate (the same reason its `apps`/`gzip` tests were already hand-written); it passes an empty glue, which its `run_app_fs` override ignores.
 
-The behavioural contract is unchanged: the same generated programs run against
-the same goldens and assertions on the same backends. Only the wiring is more
-readable — each `#[test]` name is now the case name, and each callsite shows
-exactly one case with exactly one glue.
+The behavioural contract is unchanged: the same generated programs run against the same goldens and assertions on the same backends. Only the wiring is more readable — each `#[test]` name is now the case name, and each callsite shows exactly one case with exactly one glue.
 
 ## Revision (2026-07-27): standalone scaffolding deleted, apps dissolved into per-case macros
 
 Two leftovers from the prior revision are cleaned up, no behavioural change:
 
-- **`standalone_e2e!`/`STANDALONE_CASES`/`StandaloneCase` deleted.** Every
-  standalone fixture (hello, argc) was reclassified into `WASI_CASES`
-  (`Stdio`/`ArgsEnv`, already run in `Mode::Standalone`) during the Phase-4
-  reorg, leaving `STANDALONE_CASES` an empty table with no callers of its
-  runner beyond the aggregate macro. The module, the struct, the runner, the
-  macro, and its five callsite invocations are removed outright; a per-case
-  macro will be added if a genuine non-WASI standalone case ever appears.
-- **`apps_e2e!`/`APP_CASES` dissolved into four per-case macros**
-  (`cowsay_args_e2e!`, `cowsay_stdin_e2e!`, `qjs_eval_e2e!`,
-  `sqlite3_shell_e2e!`), matching the per-case shape the previous revision
-  already gave the filesystem/C-API/multi-module tables. The cases take no
-  glue (they are standalone-mode stdin/args cases). The `heavy: bool` field is
-  dropped from `AppCase`; the two heavy cases (`QJS_EVAL`, `SQLITE3_SHELL`) get
-  their own gated runner (`run_heavy_app_case`, checking
-  `run_heavy_apps()`/`DEWASM_APPS_ALL`, same as before) plus an ungated
-  `run_heavy_app_case_forced` for wasmtime, mirroring the
-  `run_fs_app_case`/`run_fs_app_case_forced` split. `gzip_e2e!` still covers
-  minigzip's compress + round-trip pair as one macro (binary stdio does not fit
-  the `&str` `AppCase` shape) and is unchanged.
+- **`standalone_e2e!`/`STANDALONE_CASES`/`StandaloneCase` deleted.** Every standalone fixture (hello, argc) was reclassified into `WASI_CASES` (`Stdio`/`ArgsEnv`, already run in `Mode::Standalone`) during the Phase-4 reorg, leaving `STANDALONE_CASES` an empty table with no callers of its runner beyond the aggregate macro. The module, the struct, the runner, the macro, and its five callsite invocations are removed outright; a per-case macro will be added if a genuine non-WASI standalone case ever appears.
+- **`apps_e2e!`/`APP_CASES` dissolved into four per-case macros** (`cowsay_args_e2e!`, `cowsay_stdin_e2e!`, `qjs_eval_e2e!`, `sqlite3_shell_e2e!`), matching the per-case shape the previous revision already gave the filesystem/C-API/multi-module tables. The cases take no glue (they are standalone-mode stdin/args cases). The `heavy: bool` field is dropped from `AppCase`; the two heavy cases (`QJS_EVAL`, `SQLITE3_SHELL`) get their own gated runner (`run_heavy_app_case`, checking `run_heavy_apps()`/`DEWASM_APPS_ALL`, same as before) plus an ungated `run_heavy_app_case_forced` for wasmtime, mirroring the `run_fs_app_case`/`run_fs_app_case_forced` split. `gzip_e2e!` still covers minigzip's compress + round-trip pair as one macro (binary stdio does not fit the `&str` `AppCase` shape) and is unchanged.
 
 ## Revision (2026-07-27): heavy gating moves to a `heavy_test` feature; the support.md ledger section is dropped
 
-`docs/support.md`'s "Spec testsuite ledger" section (`Backend::wasm10_ledger_clean`,
-introduced by [ADR-23](23-backend-support-tiers.md)) is removed: every backend
-reported "no", so the section carried no information for a reader to act on.
-Separately, `DEWASM_APPS_ALL` and `run_heavy_apps()` are retired in favor of a
-`heavy_test` cargo feature declared by each backend crate: the heavy per-case
-macros (`qjs_eval_e2e!`, `sqlite3_shell_e2e!`, the filesystem-app and C-API
-macros, `qjs_repl_pty_e2e!`) now expand their generated `#[test]` with
-`#[cfg_attr(not(feature = "heavy_test"), ignore = "...")]` instead of gating
-inside the shared runner, which now always runs unconditionally (`_forced`
-variants are gone — there is only one runner per case). This makes the heavy
-cases ordinary `#[ignore]`d tests: `cargo test` skips them visibly, one
-`cargo test -- --include-ignored` runs everything across the whole workspace,
-and `--features heavy_test` runs them for a single crate — no bespoke env var
-to remember or keep in sync with the trait method it used to call.
+`docs/support.md`'s "Spec testsuite ledger" section (`Backend::wasm10_ledger_clean`, introduced by [ADR-23](23-backend-support-tiers.md)) is removed: every backend reported "no", so the section carried no information for a reader to act on. Separately, `DEWASM_APPS_ALL` and `run_heavy_apps()` are retired in favor of a `heavy_test` cargo feature declared by each backend crate: the heavy per-case macros (`qjs_eval_e2e!`, `sqlite3_shell_e2e!`, the filesystem-app and C-API macros, `qjs_repl_pty_e2e!`) now expand their generated `#[test]` with `#[cfg_attr(not(feature = "heavy_test"), ignore = "...")]` instead of gating inside the shared runner, which now always runs unconditionally (`_forced` variants are gone — there is only one runner per case). This makes the heavy cases ordinary `#[ignore]`d tests: `cargo test` skips them visibly, one `cargo test -- --include-ignored` runs everything across the whole workspace, and `--features heavy_test` runs them for a single crate — no bespoke env var to remember or keep in sync with the trait method it used to call.
 
 ## Revision (2026-07-27): the spec harness is per-file libtest-mimic trials
 
-`spec_suite!` no longer expands to one monolithic `#[test] fn spec()`; each
-backend's `tests/spec.rs` is now a [libtest-mimic](https://crates.io/crates/libtest-mimic)
-harness (`harness = false`, `main` supplied by the macro) that enumerates one
-trial per upstream `.wast` file (the file stem is the trial name). The bespoke
-selection env vars `DEWASM_SPEC` (file filter) and `DEWASM_SPEC_ALL` (full
-sweep) are retired in favor of cargo's own test UX: name filtering is cargo's
-built-in filter (`cargo test --test spec i32`), and the curated-vs-full split is
-the ignore mechanism — files outside `SpecBackend::curated_files` (renamed from
-`default_files`; `None` still means "run everything") become `#[ignore]`d
-trials, so a plain `cargo test` runs the curated set and `-- --include-ignored`
-sweeps the whole testsuite. Trials run in parallel on libtest-mimic's thread
-pool, so per-file state moved off the shared backend object into the harness's
-own per-file buffers (the Go/Java package/class `decls` accumulator was a
-`Mutex<String>` on the `Spec` struct; it is now a plain per-trial `String`
-threaded through `emit_instantiate`/`instantiate_call`/`assemble`). The per-file
-`EXPECTED_FAILURES` ledger checks (ADR-8) and skip-attribution gates run inside
-each trial — equivalent to the old global checks because the global sets are the
-union of the per-file sets. The old aggregate `TOTAL: pass=… fail=…` line is
-gone; per-file trial results supersede it.
+`spec_suite!` no longer expands to one monolithic `#[test] fn spec()`; each backend's `tests/spec.rs` is now a [libtest-mimic](https://crates.io/crates/libtest-mimic) harness (`harness = false`, `main` supplied by the macro) that enumerates one trial per upstream `.wast` file (the file stem is the trial name). The bespoke selection env vars `DEWASM_SPEC` (file filter) and `DEWASM_SPEC_ALL` (full sweep) are retired in favor of cargo's own test UX: name filtering is cargo's built-in filter (`cargo test --test spec i32`), and the curated-vs-full split is the ignore mechanism — files outside `SpecBackend::curated_files` (renamed from `default_files`; `None` still means "run everything") become `#[ignore]`d trials, so a plain `cargo test` runs the curated set and `-- --include-ignored` sweeps the whole testsuite. Trials run in parallel on libtest-mimic's thread pool, so per-file state moved off the shared backend object into the harness's own per-file buffers (the Go/Java package/class `decls` accumulator was a `Mutex<String>` on the `Spec` struct; it is now a plain per-trial `String` threaded through `emit_instantiate`/`instantiate_call`/`assemble`). The per-file `EXPECTED_FAILURES` ledger checks (ADR-8) and skip-attribution gates run inside each trial — equivalent to the old global checks because the global sets are the union of the per-file sets. The old aggregate `TOTAL: pass=… fail=…` line is gone; per-file trial results supersede it.
 
 ## Revision (2026-07-27): golden regeneration moves to explicit `xtask` commands
 
-The `support_docs` and `apps_wasmtime` tests' `DEWASM_UPDATE_DOCS`/
-`DEWASM_UPDATE_GOLDEN` env-var regeneration branches are removed; both tests
-are now compare-only, and regeneration is `cargo xtask update-support-docs`
-and `cargo xtask update-repl-golden` respectively (new `crates/xtask` member,
-aliased in `.cargo/config.toml`), with the rendering/capture logic shared via
-a small `dewasm-cli` library crate and `dewasm-test-helper`'s already-public
-capture functions.
+The `support_docs` and `apps_wasmtime` tests' `DEWASM_UPDATE_DOCS`/ `DEWASM_UPDATE_GOLDEN` env-var regeneration branches are removed; both tests are now compare-only, and regeneration is `cargo xtask update-support-docs` and `cargo xtask update-repl-golden` respectively (new `crates/xtask` member, aliased in `.cargo/config.toml`), with the rendering/capture logic shared via a small `dewasm-cli` library crate and `dewasm-test-helper`'s already-public capture functions.

--- a/docs/adr/28-python-backend-lowering.md
+++ b/docs/adr/28-python-backend-lowering.md
@@ -1,134 +1,34 @@
 # ADR-28 — Python Backend Lowering Conventions
 
-Status: **Accepted, 2026-07-26.** First milestone ("cowsay runs", ADR-24)
-implemented in `crates/dewasm-backend-python/src/lib.rs` + `runtime/python/`.
-**Second milestone (spec-harness green) landed 2026-07-26**: the wasm-1.0
-completion (ADR-16's model — boxed globals, imported globals/memories/tables,
-multiple tables, the table half of bulk memory) plus the shared spec harness
-(`crates/dewasm-backend-python/tests/spec.rs`). Numeric conventions are ADR-2's;
-this ADR covers the places Python forced a different shape from Ruby (ADR-4):
-control flow, float division, and (below) the harness's recursion/exhaustion
-handling. **Third milestone (full WASI preview 1, incl. the filesystem) landed
-2026-07-26**: `runtime/python/units/wasi/` mirrors the Ruby WASI unit set
-one-for-one, adopting ADR-14's filesystem model wholesale — the `preopens=`
-provider kwarg, the single fd-table with a `WasiDir` entry kind, the
-realpath-plus-prefix-containment sandboxing (with the same accepted
-TOCTOU/symlink caveat), and the ENOSYS gaps
-(`fd_fdstat_set_flags`/`fd_fdstat_set_rights`, symlink and
-`path_filestat_set_times` syscalls). The Python fd model diverges only in
-mechanics forced by the host stdlib, not in policy: files are unbuffered
-`os.fdopen(..., buffering=0)` handles (so `os.pread`/`os.pwrite` stay coherent
-with `read`/`write`/`seek`, which sqlite mixes on one fd), directory listing
-uses `os.listdir`, and the errno map keys on `OSError.errno` (the `errno`
-module) rather than exception classes. With this, `has_wasi_p1` reports the
-same surface as Ruby, and the shared WASI `Fs` suite plus the gzip byte-stdio
-and heavy filesystem app cases (QuickJS, SQLite, ripgrep) run under Python.
-**Revision, 2026-07-29 (issue #31):** the recursion/exhaustion mitigation below
-is no longer harness-only — the emitted standalone entrypoint applies the same
-raised recursion limit and big-stack guest thread itself, carrying the guest's
-exit/trap back to the main thread so ADR-31's exit codes are unchanged.
+Status: **Accepted, 2026-07-26.** First milestone ("cowsay runs", ADR-24) implemented in `crates/dewasm-backend-python/src/lib.rs` + `runtime/python/`. **Second milestone (spec-harness green) landed 2026-07-26**: the wasm-1.0 completion (ADR-16's model — boxed globals, imported globals/memories/tables, multiple tables, the table half of bulk memory) plus the shared spec harness (`crates/dewasm-backend-python/tests/spec.rs`). Numeric conventions are ADR-2's; this ADR covers the places Python forced a different shape from Ruby (ADR-4): control flow, float division, and (below) the harness's recursion/exhaustion handling. **Third milestone (full WASI preview 1, incl. the filesystem) landed 2026-07-26**: `runtime/python/units/wasi/` mirrors the Ruby WASI unit set one-for-one, adopting ADR-14's filesystem model wholesale — the `preopens=` provider kwarg, the single fd-table with a `WasiDir` entry kind, the realpath-plus-prefix-containment sandboxing (with the same accepted TOCTOU/symlink caveat), and the ENOSYS gaps (`fd_fdstat_set_flags`/`fd_fdstat_set_rights`, symlink and `path_filestat_set_times` syscalls). The Python fd model diverges only in mechanics forced by the host stdlib, not in policy: files are unbuffered `os.fdopen(..., buffering=0)` handles (so `os.pread`/`os.pwrite` stay coherent with `read`/`write`/`seek`, which sqlite mixes on one fd), directory listing uses `os.listdir`, and the errno map keys on `OSError.errno` (the `errno` module) rather than exception classes. With this, `has_wasi_p1` reports the same surface as Ruby, and the shared WASI `Fs` suite plus the gzip byte-stdio and heavy filesystem app cases (QuickJS, SQLite, ripgrep) run under Python. **Revision, 2026-07-29 (issue #31):** the recursion/exhaustion mitigation below is no longer harness-only — the emitted standalone entrypoint applies the same raised recursion limit and big-stack guest thread itself, carrying the guest's exit/trap back to the main thread so ADR-31's exit codes are unchanged.
 
 ## Context
 
-Python is dynamically typed with arbitrary-precision ints and IEEE doubles, so
-ADR-2's masked-unsigned integers and double-backed f32-with-re-rounding
-transfer from Ruby almost verbatim (`Rt.s32`/`s64`, `Rt.f32`, the software NaN
-bit paths). Three language facts did *not* transfer:
+Python is dynamically typed with arbitrary-precision ints and IEEE doubles, so ADR-2's masked-unsigned integers and double-backed f32-with-re-rounding transfer from Ruby almost verbatim (`Rt.s32`/`s64`, `Rt.f32`, the software NaN bit paths). Three language facts did *not* transfer:
 
-1. **Python has no non-local control transfer.** Ruby's whole control-flow
-   story is `catch`/`throw` (ADR-4); Python has neither that nor `goto` nor
-   labeled `break`/`continue`.
-2. **Python caps statically-nested loops/`try` at 20** ("too many statically
-   nested blocks"), while `if` nests ~100 deep. Real wasm binaries nest far
-   deeper: cowsay's hottest function nests referenced blocks/loops/ifs 42 deep
-   (measured), and blocks (forward branches) dominate that.
-3. **Python raises on `x / 0.0`**, on `math.sqrt` of a negative, and
-   `struct.pack("<f")` raises `OverflowError` past the f32 range — where Ruby
-   returns `inf`/`nan`. Integer `//`/`%` also floor rather than truncate.
+1. **Python has no non-local control transfer.** Ruby's whole control-flow story is `catch`/`throw` (ADR-4); Python has neither that nor `goto` nor labeled `break`/`continue`.
+2. **Python caps statically-nested loops/`try` at 20** ("too many statically nested blocks"), while `if` nests ~100 deep. Real wasm binaries nest far deeper: cowsay's hottest function nests referenced blocks/loops/ifs 42 deep (measured), and blocks (forward branches) dominate that.
+3. **Python raises on `x / 0.0`**, on `math.sqrt` of a negative, and `struct.pack("<f")` raises `OverflowError` past the f32 range — where Ruby returns `inf`/`nan`. Integer `//`/`%` also floor rather than truncate.
 
 ## Decision
 
-- **Forward branches (block/if exits) use a per-function branch register
-  `_br`, not a loop or `try`.** A `br` to a block/if sets `_br = <label id>`;
-  each statement after a possible branch is guarded by `if _br == 0:`; a
-  referenced label emits an `if _br == <id>: _br = 0` reset marker at its end.
-  Because only `while`/`try` count toward the 20-block cap, this keeps blocks
-  free of it.
-- **Block/if bodies are spliced inline into the enclosing statement list**, so
-  block *nesting* adds zero Python nesting; the guards are siblings, so
-  sequence *length* adds none either. cowsay's 42-deep wasm nesting lowers to
-  a max Python indent of 9. Guards are emitted only after a statement whose
-  subtree can leave `_br` set (`stmt_free_targets`), so straight-line code is
-  unguarded.
-- **Only real loops become `while True:`** with a trailer
-  `if _br == <id>: _br = 0; continue` / `break`; a back-edge `br` sets `_br`
-  and the trailer turns it into `continue`. Loop nesting is small (5 in
-  cowsay) and is the *only* contributor to the 20-block budget. A guarded `if`
-  folds its guard into the condition (`if _br == 0 and (cond) != 0:`) so a
-  trapping `cond` is not evaluated while a branch is pending.
-- **`Rt.fdiv` wraps float division** (returns IEEE `inf`/`nan` instead of
-  raising); `Rt.f32` catches `OverflowError`; `fsqrt`/`div_s`/`rem_s` guard the
-  negative/zero/truncation cases exactly as the Ruby units do (integer
-  `div_s`/`rem_s` use `abs`-based truncation, never `//`/`%`).
-- **Runtime lives at module top level, not nested in the generated class.**
-  Python method scopes cannot see an enclosing class scope, so a nested
-  `class Rt` would make `Rt.trap` unresolvable inside a method; `Rt` is emitted
-  as a top-level class (`class Memory`/`Table`/`WASI` nested inside it), one
-  self-contained module per file. Module = one class; imports resolved in
-  `__init__` (`self.ifN`), own globals as plain `self.gN` attributes, exports
-  in a `self.exports` dict with `invoke(name, *args)` as the entry point.
-- **`call_indirect` compares structural type strings** (`"i32,i64->i32"`),
-  like Ruby's symbols and for the same reason (shared tables, ADR-4).
-- **Every global is a boxed `Rt.Global`** (`value` attribute), not a plain
-  `self.gN` attribute holding the value — reversing the first milestone's
-  choice now that imported globals are supported (ADR-16). A global crossing
-  an instantiation boundary must be a shared mutable cell, and `Memory`/`Table`
-  are already objects for the same reason, so one representation keeps
-  `GlobalGet`/`GlobalSet` a single rule. `global_get` reads `.value`;
-  `global_export`/`wasm_import` hand out the box itself.
-- **The spec harness runs the whole assertion body inside `def _main()` on a
-  large-stack thread.** Python's default 1000 recursion limit is far below
-  what call/fac-style deep guest recursion needs, but simply raising
-  `sys.setrecursionlimit` on the main thread risks a C-stack overflow (a
-  segfault, not a catchable error) before the Python limit trips. So the
-  harness sets a generous recursion limit *and* launches `_main` on a thread
-  with a 512 MiB `threading.stack_size` — the guest-side analogue of the
-  build's `convert_on_big_stack`. A runaway recursion then surfaces as a
-  `RecursionError` well inside that stack, which `check_exhaust` maps to wasm's
-  `call stack exhausted` (mirroring Ruby's `SystemStackError` and Bash's
-  `FUNCNEST` subshell). Because the class definitions live inside `_main` as
-  local classes whose methods still resolve the module-level `Rt`, the
-  generated `Rt = Rt` alias line is dropped for the harness (it would rebind
-  `Rt` as a `_main` local).
+- **Forward branches (block/if exits) use a per-function branch register `_br`, not a loop or `try`.** A `br` to a block/if sets `_br = <label id>`; each statement after a possible branch is guarded by `if _br == 0:`; a referenced label emits an `if _br == <id>: _br = 0` reset marker at its end. Because only `while`/`try` count toward the 20-block cap, this keeps blocks free of it.
+- **Block/if bodies are spliced inline into the enclosing statement list**, so block *nesting* adds zero Python nesting; the guards are siblings, so sequence *length* adds none either. cowsay's 42-deep wasm nesting lowers to a max Python indent of 9. Guards are emitted only after a statement whose subtree can leave `_br` set (`stmt_free_targets`), so straight-line code is unguarded.
+- **Only real loops become `while True:`** with a trailer `if _br == <id>: _br = 0; continue` / `break`; a back-edge `br` sets `_br` and the trailer turns it into `continue`. Loop nesting is small (5 in cowsay) and is the *only* contributor to the 20-block budget. A guarded `if` folds its guard into the condition (`if _br == 0 and (cond) != 0:`) so a trapping `cond` is not evaluated while a branch is pending.
+- **`Rt.fdiv` wraps float division** (returns IEEE `inf`/`nan` instead of raising); `Rt.f32` catches `OverflowError`; `fsqrt`/`div_s`/`rem_s` guard the negative/zero/truncation cases exactly as the Ruby units do (integer `div_s`/`rem_s` use `abs`-based truncation, never `//`/`%`).
+- **Runtime lives at module top level, not nested in the generated class.** Python method scopes cannot see an enclosing class scope, so a nested `class Rt` would make `Rt.trap` unresolvable inside a method; `Rt` is emitted as a top-level class (`class Memory`/`Table`/`WASI` nested inside it), one self-contained module per file. Module = one class; imports resolved in `__init__` (`self.ifN`), own globals as plain `self.gN` attributes, exports in a `self.exports` dict with `invoke(name, *args)` as the entry point.
+- **`call_indirect` compares structural type strings** (`"i32,i64->i32"`), like Ruby's symbols and for the same reason (shared tables, ADR-4).
+- **Every global is a boxed `Rt.Global`** (`value` attribute), not a plain `self.gN` attribute holding the value — reversing the first milestone's choice now that imported globals are supported (ADR-16). A global crossing an instantiation boundary must be a shared mutable cell, and `Memory`/`Table` are already objects for the same reason, so one representation keeps `GlobalGet`/`GlobalSet` a single rule. `global_get` reads `.value`; `global_export`/`wasm_import` hand out the box itself.
+- **The spec harness runs the whole assertion body inside `def _main()` on a large-stack thread.** Python's default 1000 recursion limit is far below what call/fac-style deep guest recursion needs, but simply raising `sys.setrecursionlimit` on the main thread risks a C-stack overflow (a segfault, not a catchable error) before the Python limit trips. So the harness sets a generous recursion limit *and* launches `_main` on a thread with a 512 MiB `threading.stack_size` — the guest-side analogue of the build's `convert_on_big_stack`. A runaway recursion then surfaces as a `RecursionError` well inside that stack, which `check_exhaust` maps to wasm's `call stack exhausted` (mirroring Ruby's `SystemStackError` and Bash's `FUNCNEST` subshell). Because the class definitions live inside `_main` as local classes whose methods still resolve the module-level `Rt`, the generated `Rt = Rt` alias line is dropped for the harness (it would rebind `Rt` as a `_main` local).
 
 ## Rejected alternatives
 
-- **Exceptions for `br` (a `_Br` exception per label, or one per function).**
-  A `try` per block hits the 20-block cap exactly as loops would; a single
-  per-function `try` cannot express "resume after *this* block" without a
-  dispatch loop. The branch register is flat and cap-free.
-- **Mirror Ruby's `catch`/`throw` shape with single-iteration `while` loops
-  for blocks.** Correct, but every block then costs a loop, so cowsay's
-  38-deep block+loop nesting blows the 20-loop cap immediately.
-- **Keep own globals as plain `self.gN` attributes (the first-milestone
-  choice).** Adopted while imported globals were rejected at conversion time;
-  reversed in the second milestone (see the boxing decision above), because
-  supporting imported/exported-shared globals reintroduces exactly the
-  cross-boundary-sharing need that made plain attributes insufficient, and two
-  representations would fork every global read/write/export site.
+- **Exceptions for `br` (a `_Br` exception per label, or one per function).** A `try` per block hits the 20-block cap exactly as loops would; a single per-function `try` cannot express "resume after *this* block" without a dispatch loop. The branch register is flat and cap-free.
+- **Mirror Ruby's `catch`/`throw` shape with single-iteration `while` loops for blocks.** Correct, but every block then costs a loop, so cowsay's 38-deep block+loop nesting blows the 20-loop cap immediately.
+- **Keep own globals as plain `self.gN` attributes (the first-milestone choice).** Adopted while imported globals were rejected at conversion time; reversed in the second milestone (see the boxing decision above), because supporting imported/exported-shared globals reintroduces exactly the cross-boundary-sharing need that made plain attributes insufficient, and two representations would fork every global read/write/export site.
 
 ## Consequences
 
-- Positive: cowsay is byte-identical to the wasmtime golden for both the
-  args and stdin cases; qjs and sqlite3 convert and compile. The control-flow
-  scheme is depth-insensitive, so no relooper/label-dispatch was needed.
-- Negative: guards add an `if _br == 0:` and a comparison per branchy
-  statement — more lines and a small per-statement cost versus Ruby's
-  `catch`/`throw`. `_br` is a whole-function register, so it serializes
-  control flow textually rather than structurally.
-- Carry-over: the first milestone bundled only the eight WASI syscalls cowsay
-  needs; the second added the spec harness; the third (above) fills in the full
-  WASI preview 1 surface and the filesystem, so gzip, QuickJS, SQLite, and
-  ripgrep now run under Python. What remains ENOSYS matches Ruby (ADR-14):
-  rights narrowing, symlink creation/read, `fd_renumber`/`fd_advise`/
-  `fd_allocate`, `path_filestat_set_times`, and `poll_oneoff`.
+- Positive: cowsay is byte-identical to the wasmtime golden for both the args and stdin cases; qjs and sqlite3 convert and compile. The control-flow scheme is depth-insensitive, so no relooper/label-dispatch was needed.
+- Negative: guards add an `if _br == 0:` and a comparison per branchy statement — more lines and a small per-statement cost versus Ruby's `catch`/`throw`. `_br` is a whole-function register, so it serializes control flow textually rather than structurally.
+- Carry-over: the first milestone bundled only the eight WASI syscalls cowsay needs; the second added the spec harness; the third (above) fills in the full WASI preview 1 surface and the filesystem, so gzip, QuickJS, SQLite, and ripgrep now run under Python. What remains ENOSYS matches Ruby (ADR-14): rights narrowing, symlink creation/read, `fd_renumber`/`fd_advise`/ `fd_allocate`, `path_filestat_set_times`, and `poll_oneoff`.

--- a/docs/adr/29-go-backend-lowering.md
+++ b/docs/adr/29-go-backend-lowering.md
@@ -1,238 +1,57 @@
 # ADR-29 — Go Backend Lowering Conventions
 
-Status: **Accepted, 2026-07-26.** First milestone ("cowsay runs", ADR-24),
-second milestone (spec-harness green + wasm-1.0 completion, ADR-3/ADR-16), and
-third milestone (full WASI preview 1 incl. filesystem, adopting ADR-14's model)
-implemented in `crates/dewasm-backend-go/src/lib.rs`, `runtime/go/units/`, and
-`crates/dewasm-backend-go/tests/{spec,e2e}.rs`. Numeric conventions are ADR-2's; this
-ADR covers where Go — statically typed, with native fixed-width integers and
-floats — forced a different shape from the dynamically-typed backends (Ruby
-ADR-4, Python ADR-28). Go is also the first *compiled* backend, so it is the
-first to use ADR-27's `run()` override.
+Status: **Accepted, 2026-07-26.** First milestone ("cowsay runs", ADR-24), second milestone (spec-harness green + wasm-1.0 completion, ADR-3/ADR-16), and third milestone (full WASI preview 1 incl. filesystem, adopting ADR-14's model) implemented in `crates/dewasm-backend-go/src/lib.rs`, `runtime/go/units/`, and `crates/dewasm-backend-go/tests/{spec,e2e}.rs`. Numeric conventions are ADR-2's; this ADR covers where Go — statically typed, with native fixed-width integers and floats — forced a different shape from the dynamically-typed backends (Ruby ADR-4, Python ADR-28). Go is also the first *compiled* backend, so it is the first to use ADR-27's `run()` override.
 
 ## Context
 
-Go's type system and native numerics remove work the interpreted backends do by
-hand, and add work they never face:
+Go's type system and native numerics remove work the interpreted backends do by hand, and add work they never face:
 
-1. **Native wrapping integers.** `uint32`/`uint64` arithmetic wraps, so ADR-2's
-   masked-unsigned convention is native: `i32.add` is `a + b`, not
-   `(a + b) & 0xFFFFFFFF`. Signed views are `int32(x)`/`int64(x)` casts;
-   sign-extensions, wraps, and integer↔float conversions are native casts with
-   no runtime helper.
-2. **Native IEEE floats.** `float32`/`float64` are real machine floats, so f32
-   arithmetic re-rounds itself (`F32Add` is `a + b`), and float division is
-   trap-free (`a / b` yields inf/NaN) — no `Rt.f32`/`Rt.fdiv` helpers, unlike
-   Python/Ruby/Bash. `math.Float32bits`/`Float64bits` are bit-preserving, so
-   the NaN bit paths collapse to those; only demote/promote reconstruct NaN
-   payloads (a float64→float32 *conversion* of a NaN may canonicalize).
-3. **Unused variables, labels, and imports are compile errors.** This is the
-   Go-specific landmine (the analogue of Python's 20-block cap).
-4. **Static function values.** A dynamic `invoke(name, *args)` needs reflection;
-   `call_indirect` needs a way to store heterogeneous function signatures in one
-   table.
+1. **Native wrapping integers.** `uint32`/`uint64` arithmetic wraps, so ADR-2's masked-unsigned convention is native: `i32.add` is `a + b`, not `(a + b) & 0xFFFFFFFF`. Signed views are `int32(x)`/`int64(x)` casts; sign-extensions, wraps, and integer↔float conversions are native casts with no runtime helper.
+2. **Native IEEE floats.** `float32`/`float64` are real machine floats, so f32 arithmetic re-rounds itself (`F32Add` is `a + b`), and float division is trap-free (`a / b` yields inf/NaN) — no `Rt.f32`/`Rt.fdiv` helpers, unlike Python/Ruby/Bash. `math.Float32bits`/`Float64bits` are bit-preserving, so the NaN bit paths collapse to those; only demote/promote reconstruct NaN payloads (a float64→float32 *conversion* of a NaN may canonicalize).
+3. **Unused variables, labels, and imports are compile errors.** This is the Go-specific landmine (the analogue of Python's 20-block cap).
+4. **Static function values.** A dynamic `invoke(name, *args)` needs reflection; `call_indirect` needs a way to store heterogeneous function signatures in one table.
 
 ## Decision
 
-- **Types.** i32→`uint32`, i64→`uint64`, f32→`float32`, f64→`float64`, funcref
-  →`*funcref`. Every value-producing site is fully typed: integer constants are
-  emitted as `uint32(v)`/`uint64(v)` and float constants as
-  `Rt.f32_from_bits`/`Rt.f64_from_bits` (bit-exact, so literal formatting and
-  Go's compile-time constant-float rules never enter). A stack temp is named by
-  both depth *and* type (`s3_i32`), since one depth can hold values of different
-  types at different points.
-- **Control flow maps onto Go's labeled loops** — a natural fit, so there is no
-  branch register (contrast Python's `_br`, ADR-28). A referenced block/if
-  becomes `L: for { … ; break L }`, a referenced loop `L: for { … ; break L }`
-  with back-edges lowered to `continue L` (`BrTarget.is_loop`). Unreferenced
-  structures splice inline. `br_table` is a `switch` (labeled breaks/continues
-  target the enclosing loop, not the switch).
-- **Unused-symbol discipline.** Labels are emitted only when `label.referenced`.
-  A pre-pass over the body computes the read/used sets of locals and temps;
-  declared locals and temps that are written but never read are blanked with
-  `_ = x`. Functions with results get a trailing `return <zeros>` (unreachable
-  code is not a Go error). Imports are computed by scanning only the runtime
-  bundle (controlled code; data blobs are hex literals via `Rt.unhex`, so no
-  user string can inject a false import) plus `os` for the standalone `main`.
-- **Runtime shape.** Helpers are methods on a zero-size `rt` receiver
-  (`var Rt rt`), named in **snake_case matching their unit id 1:1**
-  (`Rt.i32_div_s`), so the units lint stays a direct name match and a unit id
-  maps to its reference without case conversion — a deliberate deviation from
-  Go's PascalCase convention (correctness/tooling over idiom, ADR-1). Every
-  scope's bundler wrapper is empty: Go methods and types are package-level
-  regardless of the struct, so the bundle is a flat list of declarations, not
-  nested classes (contrast Python). Traps/exits/link errors are `panic` of
-  `rtTrap`/`rtExit`/`rtLinkError`, recovered at the standalone boundary
-  (trap → stderr + exit 134, mirroring Ruby/Python).
-- **`call_indirect` and imports under static typing.** A table slot is a
-  `*funcref{ ty string; fn any }`; `Table.call` bounds/null/type-checks and
-  returns `fn`, which the call site type-asserts to the exact signature the
-  `type_idx` gives (`… .(func(uint32) uint32)(a)`). Import function fields are
-  typed to the wasm signature; resolution asserts the embedder's `any` value to
-  that type (a mismatch is a `link_error`), with the bundled WASI method or an
-  ENOSYS stub as the fallback (ADR-7). The import object is
-  `map[string]map[string]any`; the provider-object/`attach` protocol and
-  import *kind* checking are deferred (the type assertion enforces the
-  signature). Exports are a `map[string]any`; standalone `main` calls
-  `p.Exports["_start"].(func())()`.
-- **Library glue is concatenated** as a `func main` after the generated
-  declarations (mirroring Ruby/Bash). Go's rule that imports precede all other
-  declarations means the glue cannot carry its own `import`, so library-mode
-  output imports `fmt` up front (kept live with `var _ = fmt.Sprint`) and glue
-  prints through it. Glue accesses the instance's unexported fields/methods
-  directly (same package).
-- **Execution (`run()` override, ADR-27).** Go is compiled, so the test helper
-  is overridden to `go build` the file to a content-addressed cache binary
-  (identical sources — cowsay's args and stdin cases — build once) and run the
-  binary. Running the binary, not `go run`, is required: `go run` prints
-  "exit status N" and itself exits 1 rather than propagating the guest exit
-  code, which the WASI args/env case asserts exactly. `$DEWASM_GO` overrides the
-  toolchain; a missing one fails loud (ADR-15).
-- **Feature scope.** `Floats` is `Supported`. WASI began as the eight core
-  syscalls (stdio + args/env + `random_get` + `proc_exit`); the third milestone
-  below completes preview 1 including the filesystem.
+- **Types.** i32→`uint32`, i64→`uint64`, f32→`float32`, f64→`float64`, funcref →`*funcref`. Every value-producing site is fully typed: integer constants are emitted as `uint32(v)`/`uint64(v)` and float constants as `Rt.f32_from_bits`/`Rt.f64_from_bits` (bit-exact, so literal formatting and Go's compile-time constant-float rules never enter). A stack temp is named by both depth *and* type (`s3_i32`), since one depth can hold values of different types at different points.
+- **Control flow maps onto Go's labeled loops** — a natural fit, so there is no branch register (contrast Python's `_br`, ADR-28). A referenced block/if becomes `L: for { … ; break L }`, a referenced loop `L: for { … ; break L }` with back-edges lowered to `continue L` (`BrTarget.is_loop`). Unreferenced structures splice inline. `br_table` is a `switch` (labeled breaks/continues target the enclosing loop, not the switch).
+- **Unused-symbol discipline.** Labels are emitted only when `label.referenced`. A pre-pass over the body computes the read/used sets of locals and temps; declared locals and temps that are written but never read are blanked with `_ = x`. Functions with results get a trailing `return <zeros>` (unreachable code is not a Go error). Imports are computed by scanning only the runtime bundle (controlled code; data blobs are hex literals via `Rt.unhex`, so no user string can inject a false import) plus `os` for the standalone `main`.
+- **Runtime shape.** Helpers are methods on a zero-size `rt` receiver (`var Rt rt`), named in **snake_case matching their unit id 1:1** (`Rt.i32_div_s`), so the units lint stays a direct name match and a unit id maps to its reference without case conversion — a deliberate deviation from Go's PascalCase convention (correctness/tooling over idiom, ADR-1). Every scope's bundler wrapper is empty: Go methods and types are package-level regardless of the struct, so the bundle is a flat list of declarations, not nested classes (contrast Python). Traps/exits/link errors are `panic` of `rtTrap`/`rtExit`/`rtLinkError`, recovered at the standalone boundary (trap → stderr + exit 134, mirroring Ruby/Python).
+- **`call_indirect` and imports under static typing.** A table slot is a `*funcref{ ty string; fn any }`; `Table.call` bounds/null/type-checks and returns `fn`, which the call site type-asserts to the exact signature the `type_idx` gives (`… .(func(uint32) uint32)(a)`). Import function fields are typed to the wasm signature; resolution asserts the embedder's `any` value to that type (a mismatch is a `link_error`), with the bundled WASI method or an ENOSYS stub as the fallback (ADR-7). The import object is `map[string]map[string]any`; the provider-object/`attach` protocol and import *kind* checking are deferred (the type assertion enforces the signature). Exports are a `map[string]any`; standalone `main` calls `p.Exports["_start"].(func())()`.
+- **Library glue is concatenated** as a `func main` after the generated declarations (mirroring Ruby/Bash). Go's rule that imports precede all other declarations means the glue cannot carry its own `import`, so library-mode output imports `fmt` up front (kept live with `var _ = fmt.Sprint`) and glue prints through it. Glue accesses the instance's unexported fields/methods directly (same package).
+- **Execution (`run()` override, ADR-27).** Go is compiled, so the test helper is overridden to `go build` the file to a content-addressed cache binary (identical sources — cowsay's args and stdin cases — build once) and run the binary. Running the binary, not `go run`, is required: `go run` prints "exit status N" and itself exits 1 rather than propagating the guest exit code, which the WASI args/env case asserts exactly. `$DEWASM_GO` overrides the toolchain; a missing one fails loud (ADR-15).
+- **Feature scope.** `Floats` is `Supported`. WASI began as the eight core syscalls (stdio + args/env + `random_get` + `proc_exit`); the third milestone below completes preview 1 including the filesystem.
 
 ## Second milestone: spec harness + wasm-1.0 completion
 
-- **Boxed globals are a generic `*global[T]`** (`runtime/go/units/global/`), the
-  Go analogue of Ruby's `Rt::Global` box (ADR-16): every global is a
-  pointer-shared cell so one that crosses an instantiation boundary is shared,
-  not copied. Generics keep it statically typed — `p.g0.value` needs no
-  assertion, and an imported global resolves by asserting `v.(*global[uint32])`.
-- **Imports beyond functions** resolve through the same provider map, with the
-  ADR-16 kind check performed *by the Go type assertion itself*: `v.(*Memory)` /
-  `v.(*Table)` / `v.(*global[T])` (and the existing func-signature assertion)
-  reject a wrong-kind — and, for funcs and globals, wrong-*type* — import as a
-  `link_error`. A missing non-WASI import is a `link_error` at instantiation
-  (ADR-0), not a deferred call-time stub. **Consequence for the ledger:** Go's
-  `import-limits` gap is *narrower* than Ruby/Python's kind-only check — only
-  global mutability and table/memory min/max limits stay unchecked — so its spec
-  `EXPECTED_FAILURES` counts are lower (the two `linking` failures are both
-  global-mutability mismatches). Exports are a `map[string]any` over every kind
-  (funcs, the global box, table, memory), so a generated instance's `Exports`
-  doubles as another module's import object — what powers the harness's
-  `register` support.
-- **The spec harness compiles Go** (ADR-3). Each `.wast` file becomes one
-  `package main` program: the runtime bundle, harness helpers, every module's
-  package-level declarations, then a `func main` of instantiations and
-  assertions. Because Go has no dynamic dispatch, each generated type carries a
-  reflective `invoke(name, args...) []any` / `globalGet(name) []any` built where
-  the export signatures are known; the harness asserts the boxed results
-  bit-exactly (`math.Float32bits`). Module declarations cannot sit inside
-  `main`, so they are accumulated at package scope and prepended at assembly.
-- **Exhaustion is a generation-time recursion guard** (spec build only). A
-  runaway recursion overflows Go's goroutine stack *fatally* — the runtime
-  aborts the process uncatchably, and the harness needs the script to continue
-  after the check. Of the alternatives — lowering `debug.SetMaxStack` (still
-  process-fatal), or a subprocess per exhaustion assertion — the chosen one
-  instruments each generated function to add its frame's slot count
-  (`1 + params + locals + temps`) to a global `rtStack`, `defer`-decrement it,
-  and trap `"call stack exhausted"` past a fixed budget (1024). It is
-  deterministic, needs no extra process, and — sized by the slot *cost*, not raw
-  depth — also trips on `skip-stack-guard-page.wast`'s `function-with-many-locals`
-  (1056 locals, the only >50-slot function in the suite) even at shallow depth,
-  so that file passes with no ledger entry. The guard is **off** for shipped
-  standalone/library output, whose deep-but-valid recursions must not falsely
-  trap.
-- **Two Go-compiler float hazards** the spec suite exposed (ADR-2):
-  `float_exprs.wast` requires *no contraction* (each op rounds independently),
-  but Go fuses `x*y+z` into a hardware FMA on arm64; and it folds `x*1.0`→`x` /
-  `x/1.0`→`x`, skipping the signaling-NaN quieting the `no_fold_*` tests demand.
-  Both are defeated by routing f32/f64 **mul and div through `//go:noinline`
-  runtime helpers**, so a constant operand never reaches the op and no add can
-  fuse across the call boundary. Separately, min/max NaN results must be the
-  *wasm* canonical NaN — Go's `math.NaN()` is not bit-canonical (its low
-  mantissa bit is set), so the units build the canonical pattern explicitly.
-  f32 `sqrt` via `float32(math.Sqrt(float64(x)))` was *validated* correctly
-  rounded against `f32.wast` (double-rounding through float64 is safe for sqrt).
+- **Boxed globals are a generic `*global[T]`** (`runtime/go/units/global/`), the Go analogue of Ruby's `Rt::Global` box (ADR-16): every global is a pointer-shared cell so one that crosses an instantiation boundary is shared, not copied. Generics keep it statically typed — `p.g0.value` needs no assertion, and an imported global resolves by asserting `v.(*global[uint32])`.
+- **Imports beyond functions** resolve through the same provider map, with the ADR-16 kind check performed *by the Go type assertion itself*: `v.(*Memory)` / `v.(*Table)` / `v.(*global[T])` (and the existing func-signature assertion) reject a wrong-kind — and, for funcs and globals, wrong-*type* — import as a `link_error`. A missing non-WASI import is a `link_error` at instantiation (ADR-0), not a deferred call-time stub. **Consequence for the ledger:** Go's `import-limits` gap is *narrower* than Ruby/Python's kind-only check — only global mutability and table/memory min/max limits stay unchecked — so its spec `EXPECTED_FAILURES` counts are lower (the two `linking` failures are both global-mutability mismatches). Exports are a `map[string]any` over every kind (funcs, the global box, table, memory), so a generated instance's `Exports` doubles as another module's import object — what powers the harness's `register` support.
+- **The spec harness compiles Go** (ADR-3). Each `.wast` file becomes one `package main` program: the runtime bundle, harness helpers, every module's package-level declarations, then a `func main` of instantiations and assertions. Because Go has no dynamic dispatch, each generated type carries a reflective `invoke(name, args...) []any` / `globalGet(name) []any` built where the export signatures are known; the harness asserts the boxed results bit-exactly (`math.Float32bits`). Module declarations cannot sit inside `main`, so they are accumulated at package scope and prepended at assembly.
+- **Exhaustion is a generation-time recursion guard** (spec build only). A runaway recursion overflows Go's goroutine stack *fatally* — the runtime aborts the process uncatchably, and the harness needs the script to continue after the check. Of the alternatives — lowering `debug.SetMaxStack` (still process-fatal), or a subprocess per exhaustion assertion — the chosen one instruments each generated function to add its frame's slot count (`1 + params + locals + temps`) to a global `rtStack`, `defer`-decrement it, and trap `"call stack exhausted"` past a fixed budget (1024). It is deterministic, needs no extra process, and — sized by the slot *cost*, not raw depth — also trips on `skip-stack-guard-page.wast`'s `function-with-many-locals` (1056 locals, the only >50-slot function in the suite) even at shallow depth, so that file passes with no ledger entry. The guard is **off** for shipped standalone/library output, whose deep-but-valid recursions must not falsely trap.
+- **Two Go-compiler float hazards** the spec suite exposed (ADR-2): `float_exprs.wast` requires *no contraction* (each op rounds independently), but Go fuses `x*y+z` into a hardware FMA on arm64; and it folds `x*1.0`→`x` / `x/1.0`→`x`, skipping the signaling-NaN quieting the `no_fold_*` tests demand. Both are defeated by routing f32/f64 **mul and div through `//go:noinline` runtime helpers**, so a constant operand never reaches the op and no add can fuse across the call boundary. Separately, min/max NaN results must be the *wasm* canonical NaN — Go's `math.NaN()` is not bit-canonical (its low mantissa bit is set), so the units build the canonical pattern explicitly. f32 `sqrt` via `float32(math.Sqrt(float64(x)))` was *validated* correctly rounded against `f32.wast` (double-rounding through float64 is safe for sqrt).
 
 ## Third milestone: full WASI preview 1 (filesystem)
 
-The fd-table model, `preopens` provider kwarg, prefix-containment sandboxing,
-and the deliberate ENOSYS gaps (rights narrowing, symlink create/read,
-`fd_renumber`/`fd_advise`/`fd_allocate`, `path_filestat_set_times`,
-`poll_oneoff`) are **ADR-14's**, mirrored one-for-one into `runtime/go/units/
-wasi/` (36 units, matching the Ruby/Python set). Only where Go's standard
-library or type system forced a different shape from the interpreted backends
-is recorded here.
+The fd-table model, `preopens` provider kwarg, prefix-containment sandboxing, and the deliberate ENOSYS gaps (rights narrowing, symlink create/read, `fd_renumber`/`fd_advise`/`fd_allocate`, `path_filestat_set_times`, `poll_oneoff`) are **ADR-14's**, mirrored one-for-one into `runtime/go/units/ wasi/` (36 units, matching the Ruby/Python set). Only where Go's standard library or type system forced a different shape from the interpreted backends is recorded here.
 
-- **The fd table is `map[uint32]any`** holding either an `*os.File` (stdio and
-  files) or a `*wasiDir` (a preopen, or a directory the guest opened via
-  `path_open`); every fd-taking syscall type-asserts. Files use `*os.File`'s
-  `ReadAt`/`WriteAt`/`Seek`/`Truncate`/`Sync` for `fd_pread`/`fd_pwrite`/
-  `fd_seek`/`fd_filestat_set_size`/`fd_sync`. Stdio special-cases (SPIPE on
-  seek/tell/pread/pwrite, no close) key on pointer identity with
-  `os.Stdin`/`Stdout`/`Stderr` rather than a captured tuple.
-- **Preopens are the constructor's fourth parameter**, `New<T>(imports, args,
-  env, preopens map[string]string)` — the Go analogue of Ruby/Python's
-  `preopens:` kwarg (Go has no keyword args). Standalone `main` reads
-  `DEWASM_PREOPEN` ("guest=host,…") into it, exactly as the other backends do;
-  preopen fds are assigned in sorted key order so Go's random map iteration adds
-  no nondeterminism.
-- **`filestat` times come from the portable `os.FileInfo.ModTime`** for atim/
-  mtim/ctim; only dev/ino/nlink read the unix `syscall.Stat_t` (via
-  `FileInfo.Sys()`, cast through `uint64`, which compiles on both darwin and
-  linux — unlike the `Atim`/`Atimespec` timespec fields, whose names differ
-  per platform and would need build tags). This keeps the whole runtime a
-  single build-tag-free `.go` file (ADR-29's compile model). `fd_datasync`
-  falls back to a full `fsync` (`*os.File.Sync`) — Go exposes no portable
-  `fdatasync`, and it is absent on macOS anyway (mirroring Python).
-- **`resolve_path` derives the final path component from the raw guest string,
-  not `filepath.Base(filepath.Join(base, rel))`.** Go's `filepath.Join` *Cleans*
-  its result, folding a trailing `.`/`..` away, so `Base` of `join(dir, ".")`
-  returns `dir`'s own name and the AT_SYMLINK_NOFOLLOW branch would wrongly
-  resolve (and reject, ERRNO_NOTCAPABLE) the parent. Python's `os.path.join`
-  keeps the trailing `.`, so its `basename` is `"."` and it falls through to
-  full resolution. Computing `last` from the substring after the final `/`
-  restores that behavior (a `.`/`..`/empty final component is never a symlink).
-- **Library-mode WASI output always seeds `rt/exit`.** The host glue that
-  drives a library instance catches a `proc_exit` (`*rtExit`) to read the exit
-  code, exactly as the standalone `main` does; because Go type-asserts the
-  concrete type at compile time, `*rtExit` must be defined even for a fixture
-  that never imports `proc_exit` itself. (Python gets this for free — its
-  `except Rt.Exit` is evaluated lazily.)
-- **`scan_imports` strips line comments before matching.** With `time`,
-  `strings`, `sort`, etc. now candidate imports, a prose comment ("at
-  instantiation time.") must not pull in the `time` package and trip Go's
-  unused-import error; `//go:` directives are unaffected in the emitted bundle
-  (stripping only computes the import set).
+- **The fd table is `map[uint32]any`** holding either an `*os.File` (stdio and files) or a `*wasiDir` (a preopen, or a directory the guest opened via `path_open`); every fd-taking syscall type-asserts. Files use `*os.File`'s `ReadAt`/`WriteAt`/`Seek`/`Truncate`/`Sync` for `fd_pread`/`fd_pwrite`/ `fd_seek`/`fd_filestat_set_size`/`fd_sync`. Stdio special-cases (SPIPE on seek/tell/pread/pwrite, no close) key on pointer identity with `os.Stdin`/`Stdout`/`Stderr` rather than a captured tuple.
+- **Preopens are the constructor's fourth parameter**, `New<T>(imports, args, env, preopens map[string]string)` — the Go analogue of Ruby/Python's `preopens:` kwarg (Go has no keyword args). Standalone `main` reads `DEWASM_PREOPEN` ("guest=host,…") into it, exactly as the other backends do; preopen fds are assigned in sorted key order so Go's random map iteration adds no nondeterminism.
+- **`filestat` times come from the portable `os.FileInfo.ModTime`** for atim/ mtim/ctim; only dev/ino/nlink read the unix `syscall.Stat_t` (via `FileInfo.Sys()`, cast through `uint64`, which compiles on both darwin and linux — unlike the `Atim`/`Atimespec` timespec fields, whose names differ per platform and would need build tags). This keeps the whole runtime a single build-tag-free `.go` file (ADR-29's compile model). `fd_datasync` falls back to a full `fsync` (`*os.File.Sync`) — Go exposes no portable `fdatasync`, and it is absent on macOS anyway (mirroring Python).
+- **`resolve_path` derives the final path component from the raw guest string, not `filepath.Base(filepath.Join(base, rel))`.** Go's `filepath.Join` *Cleans* its result, folding a trailing `.`/`..` away, so `Base` of `join(dir, ".")` returns `dir`'s own name and the AT_SYMLINK_NOFOLLOW branch would wrongly resolve (and reject, ERRNO_NOTCAPABLE) the parent. Python's `os.path.join` keeps the trailing `.`, so its `basename` is `"."` and it falls through to full resolution. Computing `last` from the substring after the final `/` restores that behavior (a `.`/`..`/empty final component is never a symlink).
+- **Library-mode WASI output always seeds `rt/exit`.** The host glue that drives a library instance catches a `proc_exit` (`*rtExit`) to read the exit code, exactly as the standalone `main` does; because Go type-asserts the concrete type at compile time, `*rtExit` must be defined even for a fixture that never imports `proc_exit` itself. (Python gets this for free — its `except Rt.Exit` is evaluated lazily.)
+- **`scan_imports` strips line comments before matching.** With `time`, `strings`, `sort`, etc. now candidate imports, a prose comment ("at instantiation time.") must not pull in the `time` package and trip Go's unused-import error; `//go:` directives are unaffected in the emitted bundle (stripping only computes the import set).
 
-Result: the shared WASI `Fs` suite (five fixtures incl. the escape/symlink-
-nofollow cases), `gzip_e2e!` (byte-stdio through compiled output), and the
-filesystem app cases (qjs file-I/O + REPL, sqlite3 DB-file, ripgrep) are all
-byte-identical to the same wasmtime goldens the Ruby/Python cases use.
+Result: the shared WASI `Fs` suite (five fixtures incl. the escape/symlink- nofollow cases), `gzip_e2e!` (byte-stdio through compiled output), and the filesystem app cases (qjs file-I/O + REPL, sqlite3 DB-file, ripgrep) are all byte-identical to the same wasmtime goldens the Ruby/Python cases use.
 
 ## Rejected alternatives
 
-- **A per-function branch register (Python's `_br`, ADR-28).** Unnecessary: Go
-  has labeled `break`/`continue`, which express block exits and loop back-edges
-  directly.
-- **PascalCase runtime method names with a snake_case-converting lint.** The
-  conversion is a bug surface for no functional gain (`go build` ignores case);
-  matching unit ids verbatim keeps the lint trivial.
-- **Reflection-based `invoke`.** Storing exports as `map[string]any` and
-  type-asserting at the (test-authored) glue site avoids pulling in `reflect`
-  and its cost.
-- **Blanket `_ = x` for every local/temp.** Correct but bloats cowsay's already
-  large generated file and its compile time; the read/used pre-pass blanks only
-  the genuinely write-only ones.
+- **A per-function branch register (Python's `_br`, ADR-28).** Unnecessary: Go has labeled `break`/`continue`, which express block exits and loop back-edges directly.
+- **PascalCase runtime method names with a snake_case-converting lint.** The conversion is a bug surface for no functional gain (`go build` ignores case); matching unit ids verbatim keeps the lint trivial.
+- **Reflection-based `invoke`.** Storing exports as `map[string]any` and type-asserting at the (test-authored) glue site avoids pulling in `reflect` and its cost.
+- **Blanket `_ = x` for every local/temp.** Correct but bloats cowsay's already large generated file and its compile time; the read/used pre-pass blanks only the genuinely write-only ones.
 
 ## Consequences
 
-- Positive: cowsay is byte-identical to the wasmtime golden for both the args
-  and stdin cases; the standalone, library, and WASI stdio/args-env suites pass.
-  Native integers/floats make the generated arithmetic and the runtime smaller
-  than the interpreted backends'. Cold `go build` of cowsay's ~170k-line file is
-  a few seconds; a warm content-cache hit runs in well under 0.1 s.
-- Negative: library-mode output always imports `fmt`; the generated file is
-  verbose (fully-parenthesised, fully-cast expressions), per ADR-1.
-- Spec milestone (done): the curated default gate is green; the full
-  `DEWASM_SPEC_ALL=1` sweep is green at pass=29235 fail=38 (every failure in the
-  attributed `import-limits`/`linking` ledger), slightly *ahead* of Ruby/Python
-  (29233/40) because the Go type assertion catches two unlinkable cases their
-  kind-only import check misses. Per-file `go build` dominates the sweep, but a
-  content-addressed binary cache (shared with e2e) keeps a warm re-run to well
-  under a minute. The flagged bring-up gaps were resolved, not deferred:
-  NaN-payload conformance (min/max canonical NaN; `no_fold_*` sNaN quieting via
-  the noinline mul/div helpers), no-contraction FMA, and f32 `sqrt` (validated
-  correctly rounded) all pass.
+- Positive: cowsay is byte-identical to the wasmtime golden for both the args and stdin cases; the standalone, library, and WASI stdio/args-env suites pass. Native integers/floats make the generated arithmetic and the runtime smaller than the interpreted backends'. Cold `go build` of cowsay's ~170k-line file is a few seconds; a warm content-cache hit runs in well under 0.1 s.
+- Negative: library-mode output always imports `fmt`; the generated file is verbose (fully-parenthesised, fully-cast expressions), per ADR-1.
+- Spec milestone (done): the curated default gate is green; the full `DEWASM_SPEC_ALL=1` sweep is green at pass=29235 fail=38 (every failure in the attributed `import-limits`/`linking` ledger), slightly *ahead* of Ruby/Python (29233/40) because the Go type assertion catches two unlinkable cases their kind-only import check misses. Per-file `go build` dominates the sweep, but a content-addressed binary cache (shared with e2e) keeps a warm re-run to well under a minute. The flagged bring-up gaps were resolved, not deferred: NaN-payload conformance (min/max canonical NaN; `no_fold_*` sNaN quieting via the noinline mul/div helpers), no-contraction FMA, and f32 `sqrt` (validated correctly rounded) all pass.

--- a/docs/adr/3-testing-strategy.md
+++ b/docs/adr/3-testing-strategy.md
@@ -1,60 +1,26 @@
 # ADR-3 — Testing Strategy: Spec Testsuite on Real Interpreters
 
-Status: **Accepted, 2026-07-23.** Backfilled; implemented in
-`crates/dewasm-test-helper/src/spec.rs` for the Ruby backend. The skip
-policy (curated file list, bare skip counts) was revised the same day by
-[ADR-8](8-latest-testsuite-support-matrix.md): the harness now runs every
-testsuite file and requires each skip to be attributable to a declared-
-unsupported feature. Differential testing of WASI programs against
-wasmtime is done manually so far; automating it remains open.
+Status: **Accepted, 2026-07-23.** Backfilled; implemented in `crates/dewasm-test-helper/src/spec.rs` for the Ruby backend. The skip policy (curated file list, bare skip counts) was revised the same day by [ADR-8](8-latest-testsuite-support-matrix.md): the harness now runs every testsuite file and requires each skip to be attributable to a declared- unsupported feature. Differential testing of WASI programs against wasmtime is done manually so far; automating it remains open.
 
 ## Context
 
-dewasmify's whole value is semantic fidelity across six target languages.
-That cannot be maintained by hand-picked unit tests; it needs the official
-WebAssembly spec testsuite, applied uniformly to every backend, executed
-the way users will actually run the output.
+dewasmify's whole value is semantic fidelity across six target languages. That cannot be maintained by hand-picked unit tests; it needs the official WebAssembly spec testsuite, applied uniformly to every backend, executed the way users will actually run the output.
 
 ## Decision
 
-- **The official `WebAssembly/testsuite` is a git submodule at
-  `tests/spec`**, shallow, pinned to a commit, so upstream churn never
-  breaks CI silently and the tested revision is part of history.
-- **The harness converts `.wast` files into assertion scripts in the
-  target language and runs them on the real interpreter** (`ruby`, later
-  `bash`, `java`, ...). Criterion: *what gets tested must be the shipped
-  artifact* — generated source + embedded runtime on a stock interpreter,
-  not an in-process simulation of it.
-- **Definition of done for a backend = this harness passes.** Adding a
-  language backend means making the shared harness green for it; no
-  backend-private notion of "works".
-- **Directives that exercise unsupported features are counted as
-  `skip`**, driven by conversion failure of the module they target (the
-  converter's clear-error contract from ADR-0 doubles as the skip
-  signal). `assert_invalid` / `assert_malformed` are checked on the Rust
-  side: conversion must fail.
-- **Deviations live in an `EXPECTED_FAILURES` ledger** in the harness,
-  each entry carrying a count and a reason comment. The file still runs,
-  so regressions in its passing assertions are caught. A ledger entry is
-  a debt marker, not an exemption: fixing the cause is the default,
-  adding an entry needs the reason written down.
+- **The official `WebAssembly/testsuite` is a git submodule at `tests/spec`**, shallow, pinned to a commit, so upstream churn never breaks CI silently and the tested revision is part of history.
+- **The harness converts `.wast` files into assertion scripts in the target language and runs them on the real interpreter** (`ruby`, later `bash`, `java`, ...). Criterion: *what gets tested must be the shipped artifact* — generated source + embedded runtime on a stock interpreter, not an in-process simulation of it.
+- **Definition of done for a backend = this harness passes.** Adding a language backend means making the shared harness green for it; no backend-private notion of "works".
+- **Directives that exercise unsupported features are counted as `skip`**, driven by conversion failure of the module they target (the converter's clear-error contract from ADR-0 doubles as the skip signal). `assert_invalid` / `assert_malformed` are checked on the Rust side: conversion must fail.
+- **Deviations live in an `EXPECTED_FAILURES` ledger** in the harness, each entry carrying a count and a reason comment. The file still runs, so regressions in its passing assertions are caught. A ledger entry is a debt marker, not an exemption: fixing the cause is the default, adding an entry needs the reason written down.
 
 ## Rejected alternatives
 
-- **A reference interpreter inside dewasmify** — duplicates wasmtime/the
-  spec interpreter, and tests the wrong thing (our interpreter, not our
-  generated code).
-- **Differential testing only** (run wasm under wasmtime vs. converted
-  output) — good for WASI-level end-to-end checks and kept as a
-  complement, but it cannot pinpoint per-instruction semantics the way
-  ~20k targeted assertions do.
+- **A reference interpreter inside dewasmify** — duplicates wasmtime/the spec interpreter, and tests the wrong thing (our interpreter, not our generated code).
+- **Differential testing only** (run wasm under wasmtime vs. converted output) — good for WASI-level end-to-end checks and kept as a complement, but it cannot pinpoint per-instruction semantics the way ~20k targeted assertions do.
 
 ## Consequences
 
-- Positive: backend bugs surface as named `.wast` lines; the Ruby
-  backend's NaN and rounding defects (ADR-2) were all found this way.
-- Negative: harness runtime scales with interpreter speed — fine for
-  Ruby (~5 s), a real concern for Bash, which will need a curated subset
-  in CI with full runs out-of-band (accepted in advance).
-- The upstream testsuite tracks the latest spec, so newly added
-  proposal files simply skip until the corresponding feature lands.
+- Positive: backend bugs surface as named `.wast` lines; the Ruby backend's NaN and rounding defects (ADR-2) were all found this way.
+- Negative: harness runtime scales with interpreter speed — fine for Ruby (~5 s), a real concern for Bash, which will need a curated subset in CI with full runs out-of-band (accepted in advance).
+- The upstream testsuite tracks the latest spec, so newly added proposal files simply skip until the corresponding feature lands.

--- a/docs/adr/30-java-backend-lowering.md
+++ b/docs/adr/30-java-backend-lowering.md
@@ -1,349 +1,75 @@
 # ADR-30 — Java Backend Lowering Conventions
 
-Status: **Accepted, 2026-07-26.** First milestone ("cowsay runs", ADR-24)
-implemented in `crates/dewasm-backend-java/src/lib.rs`, `runtime/java/units/`,
-and `crates/dewasm-backend-java/tests/{e2e,units}.rs`. **Second milestone
-("spec-harness green", 2026-07-26)** added `tests/spec.rs`, the wasm-1.0
-completion set, trapping conversions, spec-grade NaN conformance, and
-multi-value results — see "Milestone 2" below. **Third milestone ("full WASI
-preview 1 incl. the filesystem", 2026-07-26)** ported the 36 WASI units
-one-for-one from the Go/Python/Ruby backends (ADR-14's fs model) and added the
-class-splitting scheme that lets qjs/sqlite/rg convert and run — see
-"Milestone 3" below. Numeric conventions are ADR-2's;
-this ADR records where Java — statically typed with native fixed-width integers
-and floats, but carrying a hard **64KB-per-method bytecode limit** — forced a
-different shape from the other compiled backend (Go, ADR-29) and from the
-interpreted ones. Java is a compiled backend, so it uses ADR-27's `run()`
-override (`javac` + a class-dir cache).
+Status: **Accepted, 2026-07-26.** First milestone ("cowsay runs", ADR-24) implemented in `crates/dewasm-backend-java/src/lib.rs`, `runtime/java/units/`, and `crates/dewasm-backend-java/tests/{e2e,units}.rs`. **Second milestone ("spec-harness green", 2026-07-26)** added `tests/spec.rs`, the wasm-1.0 completion set, trapping conversions, spec-grade NaN conformance, and multi-value results — see "Milestone 2" below. **Third milestone ("full WASI preview 1 incl. the filesystem", 2026-07-26)** ported the 36 WASI units one-for-one from the Go/Python/Ruby backends (ADR-14's fs model) and added the class-splitting scheme that lets qjs/sqlite/rg convert and run — see "Milestone 3" below. Numeric conventions are ADR-2's; this ADR records where Java — statically typed with native fixed-width integers and floats, but carrying a hard **64KB-per-method bytecode limit** — forced a different shape from the other compiled backend (Go, ADR-29) and from the interpreted ones. Java is a compiled backend, so it uses ADR-27's `run()` override (`javac` + a class-dir cache).
 
 ## Context
 
-Java's type system gives the native-numerics wins Go has (ADR-29), but the JVM
-adds a constraint no other target has: **a single method is capped at 64KB of
-bytecode**, `<clinit>`/`<init>` included, and a string constant at 65535 bytes.
-cowsay already blows both: its largest function lowers to ~11.7k statements
-(one ~11.3k-statement loop body), far past 64KB, and its data segment is 69856
-bytes, past the string-literal cap. ADR-10 predicted this would be the
-Java-specific landmine; it is real at the very first milestone, so the split
-and the data-chunking are implemented now, not deferred.
+Java's type system gives the native-numerics wins Go has (ADR-29), but the JVM adds a constraint no other target has: **a single method is capped at 64KB of bytecode**, `<clinit>`/`<init>` included, and a string constant at 65535 bytes. cowsay already blows both: its largest function lowers to ~11.7k statements (one ~11.3k-statement loop body), far past 64KB, and its data segment is 69856 bytes, past the string-literal cap. ADR-10 predicted this would be the Java-specific landmine; it is real at the very first milestone, so the split and the data-chunking are implemented now, not deferred.
 
 Two more Java facts shaped the design:
 
-1. **Unreachable code is a compile error** ("unreachable statement"), unlike
-   Go (which tolerates it) — so an emitter must never place a statement after an
-   unconditional `return`/`break`/`throw`. But *missing* a return is also an
-   error. Matching Java's exact reachability model for labelled blocks is
-   fiddly and bidirectionally fatal.
+1. **Unreachable code is a compile error** ("unreachable statement"), unlike Go (which tolerates it) — so an emitter must never place a statement after an unconditional `return`/`break`/`throw`. But *missing* a return is also an error. Matching Java's exact reachability model for labelled blocks is fiddly and bidirectionally fatal.
 2. **No tuples / multi-value returns**, and **no unsigned integer types**.
 
 ## Decision
 
-- **Types (the natural Java mapping, ADR-2).** i32→`int`, i64→`long` as
-  *signed bit patterns* (the hardware view, not Ruby/Python's masked-unsigned
-  convention); unsigned ops use `Integer`/`Long.divideUnsigned`/
-  `remainderUnsigned`/`compareUnsigned`/`toUnsignedLong`. The visible semantics
-  are identical — a masked-unsigned `x & 0xffffffff` and a signed `int` denote
-  the same 2³² residues — and this mapping makes wrapping arithmetic
-  (`a + b`), shifts, sign-extension, and memory stores native. f32→`float`,
-  f64→`double`: Java is strict IEEE with **no implicit FMA contraction**, so f32
-  re-rounding and trap-free division (`a / b` → inf/NaN) need no helper — Java is
-  actually *safer* here than Go, which had to route mul/div through `noinline`
-  helpers to defeat FMA and constant-folding (ADR-29). NaN bit paths go through
-  `Float.floatToRawIntBits`/`intBitsToFloat` (and the `double` pair).
-  Only integer div/rem carry runtime helpers (`Rt.i32_div_s`, …), for wasm's
-  two trap conditions Java's `/` does not raise (`INT_MIN/-1` overflow and,
-  uniformly, divide-by-zero with the spec message).
-- **Memory is a `byte[]` with a little-endian `ByteBuffer` view.** Chosen over
-  VarHandles for simplicity; the buffer is re-wrapped on `memory.grow`. Callers
-  compute effective addresses as unsigned `long` (`Integer.toUnsignedLong(a) +
-  offset`), so a guest-addr-plus-offset past 2³¹ is bounds-checked exactly, and
-  the `int` index handed to the buffer is safe after the check.
-- **Control flow uses the branch-register model (ADR-28's Python design),
-  not Java labelled blocks — the load-bearing deviation from the task's
-  stylistic preference.** Block/if exits and the function return set a
-  per-function register `_br`; following siblings are guarded by `if (_br == 0)`;
-  only real loops become `while (true)` with a trailer that turns `_br == <loop
-  id>` into `continue`. The criterion: **the representation must split across
-  methods** (see below), and language-level labelled `break`/`continue` cannot
-  cross a method boundary, whereas a data-carried `_br` can. This choice also
-  dissolves Java's unreachable-statement landmine for free: no bare
-  mid-sequence `return`/`break` is ever emitted, so there is nothing to be
-  unreachable. Two Java-specific adaptations of ADR-28:
-    * **The function return is itself register-based** (`_ret = v; _br = -1;`)
-      with a single tail `return _ret`, precisely so a mid-function `return`
-      never becomes a bare Java `return` with dead code behind it. (Python emits
-      native `return` and lets the dead code be; Java cannot.)
-    * **`Rt.trap`/`exit`/`link_error` are `void` methods that throw**, emitted
-      as plain statements (`Rt.trap("unreachable");`), not `throw`, so no
-      "unreachable statement" follows them.
-- **The 64KB method split.** A function whose estimated cost (an IR node count)
-  crosses a threshold has its locals, temps, and the `_br`/`_ret` registers
-  hoisted to a per-call **frame object** (`FrameNN`), and its body split at
-  statement-sequence boundaries into numbered `void fNN_pK(FrameNN f)` methods,
-  called in order. Because control flow is the `_br` data register — not
-  language labels — the parts are simply **called unconditionally**: an escaped
-  branch (`_br != 0`) makes each subsequent part's guarded statements no-op
-  until the owning loop trailer / block reset-marker consumes it. A loop keeps
-  its `while (true)` wrapper in the parent method and chunks its (possibly
-  huge) body into parts called inside the loop; the split recurses into any
-  sub-body over the threshold. This is the split ADR-10 anticipated ("numbered
-  helper methods … with locals hoisted to fields of a per-call frame object").
-  cowsay needs it: 61 of its 640 functions split, into ~1335 part methods, and
-  the whole file compiles with no "code too large".
-- **Data segments are chunked Base64.** A segment is emitted as
-  `Rt.data_from_b64(new String[]{"…", "…"})` with each chunk's Base64 under the
-  65535-byte string-literal limit (32KB raw per chunk); `java.util.Base64`
-  decodes and concatenates at instantiation. This is the honest general
-  mechanism; hex was rejected as it doubles the constant size for no benefit.
-- **Import/table/export values use one boxed calling convention at the dynamic
-  boundary.** A wasm function value is an `Rt.Fn` (`Object invoke(Object[])`);
-  the import object is `Map<String, Map<String, Object>>` (ADR-7's shape).
-  Imports resolve to an embedder `Rt.Fn`, else a bundled-WASI adapter lambda,
-  else an ENOSYS stub / link error. `call_indirect` and exports go through the
-  same `Rt.Fn` (a `Funcref` boxes a structural type string + the `Fn`, checked
-  in `Table.call`). **Direct calls to defined functions stay primitive**
-  (`fN(a, b)`); boxing is only at the dynamic edge, mirroring Go's `any`
-  boundary. The honest cost: with one uniform `Fn`, a wrong-*signature* import
-  is not rejected (a wrong-*kind* one is, via `instanceof`); this is a wider
-  import-limits gap than Go's, acceptable for the milestone.
-- **Execution (`run()` override, ADR-27).** Java is compiled, so the test helper
-  compiles the single generated `Main.java` with `javac` into a
-  content-addressed class-dir cache and runs `java -cp <dir> Main`. Measured on
-  cowsay, this beats the `java Main.java` single-file source launcher decisively:
-  the launcher recompiles in memory on **every** run (~3.3 s each), while
-  `javac` + cache pays a one-time ~2 s compile and then runs warm in ~0.15 s.
-  `$DEWASM_JAVA`/`$DEWASM_JAVAC` override the toolchain; a missing one fails
-  loud (ADR-15). One public class (`Main`) per file keeps the `javac` filename
-  contract trivial; the runtime classes and the module class are package-private.
-- **Feature scope.** `Floats` is `Supported`. WASI is the eight core syscalls
-  cowsay imports (args/env, `fd_read`, `fd_write`, `proc_exit`, `random_get`).
-  Non-function imports, multiple tables, and table bulk ops are out of scope for
-  the milestone and rejected at conversion time (`check_module_support`).
+- **Types (the natural Java mapping, ADR-2).** i32→`int`, i64→`long` as *signed bit patterns* (the hardware view, not Ruby/Python's masked-unsigned convention); unsigned ops use `Integer`/`Long.divideUnsigned`/ `remainderUnsigned`/`compareUnsigned`/`toUnsignedLong`. The visible semantics are identical — a masked-unsigned `x & 0xffffffff` and a signed `int` denote the same 2³² residues — and this mapping makes wrapping arithmetic (`a + b`), shifts, sign-extension, and memory stores native. f32→`float`, f64→`double`: Java is strict IEEE with **no implicit FMA contraction**, so f32 re-rounding and trap-free division (`a / b` → inf/NaN) need no helper — Java is actually *safer* here than Go, which had to route mul/div through `noinline` helpers to defeat FMA and constant-folding (ADR-29). NaN bit paths go through `Float.floatToRawIntBits`/`intBitsToFloat` (and the `double` pair). Only integer div/rem carry runtime helpers (`Rt.i32_div_s`, …), for wasm's two trap conditions Java's `/` does not raise (`INT_MIN/-1` overflow and, uniformly, divide-by-zero with the spec message).
+- **Memory is a `byte[]` with a little-endian `ByteBuffer` view.** Chosen over VarHandles for simplicity; the buffer is re-wrapped on `memory.grow`. Callers compute effective addresses as unsigned `long` (`Integer.toUnsignedLong(a) + offset`), so a guest-addr-plus-offset past 2³¹ is bounds-checked exactly, and the `int` index handed to the buffer is safe after the check.
+- **Control flow uses the branch-register model (ADR-28's Python design), not Java labelled blocks — the load-bearing deviation from the task's stylistic preference.** Block/if exits and the function return set a per-function register `_br`; following siblings are guarded by `if (_br == 0)`; only real loops become `while (true)` with a trailer that turns `_br == <loop id>` into `continue`. The criterion: **the representation must split across methods** (see below), and language-level labelled `break`/`continue` cannot cross a method boundary, whereas a data-carried `_br` can. This choice also dissolves Java's unreachable-statement landmine for free: no bare mid-sequence `return`/`break` is ever emitted, so there is nothing to be unreachable. Two Java-specific adaptations of ADR-28:
+    * **The function return is itself register-based** (`_ret = v; _br = -1;`) with a single tail `return _ret`, precisely so a mid-function `return` never becomes a bare Java `return` with dead code behind it. (Python emits native `return` and lets the dead code be; Java cannot.)
+    * **`Rt.trap`/`exit`/`link_error` are `void` methods that throw**, emitted as plain statements (`Rt.trap("unreachable");`), not `throw`, so no "unreachable statement" follows them.
+- **The 64KB method split.** A function whose estimated cost (an IR node count) crosses a threshold has its locals, temps, and the `_br`/`_ret` registers hoisted to a per-call **frame object** (`FrameNN`), and its body split at statement-sequence boundaries into numbered `void fNN_pK(FrameNN f)` methods, called in order. Because control flow is the `_br` data register — not language labels — the parts are simply **called unconditionally**: an escaped branch (`_br != 0`) makes each subsequent part's guarded statements no-op until the owning loop trailer / block reset-marker consumes it. A loop keeps its `while (true)` wrapper in the parent method and chunks its (possibly huge) body into parts called inside the loop; the split recurses into any sub-body over the threshold. This is the split ADR-10 anticipated ("numbered helper methods … with locals hoisted to fields of a per-call frame object"). cowsay needs it: 61 of its 640 functions split, into ~1335 part methods, and the whole file compiles with no "code too large".
+- **Data segments are chunked Base64.** A segment is emitted as `Rt.data_from_b64(new String[]{"…", "…"})` with each chunk's Base64 under the 65535-byte string-literal limit (32KB raw per chunk); `java.util.Base64` decodes and concatenates at instantiation. This is the honest general mechanism; hex was rejected as it doubles the constant size for no benefit.
+- **Import/table/export values use one boxed calling convention at the dynamic boundary.** A wasm function value is an `Rt.Fn` (`Object invoke(Object[])`); the import object is `Map<String, Map<String, Object>>` (ADR-7's shape). Imports resolve to an embedder `Rt.Fn`, else a bundled-WASI adapter lambda, else an ENOSYS stub / link error. `call_indirect` and exports go through the same `Rt.Fn` (a `Funcref` boxes a structural type string + the `Fn`, checked in `Table.call`). **Direct calls to defined functions stay primitive** (`fN(a, b)`); boxing is only at the dynamic edge, mirroring Go's `any` boundary. The honest cost: with one uniform `Fn`, a wrong-*signature* import is not rejected (a wrong-*kind* one is, via `instanceof`); this is a wider import-limits gap than Go's, acceptable for the milestone.
+- **Execution (`run()` override, ADR-27).** Java is compiled, so the test helper compiles the single generated `Main.java` with `javac` into a content-addressed class-dir cache and runs `java -cp <dir> Main`. Measured on cowsay, this beats the `java Main.java` single-file source launcher decisively: the launcher recompiles in memory on **every** run (~3.3 s each), while `javac` + cache pays a one-time ~2 s compile and then runs warm in ~0.15 s. `$DEWASM_JAVA`/`$DEWASM_JAVAC` override the toolchain; a missing one fails loud (ADR-15). One public class (`Main`) per file keeps the `javac` filename contract trivial; the runtime classes and the module class are package-private.
+- **Feature scope.** `Floats` is `Supported`. WASI is the eight core syscalls cowsay imports (args/env, `fd_read`, `fd_write`, `proc_exit`, `random_get`). Non-function imports, multiple tables, and table bulk ops are out of scope for the milestone and rejected at conversion time (`check_module_support`).
 
 ## Rejected alternatives
 
-- **Java labelled blocks (`L: { … } break L;`) for control flow** — the task's
-  stylistic preference and cleaner to read, but a `break L` cannot cross a
-  method boundary, so oversized functions could not be split without first
-  rewriting their control flow into exactly the register form adopted here.
-  Correctness under the 64KB limit outranks readability (ADR-1). It would also
-  reintroduce the unreachable-statement / missing-return tightrope.
-- **A relooper / big-`switch` state machine** — a heavier rewrite than the
-  register model for the same depth-insensitivity; ADR-28 already proved the
-  register model on cowsay.
-- **One `Funcref` dispatch method (`callByIndex`) instead of per-entry
-  lambdas** — a single giant `switch` over hundreds of functions is itself a
-  64KB-method hazard needing its own split; lambdas distribute the code.
-- **Native `(int)` casts for trapping float→int** — Java's cast saturates, so
-  the *saturating* ops (`trunc_sat_*`) are exact, but the *trapping* ones
-  silently saturate instead of trapping. Accepted as a documented milestone-1
-  gap (cowsay exercises neither); the trapping form and full NaN-payload
-  conformance for the rounding ops are spec-milestone work.
+- **Java labelled blocks (`L: { … } break L;`) for control flow** — the task's stylistic preference and cleaner to read, but a `break L` cannot cross a method boundary, so oversized functions could not be split without first rewriting their control flow into exactly the register form adopted here. Correctness under the 64KB limit outranks readability (ADR-1). It would also reintroduce the unreachable-statement / missing-return tightrope.
+- **A relooper / big-`switch` state machine** — a heavier rewrite than the register model for the same depth-insensitivity; ADR-28 already proved the register model on cowsay.
+- **One `Funcref` dispatch method (`callByIndex`) instead of per-entry lambdas** — a single giant `switch` over hundreds of functions is itself a 64KB-method hazard needing its own split; lambdas distribute the code.
+- **Native `(int)` casts for trapping float→int** — Java's cast saturates, so the *saturating* ops (`trunc_sat_*`) are exact, but the *trapping* ones silently saturate instead of trapping. Accepted as a documented milestone-1 gap (cowsay exercises neither); the trapping form and full NaN-payload conformance for the rounding ops are spec-milestone work.
 
 ## Consequences
 
-- Positive: cowsay is byte-identical to the wasmtime golden for both the args
-  and stdin cases; the standalone, library, and WASI stdio/args-env suites pass.
-  Native integers/floats keep the arithmetic and runtime small; Java's strict
-  IEEE avoids Go's FMA/fold workarounds entirely.
-- Negative: the generated file is large and verbose (frame classes, part
-  methods, per-statement `_br` guards); the boxed `Fn` boundary autoboxes at
-  every import/indirect/export call.
-- Deferred, recorded for later milestones (milestone 2 closed the first four,
-  milestone 3 below closed the rest):
-  ~~trapping float→int conversions and spec-grade NaN/rounding conformance;
-  multi-value function results; wasm-1.0 completion (imported globals/memories/
-  tables, multiple tables, table bulk ops)~~ — all landed in milestone 2 below.
-  ~~The full WASI preview 1 surface incl. the filesystem, and multi-MB data
-  segments (qjs/sqlite)~~ — landed in milestone 3 below.
+- Positive: cowsay is byte-identical to the wasmtime golden for both the args and stdin cases; the standalone, library, and WASI stdio/args-env suites pass. Native integers/floats keep the arithmetic and runtime small; Java's strict IEEE avoids Go's FMA/fold workarounds entirely.
+- Negative: the generated file is large and verbose (frame classes, part methods, per-statement `_br` guards); the boxed `Fn` boundary autoboxes at every import/indirect/export call.
+- Deferred, recorded for later milestones (milestone 2 closed the first four, milestone 3 below closed the rest): ~~trapping float→int conversions and spec-grade NaN/rounding conformance; multi-value function results; wasm-1.0 completion (imported globals/memories/ tables, multiple tables, table bulk ops)~~ — all landed in milestone 2 below. ~~The full WASI preview 1 surface incl. the filesystem, and multi-MB data segments (qjs/sqlite)~~ — landed in milestone 3 below.
 
 ## Milestone 2 — spec-harness green
 
-The shared spec harness (ADR-3) passes for Java: **29233 pass / 40 fail** on the
-full `DEWASM_SPEC_ALL=1` sweep (~40 s, `javac` per `.wast` file), matching the
-other backends. The 40 failures are all in the `EXPECTED_FAILURES` ledger
-(import-limits + a linking artefact, below). `tests/spec.rs` mirrors Go's
-compiled `SpecBackend` (content-addressed class-dir cache, curated
-`default_files` + sweep) with Java-specific phrasing decisions:
+The shared spec harness (ADR-3) passes for Java: **29233 pass / 40 fail** on the full `DEWASM_SPEC_ALL=1` sweep (~40 s, `javac` per `.wast` file), matching the other backends. The 40 failures are all in the `EXPECTED_FAILURES` ledger (import-limits + a linking artefact, below). `tests/spec.rs` mirrors Go's compiled `SpecBackend` (content-addressed class-dir cache, curated `default_files` + sweep) with Java-specific phrasing decisions:
 
-- **Exhaustion maps to `StackOverflowError`, which the JVM makes catchable** —
-  unlike Go's *fatal* goroutine overflow, which forced ADR-29's spec-build
-  recursion guard. `check_exhaust` catches it directly, exactly as Ruby's harness
-  catches `SystemStackError` (ADR-3). The honest risk — a mid-call overflow
-  leaving the module instance in a partially-mutated state — is bounded because
-  each spec assertion is independent: the harness never reads that instance's
-  post-overflow state in a way a later assertion depends on, and the JVM stack is
-  fully unwound before the next check. No recursion guard is instrumented into
-  the generated functions, so the shipped standalone/library output is unchanged
-  by spec support. The harness runs `java -Xss16m` so genuinely deep but
-  terminating recursions (fac, long `br` chains) stay under the limit while a
-  runaway still overflows.
-- **Multi-value results return a boxed `Object[]`.** A JVM method returns one
-  value, so a signature with >1 result lowers to an `Object[]`-returning method;
-  the per-function result register (`_ret` / frame `ret`) and a `return`/`br` to
-  the function boundary build `new Object[]{ v0, v1, … }` (autoboxing each
-  primitive), and a multi-value call site destructures `__mvN[i]` back to
-  primitives. This is the boxed dynamic-edge convention (ADR-30's `Fn` boundary)
-  reused for the result tuple; single-value and void functions keep their
-  primitive/`void` return. The harness's `invoke` dispatcher always hands back an
-  `Object[]` (empty / one element / the function's own tuple), so multi-value
-  checks compare element-wise uniformly.
-- **Trapping conversions and NaN conformance are runtime units, not Java
-  casts.** Java's `(int)`/`(long)` float casts *saturate*, so the trapping
-  `trunc_*` ops route through `Rt.i32_trunc_s`/… helpers that trap on NaN
-  ("invalid conversion to integer") and out-of-range ("integer overflow"); the
-  *saturating* signed forms are exactly Java's cast, but the saturating
-  *unsigned* forms need helpers (the cast wraps past the unsigned range).
-  For floats, Java is strict IEEE but its `Math.*` library is not wasm-faithful
-  on NaN: `abs`/`copysign` are re-expressed as sign-bit ops (they must *not*
-  quiet a NaN), while `ceil`/`floor`/`trunc`/`nearest`/`sqrt`/`min`/`max` route
-  through helpers that canonicalize a NaN result to wasm's arithmetic NaN (Java
-  would pass a signaling operand through unquieted). `min`/`max` also fix the
-  ±0 tie and NaN-operand result; `demote`/`promote` reconstruct the NaN payload;
-  `convert_i64_u` uses a round-to-odd trick so Java's *signed* l2f/l2d rounds a
-  ≥2⁶³ value correctly. (Wrapping add/sub/mul/div need no helper: HotSpot's
-  `fadd`/… already canonicalize a NaN operand, and Java performs no FMA
-  contraction — ADR-2.)
-- **Globals are boxed as a shared `Global` cell (ADR-16).** Every global — not
-  just imported/exported ones — is a `Global` holding an `Object` value, so a
-  global crossing an instantiation boundary is a shared cell (the reason
-  Memory/Table are objects). Imported globals/memories/tables resolve through the
-  provider map with an `instanceof` **kind** check; multiple tables (index space
-  `imported_tables ++ tables`), passive/declared element segments, and
-  `table.init`/`table.copy`/`elem.drop` are implemented, and the five wasm-1.0
-  `feature_status` entries are flipped to `Supported`. `register`/cross-module
-  linking works (`supports_registered_imports`): an instance's `Exports` map
-  doubles as an ADR-7 provider.
-- **The import-limits gap is wider than Go's, matching Ruby's ledger.** Because
-  a func value is one uniform `Rt.Fn` (no signature carried) and a `Global` boxes
-  an untyped `Object`, an import of the right *kind* but wrong *type* (a func
-  with a mismatched signature, a global with a mismatched value type or
-  mutability, a table/memory with mismatched limits) is not rejected — only a
-  wrong *kind* is (`instanceof`). So Java's ledger equals Ruby's
-  (imports 28, imports2 2, **linking 4**), not Go's lower counts (Go's typed
-  assertion catches the func-signature and global-value-type cases). `linking0`
-  (1) and `load1` (5) are the shared "downstream of an unrelated multi-memory
-  module that also uses `register`" artefact, not a cross-module-linking gap.
+- **Exhaustion maps to `StackOverflowError`, which the JVM makes catchable** — unlike Go's *fatal* goroutine overflow, which forced ADR-29's spec-build recursion guard. `check_exhaust` catches it directly, exactly as Ruby's harness catches `SystemStackError` (ADR-3). The honest risk — a mid-call overflow leaving the module instance in a partially-mutated state — is bounded because each spec assertion is independent: the harness never reads that instance's post-overflow state in a way a later assertion depends on, and the JVM stack is fully unwound before the next check. No recursion guard is instrumented into the generated functions, so the shipped standalone/library output is unchanged by spec support. The harness runs `java -Xss16m` so genuinely deep but terminating recursions (fac, long `br` chains) stay under the limit while a runaway still overflows.
+- **Multi-value results return a boxed `Object[]`.** A JVM method returns one value, so a signature with >1 result lowers to an `Object[]`-returning method; the per-function result register (`_ret` / frame `ret`) and a `return`/`br` to the function boundary build `new Object[]{ v0, v1, … }` (autoboxing each primitive), and a multi-value call site destructures `__mvN[i]` back to primitives. This is the boxed dynamic-edge convention (ADR-30's `Fn` boundary) reused for the result tuple; single-value and void functions keep their primitive/`void` return. The harness's `invoke` dispatcher always hands back an `Object[]` (empty / one element / the function's own tuple), so multi-value checks compare element-wise uniformly.
+- **Trapping conversions and NaN conformance are runtime units, not Java casts.** Java's `(int)`/`(long)` float casts *saturate*, so the trapping `trunc_*` ops route through `Rt.i32_trunc_s`/… helpers that trap on NaN ("invalid conversion to integer") and out-of-range ("integer overflow"); the *saturating* signed forms are exactly Java's cast, but the saturating *unsigned* forms need helpers (the cast wraps past the unsigned range). For floats, Java is strict IEEE but its `Math.*` library is not wasm-faithful on NaN: `abs`/`copysign` are re-expressed as sign-bit ops (they must *not* quiet a NaN), while `ceil`/`floor`/`trunc`/`nearest`/`sqrt`/`min`/`max` route through helpers that canonicalize a NaN result to wasm's arithmetic NaN (Java would pass a signaling operand through unquieted). `min`/`max` also fix the ±0 tie and NaN-operand result; `demote`/`promote` reconstruct the NaN payload; `convert_i64_u` uses a round-to-odd trick so Java's *signed* l2f/l2d rounds a ≥2⁶³ value correctly. (Wrapping add/sub/mul/div need no helper: HotSpot's `fadd`/… already canonicalize a NaN operand, and Java performs no FMA contraction — ADR-2.)
+- **Globals are boxed as a shared `Global` cell (ADR-16).** Every global — not just imported/exported ones — is a `Global` holding an `Object` value, so a global crossing an instantiation boundary is a shared cell (the reason Memory/Table are objects). Imported globals/memories/tables resolve through the provider map with an `instanceof` **kind** check; multiple tables (index space `imported_tables ++ tables`), passive/declared element segments, and `table.init`/`table.copy`/`elem.drop` are implemented, and the five wasm-1.0 `feature_status` entries are flipped to `Supported`. `register`/cross-module linking works (`supports_registered_imports`): an instance's `Exports` map doubles as an ADR-7 provider.
+- **The import-limits gap is wider than Go's, matching Ruby's ledger.** Because a func value is one uniform `Rt.Fn` (no signature carried) and a `Global` boxes an untyped `Object`, an import of the right *kind* but wrong *type* (a func with a mismatched signature, a global with a mismatched value type or mutability, a table/memory with mismatched limits) is not rejected — only a wrong *kind* is (`instanceof`). So Java's ledger equals Ruby's (imports 28, imports2 2, **linking 4**), not Go's lower counts (Go's typed assertion catches the func-signature and global-value-type cases). `linking0` (1) and `load1` (5) are the shared "downstream of an unrelated multi-memory module that also uses `register`" artefact, not a cross-module-linking gap.
 
 ## Rejected alternatives (milestone 2)
 
-- **A spec-build recursion guard (Go's ADR-29 counter) for exhaustion** —
-  unnecessary because the JVM's `StackOverflowError` is catchable; a guard would
-  also change the generated functions only for the spec build, adding a divergence
-  the `StackOverflowError` path avoids.
-- **A per-signature small record/tuple class for multi-value** — `Object[]` reuses
-  the existing boxed dynamic-edge convention with no extra generated types; the
-  autoboxing cost is the same one already paid at every import/indirect/export.
-- **Typing the `Global` box (e.g. `Global<T>` or a value-type tag) to catch
-  wrong-type global imports** — Java generics cannot hold a primitive, and a tag
-  would still not close the func-signature gap (the `Rt.Fn` boundary), so it
-  would only partially narrow an already-documented, Ruby-parity import-limits
-  gap; deferred as not worth the per-global complexity.
+- **A spec-build recursion guard (Go's ADR-29 counter) for exhaustion** — unnecessary because the JVM's `StackOverflowError` is catchable; a guard would also change the generated functions only for the spec build, adding a divergence the `StackOverflowError` path avoids.
+- **A per-signature small record/tuple class for multi-value** — `Object[]` reuses the existing boxed dynamic-edge convention with no extra generated types; the autoboxing cost is the same one already paid at every import/indirect/export.
+- **Typing the `Global` box (e.g. `Global<T>` or a value-type tag) to catch wrong-type global imports** — Java generics cannot hold a primitive, and a tag would still not close the func-signature gap (the `Rt.Fn` boundary), so it would only partially narrow an already-documented, Ruby-parity import-limits gap; deferred as not worth the per-global complexity.
 
 ## Milestone 3 — full WASI preview 1 (incl. the filesystem)
 
-The 36 WASI units under `runtime/java/units/wasi/` now match the Go/Python/Ruby
-backends one-for-one (ADR-14's model), and the whole-program `Fs` WASI suite,
-`gzip_e2e!` byte-stdio, and the mirrored filesystem app cases
-(`qjs_file_io_java`/`qjs_repl_java`/`sqlite3_shell_dbfile_java`/`rg_search_java`,
-`DEWASM_APPS_ALL`-gated) all pass byte-identically to the wasmtime goldens.
-`has_wasi_p1` now derives `true` for the full surface; `docs/support.md` shows
-Java at parity with the other native backends, carrying the **same deliberate
-ENOSYS gaps** (`fd_advise`/`fd_allocate`/`fd_fdstat_set_flags`/
-`fd_filestat_set_times`/`path_link`/`path_readlink`/`path_symlink`/`poll_oneoff`/
-`fd_renumber`/`fd_fdstat_set_rights`). `run_heavy_apps` is now `true`: qjs and
-sqlite3-shell pass in the default `cargo test`.
+The 36 WASI units under `runtime/java/units/wasi/` now match the Go/Python/Ruby backends one-for-one (ADR-14's model), and the whole-program `Fs` WASI suite, `gzip_e2e!` byte-stdio, and the mirrored filesystem app cases (`qjs_file_io_java`/`qjs_repl_java`/`sqlite3_shell_dbfile_java`/`rg_search_java`, `DEWASM_APPS_ALL`-gated) all pass byte-identically to the wasmtime goldens. `has_wasi_p1` now derives `true` for the full surface; `docs/support.md` shows Java at parity with the other native backends, carrying the **same deliberate ENOSYS gaps** (`fd_advise`/`fd_allocate`/`fd_fdstat_set_flags`/ `fd_filestat_set_times`/`path_link`/`path_readlink`/`path_symlink`/`poll_oneoff`/ `fd_renumber`/`fd_fdstat_set_rights`). `run_heavy_apps` is now `true`: qjs and sqlite3-shell pass in the default `cargo test`.
 
-- **The fd table and the stdlib mapping.** The `WASI` class holds a
-  `Map<Integer, Object>` fd table whose entries are an `InputStream`/
-  `OutputStream` (the inherited stdio, fds 0/1/2), a `Handle` (a guest-opened
-  regular file over a **seekable `FileChannel`**), or a `Dir` (a preopen or a
-  directory the guest opened via `path_open`). One `FileChannel` per open file
-  gives coherent `read`/`write`/`seek`/`tell` plus positional `pread`/`pwrite`
-  (`read`/`write(ByteBuffer, position)`, which do not move the channel's own
-  position); `O_APPEND` is reproduced by seeking to end before each write
-  (FileChannel's APPEND option forbids combining with READ/TRUNCATE). Preopens
-  arrive as a new constructor kwarg `java.util.Map<String, String> preopens`
-  (guest→host), assigned fds in sorted guest-path order for determinism; the
-  standalone `main` parses `DEWASM_PREOPEN` ("guest=host,...") into it, kept
-  separate from argv (ADR-14). Directory listings use `DirectoryStream` sorted by
-  name; `pack_filestat` reads dev/ino/nlink from the `"unix:*"` attribute view
-  (falling back to zeros/nlink=1 off unix) and size/mtime from
-  `BasicFileAttributes`.
-- **The errno map is exception-typed, not errno-typed.** Java's NIO raises typed
-  `IOException` subclasses, so `fs_errno` maps `NoSuchFileException`→ENOENT,
-  `FileAlreadyExistsException`→EEXIST, `AccessDeniedException`→EACCES,
-  `DirectoryNotEmptyException`→ENOTEMPTY, `NotDirectoryException`→ENOTDIR, and
-  everything else→EIO. The honest deviations from the Go/Python backends (which
-  read the raw `errno`): Java exposes no distinct exception for EISDIR, ELOOP, or
-  ENAMETOOLONG at open/stat time, so those surface as EIO unless a syscall
-  detects them itself. `path_remove_directory`/`path_unlink_file` therefore
-  pre-check `isDirectory` to reproduce rmdir's ENOTDIR and unlink's EISDIR
-  (Java's `Files.delete` would otherwise delete either). The sandboxing
-  discipline is ADR-14's, expressed with `Path`: `resolve_path` joins as Go's
-  `filepath.Join` does (so an absolute `rel` stays confined), `normalize()`s,
-  `toRealPath()`s the parent, and re-validates containment with `Path.startsWith`
-  on every call. `wasi_filetype` collapses block/char devices and sockets to
-  "unknown" (BasicFileAttributes cannot distinguish them); a piped stdin reports
-  filetype 4 (regular) and a tty reports 2, via `System.console()`, so a guest's
-  `isatty` stays false under the piped test harness — matching the wasmtime
-  golden.
+- **The fd table and the stdlib mapping.** The `WASI` class holds a `Map<Integer, Object>` fd table whose entries are an `InputStream`/ `OutputStream` (the inherited stdio, fds 0/1/2), a `Handle` (a guest-opened regular file over a **seekable `FileChannel`**), or a `Dir` (a preopen or a directory the guest opened via `path_open`). One `FileChannel` per open file gives coherent `read`/`write`/`seek`/`tell` plus positional `pread`/`pwrite` (`read`/`write(ByteBuffer, position)`, which do not move the channel's own position); `O_APPEND` is reproduced by seeking to end before each write (FileChannel's APPEND option forbids combining with READ/TRUNCATE). Preopens arrive as a new constructor kwarg `java.util.Map<String, String> preopens` (guest→host), assigned fds in sorted guest-path order for determinism; the standalone `main` parses `DEWASM_PREOPEN` ("guest=host,...") into it, kept separate from argv (ADR-14). Directory listings use `DirectoryStream` sorted by name; `pack_filestat` reads dev/ino/nlink from the `"unix:*"` attribute view (falling back to zeros/nlink=1 off unix) and size/mtime from `BasicFileAttributes`.
+- **The errno map is exception-typed, not errno-typed.** Java's NIO raises typed `IOException` subclasses, so `fs_errno` maps `NoSuchFileException`→ENOENT, `FileAlreadyExistsException`→EEXIST, `AccessDeniedException`→EACCES, `DirectoryNotEmptyException`→ENOTEMPTY, `NotDirectoryException`→ENOTDIR, and everything else→EIO. The honest deviations from the Go/Python backends (which read the raw `errno`): Java exposes no distinct exception for EISDIR, ELOOP, or ENAMETOOLONG at open/stat time, so those surface as EIO unless a syscall detects them itself. `path_remove_directory`/`path_unlink_file` therefore pre-check `isDirectory` to reproduce rmdir's ENOTDIR and unlink's EISDIR (Java's `Files.delete` would otherwise delete either). The sandboxing discipline is ADR-14's, expressed with `Path`: `resolve_path` joins as Go's `filepath.Join` does (so an absolute `rel` stays confined), `normalize()`s, `toRealPath()`s the parent, and re-validates containment with `Path.startsWith` on every call. `wasi_filetype` collapses block/char devices and sockets to "unknown" (BasicFileAttributes cannot distinguish them); a piped stdin reports filetype 4 (regular) and a tty reports 2, via `System.console()`, so a guest's `isatty` stays false under the piped test harness — matching the wasmtime golden.
 
 ### The class-splitting scheme (data segments, function tables, functions)
 
-ADR-10 and milestone 1 predicted the JVM's **65535-entry constant pool** and the
-64KB `<init>` limit would bite the heavy apps. Measured on the pinned binaries,
-the picture is more nuanced than "multi-MB data segments overflow", and the
-scheme splits along three axes, gated so cowsay/spec and even qjs/sqlite keep
-their milestone-1/2 single-class shape:
+ADR-10 and milestone 1 predicted the JVM's **65535-entry constant pool** and the 64KB `<init>` limit would bite the heavy apps. Measured on the pinned binaries, the picture is more nuanced than "multi-MB data segments overflow", and the scheme splits along three axes, gated so cowsay/spec and even qjs/sqlite keep their milestone-1/2 single-class shape:
 
-- **Data segments → per-segment `initData{i}()` methods.** Each segment's
-  chunked-Base64 array (`Rt.data_from_b64(new String[]{…})`) plus its
-  `memory.init` copy is materialized in its own method called from the
-  constructor, so `<init>` never accumulates data-init bytecode. *Honest
-  finding:* the predicted multi-MB single-segment overflow does **not** occur for
-  the pinned binaries — qjs's largest data segment is ~6 Base64 chunks, sqlite's
-  ~4, rg's ~36 (~1.15 MB); the array-initializer bytecode is compact (~8 bytes
-  per chunk), so a single method would in fact have sufficed. The per-segment
-  split is the honest general bound (a 10 MB segment is ~312 chunks, still tiny),
-  kept because it is always exercised and costs nothing.
-- **Oversized element segments → a nested `Elem` class.** rg's active element
-  segment is a **4915-entry funcref table**; inline in the constructor its 4915
-  lambdas blew both `<init>`'s 64KB limit and the module class's constant pool.
-  A segment over `ELEM_SPLIT` (1024 entries) is built by a nested `static final
-  class Elem` — its own constant pool — via chunked `elem{i}_pK(inst, a)` part
-  methods (`ELEM_PART` = 512 entries each, under the method limit). qjs (~580)
-  and sqlite (~550) stay inline.
-- **Oversized modules → nested `P{k}` function-partition classes.** Moving the
-  element lambdas out was necessary but **not sufficient** for rg: its ~7300
-  functions' own numeric literals, method refs, and names still overflow one
-  class's pool (qjs ~1500 and sqlite ~1970 functions fit; rg ~7300 does not). A
-  module with more than `FN_PARTITION_THRESHOLD` (3000) defined functions has
-  them emitted as `static` methods split across nested `P{k}` classes of
-  `FN_PER_PARTITION` (1500) each — kept under sqlite's proven single-class count
-  — each class with its own constant pool. Static methods take the module
-  instance `inst` as their first parameter; instance references (`memory`,
-  `g{i}`, `t{i}`, `if{i}`, `data{i}`, `elem{i}`) resolve through it (`iref`), and
-  call sites reach a defined function class-qualified (`P{k}.f{idx}(inst, …)`,
-  via `defined_call`). Frame classes and part methods nest inside their owning
-  `P{k}`. The gate is load-bearing for safety: with partitioning **off** the
-  emitter output is byte-identical to milestone 2, so the 29k-assertion spec
-  suite and qjs/sqlite are on their proven path; only rg-scale modules exercise
-  the partitioned path, validated end-to-end by `rg_search_java`'s byte-identical
-  golden. Measured on rg: convert ~2 s, `javac` ~10 s (5 partition classes), run
-  warm.
+- **Data segments → per-segment `initData{i}()` methods.** Each segment's chunked-Base64 array (`Rt.data_from_b64(new String[]{…})`) plus its `memory.init` copy is materialized in its own method called from the constructor, so `<init>` never accumulates data-init bytecode. *Honest finding:* the predicted multi-MB single-segment overflow does **not** occur for the pinned binaries — qjs's largest data segment is ~6 Base64 chunks, sqlite's ~4, rg's ~36 (~1.15 MB); the array-initializer bytecode is compact (~8 bytes per chunk), so a single method would in fact have sufficed. The per-segment split is the honest general bound (a 10 MB segment is ~312 chunks, still tiny), kept because it is always exercised and costs nothing.
+- **Oversized element segments → a nested `Elem` class.** rg's active element segment is a **4915-entry funcref table**; inline in the constructor its 4915 lambdas blew both `<init>`'s 64KB limit and the module class's constant pool. A segment over `ELEM_SPLIT` (1024 entries) is built by a nested `static final class Elem` — its own constant pool — via chunked `elem{i}_pK(inst, a)` part methods (`ELEM_PART` = 512 entries each, under the method limit). qjs (~580) and sqlite (~550) stay inline.
+- **Oversized modules → nested `P{k}` function-partition classes.** Moving the element lambdas out was necessary but **not sufficient** for rg: its ~7300 functions' own numeric literals, method refs, and names still overflow one class's pool (qjs ~1500 and sqlite ~1970 functions fit; rg ~7300 does not). A module with more than `FN_PARTITION_THRESHOLD` (3000) defined functions has them emitted as `static` methods split across nested `P{k}` classes of `FN_PER_PARTITION` (1500) each — kept under sqlite's proven single-class count — each class with its own constant pool. Static methods take the module instance `inst` as their first parameter; instance references (`memory`, `g{i}`, `t{i}`, `if{i}`, `data{i}`, `elem{i}`) resolve through it (`iref`), and call sites reach a defined function class-qualified (`P{k}.f{idx}(inst, …)`, via `defined_call`). Frame classes and part methods nest inside their owning `P{k}`. The gate is load-bearing for safety: with partitioning **off** the emitter output is byte-identical to milestone 2, so the 29k-assertion spec suite and qjs/sqlite are on their proven path; only rg-scale modules exercise the partitioned path, validated end-to-end by `rg_search_java`'s byte-identical golden. Measured on rg: convert ~2 s, `javac` ~10 s (5 partition classes), run warm.
 
 ## Rejected alternatives (milestone 3)
 
-- **A big `switch` indirect-dispatch method instead of the `Elem` class** — would
-  reintroduce the 64KB-method hazard milestone 1 already rejected for the funcref
-  boundary, and does not by itself address the whole-class pool.
-- **Inheritance (`Rg extends RgP1 extends RgP0`) to distribute functions across
-  class files without call-site qualification** — a base class cannot call a
-  subclass's methods, so mutual recursion across partitions (the common case)
-  would not resolve; declaring every function abstract in the base reinstates the
-  pool pressure it was meant to relieve.
-- **Always partitioning / always routing elems through `Elem`** — would change
-  the generated code for the already-passing cowsay/qjs/sqlite/spec outputs for
-  no benefit; gating on size keeps those on their proven single-class path and
-  confines the new machinery's risk to the one module that needs it.
+- **A big `switch` indirect-dispatch method instead of the `Elem` class** — would reintroduce the 64KB-method hazard milestone 1 already rejected for the funcref boundary, and does not by itself address the whole-class pool.
+- **Inheritance (`Rg extends RgP1 extends RgP0`) to distribute functions across class files without call-site qualification** — a base class cannot call a subclass's methods, so mutual recursion across partitions (the common case) would not resolve; declaring every function abstract in the base reinstates the pool pressure it was meant to relieve.
+- **Always partitioning / always routing elems through `Elem`** — would change the generated code for the already-passing cowsay/qjs/sqlite/spec outputs for no benefit; gating on size keeps those on their proven single-class path and confines the new machinery's risk to the one module that needs it.

--- a/docs/adr/31-standalone-runtime-interface.md
+++ b/docs/adr/31-standalone-runtime-interface.md
@@ -1,84 +1,39 @@
 # ADR-31: Standalone Runtime Interface (argv, --dir, env, exit)
 
-**Status:** Accepted — 2026-07-27. The runtime conventions of a `--mode
-standalone` program — how it receives argv and directory preopens, and how
-`proc_exit`/trap map to a process exit — are now one interface, uniform across
-all five backends and modelled on wasmtime's CLI. Landed: repeatable `--dir
-HOST::GUEST` flags parsed by the generated main; `DEWASM_PREOPEN` removed;
-argv[0], env, and the trap exit code unified; Bash rejects `--dir` loudly. The
-reference is [docs/standalone-interface.md](../standalone-interface.md).
+**Status:** Accepted — 2026-07-27. The runtime conventions of a `--mode standalone` program — how it receives argv and directory preopens, and how `proc_exit`/trap map to a process exit — are now one interface, uniform across all five backends and modelled on wasmtime's CLI. Landed: repeatable `--dir HOST::GUEST` flags parsed by the generated main; `DEWASM_PREOPEN` removed; argv[0], env, and the trap exit code unified; Bash rejects `--dir` loudly. The reference is [docs/standalone-interface.md](../standalone-interface.md).
 
-**Revision, 2026-07-27:** Bash's `--dir` rejection is superseded by
-[ADR-34](34-bash-wasi-filesystem.md) — the Bash backend now honors `--dir`
-with real filesystem support.
+**Revision, 2026-07-27:** Bash's `--dir` rejection is superseded by [ADR-34](34-bash-wasi-filesystem.md) — the Bash backend now honors `--dir` with real filesystem support.
 
 ## Context
 
-A converted `--mode standalone` program is a real CLI: a WASI guest wrapped in a
-generated `main` that supplies argv, env, filesystem preopens, and translates the
-guest's exit/trap into a process exit code. That wrapper is cross-backend product
-surface, but it grew backend-by-backend and diverged:
+A converted `--mode standalone` program is a real CLI: a WASI guest wrapped in a generated `main` that supplies argv, env, filesystem preopens, and translates the guest's exit/trap into a process exit code. That wrapper is cross-backend product surface, but it grew backend-by-backend and diverged:
 
-- **Preopens** arrived through a `DEWASM_PREOPEN` env var (`"guest=host,..."`)
-  parsed in each generated main (~9 sites across the five backends, ADR-14/29/30).
-  An env var is invisible in `ps`, awkward for several mounts, and unlike every
-  wasm runtime's CLI.
-- **argv[0]** was the program basename in Ruby/Python/Bash, the *full* `os.Args[0]`
-  path in Go, and the module class name in Java.
-- **env** passed through in Ruby/Python/Go/Bash, but Java handed the guest an
-  empty environment.
-- The **trap** exit code (134) and the `proc_exit`/`_start`-return mapping were
-  already uniform.
+- **Preopens** arrived through a `DEWASM_PREOPEN` env var (`"guest=host,..."`) parsed in each generated main (~9 sites across the five backends, ADR-14/29/30). An env var is invisible in `ps`, awkward for several mounts, and unlike every wasm runtime's CLI.
+- **argv[0]** was the program basename in Ruby/Python/Bash, the *full* `os.Args[0]` path in Go, and the module class name in Java.
+- **env** passed through in Ruby/Python/Go/Bash, but Java handed the guest an empty environment.
+- The **trap** exit code (134) and the `proc_exit`/`_start`-return mapping were already uniform.
 
-wasmtime — the ground-truth engine the app goldens are captured from (ADR-9/15) —
-takes `wasmtime run [--dir HOST::GUEST]... <wasm> [args...]` and gives the guest
-`argv[0] = basename(wasm)`. Aligning to it makes the generated programs behave
-like the binary they were converted from.
+wasmtime — the ground-truth engine the app goldens are captured from (ADR-9/15) — takes `wasmtime run [--dir HOST::GUEST]... <wasm> [args...]` and gives the guest `argv[0] = basename(wasm)`. Aligning to it makes the generated programs behave like the binary they were converted from.
 
 ## Decision
 
-One documented interface, implemented in every backend's generated standalone
-main. Full reference: [docs/standalone-interface.md](../standalone-interface.md).
+One documented interface, implemented in every backend's generated standalone main. Full reference: [docs/standalone-interface.md](../standalone-interface.md).
 
-- **Invocation:** `<runner> <program> [--dir HOST::GUEST]... [--] [guest args...]`.
-  The generated main consumes a leading run of `--dir` flags (both `--dir X` and
-  `--dir=X`), stopping at `--` or the first non-`--dir` token; everything after is
-  the guest's `argv[1..]`. `HOST::GUEST` mirrors wasmtime; a value without `::`
-  mounts host==guest. This is a *shim in the generated program*, not a host
-  runtime flag — the criterion that shapes it: match wasmtime's user-facing CLI
-  even though the layer that consumes it differs.
-- **argv[0]** is the program name: the basename of the invoked program file
-  (`hello.rb`, `hello`, `hello.sh`, ...), matching `basename(wasm)` under
-  wasmtime. Java is the one deviation — the JVM does not pass the launched file
-  name to `main`, so it uses the module class name — documented, not hidden.
-- **env:** the whole process environment passes through to the guest (Java fixed
-  to `System.getenv()` from an empty array).
-- **exit:** `proc_exit(N)` → process exit `N`; `_start` returning → `0`; a trap →
-  `trap: <message>` on stderr + exit **134**. Bash reaches the same surface via
-  its status-cascade protocol (133 = proc_exit, 134 = trap; ADR-11/12).
-- **Bash + `--dir`:** the Bash backend has no filesystem support (ADR-12), so a
-  leading `--dir` fails loudly with a clear message and a nonzero exit rather than
-  being silently ignored (ADR-0: unsupported features fail, never no-op).
+- **Invocation:** `<runner> <program> [--dir HOST::GUEST]... [--] [guest args...]`. The generated main consumes a leading run of `--dir` flags (both `--dir X` and `--dir=X`), stopping at `--` or the first non-`--dir` token; everything after is the guest's `argv[1..]`. `HOST::GUEST` mirrors wasmtime; a value without `::` mounts host==guest. This is a *shim in the generated program*, not a host runtime flag — the criterion that shapes it: match wasmtime's user-facing CLI even though the layer that consumes it differs.
+- **argv[0]** is the program name: the basename of the invoked program file (`hello.rb`, `hello`, `hello.sh`, ...), matching `basename(wasm)` under wasmtime. Java is the one deviation — the JVM does not pass the launched file name to `main`, so it uses the module class name — documented, not hidden.
+- **env:** the whole process environment passes through to the guest (Java fixed to `System.getenv()` from an empty array).
+- **exit:** `proc_exit(N)` → process exit `N`; `_start` returning → `0`; a trap → `trap: <message>` on stderr + exit **134**. Bash reaches the same surface via its status-cascade protocol (133 = proc_exit, 134 = trap; ADR-11/12).
+- **Bash + `--dir`:** the Bash backend has no filesystem support (ADR-12), so a leading `--dir` fails loudly with a clear message and a nonzero exit rather than being silently ignored (ADR-0: unsupported features fail, never no-op).
 
 ## Rejected alternatives
 
-- **Keep `DEWASM_PREOPEN` (env var for preopens).** Invisible in `ps`, clumsy for
-  multiple mounts, and diverges from every wasm runtime's CLI. Replaced by
-  `--dir`.
-- **A separate host launcher/wrapper script per backend.** More moving parts and
-  another artifact to ship; the parsing is a handful of lines inline in the main.
-- **Ignore `--dir` under Bash silently.** Violates ADR-0's fail-at-the-boundary
-  rule; a user mounting a directory must be told Bash cannot honor it.
-- **argv[0] = the full invocation path.** Go's prior behavior; wasmtime uses the
-  basename, and the basename is the stable, backend-independent choice.
+- **Keep `DEWASM_PREOPEN` (env var for preopens).** Invisible in `ps`, clumsy for multiple mounts, and diverges from every wasm runtime's CLI. Replaced by `--dir`.
+- **A separate host launcher/wrapper script per backend.** More moving parts and another artifact to ship; the parsing is a handful of lines inline in the main.
+- **Ignore `--dir` under Bash silently.** Violates ADR-0's fail-at-the-boundary rule; a user mounting a directory must be told Bash cannot honor it.
+- **argv[0] = the full invocation path.** Go's prior behavior; wasmtime uses the basename, and the basename is the stable, backend-independent choice.
 
 ## Consequences
 
-- The generated mains gained a tiny arg-parser; `DEWASM_PREOPEN` is gone from all
-  code and living docs (historical ADRs keep their mentions).
-- One shared end-to-end case (`wasi_standalone_dir`, a `path_open` round-trip run
-  with `--dir`) exercises the interface on the four filesystem backends and is
-  re-run under wasmtime as ground truth (ADR-27); a companion case asserts Bash's
-  `--dir` rejection.
-- Behavior changes for callers: Go's argv[0] is now a basename; Java now receives
-  the real environment; preopens are CLI flags, not an env var.
+- The generated mains gained a tiny arg-parser; `DEWASM_PREOPEN` is gone from all code and living docs (historical ADRs keep their mentions).
+- One shared end-to-end case (`wasi_standalone_dir`, a `path_open` round-trip run with `--dir`) exercises the interface on the four filesystem backends and is re-run under wasmtime as ground truth (ADR-27); a companion case asserts Bash's `--dir` rejection.
+- Behavior changes for callers: Go's argv[0] is now a basename; Java now receives the real environment; preopens are CLI flags, not an env var.

--- a/docs/adr/32-expression-folding.md
+++ b/docs/adr/32-expression-folding.md
@@ -1,113 +1,47 @@
 # ADR-32 — Build-time Expression Folding
 
-Status: **Accepted, 2026-07-28.** The func builder folds single-use stack
-values into their consumers at IR-build time, always on and identical for
-every backend, replacing the previous one-temp-per-instruction scheme. Landed
-in `crates/dewasm-core/src/func.rs` behind no flag; the `Expr` tree and every
-backend's `expr()` recursion are unchanged.
+Status: **Accepted, 2026-07-28.** The func builder folds single-use stack values into their consumers at IR-build time, always on and identical for every backend, replacing the previous one-temp-per-instruction scheme. Landed in `crates/dewasm-core/src/func.rs` behind no flag; the `Expr` tree and every backend's `expr()` recursion are unchanged.
 
 ## Context
 
-The IR flattened the wasm value stack into "temps": one variable per (stack
-depth, type) pair, and *every* value-producing instruction emitted a
-`temp = <expr>` assignment (wasm2c style). That made evaluation order and trap
-points trivially correct, but it is one statement per instruction. Converting
-the 35 MB `ruby.wasm` produced a 335 MB, 6.5-million-line `.rb`: ~60 % of its
-statements were `sN = ...` assigns, and a third of *those* were trivial
-`sN = <const|local|temp>` copies. The cost is paid by every backend and at
-every stage — file size, the target's parse time, its compile/load time, and
-runtime (an extra variable write and read per instruction).
+The IR flattened the wasm value stack into "temps": one variable per (stack depth, type) pair, and *every* value-producing instruction emitted a `temp = <expr>` assignment (wasm2c style). That made evaluation order and trap points trivially correct, but it is one statement per instruction. Converting the 35 MB `ruby.wasm` produced a 335 MB, 6.5-million-line `.rb`: ~60 % of its statements were `sN = ...` assigns, and a third of *those* were trivial `sN = <const|local|temp>` copies. The cost is paid by every backend and at every stage — file size, the target's parse time, its compile/load time, and runtime (an extra variable write and read per instruction).
 
-`Expr` was already a nested tree (`Un`/`Bin`/`Load`/`Select` hold `Box<Expr>`)
-and every backend's `expr()` already recursed. So the machinery to *emit* folded
-expressions existed on the backend side; only the builder materialized eagerly.
+`Expr` was already a nested tree (`Un`/`Bin`/`Load`/`Select` hold `Box<Expr>`) and every backend's `expr()` already recursed. So the machinery to *emit* folded expressions existed on the backend side; only the builder materialized eagerly.
 
-The hard part is correctness: folding a value into a later consumer moves *when*
-it is evaluated. wasm evaluates strictly, left to right, and the spec asserts
-specific trap messages and post-trap state. A fold is only sound if the moved
-expression cannot observe an intervening effect, its own trap still fires at the
-right point, and it does not cross a control-flow boundary the temp model relies
-on.
+The hard part is correctness: folding a value into a later consumer moves *when* it is evaluated. wasm evaluates strictly, left to right, and the spec asserts specific trap messages and post-trap state. A fold is only sound if the moved expression cannot observe an intervening effect, its own trap still fires at the right point, and it does not cross a control-flow boundary the temp model relies on.
 
 ## Decision
 
-Rework `FuncBuilder` into a **pending-expression stack** (w2c2 style). Each
-operand-stack slot may hold a *pending* `Expr` together with its `Effects` (which
-locals/globals/memory it reads, and whether it can trap) and its node count. A
-value producer pushes a pending instead of emitting an assign; a consumer pops
-its operands as expressions and composes them. A pending is **spilled** to a temp
-(`sN = <expr>`, the only thing that now creates a temp besides call/branch
-results) only when keeping it folded would be unsafe or unprofitable. No IR types
-change; `Func.temps` ends up listing exactly the materialized temps, so every
-backend's temp declarations shrink for free.
+Rework `FuncBuilder` into a **pending-expression stack** (w2c2 style). Each operand-stack slot may hold a *pending* `Expr` together with its `Effects` (which locals/globals/memory it reads, and whether it can trap) and its node count. A value producer pushes a pending instead of emitting an assign; a consumer pops its operands as expressions and composes them. A pending is **spilled** to a temp (`sN = <expr>`, the only thing that now creates a temp besides call/branch results) only when keeping it folded would be unsafe or unprofitable. No IR types change; `Func.temps` ends up listing exactly the materialized temps, so every backend's temp declarations shrink for free.
 
-**Spill discipline** (before emitting each statement, spill the pendings that
-could observe its effect or whose trap must fire first):
+**Spill discipline** (before emitting each statement, spill the pendings that could observe its effect or whose trap must fire first):
 
 - `local.set{k}` / `local.tee{k}`: pendings that read local `k`.
 - `global.set`: `globals || trap` (post-trap global state is observable).
 - `store` / `memory.{grow,copy,fill,init}`: `memory || trap`.
-- `call` / `call_indirect`: `globals || memory || trap` — pure-local args
-  survive and fold into the call (the main win, `_f5(l0, l1)`). `call_indirect`
-  spills effectful operands *before* popping so the index/arg fragments left
-  inline are pure and cannot reorder an observable effect.
-- `unreachable`: `trap` (a pending OOB load must trap with its own "out of
-  bounds" message, not be shadowed by "unreachable").
-- `br`/`br_if`/`br_table` to a label: spill everything (branch targets read
-  temps at canonical depths, and a not-taken `br_if` must leave the operands
-  reusable). `return` / `br` to the function frame / fall-through instead *fold*
-  the return values, after spilling any deeper trapping pending.
-- block/loop/if entry, `else`, `end`: spill everything, so
-  control-boundary-crossing values stay materialized. The `if` condition is
-  folded into the frame first.
-- `select`: `cond` folds freely, but a trapping `then`/`els` arm is spilled —
-  wasm evaluates both arms eagerly, whereas Ruby/Java/Python/Bash lower `select`
-  to a conditionally-evaluated ternary, so only trap-free arms may be inlined.
-- `drop`: a trapping pending is spilled (its trap must fire); a pure one is
-  discarded.
+- `call` / `call_indirect`: `globals || memory || trap` — pure-local args survive and fold into the call (the main win, `_f5(l0, l1)`). `call_indirect` spills effectful operands *before* popping so the index/arg fragments left inline are pure and cannot reorder an observable effect.
+- `unreachable`: `trap` (a pending OOB load must trap with its own "out of bounds" message, not be shadowed by "unreachable").
+- `br`/`br_if`/`br_table` to a label: spill everything (branch targets read temps at canonical depths, and a not-taken `br_if` must leave the operands reusable). `return` / `br` to the function frame / fall-through instead *fold* the return values, after spilling any deeper trapping pending.
+- block/loop/if entry, `else`, `end`: spill everything, so control-boundary-crossing values stay materialized. The `if` condition is folded into the frame first.
+- `select`: `cond` folds freely, but a trapping `then`/`els` arm is spilled — wasm evaluates both arms eagerly, whereas Ruby/Java/Python/Bash lower `select` to a conditionally-evaluated ternary, so only trap-free arms may be inlined.
+- `drop`: a trapping pending is spilled (its trap must fire); a pure one is discarded.
 
-**Cap.** `MAX_FOLD_SIZE = 32` nodes. When composing would exceed it, the
-operands are spilled first and referenced as temps. The cap keeps expressions
-shallow enough not to blow a target language's recursive-descent parser stack,
-and bounds the worst-case textual blow-up of backends whose inline lowerings
-duplicate an operand.
+**Cap.** `MAX_FOLD_SIZE = 32` nodes. When composing would exceed it, the operands are spilled first and referenced as temps. The cap keeps expressions shallow enough not to blow a target language's recursive-descent parser stack, and bounds the worst-case textual blow-up of backends whose inline lowerings duplicate an operand.
 
-Two backend adjustments were needed because folded expressions now reach code
-that assumed bare-variable operands:
+Two backend adjustments were needed because folded expressions now reach code that assumed bare-variable operands:
 
-- **Go** rejects a compile-time constant conversion outside the destination
-  range (`int32(uint32(4294967231))`). A folded i32/i64 constant can land
-  directly inside a signed cast, so large constants are laundered through new
-  `rt/i32c`/`rt/i64c` identity helpers — a call result is never a constant, so
-  the conversion becomes a runtime one (as it was before folding, when every
-  value passed through a variable).
-- **Bash**: `memory.grow` evaluated its delta fragment three times (a folded
-  `memory.size` delta would read the already-grown `pages`); it now snapshots
-  the candidate page count once. And `value()`'s `Bin` arm snapshots non-trivial
-  operands before inline lowerings that textually repeat them (`I64ShrU` names an
-  operand four times).
+- **Go** rejects a compile-time constant conversion outside the destination range (`int32(uint32(4294967231))`). A folded i32/i64 constant can land directly inside a signed cast, so large constants are laundered through new `rt/i32c`/`rt/i64c` identity helpers — a call result is never a constant, so the conversion becomes a runtime one (as it was before folding, when every value passed through a variable).
+- **Bash**: `memory.grow` evaluated its delta fragment three times (a folded `memory.size` delta would read the already-grown `pages`); it now snapshots the candidate page count once. And `value()`'s `Bin` arm snapshots non-trivial operands before inline lowerings that textually repeat them (`I64ShrU` names an operand four times).
 
 ## Rejected alternatives
 
-- **Status quo (one temp per instruction).** Simplest and obviously correct, but
-  leaves the measured 335 MB / 6.5 M-line output and its parse/compile/runtime
-  cost on the table for every backend.
-- **A post-build optimization pass over the IR.** Fold as a separate pass that
-  rewrites `Assign`-heavy IR into nested expressions. It would need to
-  re-derive the effect/aliasing information the builder already has as it walks
-  the operand stack, re-doing the trap- and effect-ordering analysis on a form
-  that has already lost the stack structure. Building the folded form directly
-  is less code and less duplicated reasoning; readability passes (ADR-1) can
-  still layer on top.
-- **Per-backend folding.** Each backend folds during its own lowering. That
-  multiplies the delicate trap/effect-ordering logic by the number of backends
-  and invites divergence; doing it once in the shared builder keeps a single
-  audited implementation and one spec-harness gate.
+- **Status quo (one temp per instruction).** Simplest and obviously correct, but leaves the measured 335 MB / 6.5 M-line output and its parse/compile/runtime cost on the table for every backend.
+- **A post-build optimization pass over the IR.** Fold as a separate pass that rewrites `Assign`-heavy IR into nested expressions. It would need to re-derive the effect/aliasing information the builder already has as it walks the operand stack, re-doing the trap- and effect-ordering analysis on a form that has already lost the stack structure. Building the folded form directly is less code and less duplicated reasoning; readability passes (ADR-1) can still layer on top.
+- **Per-backend folding.** Each backend folds during its own lowering. That multiplies the delicate trap/effect-ordering logic by the number of backends and invites divergence; doing it once in the shared builder keeps a single audited implementation and one spec-harness gate.
 
 ## Consequences
 
-- Output shrinks and loads/runs faster for **all** backends at once; no backend
-  opted in. On the 35 MB `ruby.wasm` (`--mode standalone`):
+- Output shrinks and loads/runs faster for **all** backends at once; no backend opted in. On the 35 MB `ruby.wasm` (`--mode standalone`):
 
   | metric | baseline (unfolded) | folded | change |
   | --- | --- | --- | --- |
@@ -117,18 +51,7 @@ that assumed bare-variable operands:
   | ISeq compile | 10.7 s | 6.4 s | −40 % |
   | run (`--dir …::/usr -- -e 'puts "hello #{6*7}"'`) | 63 s | 37.9 s | 1.66× |
 
-- `Func.temps` now holds only materialized temps (spills, call results,
-  branch-assign destinations); backends that iterate it to declare variables
-  shrink automatically, with no backend change for declarations.
-- Correctness is bound by the spec harness, as always (ADR-3): the full
-  testsuite passes for every backend, plus targeted IR-shape unit tests in
-  `crates/dewasm-core/tests/folding.rs`. Generated output was verified
-  byte-identical to the previous scheme with folding disabled, de-risking the
-  refactor before the fold was turned on.
-- New invariants a backend may rely on (documented in `ir.rs`): an `Expr` tree
-  preserves wasm's left-to-right evaluation order and trap points; a `Select`'s
-  `then`/`els` subexpressions are pure and non-trapping; `Func.temps` lists
-  exactly the materialized temps.
-- The `Effects` local set is a 64-bit mask plus an `any_high_local` catch-all for
-  indices ≥ 64 — conservative (a set of a high local spills all pendings reading
-  any high local), which is rare and never wrong.
+- `Func.temps` now holds only materialized temps (spills, call results, branch-assign destinations); backends that iterate it to declare variables shrink automatically, with no backend change for declarations.
+- Correctness is bound by the spec harness, as always (ADR-3): the full testsuite passes for every backend, plus targeted IR-shape unit tests in `crates/dewasm-core/tests/folding.rs`. Generated output was verified byte-identical to the previous scheme with folding disabled, de-risking the refactor before the fold was turned on.
+- New invariants a backend may rely on (documented in `ir.rs`): an `Expr` tree preserves wasm's left-to-right evaluation order and trap points; a `Select`'s `then`/`els` subexpressions are pure and non-trapping; `Func.temps` lists exactly the materialized temps.
+- The `Effects` local set is a 64-bit mask plus an `any_high_local` catch-all for indices ≥ 64 — conservative (a set of a high local spills all pendings reading any high local), which is rare and never wrong.

--- a/docs/adr/33-ruby-io-buffer-memory.md
+++ b/docs/adr/33-ruby-io-buffer-memory.md
@@ -1,121 +1,36 @@
 # ADR-33 — `IO::Buffer`-Backed Linear Memory for Ruby
 
-Status: **Accepted, 2026-07-28.** Implemented:
-`runtime/ruby/units/memory/*.rb`, `crates/dewasm-backend-ruby/src/lib.rs` (`find_ruby`),
-`docs/testing.md`, `AGENTS.md`.
+Status: **Accepted, 2026-07-28.** Implemented: `runtime/ruby/units/memory/*.rb`, `crates/dewasm-backend-ruby/src/lib.rs` (`find_ruby`), `docs/testing.md`, `AGENTS.md`.
 
 ## Context
 
-Measured on a converted `ruby.wasm` (35MB) running a trivial script under the standalone
-runtime: 63s total, with `stackprof` attributing 41% of samples to GC (39% of all samples in
-sweep alone) and ~9% self time to memory load/store ops. The prior `Rt::Memory` represented
-linear memory as a single mutable binary `String` (`@bytes`), with loads via
-`String#unpack1`/`#getbyte` and stores via `String#[]=`/`#setbyte`. `String#unpack1` with a
-format string allocates the format's intermediate Array before returning the scalar (1 alloc per
-load); byte-range assignment (`@bytes[a, n] = ...`) allocates both the packed source string and,
-internally, a new buffer for the mutated string (2 allocs per store). At WASI-syscall or C-API
-density (every `fd_write`, every SQLite row, every printf) this dominates GC pressure.
+Measured on a converted `ruby.wasm` (35MB) running a trivial script under the standalone runtime: 63s total, with `stackprof` attributing 41% of samples to GC (39% of all samples in sweep alone) and ~9% self time to memory load/store ops. The prior `Rt::Memory` represented linear memory as a single mutable binary `String` (`@bytes`), with loads via `String#unpack1`/`#getbyte` and stores via `String#[]=`/`#setbyte`. `String#unpack1` with a format string allocates the format's intermediate Array before returning the scalar (1 alloc per load); byte-range assignment (`@bytes[a, n] = ...`) allocates both the packed source string and, internally, a new buffer for the mutated string (2 allocs per store). At WASI-syscall or C-API density (every `fd_write`, every SQLite row, every printf) this dominates GC pressure.
 
-Ruby's `IO::Buffer` (stable since 3.0, marked experimental through recent releases) wraps a raw
-native memory region and exposes typed `get_value`/`set_value` accessors that read/write
-directly without an intermediate Ruby object — measured 2-3x faster and zero-alloc for scalar
-loads/stores on Ruby 4.0.4, the version available in this environment.
+Ruby's `IO::Buffer` (stable since 3.0, marked experimental through recent releases) wraps a raw native memory region and exposes typed `get_value`/`set_value` accessors that read/write directly without an intermediate Ruby object — measured 2-3x faster and zero-alloc for scalar loads/stores on Ruby 4.0.4, the version available in this environment.
 
 ## Decision
 
-- **Linear memory is `IO::Buffer`-backed.** `Rt::Memory#initialize` allocates
-  `@buffer = IO::Buffer.new(@size)`; `@size` is tracked as a plain ivar (updated on `grow`)
-  since `IO::Buffer` has no cheap bytesize query worth relying on for the hot bounds check.
-  `attr_reader :buffer` replaces the former `attr_reader :bytes`.
-- **The experimental warning is suppressed around allocation only**, by saving and restoring
-  `Warning[:experimental]` (`false` for the `IO::Buffer.new` call, restored in an `ensure`
-  immediately after). This matters beyond cosmetics: the qjs pty golden (`crates/dewasm-backend-
-  ruby/tests/e2e.rs`) captures stderr verbatim, and an unsuppressed experimental warning would
-  corrupt it.
-- **Explicit bounds checks are kept as the trap mechanism, not `IO::Buffer`'s `ArgumentError`.**
-  `Rt::Memory#check(addr, len)` still raises `Rt.trap("out of bounds memory access")` — the exact
-  message the spec harness's `address.wast`, `memory_trap.wast`, `align.wast`, and `traps.wast`
-  assertions match. In the one-liner load/store units the bounds test is inlined
-  (`Rt.trap(...) if a + N > @size`) rather than calling `check`, trading one dispatch for a
-  `# requires: rt/trap` header; `copy`/`fill`/`init`/`read_string` keep calling `check` since
-  they are not single-expression hot paths.
-- **Signed narrow loads read the signed view directly and mask**, replacing the previous
-  two-hop `Rt.sext(unsigned_load, bits, mask)`: `i32_load8_s` is `get_value(:S8, a) & M32`,
-  `i64_load16_s` is `get_value(:s16, a) & M64`, etc. `IO::Buffer` names 8-bit types
-  uppercase-only (`:U8`/`:S8`); multi-byte lowercase names (`:u16`/`:s16`/`:u32`/`:s32`/`:u64`/
-  `:s64`) are little-endian, matching wasm's memory byte order directly — no explicit `<`
-  suffix needed the way `Array#pack`/`String#unpack1` required (`"L<"`, `"S<"`).
-- **`f32_load`/`f32_store` are unchanged**, still routed through the `i32` bit path
-  (`Rt.f32_from_bits(i32_load(a))` / `i32_store(a, Rt.f32_bits(v))`) to preserve NaN sign/payload
-  per ADR-2. They get `IO::Buffer`'s speedup transitively via `i32_load`/`i32_store`.
-  `f64_load`/`f64_store` switch to `get_value(:f64, a)`/`set_value(:f64, a, v)` directly: an
-  8-byte little-endian IEEE double is bit-preserving with no lossy host path, unlike the f32
-  double-rounding concern ADR-2 documents.
-- **`grow` uses `@buffer.resize(@size)`** (after bumping `@size`); `IO::Buffer#resize` zero-fills
-  the new tail, matching wasm's `memory.grow` semantics for free. **`copy` uses
-  `@buffer.copy(@buffer, dst, len, src)`** — `IO::Buffer#copy` has `memmove` overlap semantics,
-  matching wasm's `memory.copy` (defined for overlapping regions) without the `String#byteslice`
-  workaround the old code needed. **`fill` uses `@buffer.clear(val & 0xff, dst, len)`.** **`init`**
-  (also used for active data-segment instantiation) uses `@buffer.set_string(data, dst, len,
-  src)`, keeping its existing out-of-bounds-source trap ahead of the bounds `check`.
-  **`read_string`** uses `@buffer.get_string(ptr, len)`.
-- **Ruby >= 3.4 is now the floor**, enforced in `find_ruby()`
-  (`crates/dewasm-backend-ruby/src/lib.rs`) by running `ruby -e 'print RUBY_VERSION'` and
-  rejecting anything below `3.4`, modeled on `dewasm_backend_bash::find_bash5`'s fail-loud
-  version gate (ADR-15: fail loud with a setup instruction, never silently skip). `docs/testing.md`
-  and `AGENTS.md` were updated to state the floor and its reason.
+- **Linear memory is `IO::Buffer`-backed.** `Rt::Memory#initialize` allocates `@buffer = IO::Buffer.new(@size)`; `@size` is tracked as a plain ivar (updated on `grow`) since `IO::Buffer` has no cheap bytesize query worth relying on for the hot bounds check. `attr_reader :buffer` replaces the former `attr_reader :bytes`.
+- **The experimental warning is suppressed around allocation only**, by saving and restoring `Warning[:experimental]` (`false` for the `IO::Buffer.new` call, restored in an `ensure` immediately after). This matters beyond cosmetics: the qjs pty golden (`crates/dewasm-backend- ruby/tests/e2e.rs`) captures stderr verbatim, and an unsuppressed experimental warning would corrupt it.
+- **Explicit bounds checks are kept as the trap mechanism, not `IO::Buffer`'s `ArgumentError`.** `Rt::Memory#check(addr, len)` still raises `Rt.trap("out of bounds memory access")` — the exact message the spec harness's `address.wast`, `memory_trap.wast`, `align.wast`, and `traps.wast` assertions match. In the one-liner load/store units the bounds test is inlined (`Rt.trap(...) if a + N > @size`) rather than calling `check`, trading one dispatch for a `# requires: rt/trap` header; `copy`/`fill`/`init`/`read_string` keep calling `check` since they are not single-expression hot paths.
+- **Signed narrow loads read the signed view directly and mask**, replacing the previous two-hop `Rt.sext(unsigned_load, bits, mask)`: `i32_load8_s` is `get_value(:S8, a) & M32`, `i64_load16_s` is `get_value(:s16, a) & M64`, etc. `IO::Buffer` names 8-bit types uppercase-only (`:U8`/`:S8`); multi-byte lowercase names (`:u16`/`:s16`/`:u32`/`:s32`/`:u64`/ `:s64`) are little-endian, matching wasm's memory byte order directly — no explicit `<` suffix needed the way `Array#pack`/`String#unpack1` required (`"L<"`, `"S<"`).
+- **`f32_load`/`f32_store` are unchanged**, still routed through the `i32` bit path (`Rt.f32_from_bits(i32_load(a))` / `i32_store(a, Rt.f32_bits(v))`) to preserve NaN sign/payload per ADR-2. They get `IO::Buffer`'s speedup transitively via `i32_load`/`i32_store`. `f64_load`/`f64_store` switch to `get_value(:f64, a)`/`set_value(:f64, a, v)` directly: an 8-byte little-endian IEEE double is bit-preserving with no lossy host path, unlike the f32 double-rounding concern ADR-2 documents.
+- **`grow` uses `@buffer.resize(@size)`** (after bumping `@size`); `IO::Buffer#resize` zero-fills the new tail, matching wasm's `memory.grow` semantics for free. **`copy` uses `@buffer.copy(@buffer, dst, len, src)`** — `IO::Buffer#copy` has `memmove` overlap semantics, matching wasm's `memory.copy` (defined for overlapping regions) without the `String#byteslice` workaround the old code needed. **`fill` uses `@buffer.clear(val & 0xff, dst, len)`.** **`init`** (also used for active data-segment instantiation) uses `@buffer.set_string(data, dst, len, src)`, keeping its existing out-of-bounds-source trap ahead of the bounds `check`. **`read_string`** uses `@buffer.get_string(ptr, len)`.
+- **Ruby >= 3.4 is now the floor**, enforced in `find_ruby()` (`crates/dewasm-backend-ruby/src/lib.rs`) by running `ruby -e 'print RUBY_VERSION'` and rejecting anything below `3.4`, modeled on `dewasm_backend_bash::find_bash5`'s fail-loud version gate (ADR-15: fail loud with a setup instruction, never silently skip). `docs/testing.md` and `AGENTS.md` were updated to state the floor and its reason.
 
 ## Rejected alternatives
 
-- **Keep `String` + `pack`/`unpack1` (status quo)** — the measured baseline: 1 allocation per
-  load, 2 per store, and 41% GC time (39% sweep) on the ruby.wasm benchmark. Rejected on
-  measured evidence, not a hunch.
-- **A byte `Array`** — trades one allocation problem for a worse one (boxed `Integer` elements,
-  far larger footprint than a packed `String`); never seriously considered given `IO::Buffer`
-  exists.
-- **Rescue `IO::Buffer`'s `ArgumentError` as the bounds-trap mechanism** — `IO::Buffer` does
-  raise `ArgumentError` on out-of-range access, which could in principle replace the explicit
-  `check`. Rejected because the spec harness pins an exact trap *message*
-  (`"out of bounds memory access"`) that `ArgumentError`'s wording does not produce, and because
-  relying on the accessor's own bounds behavior would couple correctness to an experimental API's
-  error text rather than to a rule dewasm controls.
-- **Direct `:f32` loads/stores via `IO::Buffer`** — `get_value(:f32, ...)` widens the packed
-  32-bit float to a Ruby `Float` (host double) by hardware conversion, which quiets signaling
-  NaNs in the widening step. ADR-2 requires bit-exact NaN payload preservation through `reinterpret`
-  and memory traffic; only the existing bit-pattern path (`Rt.f32_from_bits`/`Rt.f32_bits` over
-  `i32_load`/`i32_store`) satisfies that, so f32 memory ops keep the indirection.
+- **Keep `String` + `pack`/`unpack1` (status quo)** — the measured baseline: 1 allocation per load, 2 per store, and 41% GC time (39% sweep) on the ruby.wasm benchmark. Rejected on measured evidence, not a hunch.
+- **A byte `Array`** — trades one allocation problem for a worse one (boxed `Integer` elements, far larger footprint than a packed `String`); never seriously considered given `IO::Buffer` exists.
+- **Rescue `IO::Buffer`'s `ArgumentError` as the bounds-trap mechanism** — `IO::Buffer` does raise `ArgumentError` on out-of-range access, which could in principle replace the explicit `check`. Rejected because the spec harness pins an exact trap *message* (`"out of bounds memory access"`) that `ArgumentError`'s wording does not produce, and because relying on the accessor's own bounds behavior would couple correctness to an experimental API's error text rather than to a rule dewasm controls.
+- **Direct `:f32` loads/stores via `IO::Buffer`** — `get_value(:f32, ...)` widens the packed 32-bit float to a Ruby `Float` (host double) by hardware conversion, which quiets signaling NaNs in the widening step. ADR-2 requires bit-exact NaN payload preservation through `reinterpret` and memory traffic; only the existing bit-pattern path (`Rt.f32_from_bits`/`Rt.f32_bits` over `i32_load`/`i32_store`) satisfies that, so f32 memory ops keep the indirection.
 
 ## Consequences
 
-- Positive: eliminates 1 allocation per scalar load and 2 per scalar store (measured zero-alloc
-  on Ruby 4.0.4's `IO::Buffer#get_value`/`#set_value`), the largest single contributor to the
-  measured GC/sweep dominance in the ruby.wasm benchmark.
-- **Measured, with the depth-1 `br`/`next` (ADR-4) and global-unboxing (ADR-16) changes landed
-  alongside it** (same `crates/dewasm-backend-ruby/src/lib.rs` change series, so isolating this
-  change's wall-clock share alone wasn't practical — `stackprof`'s GC line attributes cleanly to
-  this one, the two below don't): converting `ruby.wasm` (35MB) to the standalone Ruby runtime and
-  running `ruby out.rb --dir <ruby-lib>::/usr -- -e 'puts "hello #{6*7}"'` on the same machine as
-  the original 63s baseline, averaged over two runs each: **before 67.2s wall / 63.1s user, after
-  53.6s wall / 51.5s user — ~1.26x wall-clock, ~18% reduction in absolute terms.** A fresh
-  `stackprof` capture on the *after* build shows GC collapsed from the baseline's 41% (39% sweep)
-  to **0.93%** (0.5% marking + 0.4% sweeping) of samples — the memory representation was in fact
-  the dominant GC driver, exactly as hypothesized. The wall-clock gain is smaller than the GC
-  collapse alone would suggest because `Kernel#catch`/`#throw` (still used for every `br` whose
-  target isn't the innermost frame — ADR-4's depth-1 optimization doesn't reach multi-level
-  branches) now accounts for ~18.6% of samples and dominates what's left, and raw Ruby method-call
-  dispatch (one method per wasm function, one line per wasm instruction) is the CPU-bound floor
-  under all of it. GC is no longer the bottleneck; control-flow dispatch is.
-- Positive: `copy`/`fill` gain native `memmove`/`memset`-equivalent implementations instead of
-  Ruby-level string slicing and reassembly.
-- Negative: Ruby >= 3.4 is now a hard requirement to run *any* generated Ruby output, not just to
-  develop dewasm itself — a real constraint for embedders on older Ruby, accepted because
-  `IO::Buffer`'s typed accessors (and their measured performance) are unavailable earlier and
-  `IO::Buffer` itself remains marked experimental upstream (mitigated by the save/restore
-  suppression above, but the API could still change in a future Ruby release we'd need to track).
-- Carry-over: `IO::Buffer` is explicitly experimental in the Ruby API itself; if a future Ruby
-  release changes its interface, the units under `runtime/ruby/units/memory/` are the sole
-  integration point to update.
+- Positive: eliminates 1 allocation per scalar load and 2 per scalar store (measured zero-alloc on Ruby 4.0.4's `IO::Buffer#get_value`/`#set_value`), the largest single contributor to the measured GC/sweep dominance in the ruby.wasm benchmark.
+- **Measured, with the depth-1 `br`/`next` (ADR-4) and global-unboxing (ADR-16) changes landed alongside it** (same `crates/dewasm-backend-ruby/src/lib.rs` change series, so isolating this change's wall-clock share alone wasn't practical — `stackprof`'s GC line attributes cleanly to this one, the two below don't): converting `ruby.wasm` (35MB) to the standalone Ruby runtime and running `ruby out.rb --dir <ruby-lib>::/usr -- -e 'puts "hello #{6*7}"'` on the same machine as the original 63s baseline, averaged over two runs each: **before 67.2s wall / 63.1s user, after 53.6s wall / 51.5s user — ~1.26x wall-clock, ~18% reduction in absolute terms.** A fresh `stackprof` capture on the *after* build shows GC collapsed from the baseline's 41% (39% sweep) to **0.93%** (0.5% marking + 0.4% sweeping) of samples — the memory representation was in fact the dominant GC driver, exactly as hypothesized. The wall-clock gain is smaller than the GC collapse alone would suggest because `Kernel#catch`/`#throw` (still used for every `br` whose target isn't the innermost frame — ADR-4's depth-1 optimization doesn't reach multi-level branches) now accounts for ~18.6% of samples and dominates what's left, and raw Ruby method-call dispatch (one method per wasm function, one line per wasm instruction) is the CPU-bound floor under all of it. GC is no longer the bottleneck; control-flow dispatch is.
+- Positive: `copy`/`fill` gain native `memmove`/`memset`-equivalent implementations instead of Ruby-level string slicing and reassembly.
+- Negative: Ruby >= 3.4 is now a hard requirement to run *any* generated Ruby output, not just to develop dewasm itself — a real constraint for embedders on older Ruby, accepted because `IO::Buffer`'s typed accessors (and their measured performance) are unavailable earlier and `IO::Buffer` itself remains marked experimental upstream (mitigated by the save/restore suppression above, but the API could still change in a future Ruby release we'd need to track).
+- Carry-over: `IO::Buffer` is explicitly experimental in the Ruby API itself; if a future Ruby release changes its interface, the units under `runtime/ruby/units/memory/` are the sole integration point to update.
 
-See also: [ADR-2](2-numeric-semantics.md) (masked-unsigned integers, f32 re-rounding, NaN bit
-paths this preserves), [ADR-6](6-runtime-units.md) (per-method unit / `# requires:` convention),
-[ADR-15](15-tests-fail-not-skip.md) (fail-loud version gating this follows for `find_ruby`).
+See also: [ADR-2](2-numeric-semantics.md) (masked-unsigned integers, f32 re-rounding, NaN bit paths this preserves), [ADR-6](6-runtime-units.md) (per-method unit / `# requires:` convention), [ADR-15](15-tests-fail-not-skip.md) (fail-loud version gating this follows for `find_ruby`).

--- a/docs/adr/34-bash-wasi-filesystem.md
+++ b/docs/adr/34-bash-wasi-filesystem.md
@@ -1,172 +1,54 @@
 # ADR-34 — Bash WASI Filesystem
 
-Status: **Accepted, 2026-07-27; fully landed 2026-07-28.** The Bash backend
-gains WASI preview-1 filesystem support, mirroring the Ruby design
-([ADR-14](14-ruby-wasi-filesystem.md)) within Bash's constraints: the fd-table
-state, `path_open`, the reworked
-`fd_read`/`fd_write`/`fd_seek`/`fd_tell`/`fd_close`/`fd_fdstat_get`/`fd_prestat_get`
-units, `fd_prestat_dir_name`, the standalone `--dir` parser, the stat family,
-the four namespace-mutation syscalls, and `poll_oneoff` — all under
-`runtime/bash/units/wasi/`. The same syscalls that stay ENOSYS on Ruby stay
-ENOSYS here.
+Status: **Accepted, 2026-07-27; fully landed 2026-07-28.** The Bash backend gains WASI preview-1 filesystem support, mirroring the Ruby design ([ADR-14](14-ruby-wasi-filesystem.md)) within Bash's constraints: the fd-table state, `path_open`, the reworked `fd_read`/`fd_write`/`fd_seek`/`fd_tell`/`fd_close`/`fd_fdstat_get`/`fd_prestat_get` units, `fd_prestat_dir_name`, the standalone `--dir` parser, the stat family, the four namespace-mutation syscalls, and `poll_oneoff` — all under `runtime/bash/units/wasi/`. The same syscalls that stay ENOSYS on Ruby stay ENOSYS here.
 
-**Revision, 2026-07-28 ([ADR-40](40-wasi-p1-completion.md)):** the D2
-external-command license extends to `ln -s`, `ln`, and `readlink` for the
-symlink family (namespace mutation, plus the capability-completeness clause
-for `readlink`); `fd_advise`/`fd_allocate`/`fd_renumber` and the per-fd
-rights model are implemented in pure Bash. Timestamps (`touch` fails the D2
-criterion), d_ino/dev-ino (D6, no `stat`), the D1 cross-fd read-back, and
-following a *file* symlink (D3, ELOOP) remain the declared gaps.
+**Revision, 2026-07-28 ([ADR-40](40-wasi-p1-completion.md)):** the D2 external-command license extends to `ln -s`, `ln`, and `readlink` for the symlink family (namespace mutation, plus the capability-completeness clause for `readlink`); `fd_advise`/`fd_allocate`/`fd_renumber` and the per-fd rights model are implemented in pure Bash. Timestamps (`touch` fails the D2 criterion), d_ino/dev-ino (D6, no `stat`), the D1 cross-fd read-back, and following a *file* symlink (D3, ELOOP) remain the declared gaps.
 
 ## Context
 
-[ADR-12](12-bash-wasi.md) built the Bash WASI surface (stdio, args/env,
-clock, random) but scoped every `path_*` and filesystem-only `fd_*` call
-out to ENOSYS — a 15-function gap versus Ruby. [ADR-14](14-ruby-wasi-filesystem.md)
-answered those questions for Ruby and closed noting a Bash filesystem
-backend "would need its own ADR". This is it. Bash makes the design
-different in kind, not degree, from Ruby's `File`-backed fds: Bash has no
-random-access file object, no `openat`, no `realpath`/`readlink`/`stat`
-builtins, and — under [ADR-5](5-bash-softfloat.md)'s dependency criterion —
-no license to shell out for them either. The decisions below are what that
-leaves possible.
+[ADR-12](12-bash-wasi.md) built the Bash WASI surface (stdio, args/env, clock, random) but scoped every `path_*` and filesystem-only `fd_*` call out to ENOSYS — a 15-function gap versus Ruby. [ADR-14](14-ruby-wasi-filesystem.md) answered those questions for Ruby and closed noting a Bash filesystem backend "would need its own ADR". This is it. Bash makes the design different in kind, not degree, from Ruby's `File`-backed fds: Bash has no random-access file object, no `openat`, no `realpath`/`readlink`/`stat` builtins, and — under [ADR-5](5-bash-softfloat.md)'s dependency criterion — no license to shell out for them either. The decisions below are what that leaves possible.
 
 ## Decision
 
 ### D1 — Files are whole-file byte buffers, flushed on close/sync
 
-A Bash redirection can only truncate-create (`>`) or append (`>>`) a file;
-it cannot write at an offset. So an open file fd holds the entire file
-content as an indexed array of byte ordinals (`<p>wbuf<fd>`), with a
-separate offset (`<p>wtell[fd]`). `path_open` slurps the file into the
-array (skipping the slurp for `O_TRUNC` or a fresh `O_CREAT`); `fd_read`/
-`fd_write`/`fd_seek` operate on the array and the offset; a dirty buffer is
-flushed to disk on `fd_close` (and later on `fd_sync`/`fd_datasync`) by a
-single `exec {fd}>"$path"` followed by chunked `printf` of a `'\x%02x'`
-format built in ~4 KiB batches. Criterion: represent a file as the one
-thing Bash *can* rewrite atomically — the whole thing — rather than
-emulating random-access I/O Bash does not have.
+A Bash redirection can only truncate-create (`>`) or append (`>>`) a file; it cannot write at an offset. So an open file fd holds the entire file content as an indexed array of byte ordinals (`<p>wbuf<fd>`), with a separate offset (`<p>wtell[fd]`). `path_open` slurps the file into the array (skipping the slurp for `O_TRUNC` or a fresh `O_CREAT`); `fd_read`/ `fd_write`/`fd_seek` operate on the array and the offset; a dirty buffer is flushed to disk on `fd_close` (and later on `fd_sync`/`fd_datasync`) by a single `exec {fd}>"$path"` followed by chunked `printf` of a `'\x%02x'` format built in ~4 KiB batches. Criterion: represent a file as the one thing Bash *can* rewrite atomically — the whole thing — rather than emulating random-access I/O Bash does not have.
 
-Caveats, recorded not fixed: two fds open on one file diverge (each has its
-own buffer; last flush wins), open and close are O(file size), the flush is
-non-atomic (a crash mid-flush leaves a partial file), and `fd_sync`/
-`fd_datasync` are just a flush — there is no separate durability barrier.
+Caveats, recorded not fixed: two fds open on one file diverge (each has its own buffer; last flush wins), open and close are O(file size), the flush is non-atomic (a crash mid-flush leaves a partial file), and `fd_sync`/ `fd_datasync` are just a flush — there is no separate durability barrier.
 
 ### D2 — Four namespace-mutation syscalls may call one POSIX command each
 
-**This is the headline decision.** [ADR-5](5-bash-softfloat.md)'s criterion —
-the generated program's dependency set is *exactly a Bash interpreter* — is
-narrowed here: the four namespace-mutation units `path_create_directory`,
-`path_remove_directory`, `path_unlink_file`, and `path_rename` (and **only**
-they) may invoke the POSIX-mandated `mkdir` / `rmdir` / `rm` / `mv`
-respectively, as a single direct `command` invocation, `--`-guarded, on
-resolved absolute paths, with the errno derived from post-hoc `[[ -e ]]` /
-`[[ -d ]]` probes rather than the command's own diagnostics.
+**This is the headline decision.** [ADR-5](5-bash-softfloat.md)'s criterion — the generated program's dependency set is *exactly a Bash interpreter* — is narrowed here: the four namespace-mutation units `path_create_directory`, `path_remove_directory`, `path_unlink_file`, and `path_rename` (and **only** they) may invoke the POSIX-mandated `mkdir` / `rmdir` / `rm` / `mv` respectively, as a single direct `command` invocation, `--`-guarded, on resolved absolute paths, with the errno derived from post-hoc `[[ -e ]]` / `[[ -d ]]` probes rather than the command's own diagnostics.
 
-The justification is impossibility, not convenience: pure Bash cannot
-express the creation, removal, or renaming of a directory entry *at all* —
-there is no builtin that mutates the namespace, the way `>` mutates file
-content. Everything else the filesystem surface needs (read, write, stat by
-test builtins, directory listing by globbing) is expressible in pure Bash;
-these four are not. Because runtime units are bundled per import
-([ADR-6](6-runtime-units.md)), a converted module that never imports these
-four syscalls carries none of these commands and remains a pure-Bash
-artifact — the ADR-5 promise still holds for the programs that do not need
-namespace mutation, which is the property worth protecting.
+The justification is impossibility, not convenience: pure Bash cannot express the creation, removal, or renaming of a directory entry *at all* — there is no builtin that mutates the namespace, the way `>` mutates file content. Everything else the filesystem surface needs (read, write, stat by test builtins, directory listing by globbing) is expressible in pure Bash; these four are not. Because runtime units are bundled per import ([ADR-6](6-runtime-units.md)), a converted module that never imports these four syscalls carries none of these commands and remains a pure-Bash artifact — the ADR-5 promise still holds for the programs that do not need namespace mutation, which is the property worth protecting.
 
 ### D3 — Sandboxing: physical resolution plus per-dirfd containment
 
-Preopen roots are resolved to a physical path once, via
-`$(cd -P -- "$host" && pwd -P)`. Every guest path resolution re-derives the
-parent's physical path the same way and checks prefix-containment against
-*that dirfd's own* stored root — nesting cannot launder an escape one level
-cheaper, exactly the model [ADR-14](14-ruby-wasi-filesystem.md) uses. The
-containment test is `[[ $real == "$root" || $real == "${root%/}/"* ]]`; the
-`${root%/}/` form makes a root of `/` contain everything.
+Preopen roots are resolved to a physical path once, via `$(cd -P -- "$host" && pwd -P)`. Every guest path resolution re-derives the parent's physical path the same way and checks prefix-containment against *that dirfd's own* stored root — nesting cannot launder an escape one level cheaper, exactly the model [ADR-14](14-ruby-wasi-filesystem.md) uses. The containment test is `[[ $real == "$root" || $real == "${root%/}/"* ]]`; the `${root%/}/` form makes a root of `/` contain everything.
 
-Two deviations from Ruby, both from missing builtins and both documented:
-Bash has no `readlink`, so a **file** symlink as the final path component
-cannot be followed and resolves to `ELOOP` (stricter than Ruby, which
-follows it); a **directory** symlink is still followed, because `cd -P`
-resolves it. The check-then-open TOCTOU caveat from ADR-14 carries over
-unchanged: this is a single-process research/demo runtime, not a
-multi-tenant sandbox host.
+Two deviations from Ruby, both from missing builtins and both documented: Bash has no `readlink`, so a **file** symlink as the final path component cannot be followed and resolves to `ELOOP` (stricter than Ruby, which follows it); a **directory** symlink is still followed, because `cd -P` resolves it. The check-then-open TOCTOU caveat from ADR-14 carries over unchanged: this is a single-process research/demo runtime, not a multi-tenant sandbox host.
 
 ### D4 — `poll_oneoff` (later step)
 
-Implemented in a later step, summarized here so the shape is on record: an
-`fd_read`-on-stdin subscription waits with `read -t <deadline> -n 1`, and if
-a byte arrives it is held in a one-byte pushback slot (`<p>wpush`) for the
-next `fd_read` to consume; a clock-only subscription sleeps via a bash-only
-`coproc` timer (`coproc __slp { read _; }` then `read -rt <secs> -u
-"${__slp[0]}"`) rather than the process-substitution idiom
-`read -t <secs> <> <(:)` — the latter is rejected (`Permission denied`) on
-some hosts (macOS), so the coproc is the portable one. Every other
-subscription (regular files, stdout/stderr, `fd_write`) is immediately
-ready, as on Ruby. One deviation: when a stdin wait hits real EOF (not a
-timeout), this unit reports each waiting `fd_read` ready with `nbytes` 0,
-where Ruby's `IO.select`-based equivalent instead reports the closed fd
-itself as readable and lets the subsequent `fd_read` discover EOF — both
-converge on the guest's next `fd_read` returning 0 bytes, so the observable
-behavior matches even though the intermediate event differs.
+Implemented in a later step, summarized here so the shape is on record: an `fd_read`-on-stdin subscription waits with `read -t <deadline> -n 1`, and if a byte arrives it is held in a one-byte pushback slot (`<p>wpush`) for the next `fd_read` to consume; a clock-only subscription sleeps via a bash-only `coproc` timer (`coproc __slp { read _; }` then `read -rt <secs> -u "${__slp[0]}"`) rather than the process-substitution idiom `read -t <secs> <> <(:)` — the latter is rejected (`Permission denied`) on some hosts (macOS), so the coproc is the portable one. Every other subscription (regular files, stdout/stderr, `fd_write`) is immediately ready, as on Ruby. One deviation: when a stdin wait hits real EOF (not a timeout), this unit reports each waiting `fd_read` ready with `nbytes` 0, where Ruby's `IO.select`-based equivalent instead reports the closed fd itself as readable and lets the subsequent `fd_read` discover EOF — both converge on the guest's next `fd_read` returning 0 bytes, so the observable behavior matches even though the intermediate event differs.
 
 ### D5 — fd-table shape
 
-One kind table `<p>wfds` (stdio=1, file=2, dir=3) keyed by fd, with parallel
-indexed arrays for the rest: `<p>wtell` (offset), `<p>wpath` (physical host
-path), `<p>wname` (preopen guest name — set iff prestat-visible), `<p>wrd`/
-`<p>wwr`/`<p>wapp` (open-mode flags, derived once and never re-checked, the
-ADR-14 rights policy), `<p>wdirty`, and the per-fd `<p>wbuf<fd>` byte array.
-`<p>wnext` is the next fd (starting past the preopens, never reused, per
-ADR-14). Preopens arrive through an ordered indexed array
-`WASI_DIRS=('HOST::GUEST' ...)` — the Bash analogue of Ruby's `preopens:`
-kwarg — consumed by `init_preopens` into dir fds from 3 upward. The
-standalone main fills `WASI_DIRS` from repeated `--dir` flags
-([ADR-31](31-standalone-runtime-interface.md)).
+One kind table `<p>wfds` (stdio=1, file=2, dir=3) keyed by fd, with parallel indexed arrays for the rest: `<p>wtell` (offset), `<p>wpath` (physical host path), `<p>wname` (preopen guest name — set iff prestat-visible), `<p>wrd`/ `<p>wwr`/`<p>wapp` (open-mode flags, derived once and never re-checked, the ADR-14 rights policy), `<p>wdirty`, and the per-fd `<p>wbuf<fd>` byte array. `<p>wnext` is the next fd (starting past the preopens, never reused, per ADR-14). Preopens arrive through an ordered indexed array `WASI_DIRS=('HOST::GUEST' ...)` — the Bash analogue of Ruby's `preopens:` kwarg — consumed by `init_preopens` into dir fds from 3 upward. The standalone main fills `WASI_DIRS` from repeated `--dir` flags ([ADR-31](31-standalone-runtime-interface.md)).
 
 ### D6 — stat fidelity (stat family lands later)
 
-Filetype comes from the test builtins (`-d`/`-f`/`-h`/`-t`); `size` is the
-live buffer length for an open fd. `atim`/`mtim`/`ctim` report 0 and
-`dev`/`ino` report 0 — Bash cannot stat a file for real numbers — a
-documented deviation, the filesystem analogue of ADR-12's clock fallback.
+Filetype comes from the test builtins (`-d`/`-f`/`-h`/`-t`); `size` is the live buffer length for an open fd. `atim`/`mtim`/`ctim` report 0 and `dev`/`ino` report 0 — Bash cannot stat a file for real numbers — a documented deviation, the filesystem analogue of ADR-12's clock fallback.
 
 ## Rejected alternatives
 
-- **Leave the four namespace-mutation syscalls ENOSYS.** Honest to ADR-5
-  but leaves the surface permanently unable to do what SQLite's journal/WAL
-  lifecycle (ADR-14's north star) needs — create and delete files and
-  directories. The impossibility argument (D2) is what tips it: this is the
-  one capability pure Bash *cannot* provide, so it is the one place the
-  criterion earns a narrow exception.
-- **Loadable builtins (`enable -f mkdir.so`).** A platform-specific `.so`
-  is a heavier and less portable dependency than a POSIX command already
-  guaranteed on every system with a Bash; it defeats the "runs anywhere
-  Bash runs" property more than one `command mkdir` does.
-- **A virtual filesystem overlay in Bash arrays.** State would diverge from
-  the host (the whole point of `--dir` is to touch real host files) and the
-  standalone `--dir` goldens, captured under wasmtime (ADR-9), would not
-  match.
-- **General external-command use for the rest of the surface** (`od`/`dd`
-  for bytes, `stat` for metadata). Rejected as ADR-5 always rejected them:
-  those capabilities *are* expressible in pure Bash (byte-wise `read`/
-  `printf`, test builtins), so there is no impossibility to license the
-  exception. D2 is scoped to exactly the operations that have no pure-Bash
-  form.
+- **Leave the four namespace-mutation syscalls ENOSYS.** Honest to ADR-5 but leaves the surface permanently unable to do what SQLite's journal/WAL lifecycle (ADR-14's north star) needs — create and delete files and directories. The impossibility argument (D2) is what tips it: this is the one capability pure Bash *cannot* provide, so it is the one place the criterion earns a narrow exception.
+- **Loadable builtins (`enable -f mkdir.so`).** A platform-specific `.so` is a heavier and less portable dependency than a POSIX command already guaranteed on every system with a Bash; it defeats the "runs anywhere Bash runs" property more than one `command mkdir` does.
+- **A virtual filesystem overlay in Bash arrays.** State would diverge from the host (the whole point of `--dir` is to touch real host files) and the standalone `--dir` goldens, captured under wasmtime (ADR-9), would not match.
+- **General external-command use for the rest of the surface** (`od`/`dd` for bytes, `stat` for metadata). Rejected as ADR-5 always rejected them: those capabilities *are* expressible in pure Bash (byte-wise `read`/ `printf`, test builtins), so there is no impossibility to license the exception. D2 is scoped to exactly the operations that have no pure-Bash form.
 
 ## Consequences
 
-- Positive: the Bash backend reaches the same WASI p1 filesystem surface as
-  Ruby, so `--dir` round-trips and the shared filesystem e2e suite apply to
-  it; a module that imports no namespace-mutation syscall stays pure Bash.
-- Negative / accepted: whole-file buffering makes open/close O(size) and the
-  slurp/flush cost ~microseconds per byte — in line with ADR-5's "value is
-  existence, not speed". The D2 dependency-statement change is real: a
-  module importing the four mutation syscalls now also depends on
-  `mkdir`/`rmdir`/`rm`/`mv`. The D1/D3/D6 caveats (two-fd divergence,
-  non-atomic flush, TOCTOU, file-symlink ELOOP, zeroed timestamps/dev/ino)
-  are standing deviations, not bugs.
-- Carry-over: `fd_advise`, `fd_allocate`, `fd_renumber`, the symlink
-  syscalls, rights-narrowing (`fd_fdstat_set_flags`/`_rights`), and
-  `path_filestat_set_times` stay ENOSYS, exactly as on Ruby (ADR-14) — the
-  lower-value and security-motivated gaps are not reopened here.
+- Positive: the Bash backend reaches the same WASI p1 filesystem surface as Ruby, so `--dir` round-trips and the shared filesystem e2e suite apply to it; a module that imports no namespace-mutation syscall stays pure Bash.
+- Negative / accepted: whole-file buffering makes open/close O(size) and the slurp/flush cost ~microseconds per byte — in line with ADR-5's "value is existence, not speed". The D2 dependency-statement change is real: a module importing the four mutation syscalls now also depends on `mkdir`/`rmdir`/`rm`/`mv`. The D1/D3/D6 caveats (two-fd divergence, non-atomic flush, TOCTOU, file-symlink ELOOP, zeroed timestamps/dev/ino) are standing deviations, not bugs.
+- Carry-over: `fd_advise`, `fd_allocate`, `fd_renumber`, the symlink syscalls, rights-narrowing (`fd_fdstat_set_flags`/`_rights`), and `path_filestat_set_times` stay ENOSYS, exactly as on Ruby (ADR-14) — the lower-value and security-motivated gaps are not reopened here.

--- a/docs/adr/35-bash-cross-module-linking.md
+++ b/docs/adr/35-bash-cross-module-linking.md
@@ -1,114 +1,33 @@
 # ADR-35 — Bash Cross-Module Linking
 
-Status: **Accepted, 2026-07-27.** Implemented in
-`crates/dewasm-backend-bash/src/lib.rs` (`Gen::init`) +
-`runtime/bash/units/rt/resolve_import.sh` and `rt/link_err.sh`. Covers every
-wasm 1.0 import kind: imported functions (retained), imported globals
-(`Feature::ImportedGlobals` Supported), imported memories
-(`Feature::ImportedMemories` Supported), and imported tables
-(`Feature::ImportedTables` Supported) — plus the `shared_table_call_indirect`
-multi-module e2e case (`crates/dewasm-backend-bash/tests/e2e.rs`,
-`BackendUnderTest::compose_modules`). Extends
-[ADR-11](11-bash-backend-lowering.md).
+Status: **Accepted, 2026-07-27.** Implemented in `crates/dewasm-backend-bash/src/lib.rs` (`Gen::init`) + `runtime/bash/units/rt/resolve_import.sh` and `rt/link_err.sh`. Covers every wasm 1.0 import kind: imported functions (retained), imported globals (`Feature::ImportedGlobals` Supported), imported memories (`Feature::ImportedMemories` Supported), and imported tables (`Feature::ImportedTables` Supported) — plus the `shared_table_call_indirect` multi-module e2e case (`crates/dewasm-backend-bash/tests/e2e.rs`, `BackendUnderTest::compose_modules`). Extends [ADR-11](11-bash-backend-lowering.md).
 
 ## Context
 
-The Ruby backend links across modules with a single `import(name)` provider
-protocol and a boxed `Rt::Global` cell that mutable imports share by
-reference ([ADR-16](16-ruby-wasm1-completion.md)). Bash has neither objects
-nor references: state lives in prefix-scoped variables and arrays
-(`<p>g<i>`, `<p>t<i>`, `<p>mem`), and until now the only import mechanism was
-the `IMPORTS[module.name]=command` associative array — functions only, no
-shared mutable state, no kind checking.
+The Ruby backend links across modules with a single `import(name)` provider protocol and a boxed `Rt::Global` cell that mutable imports share by reference ([ADR-16](16-ruby-wasm1-completion.md)). Bash has neither objects nor references: state lives in prefix-scoped variables and arrays (`<p>g<i>`, `<p>t<i>`, `<p>mem`), and until now the only import mechanism was the `IMPORTS[module.name]=command` associative array — functions only, no shared mutable state, no kind checking.
 
-Wasm imports need three things Bash did not have: a way to alias another
-module's global cell so reads *and* writes reach it; a provider protocol
-that spans every import kind, not just functions; and a link-error signal
-distinct from a trap. The spec harness's `register`/`assert_unlinkable`
-directives exercise all three, so the harness could not be turned on for
-Bash without them.
+Wasm imports need three things Bash did not have: a way to alias another module's global cell so reads *and* writes reach it; a provider protocol that spans every import kind, not just functions; and a link-error signal distinct from a trap. The spec harness's `register`/`assert_unlinkable` directives exercise all three, so the harness could not be turned on for Bash without them.
 
 ## Decision
 
-**Imported globals alias the provider's cell with a `declare -gn` nameref.**
-For imported global `i`, `Gen::init` emits `declare -gn <p>g<i>=$RESOLVED`,
-where `$RESOLVED` is the *variable name* of the owning module's cell. Reads
-(`(( x = <p>g<i> ))`), mutable writes (`(( <p>g<i> = v ))`), and init-expr
-`global.get` offsets all resolve through the nameref to the shared variable,
-so mutation is visible in both modules with no boxing. Defined globals keep
-their literal `<p>g<num_imported_globals + i>` slot in the unified index
-space.
+**Imported globals alias the provider's cell with a `declare -gn` nameref.** For imported global `i`, `Gen::init` emits `declare -gn <p>g<i>=$RESOLVED`, where `$RESOLVED` is the *variable name* of the owning module's cell. Reads (`(( x = <p>g<i> ))`), mutable writes (`(( <p>g<i> = v ))`), and init-expr `global.get` offsets all resolve through the nameref to the shared variable, so mutation is visible in both modules with no boxing. Defined globals keep their literal `<p>g<num_imported_globals + i>` slot in the unified index space.
 
-**PROVIDERS + per-kind export maps are the Bash shape of the provider
-protocol.** `PROVIDERS[module]` names a prefix `<q>` that owns the export
-maps `<q>EXPORTS` (functions), `<q>GLOBAL_EXPORTS`, `<q>TABLE_EXPORTS`,
-`<q>MEMORY_EXPORTS` — exactly the shape another generated module already
-emits. `rt_resolve_import <mod> <name> <kind>` looks the name up in the
-kind's map and returns the value in `RESOLVED`. Discriminating rule: a name
-found under a *different* kind's map is an incompatible-type link error; a
-name found nowhere leaves `RESOLVED=''` so the caller chooses (WASI/ENOSYS
-fallback for WASI modules, else a link error). `IMPORTS` is retained as a
-function-only host override, checked ahead of `PROVIDERS`.
+**PROVIDERS + per-kind export maps are the Bash shape of the provider protocol.** `PROVIDERS[module]` names a prefix `<q>` that owns the export maps `<q>EXPORTS` (functions), `<q>GLOBAL_EXPORTS`, `<q>TABLE_EXPORTS`, `<q>MEMORY_EXPORTS` — exactly the shape another generated module already emits. `rt_resolve_import <mod> <name> <kind>` looks the name up in the kind's map and returns the value in `RESOLVED`. Discriminating rule: a name found under a *different* kind's map is an incompatible-type link error; a name found nowhere leaves `RESOLVED=''` so the caller chooses (WASI/ENOSYS fallback for WASI modules, else a link error). `IMPORTS` is retained as a function-only host override, checked ahead of `PROVIDERS`.
 
-**Export values are flattened so nameref chains stay depth ≤ 1.** A global or
-table export publishes its backing variable *name*: a defined global/table
-publishes its own `<p>g<idx>`/`<p>t<idx>`, a re-exported imported one
-publishes `${!<p>g<idx>}`/`${!<p>t<idx>}` (the nameref's target, not the
-nameref itself). A consumer's `declare -gn` then points one hop at the real
-cell/array, so `${!name}` never has to chase a chain. Memory has no single
-name to flatten to — its derived state (`mem`/`pages`/`max_pages`) is three
-variables, not one cell — so `MEMORY_EXPORTS` instead publishes the owning
-module's *prefix* (`<p>memown`); a re-export just forwards that string, and a
-consumer's three `declare -gn`s (`${RESOLVED}mem`/`pages`/`max_pages`) still
-each resolve in one hop.
+**Export values are flattened so nameref chains stay depth ≤ 1.** A global or table export publishes its backing variable *name*: a defined global/table publishes its own `<p>g<idx>`/`<p>t<idx>`, a re-exported imported one publishes `${!<p>g<idx>}`/`${!<p>t<idx>}` (the nameref's target, not the nameref itself). A consumer's `declare -gn` then points one hop at the real cell/array, so `${!name}` never has to chase a chain. Memory has no single name to flatten to — its derived state (`mem`/`pages`/`max_pages`) is three variables, not one cell — so `MEMORY_EXPORTS` instead publishes the owning module's *prefix* (`<p>memown`); a re-export just forwards that string, and a consumer's three `declare -gn`s (`${RESOLVED}mem`/`pages`/`max_pages`) still each resolve in one hop.
 
-**Link errors return status 135** (`rt_link_err`), the linking sibling of
-`rt_trap`'s 134 and `rt_exit`'s 133, propagated through the same
-`|| return $?` cascade. This is an observable change: a missing import used
-to `echo ...; return 1`.
+**Link errors return status 135** (`rt_link_err`), the linking sibling of `rt_trap`'s 134 and `rt_exit`'s 133, propagated through the same `|| return $?` cascade. This is an observable change: a missing import used to `echo ...; return 1`.
 
-**Type identity across a shared table is the structural type key**, not a
-module-local numeric id (already landed for defined tables): two modules
-sharing a table must agree on `call_indirect` types, and their type sections
-do not, so the tag is derived from the type's shape (`i32,i64->f32`).
+**Type identity across a shared table is the structural type key**, not a module-local numeric id (already landed for defined tables): two modules sharing a table must agree on `call_indirect` types, and their type sections do not, so the tag is derived from the type's shape (`i32,i64->f32`).
 
 ## Rejected alternatives
 
-- **Handle-prefix threading** — pass the owning module's prefix to every
-  operation that touches imported state. Touches every lowering site and
-  cannot express an inline `(( <p>g<i> += 1 ))` on a shared global; the
-  nameref makes the shared cell look local everywhere it is used.
-- **Boxed indirection via `${!name}` / `printf -v` everywhere** — model a
-  global as a name and read/write it indirectly at every use. Works, but
-  churns every global access into a two-step indirect read/write and is
-  slower; the nameref confines the indirection to one `declare -gn` at
-  instantiation.
-- **Numeric canonical type ids for `call_indirect`** — compact, but a table
-  shared across independently generated modules has no shared id space, so
-  the tag would disagree across the boundary.
+- **Handle-prefix threading** — pass the owning module's prefix to every operation that touches imported state. Touches every lowering site and cannot express an inline `(( <p>g<i> += 1 ))` on a shared global; the nameref makes the shared cell look local everywhere it is used.
+- **Boxed indirection via `${!name}` / `printf -v` everywhere** — model a global as a name and read/write it indirectly at every use. Works, but churns every global access into a two-step indirect read/write and is slower; the nameref confines the indirection to one `declare -gn` at instantiation.
+- **Numeric canonical type ids for `call_indirect`** — compact, but a table shared across independently generated modules has no shared id space, so the tag would disagree across the boundary.
 
 ## Consequences
 
-- Positive: mutable imported globals, memory, and tables all share state
-  correctly with no boxing, through the same `declare -gn` mechanism;
-  `assert_unlinkable` is checked for real (status 135), so the spec harness's
-  `register` support is fully on for Bash and every import kind's `linking`
-  ledger cluster clears (`elem`, `linking0`→table entries, `linking3`). A
-  shared table crossing independently-generated modules now has an e2e case
-  too (`shared_table_call_indirect`, `compose_modules` generating each module
-  against one bundled runtime).
-- Negative: `rt_resolve_import` validates import *kind* but not the finer
-  wasm type — a function's signature, a global's mutability, a table's
-  min/max limits, or a memory's min/max limits — so a number of
-  `assert_unlinkable` cases link instead of failing (the `import-limits`
-  ledger cluster: `imports`/`imports2`/part of `linking`, the same accepted
-  gap as Ruby, now at the same counts since Bash covers every import kind
-  Ruby does). 135 collides with the `128 + SIGBUS` signal convention; no
-  generated module spawns a subprocess that can raise SIGBUS, so the
-  collision is accepted.
-- Residual, unrelated to this ADR: `linking0` and `load1` still fail one
-  assertion apiece downstream of a *different*, permanently out-of-scope gap
-  — a module declaring two memories is rejected outright by the core builder
-  (`Feature::MultiMemory`, a post-1.0 proposal, ADR-24), so data meant for a
-  shared memory through that module never runs (the `multi-memory` ledger
-  tag in `crates/dewasm-backend-bash/tests/spec.rs`).
+- Positive: mutable imported globals, memory, and tables all share state correctly with no boxing, through the same `declare -gn` mechanism; `assert_unlinkable` is checked for real (status 135), so the spec harness's `register` support is fully on for Bash and every import kind's `linking` ledger cluster clears (`elem`, `linking0`→table entries, `linking3`). A shared table crossing independently-generated modules now has an e2e case too (`shared_table_call_indirect`, `compose_modules` generating each module against one bundled runtime).
+- Negative: `rt_resolve_import` validates import *kind* but not the finer wasm type — a function's signature, a global's mutability, a table's min/max limits, or a memory's min/max limits — so a number of `assert_unlinkable` cases link instead of failing (the `import-limits` ledger cluster: `imports`/`imports2`/part of `linking`, the same accepted gap as Ruby, now at the same counts since Bash covers every import kind Ruby does). 135 collides with the `128 + SIGBUS` signal convention; no generated module spawns a subprocess that can raise SIGBUS, so the collision is accepted.
+- Residual, unrelated to this ADR: `linking0` and `load1` still fail one assertion apiece downstream of a *different*, permanently out-of-scope gap — a module declaring two memories is rejected outright by the core builder (`Feature::MultiMemory`, a post-1.0 proposal, ADR-24), so data meant for a shared memory through that module never runs (the `multi-memory` ledger tag in `crates/dewasm-backend-bash/tests/spec.rs`).

--- a/docs/adr/36-wasi-testsuite-conformance.md
+++ b/docs/adr/36-wasi-testsuite-conformance.md
@@ -1,113 +1,29 @@
 # ADR-36 — Official WASI p1 Conformance Suite as a Harness Layer
 
-Status: **Accepted, 2026-07-28.** Implemented: the `tests/wasi-testsuite`
-submodule (branch `prod/testsuite-base`), the shared runner
-(`crates/dewasm-test-helper/src/wasi_testsuite.rs` + `wasi_testsuite_suite!`),
-the `BackendUnderTest::run_standalone_wasi` execution path, and a per-backend
-`tests/wasi_testsuite.rs` with its own attributed ledger for all five backends.
-Builds on ADR-8 (ledger-with-attribution) and ADR-31 (standalone interface).
+Status: **Accepted, 2026-07-28.** Implemented: the `tests/wasi-testsuite` submodule (branch `prod/testsuite-base`), the shared runner (`crates/dewasm-test-helper/src/wasi_testsuite.rs` + `wasi_testsuite_suite!`), the `BackendUnderTest::run_standalone_wasi` execution path, and a per-backend `tests/wasi_testsuite.rs` with its own attributed ledger for all five backends. Builds on ADR-8 (ledger-with-attribution) and ADR-31 (standalone interface).
 
 ## Context
 
-dewasm's own WASI p1 fixtures (`crates/dewasm-test-helper/src/wasi.rs`) are a
-handful of hand-written `.wat` probes grouped by feature unit — enough to guard
-the units we wrote, but not a conformance bar. The
-[WebAssembly/wasi-testsuite](https://github.com/WebAssembly/wasi-testsuite)
-project publishes prebuilt `.wasm` modules (compiled from C, Rust, and
-AssemblyScript sources) that exercise WASI p1 syscalls against expected
-exit codes and output, with a per-test JSON manifest (`args`, `env`, `root`,
-`exit_code`, `stdout`). It is the closest thing to an official WASI conformance
-suite, and dewasm already produces standalone programs that behave like the
-`.wasm` they came from (ADR-31), so the modules can run through that interface
-unchanged.
+dewasm's own WASI p1 fixtures (`crates/dewasm-test-helper/src/wasi.rs`) are a handful of hand-written `.wat` probes grouped by feature unit — enough to guard the units we wrote, but not a conformance bar. The [WebAssembly/wasi-testsuite](https://github.com/WebAssembly/wasi-testsuite) project publishes prebuilt `.wasm` modules (compiled from C, Rust, and AssemblyScript sources) that exercise WASI p1 syscalls against expected exit codes and output, with a per-test JSON manifest (`args`, `env`, `root`, `exit_code`, `stdout`). It is the closest thing to an official WASI conformance suite, and dewasm already produces standalone programs that behave like the `.wasm` they came from (ADR-31), so the modules can run through that interface unchanged.
 
 ## Decision
 
-- **Vendor the suite as a git submodule**, `tests/wasi-testsuite` on branch
-  `prod/testsuite-base` (the branch carrying the *prebuilt* artifacts under
-  `tests/{c,rust,assemblyscript}/testsuite/wasm32-wasip1/`), mirroring the
-  `tests/spec` submodule. Criterion: *upstream that ships built artifacts we do
-  not rebuild is a submodule, not a fetch script* — there is no toolchain step
-  to run, the pin is a commit, and updating it is a deliberate commit like
-  `tests/spec`.
-- **Execute through the ADR-31 standalone interface, not a bespoke host.** A
-  new `BackendUnderTest::run_standalone_wasi` reuses each backend's own launch
-  recipe (`pty_command`) to run a converted standalone program with the
-  manifest translated to that interface: `root` → a `--dir <root>::/` preopen
-  (mirroring upstream's own wasmtime adapter, which mounts `root` at guest `/`),
-  `args` → guest `argv[1..]`, `env` → child-process environment, then assert the
-  process exit code and pinned stdout. Each `root` fixture is staged into a
-  fresh temp copy so a test that creates or removes files stays hermetic and the
-  committed submodule is never mutated. Criterion: *a conformance runner tests
-  the shipping interface, not a test-only shortcut* — running the modules the
-  way a user runs a converted program is what makes a pass meaningful.
-- **Scope: c + rust + assemblyscript, `wasm32-wasip1` only.** The Rust
-  `wasm32-wasip3` tree is excluded (preview 3 is component-model territory,
-  rejected outright by ADR-24). AssemblyScript is included: its modules convert
-  cleanly and run.
-- **Known failures are ledgered with attribution, not implemented now**
-  (ADR-8). Each backend's `WASI_TESTSUITE_EXPECTED_FAILURES` maps a trial to a
-  tag naming its cause, in three honest kinds: (a) a declared ENOSYS /
-  out-of-scope syscall (`docs/support.md` — `path_link`, `path_readlink`,
-  `path_symlink`, `fd_renumber`, `fd_advise`, `fd_allocate`,
-  `fd_fdstat_set_flags`/`set_rights`, `*_filestat_set_times`, `sock_shutdown`);
-  (b) a semantics-precision gap on a *supported* syscall (errno codes,
-  per-filetype rights masking, dirent `.`/`..`, trailing-slash handling) —
-  tracked bugs in the shared WASI runtime; (c) the ADR-31 choice that a
-  standalone program inherits the whole host environment, which the `environ_*`
-  count assertions cannot satisfy. As in `spec.rs` the ledger is checked both
-  ways — a ledgered trial that unexpectedly *passes* is a hard failure, so
-  filling a gap (kind a) or fixing a bug (kind b) forces its entry to be
-  removed. This is ADR-8's contract applied to conformance points: a known
-  failure must be the consequence of a declaration or a tracked defect, never
-  silence.
-- **Manifests are read with `serde_json`.** `dewasm-test-helper` is test-only
-  (`publish = false`), so a JSON dependency never reaches a shipped artifact;
-  deriving `Deserialize` on the `Manifest` struct is smaller and less
-  bug-prone than a hand-written parser, which would be its own maintenance
-  surface.
+- **Vendor the suite as a git submodule**, `tests/wasi-testsuite` on branch `prod/testsuite-base` (the branch carrying the *prebuilt* artifacts under `tests/{c,rust,assemblyscript}/testsuite/wasm32-wasip1/`), mirroring the `tests/spec` submodule. Criterion: *upstream that ships built artifacts we do not rebuild is a submodule, not a fetch script* — there is no toolchain step to run, the pin is a commit, and updating it is a deliberate commit like `tests/spec`.
+- **Execute through the ADR-31 standalone interface, not a bespoke host.** A new `BackendUnderTest::run_standalone_wasi` reuses each backend's own launch recipe (`pty_command`) to run a converted standalone program with the manifest translated to that interface: `root` → a `--dir <root>::/` preopen (mirroring upstream's own wasmtime adapter, which mounts `root` at guest `/`), `args` → guest `argv[1..]`, `env` → child-process environment, then assert the process exit code and pinned stdout. Each `root` fixture is staged into a fresh temp copy so a test that creates or removes files stays hermetic and the committed submodule is never mutated. Criterion: *a conformance runner tests the shipping interface, not a test-only shortcut* — running the modules the way a user runs a converted program is what makes a pass meaningful.
+- **Scope: c + rust + assemblyscript, `wasm32-wasip1` only.** The Rust `wasm32-wasip3` tree is excluded (preview 3 is component-model territory, rejected outright by ADR-24). AssemblyScript is included: its modules convert cleanly and run.
+- **Known failures are ledgered with attribution, not implemented now** (ADR-8). Each backend's `WASI_TESTSUITE_EXPECTED_FAILURES` maps a trial to a tag naming its cause, in three honest kinds: (a) a declared ENOSYS / out-of-scope syscall (`docs/support.md` — `path_link`, `path_readlink`, `path_symlink`, `fd_renumber`, `fd_advise`, `fd_allocate`, `fd_fdstat_set_flags`/`set_rights`, `*_filestat_set_times`, `sock_shutdown`); (b) a semantics-precision gap on a *supported* syscall (errno codes, per-filetype rights masking, dirent `.`/`..`, trailing-slash handling) — tracked bugs in the shared WASI runtime; (c) the ADR-31 choice that a standalone program inherits the whole host environment, which the `environ_*` count assertions cannot satisfy. As in `spec.rs` the ledger is checked both ways — a ledgered trial that unexpectedly *passes* is a hard failure, so filling a gap (kind a) or fixing a bug (kind b) forces its entry to be removed. This is ADR-8's contract applied to conformance points: a known failure must be the consequence of a declaration or a tracked defect, never silence.
+- **Manifests are read with `serde_json`.** `dewasm-test-helper` is test-only (`publish = false`), so a JSON dependency never reaches a shipped artifact; deriving `Deserialize` on the `Manifest` struct is smaller and less bug-prone than a hand-written parser, which would be its own maintenance surface.
 
 ## Rejected alternatives
 
-- **A fetch script (like `examples/apps/fetch.sh`).** That pattern exists for
-  artifacts we rebuild from pinned source or download per-shape (ADR-9); this
-  suite ships built `.wasm` we consume verbatim, so a submodule is the lighter,
-  reproducible pin — no build tools, and the version is a commit.
-- **A dedicated WASI host/runner in the harness** that instantiates the module
-  and services syscalls directly. It would bypass the generated standalone
-  `main` — the very thing that makes a converted program usable — so a green run
-  would prove less. Reusing `run_standalone_dir`'s path (extended with env and
-  exit-code capture) tests what ships.
-- **Clearing the child environment to match wasmtime's `--env`-only model**, so
-  the `environ_*` tests pass. Rejected: dewasm's standalone programs inherit the
-  whole process environment by design (ADR-31); a special clean-env mode would
-  test behaviour the CLI never produces, and env-clearing risks the interpreter
-  launch itself. Ledgering the three count-exact `environ_*` tests under
-  `env-passthrough` is the honest record.
-  **Superseded, 2026-07-28 ([ADR-40](40-wasi-p1-completion.md)):** the runner
-  now clears the child environment (the launch risk is handled by resolving
-  the interpreter against the parent PATH), which is exactly how upstream's
-  wasmtime adapter isolates the guest; the rows that remain ledgered on
-  interpreted backends are re-attributed to host-interpreter env injection,
-  not to ADR-31.
-- **Fixing the kind-(b) precision gaps now.** They live in the per-language
-  WASI runtime and would need care across all five backends without regressing
-  the curated `wasi.rs` suite — larger than this integration. They are ledgered
-  with a precise tag and left as tracked follow-ups.
-- **Pinning `prod/testsuite-all`** (proposals + p2/p3) instead of
-  `-base`. Out of scope for a wasm-1.0 + p1 toolchain (ADR-24).
+- **A fetch script (like `examples/apps/fetch.sh`).** That pattern exists for artifacts we rebuild from pinned source or download per-shape (ADR-9); this suite ships built `.wasm` we consume verbatim, so a submodule is the lighter, reproducible pin — no build tools, and the version is a commit.
+- **A dedicated WASI host/runner in the harness** that instantiates the module and services syscalls directly. It would bypass the generated standalone `main` — the very thing that makes a converted program usable — so a green run would prove less. Reusing `run_standalone_dir`'s path (extended with env and exit-code capture) tests what ships.
+- **Clearing the child environment to match wasmtime's `--env`-only model**, so the `environ_*` tests pass. Rejected: dewasm's standalone programs inherit the whole process environment by design (ADR-31); a special clean-env mode would test behaviour the CLI never produces, and env-clearing risks the interpreter launch itself. Ledgering the three count-exact `environ_*` tests under `env-passthrough` is the honest record. **Superseded, 2026-07-28 ([ADR-40](40-wasi-p1-completion.md)):** the runner now clears the child environment (the launch risk is handled by resolving the interpreter against the parent PATH), which is exactly how upstream's wasmtime adapter isolates the guest; the rows that remain ledgered on interpreted backends are re-attributed to host-interpreter env injection, not to ADR-31.
+- **Fixing the kind-(b) precision gaps now.** They live in the per-language WASI runtime and would need care across all five backends without regressing the curated `wasi.rs` suite — larger than this integration. They are ledgered with a precise tag and left as tracked follow-ups.
+- **Pinning `prod/testsuite-all`** (proposals + p2/p3) instead of `-base`. Out of scope for a wasm-1.0 + p1 toolchain (ADR-24).
 
 ## Consequences
 
-- Positive: an independent, upstream conformance bar for WASI p1 now gates every
-  backend; ~40 modules pass per backend and the honest ledger surfaces exactly
-  which syscalls are unimplemented or imprecise. The both-ways check turns any
-  future WASI fix into a required ledger edit, so the declaration and the tests
-  cannot drift.
-- Negative: two submodules to initialize (`docs/testing.md` covers both). The
-  compiled backends (Go, Java) build one program per module; the content-address
-  cache amortizes it after the first run.
-- Carry-over: the kind-(b) precision failures and Java's `path_open`+`O_CREAT`
-  NOENT cluster are tracked in the ledgers as the backlog of WASI-runtime
-  fixes; each fix flips its ledger entries to hard failures until the trial
-  passes.
+- Positive: an independent, upstream conformance bar for WASI p1 now gates every backend; ~40 modules pass per backend and the honest ledger surfaces exactly which syscalls are unimplemented or imprecise. The both-ways check turns any future WASI fix into a required ledger edit, so the declaration and the tests cannot drift.
+- Negative: two submodules to initialize (`docs/testing.md` covers both). The compiled backends (Go, Java) build one program per module; the content-address cache amortizes it after the first run.
+- Carry-over: the kind-(b) precision failures and Java's `path_open`+`O_CREAT` NOENT cluster are tracked in the ledgers as the backlog of WASI-runtime fixes; each fix flips its ledger entries to hard failures until the trial passes.

--- a/docs/adr/37-data-segment-externalization.md
+++ b/docs/adr/37-data-segment-externalization.md
@@ -1,92 +1,39 @@
 # ADR-37 — Opt-in Data-Segment Externalization (`--data-file`)
 
-Status: **Accepted, 2026-07-28.** Implemented for the Ruby, Go, Python and Java
-backends behind the CLI's `--data-file` flag; Bash rejects it loudly at the CLI
-(its data lives in the runtime, not a standalone literal). Default (no-flag)
-output is byte-identical to before. Extended 2026-07-28 with the Python and Java
-backends and the Java code-source load strategy.
+Status: **Accepted, 2026-07-28.** Implemented for the Ruby, Go, Python and Java backends behind the CLI's `--data-file` flag; Bash rejects it loudly at the CLI (its data lives in the runtime, not a standalone literal). Default (no-flag) output is byte-identical to before. Extended 2026-07-28 with the Python and Java backends and the Java code-source load strategy.
 
 ## Context
 
-A wasm module's data segments are lowered into the generated source as inline
-literals: Ruby `["<hex>"].pack("H*")` (`crates/dewasm-backend-ruby/src/lib.rs`,
-`hex_bytes`), Go `Rt.unhex("<hex>")` (`crates/dewasm-backend-go/src/lib.rs`,
-`hex_bytes`). Hex costs two source bytes per data byte, and the bytes then live
-inside the parsed program forever.
+A wasm module's data segments are lowered into the generated source as inline literals: Ruby `["<hex>"].pack("H*")` (`crates/dewasm-backend-ruby/src/lib.rs`, `hex_bytes`), Go `Rt.unhex("<hex>")` (`crates/dewasm-backend-go/src/lib.rs`, `hex_bytes`). Hex costs two source bytes per data byte, and the bytes then live inside the parsed program forever.
 
-For data-heavy modules this bloats the source. wasm2go's `-embed` flag is the
-prior art: move the segment bytes into a binary sidecar the program loads at
-startup, keeping only offset/length constants in the code. The open question was
-whether to do this always, and how to shape the sidecar.
+For data-heavy modules this bloats the source. wasm2go's `-embed` flag is the prior art: move the segment bytes into a binary sidecar the program loads at startup, keeping only offset/length constants in the code. The open question was whether to do this always, and how to shape the sidecar.
 
 ## Decision
 
-Add an **opt-in** `--data-file <path>` CLI flag (ADR-0's "unsupported fails at
-conversion time" applies to the rejections below). When set, the backend:
+Add an **opt-in** `--data-file <path>` CLI flag (ADR-0's "unsupported fails at conversion time" applies to the rejections below). When set, the backend:
 
-- concatenates every segment's bytes into one blob, returned as a second
-  `OutputFile` whose `name` is the sidecar filename; the CLI routes it to
-  `--data-file`'s path and the primary source to `-o`;
-- bakes per-segment `(blob_offset, len)` prefix sums into codegen; active
-  segments init a memory from a blob slice, passive segments keep an addressable
-  slice view for `memory.init`/`data.drop`;
-- references the sidecar **relative to the program itself**: Ruby
-  `File.binread(File.join(__dir__, "<name>"))` read once into a frozen
-  `DATA_BLOB` constant, then `DATA_BLOB.byteslice(o, len)` (kept ASCII-8BIT, as
-  `binread` returns); Go a package-scope `//go:embed <name>` / `var dataBlob
-  []byte` sliced `dataBlob[o:o+len]`; Python a module-level `DATA_BLOB =
-  open(os.path.join(os.path.dirname(__file__), "<name>"), "rb").read()` sliced
-  `DATA_BLOB[o:o+len]`; Java a `static final byte[] DATA_BLOB` loaded by a
-  static method (see the code-source rule below) and sliced
-  `java.util.Arrays.copyOfRange(DATA_BLOB, o, o+len)` — a fresh array per
-  segment, so `data.drop` can still empty the field.
+- concatenates every segment's bytes into one blob, returned as a second `OutputFile` whose `name` is the sidecar filename; the CLI routes it to `--data-file`'s path and the primary source to `-o`;
+- bakes per-segment `(blob_offset, len)` prefix sums into codegen; active segments init a memory from a blob slice, passive segments keep an addressable slice view for `memory.init`/`data.drop`;
+- references the sidecar **relative to the program itself**: Ruby `File.binread(File.join(__dir__, "<name>"))` read once into a frozen `DATA_BLOB` constant, then `DATA_BLOB.byteslice(o, len)` (kept ASCII-8BIT, as `binread` returns); Go a package-scope `//go:embed <name>` / `var dataBlob []byte` sliced `dataBlob[o:o+len]`; Python a module-level `DATA_BLOB = open(os.path.join(os.path.dirname(__file__), "<name>"), "rb").read()` sliced `DATA_BLOB[o:o+len]`; Java a `static final byte[] DATA_BLOB` loaded by a static method (see the code-source rule below) and sliced `java.util.Arrays.copyOfRange(DATA_BLOB, o, o+len)` — a fresh array per segment, so `data.drop` can still empty the field.
 
-**Java load strategy — code-source-relative, not a working-directory guess.**
-Java has no `__file__`/`__dir__`, and a compiled program may run from a class
-directory or a packaged jar. The generated loader resolves the sidecar against
-the class's own `getProtectionDomain().getCodeSource().getLocation()`: a regular
-file (the jar) contributes its *parent* directory, a directory (the class dir)
-is used directly, and the sidecar name is resolved there with
-`Files.readAllBytes`, rethrowing any failure as an unchecked `RuntimeException`.
-The discriminating criterion is locating the sidecar by *where the program's own
-code lives*, which both deployment shapes answer, rather than by the process
-CWD, which neither reliably does.
+**Java load strategy — code-source-relative, not a working-directory guess.** Java has no `__file__`/`__dir__`, and a compiled program may run from a class directory or a packaged jar. The generated loader resolves the sidecar against the class's own `getProtectionDomain().getCodeSource().getLocation()`: a regular file (the jar) contributes its *parent* directory, a directory (the class dir) is used directly, and the sidecar name is resolved there with `Files.readAllBytes`, rethrowing any failure as an unchecked `RuntimeException`. The discriminating criterion is locating the sidecar by *where the program's own code lives*, which both deployment shapes answer, rather than by the process CWD, which neither reliably does.
 
-`OutputFile.contents` widened from `String` to `Vec<u8>` so a backend can return
-raw binary alongside UTF-8 source.
+`OutputFile.contents` widened from `String` to `Vec<u8>` so a backend can return raw binary alongside UTF-8 source.
 
-**Discriminating rule:** externalization is a size/layout trade-off with no
-semantic content, so it is a per-invocation *flag*, never a default and never a
-backend capability flip — the generated program's behaviour is identical either
-way (the spec harness, which never sets the flag, still binds; ADR-3).
+**Discriminating rule:** externalization is a size/layout trade-off with no semantic content, so it is a per-invocation *flag*, never a default and never a backend capability flip — the generated program's behaviour is identical either way (the spec harness, which never sets the flag, still binds; ADR-3).
 
-**Scope:** Ruby, Go, Python and Java. Bash embeds data in its runtime rather
-than as a standalone literal, so a sidecar would be a larger change; it alone
-*rejects* `--data-file` at the CLI with an attributed error rather than silently
-ignoring it. `--data-file` with `-o -` (stdout) is likewise rejected: the sidecar
-needs a real path next to the program.
+**Scope:** Ruby, Go, Python and Java. Bash embeds data in its runtime rather than as a standalone literal, so a sidecar would be a larger change; it alone *rejects* `--data-file` at the CLI with an attributed error rather than silently ignoring it. `--data-file` with `-o -` (stdout) is likewise rejected: the sidecar needs a real path next to the program.
 
-Go mechanics (ADR-29): `//go:embed` is a directive, not a package selector, so
-the import scanner cannot see it — `embed` is added as a blank `import _
-"embed"` and the directive is emitted verbatim (the scanner's comment-stripping
-only computes the import *set*; it never rewrites the output). The directive
-must sit immediately above its `var`.
+Go mechanics (ADR-29): `//go:embed` is a directive, not a package selector, so the import scanner cannot see it — `embed` is added as a blank `import _ "embed"` and the directive is emitted verbatim (the scanner's comment-stripping only computes the import *set*; it never rewrites the output). The directive must sit immediately above its `var`.
 
 ## Rejected alternatives
 
-- **Always externalize.** Rejected: it forces a two-file deployment on every
-  user and breaks the single-file `-o -`/stdout path. The benefit is real only
-  for data-heavy modules (see Consequences), so it belongs behind a flag.
-- **A single in-file base64/blob literal.** Keeps one file but still parses the
-  whole payload as a source token every load, and base64 is still 1.33× the raw
-  bytes. A binary sidecar is the actual bytes (mmap-friendly) and leaves the
-  parsed source entirely.
+- **Always externalize.** Rejected: it forces a two-file deployment on every user and breaks the single-file `-o -`/stdout path. The benefit is real only for data-heavy modules (see Consequences), so it belongs behind a flag.
+- **A single in-file base64/blob literal.** Keeps one file but still parses the whole payload as a source token every load, and base64 is still 1.33× the raw bytes. A binary sidecar is the actual bytes (mmap-friendly) and leaves the parsed source entirely.
 
 ## Consequences
 
-Positive: opt-in, correctness-neutral, default output unchanged
-(byte-identical, verified by diffing every backend/mode before and after). The
-data payload leaves the parsed source; the sidecar is the raw bytes.
+Positive: opt-in, correctness-neutral, default output unchanged (byte-identical, verified by diffing every backend/mode before and after). The data payload leaves the parsed source; the sidecar is the raw bytes.
 
 Measured (release CLI; `ruby.wasm` = CRuby, 35 MB wasm; `qjs.wasm`, 1.5 MB):
 
@@ -99,32 +46,12 @@ Measured (release CLI; `ruby.wasm` = CRuby, 35 MB wasm; `qjs.wasm`, 1.5 MB):
 | qjs.wasm / Python | 11.46 MB | 11.19 MB | 0.13 MB |
 | qjs.wasm / Java | 15.17 MB | 14.99 MB | 0.13 MB |
 
-The Python and Java `qjs.wasm` deltas (measured after this revision, release CLI)
-match the Ruby/Go pattern exactly: the source shrinks by roughly the eliminated
-inline encoding (`bytes.fromhex` / chunked Base64) minus the shared 0.13 MB
-sidecar, a ~2–3 % code-dominated reduction, confirming the win is a source-size
-one, not a parse-time one.
+The Python and Java `qjs.wasm` deltas (measured after this revision, release CLI) match the Ruby/Go pattern exactly: the source shrinks by roughly the eliminated inline encoding (`bytes.fromhex` / chunked Base64) minus the shared 0.13 MB sidecar, a ~2–3 % code-dominated reduction, confirming the win is a source-size one, not a parse-time one.
 
-Ruby `compile_file` parse of `ruby.wasm`: 6.15 s → 5.97 s. Go `build` of
-`qjs.wasm`: 10.8 s → 11.1 s (within noise; `ruby.wasm`/Go build is impractical
-at either setting — CRuby exceeds the practicality bar, see docs/apps-audit.md).
+Ruby `compile_file` parse of `ruby.wasm`: 6.15 s → 5.97 s. Go `build` of `qjs.wasm`: 10.8 s → 11.1 s (within noise; `ruby.wasm`/Go build is impractical at either setting — CRuby exceeds the practicality bar, see docs/apps-audit.md).
 
-Honest finding: these interpreters are **code-dominated**, so the source shrinks
-by roughly `2 × data_bytes − blob` (the eliminated hex) — ~8 MB / 5 % for
-`ruby.wasm`, not the "dominated by data" the motivating framing assumed. Parse
-and build time are governed by the code, so they barely move. The win scales
-with a module's data:code ratio and is largest for data-heavy modules; for the
-current app corpus it is a modest source-size reduction, not a parse-time one.
+Honest finding: these interpreters are **code-dominated**, so the source shrinks by roughly `2 × data_bytes − blob` (the eliminated hex) — ~8 MB / 5 % for `ruby.wasm`, not the "dominated by data" the motivating framing assumed. Parse and build time are governed by the code, so they barely move. The win scales with a module's data:code ratio and is largest for data-heavy modules; for the current app corpus it is a modest source-size reduction, not a parse-time one.
 
-Follow-ups: adjacent-segment merging to reduce the per-segment `memory.init`
-count landed as its own core pass (ADR-41). Python and Java support landed in
-this revision. Extending the test-helper `BackendUnderTest` with an aux-files
-channel — so the shared app/e2e suites (not just the CLI integration test) can
-exercise sidecar output — is again deliberately deferred: the CLI
-integration test (`crates/dewasm-cli/tests/data_file.rs`) covers all four
-backends end-to-end, so the harness extension buys coverage breadth, not a gap,
-and is not worth the test-helper churn yet.
+Follow-ups: adjacent-segment merging to reduce the per-segment `memory.init` count landed as its own core pass (ADR-41). Python and Java support landed in this revision. Extending the test-helper `BackendUnderTest` with an aux-files channel — so the shared app/e2e suites (not just the CLI integration test) can exercise sidecar output — is again deliberately deferred: the CLI integration test (`crates/dewasm-cli/tests/data_file.rs`) covers all four backends end-to-end, so the harness extension buys coverage breadth, not a gap, and is not worth the test-helper churn yet.
 
-Cross-refs: ADR-29 (Go lowering / import scanning), ADR-30 (Java lowering),
-ADR-31 (standalone runtime interface — the generated main that loads the
-sidecar), ADR-41 (adjacent data-segment merging, the segment-count follow-up).
+Cross-refs: ADR-29 (Go lowering / import scanning), ADR-30 (Java lowering), ADR-31 (standalone runtime interface — the generated main that loads the sidecar), ADR-41 (adjacent data-segment merging, the segment-count follow-up).

--- a/docs/adr/38-dwarf-line-back-mapping.md
+++ b/docs/adr/38-dwarf-line-back-mapping.md
@@ -1,121 +1,47 @@
 # ADR-38 — Opt-in DWARF Line-Number Back-Mapping (`--dwarf-line`)
 
-Status: **Accepted, 2026-07-28.** Implemented in `dewasm-core` behind the CLI's
-`--dwarf-line` flag; Go renders `//line` directives, Ruby and Python source-line
-comments, Bash and Java nothing. Default (no-flag) output is byte-identical to
-before.
+Status: **Accepted, 2026-07-28.** Implemented in `dewasm-core` behind the CLI's `--dwarf-line` flag; Go renders `//line` directives, Ruby and Python source-line comments, Bash and Java nothing. Default (no-flag) output is byte-identical to before.
 
 ## Context
 
-A converted module is a wall of generated code with no tie back to the original
-C/Rust. When it traps or misbehaves, there is nothing pointing at the source line
-that produced a given statement. wasm2go's `-dwarfline` is the prior art: read the
-`.debug_*` custom sections and emit source-position markers so the generated code
-maps back to the origin.
+A converted module is a wall of generated code with no tie back to the original C/Rust. When it traps or misbehaves, there is nothing pointing at the source line that produced a given statement. wasm2go's `-dwarfline` is the prior art: read the `.debug_*` custom sections and emit source-position markers so the generated code maps back to the origin.
 
-The wasm carries this already — clang/`zig cc -g` emit standard DWARF as custom
-sections. The open questions were where the DWARF reader lives, how a marker is
-represented in the IR, how dense the markers should be, and which backends can
-render one at all.
+The wasm carries this already — clang/`zig cc -g` emit standard DWARF as custom sections. The open questions were where the DWARF reader lives, how a marker is represented in the IR, how dense the markers should be, and which backends can render one at all.
 
 ## Decision
 
-Add an **opt-in** `--dwarf-line` CLI flag → `BuildOptions { debug_line }` →
-`build_module_with_options` (`build_module` stays a zero-arg wrapper, so every
-existing call site is untouched and byte-identical). When set, core parses the
-`.debug_line` program and annotates the IR; a backend renders or drops the
-annotation.
+Add an **opt-in** `--dwarf-line` CLI flag → `BuildOptions { debug_line }` → `build_module_with_options` (`build_module` stays a zero-arg wrapper, so every existing call site is untouched and byte-identical). When set, core parses the `.debug_line` program and annotates the IR; a backend renders or drops the annotation.
 
-- **gimli lives in `dewasm-core` only** (`crates/dewasm-core/src/debug_line.rs`),
-  `default-features = false, features = ["read", "std"]`. Backends never see
-  gimli or any DWARF type — they only ever see the resolved `ir::SourcePos`.
-- **Marker representation:** a new IR statement `Stmt::SourceLine(SourcePos)`
-  (`{ file, line, col }`, `file` indexing `Module::debug_files`), emitted just
-  before the statement it annotates. It is semantically inert — a backend renders
-  it as a directive/comment or drops it, and its presence never changes the
-  surrounding statements' meaning.
-- **Change-points only:** `FuncBuilder` tracks the source position resolved from
-  each operator's module-file offset (wasmparser 0.254
-  `OperatorsReader::read_with_offset`) as the body streams, and emits a marker
-  only when the position *changes*. Marker count is proportional to line
-  transitions, not statements.
-- **Address-base calibration (one named constant):** a wasm DWARF code address is
-  an offset **relative to the start of the code section's contents**, whereas
-  wasmparser reports operator positions as absolute module-file offsets, so the
-  lookup subtracts the code-section content start (`address_base`). This is
-  *calibrated, not assumed*: the fixture test asserts that `add_mul`'s marker
-  lands on the exact source line of its first statement, which fails for any
-  wrong base.
+- **gimli lives in `dewasm-core` only** (`crates/dewasm-core/src/debug_line.rs`), `default-features = false, features = ["read", "std"]`. Backends never see gimli or any DWARF type — they only ever see the resolved `ir::SourcePos`.
+- **Marker representation:** a new IR statement `Stmt::SourceLine(SourcePos)` (`{ file, line, col }`, `file` indexing `Module::debug_files`), emitted just before the statement it annotates. It is semantically inert — a backend renders it as a directive/comment or drops it, and its presence never changes the surrounding statements' meaning.
+- **Change-points only:** `FuncBuilder` tracks the source position resolved from each operator's module-file offset (wasmparser 0.254 `OperatorsReader::read_with_offset`) as the body streams, and emits a marker only when the position *changes*. Marker count is proportional to line transitions, not statements.
+- **Address-base calibration (one named constant):** a wasm DWARF code address is an offset **relative to the start of the code section's contents**, whereas wasmparser reports operator positions as absolute module-file offsets, so the lookup subtracts the code-section content start (`address_base`). This is *calibrated, not assumed*: the fixture test asserts that `add_mul`'s marker lands on the exact source line of its first statement, which fails for any wrong base.
 
-**Discriminating rule:** source back-mapping is debug metadata with no semantic
-content, so it is a per-invocation *flag*, never a default and never a backend
-capability flip — the generated program's behaviour is identical with or without
-it (the spec harness, which never sets the flag, still binds; ADR-3).
+**Discriminating rule:** source back-mapping is debug metadata with no semantic content, so it is a per-invocation *flag*, never a default and never a backend capability flip — the generated program's behaviour is identical with or without it (the spec harness, which never sets the flag, still binds; ADR-3).
 
 **Per-backend applicability:**
 
-- **Go** honors a `//line file:line:col` directive *only at column 1*, so the
-  marker is written through the writer's `raw` path (bypassing indentation) and
-  never carries a `line 0` (which `go build` rejects — DWARF's line-0 "no source"
-  rows are dropped to gaps in core). This is the one backend where the marker is
-  machine-consumed: it retargets compiler errors and stack traces.
-- **Ruby / Python** render a `# <file>:<line>` comment — human-readable only;
-  neither language has a line-directive.
-- **Bash / Java** render nothing (a one-line REASON at the match arm). Bash's
-  status-cascade lowering (ADR-11) has no place for an inert line, and Java has
-  no directive; both stay byte-identical to a non-flag build.
+- **Go** honors a `//line file:line:col` directive *only at column 1*, so the marker is written through the writer's `raw` path (bypassing indentation) and never carries a `line 0` (which `go build` rejects — DWARF's line-0 "no source" rows are dropped to gaps in core). This is the one backend where the marker is machine-consumed: it retargets compiler errors and stack traces.
+- **Ruby / Python** render a `# <file>:<line>` comment — human-readable only; neither language has a line-directive.
+- **Bash / Java** render nothing (a one-line REASON at the match arm). Bash's status-cascade lowering (ADR-11) has no place for an inert line, and Java has no directive; both stay byte-identical to a non-flag build.
 
-The two folded-code subtleties both flow from ADR-32's expression folding: a
-folded function often collapses to a single fallthrough `Return` emitted off the
-function `end` operator, whose offset sits on a line-table gap — so the tracker
-holds the *last known* position across gaps rather than clearing it, and the
-fallthrough-return path (which does not route through `emit`) is annotated
-explicitly. Without both, a whole small function would carry no marker.
+The two folded-code subtleties both flow from ADR-32's expression folding: a folded function often collapses to a single fallthrough `Return` emitted off the function `end` operator, whose offset sits on a line-table gap — so the tracker holds the *last known* position across gaps rather than clearing it, and the fallthrough-return path (which does not route through `emit`) is annotated explicitly. Without both, a whole small function would carry no marker.
 
 ## Rejected alternatives
 
-- **A per-`Stmt` optional position field.** Rejected: it widens every statement
-  variant and every exhaustive match for metadata that most statements do not
-  carry; a distinct inert `SourceLine` statement keeps the position on the ~0.7
-  of statements that begin a new source line and leaves the rest untouched.
-- **A side table (offset → position) consulted by backends.** Rejected: it would
-  leak the DWARF/offset model past core into every backend and force each to
-  re-derive change-points; the whole point is that backends see only a resolved,
-  pre-thinned marker.
-- **Always on.** Rejected for the same reason as ADR-37: it is a size/noise
-  trade-off (the Go fixture gains ~1266 directives) with no upside for a module
-  built without `-g`, so it belongs behind a flag.
-- **Resolving position at emit-time from the emit-triggering operator.** The
-  inherited first cut did this; it dropped markers for folded bodies (the
-  triggering `end` lands on a gap) and mis-attributed others. Tracking as
-  operators stream is what makes folded code map correctly.
+- **A per-`Stmt` optional position field.** Rejected: it widens every statement variant and every exhaustive match for metadata that most statements do not carry; a distinct inert `SourceLine` statement keeps the position on the ~0.7 of statements that begin a new source line and leaves the rest untouched.
+- **A side table (offset → position) consulted by backends.** Rejected: it would leak the DWARF/offset model past core into every backend and force each to re-derive change-points; the whole point is that backends see only a resolved, pre-thinned marker.
+- **Always on.** Rejected for the same reason as ADR-37: it is a size/noise trade-off (the Go fixture gains ~1266 directives) with no upside for a module built without `-g`, so it belongs behind a flag.
+- **Resolving position at emit-time from the emit-triggering operator.** The inherited first cut did this; it dropped markers for folded bodies (the triggering `end` lands on a gap) and mis-attributed others. Tracking as operators stream is what makes folded code map correctly.
 
 ## Consequences
 
-Positive: opt-in, correctness-neutral, default output byte-identical (verified by
-stripping marker lines and diffing Go and Ruby before/after, and by re-running
-both to identical stdout/exit). gimli is confined to core; the backend surface is
-one `SourcePos`.
+Positive: opt-in, correctness-neutral, default output byte-identical (verified by stripping marker lines and diffing Go and Ruby before/after, and by re-running both to identical stdout/exit). gimli is confined to core; the backend surface is one `SourcePos`.
 
-Density (first-party `dwarf-fixture.wasm`, Go standalone): 1266 `//line`
-directives across 103 functions (~12/function, ~0.7 per statement-bearing line),
-spanning 45 source files — 14 into our `dwarf_fixture.c`, the rest into the
-statically linked wasi-libc/musl the fixture pulls in. So the markers faithfully
-follow inlined library code too, which is the honest picture of a `-g -O1` binary.
+Density (first-party `dwarf-fixture.wasm`, Go standalone): 1266 `//line` directives across 103 functions (~12/function, ~0.7 per statement-bearing line), spanning 45 source files — 14 into our `dwarf_fixture.c`, the rest into the statically linked wasi-libc/musl the fixture pulls in. So the markers faithfully follow inlined library code too, which is the honest picture of a `-g -O1` binary.
 
-Caveats: the address base is calibrated against clang/lld output (`zig cc`); a
-toolchain emitting a different code-address convention would need `address_base`
-re-pinned (a one-line change, guarded by the fixture test). Most *released* wasm
-(e.g. the cached `qjs.wasm`, `ruby.wasm`) ships stripped of DWARF, so `--dwarf-line`
-simply yields no markers there — the feature pays off for locally built, debug
-modules. Column info is emitted for Go where present; Ruby/Python drop it.
+Caveats: the address base is calibrated against clang/lld output (`zig cc`); a toolchain emitting a different code-address convention would need `address_base` re-pinned (a one-line change, guarded by the fixture test). Most *released* wasm (e.g. the cached `qjs.wasm`, `ruby.wasm`) ships stripped of DWARF, so `--dwarf-line` simply yields no markers there — the feature pays off for locally built, debug modules. Column info is emitted for Go where present; Ruby/Python drop it.
 
-Fixture: `examples/apps/src/dwarf_fixture.c` is first-party (ADR-9), built by
-`examples/apps/fetch.sh` with `zig cc -target wasm32-wasi -g -O1`; its line
-numbers are load-bearing for the calibration test.
+Fixture: `examples/apps/src/dwarf_fixture.c` is first-party (ADR-9), built by `examples/apps/fetch.sh` with `zig cc -target wasm32-wasi -g -O1`; its line numbers are load-bearing for the calibration test.
 
-Cross-refs: ADR-1 (IR design — semantics-neutral additions), ADR-3 (the spec
-harness binds; the flag never changes it), ADR-9 (first-party fixture source),
-ADR-29 (Go lowering — the `raw`/column-1 constraint), ADR-32 (expression folding —
-the folded-return marker subtlety), ADR-37 (the sibling opt-in `--data-file`, same
-flag-not-default shape).
+Cross-refs: ADR-1 (IR design — semantics-neutral additions), ADR-3 (the spec harness binds; the flag never changes it), ADR-9 (first-party fixture source), ADR-29 (Go lowering — the `raw`/column-1 constraint), ADR-32 (expression folding — the folded-return marker subtlety), ADR-37 (the sibling opt-in `--data-file`, same flag-not-default shape).

--- a/docs/adr/39-wasm-opt-preprocessing.md
+++ b/docs/adr/39-wasm-opt-preprocessing.md
@@ -1,97 +1,37 @@
 # ADR-39 — wasm-opt Preprocessing of Locally-Built App Modules
 
-Status: **Accepted, 2026-07-28.** Implemented in `examples/apps/fetch.sh`: a
-`wasm_opt_inplace` helper runs `wasm-opt -O2` (baseline features only) over the
-three modules the script builds locally — `cache/libpcap.wasm`,
-`cache/treesitter.wasm`, and `cache/rg.wasm` — with `wasm-opt --version` folded
-into each module's rebuild stamp.
+Status: **Accepted, 2026-07-28.** Implemented in `examples/apps/fetch.sh`: a `wasm_opt_inplace` helper runs `wasm-opt -O2` (baseline features only) over the three modules the script builds locally — `cache/libpcap.wasm`, `cache/treesitter.wasm`, and `cache/rg.wasm` — with `wasm-opt --version` folded into each module's rebuild stamp.
 
 ## Context
 
-The example apps split into two kinds ([ADR-9](9-example-apps-from-registry.md),
-[ADR-22](22-sqlite3-built-from-source.md)): prebuilt upstream artifacts we only
-download, and modules we build ourselves from pinned source (the sqlite3
-shapes, minigzip, ripgrep, and — Track A — libpcap and tree-sitter). The
-locally-built ones ship as the raw toolchain output, which is bigger than it
-needs to be and carries two encoding quirks: zig/clang emit DWARF debug info
-and overlong LEB `call_indirect` immediates (the "reference-types encoding
-only" artifact the audit tolerates, [ADR-8](8-latest-testsuite-support-matrix.md)
-footnote). Every extra kilobyte is paid again at conversion time, and the
-libpcap/tree-sitter modules are converted on every heavy-gated e2e run.
+The example apps split into two kinds ([ADR-9](9-example-apps-from-registry.md), [ADR-22](22-sqlite3-built-from-source.md)): prebuilt upstream artifacts we only download, and modules we build ourselves from pinned source (the sqlite3 shapes, minigzip, ripgrep, and — Track A — libpcap and tree-sitter). The locally-built ones ship as the raw toolchain output, which is bigger than it needs to be and carries two encoding quirks: zig/clang emit DWARF debug info and overlong LEB `call_indirect` immediates (the "reference-types encoding only" artifact the audit tolerates, [ADR-8](8-latest-testsuite-support-matrix.md) footnote). Every extra kilobyte is paid again at conversion time, and the libpcap/tree-sitter modules are converted on every heavy-gated e2e run.
 
-`wasm-opt -O2` (binaryen) shrinks these substantially — libpcap 2.0 MB → 263 KB,
-tree-sitter 1.5 MB → 87 KB, ripgrep 22 MB → 18 MB — and, as a side effect,
-re-encodes the `call_indirect` immediates so the modules audit as *pure*
-baseline rather than baseline + the reference-types bit. Only modules we build
-qualify: a downloaded upstream artifact is pinned by its published checksum and
-must not be silently rewritten.
+`wasm-opt -O2` (binaryen) shrinks these substantially — libpcap 2.0 MB → 263 KB, tree-sitter 1.5 MB → 87 KB, ripgrep 22 MB → 18 MB — and, as a side effect, re-encodes the `call_indirect` immediates so the modules audit as *pure* baseline rather than baseline + the reference-types bit. Only modules we build qualify: a downloaded upstream artifact is pinned by its published checksum and must not be silently rewritten.
 
 ## Decision
 
-Run `wasm-opt -O2` in-place over each locally-built module immediately after it
-is compiled, before it lands in the cache. The discriminating rule: **preprocess
-a module only if `fetch.sh` builds it from source (and can therefore re-verify
-it); never a downloaded artifact.** Concretely this is libpcap and tree-sitter
-(the Track A reactor libs) and ripgrep.
+Run `wasm-opt -O2` in-place over each locally-built module immediately after it is compiled, before it lands in the cache. The discriminating rule: **preprocess a module only if `fetch.sh` builds it from source (and can therefore re-verify it); never a downloaded artifact.** Concretely this is libpcap and tree-sitter (the Track A reactor libs) and ripgrep.
 
 Three constraints on how:
 
-- **Baseline features only.** `wasm-opt` is invoked with exactly the universal
-  baseline feature set enabled (`--enable-bulk-memory --enable-sign-ext
-  --enable-nontrapping-float-to-int --enable-mutable-globals --enable-multivalue
-  --enable-reference-types`) and nothing else, so it can neither reject the
-  bulk-memory the toolchain emits nor introduce a construct outside 0.1 scope
-  (SIMD/atomics/exception-handling, [ADR-24](24-01-scope-reset.md)). The audit
-  is re-run on the output to confirm it stays in scope.
-- **No `wasm-ctor-eval.`** Only `wasm-opt`; the ctor-evaluator (which partially
-  executes a module's start/ctors at build time) is deliberately not used — it
-  is a heavier, behaviour-altering transform we do not need and would have to
-  re-validate separately.
-- **`--strip-debug` at link for the zig builds.** `wasm-opt` cannot parse the
-  DWARF zig emits (`Fatal: TODO: DW_LNE_define_file`), so the two `zig cc`
-  reactor links pass `-Wl,--strip-debug`; ripgrep's rustc release output needs
-  no stripping.
+- **Baseline features only.** `wasm-opt` is invoked with exactly the universal baseline feature set enabled (`--enable-bulk-memory --enable-sign-ext --enable-nontrapping-float-to-int --enable-mutable-globals --enable-multivalue --enable-reference-types`) and nothing else, so it can neither reject the bulk-memory the toolchain emits nor introduce a construct outside 0.1 scope (SIMD/atomics/exception-handling, [ADR-24](24-01-scope-reset.md)). The audit is re-run on the output to confirm it stays in scope.
+- **No `wasm-ctor-eval.`** Only `wasm-opt`; the ctor-evaluator (which partially executes a module's start/ctors at build time) is deliberately not used — it is a heavier, behaviour-altering transform we do not need and would have to re-validate separately.
+- **`--strip-debug` at link for the zig builds.** `wasm-opt` cannot parse the DWARF zig emits (`Fatal: TODO: DW_LNE_define_file`), so the two `zig cc` reactor links pass `-Wl,--strip-debug`; ripgrep's rustc release output needs no stripping.
 
-Behaviour preservation is verified, not assumed: after adoption the libpcap /
-tree-sitter C-API cases and ripgrep's `rg_search` e2e were re-run, and ripgrep's
-wasmtime golden was re-checked via
-`cargo test -p dewasm-test-helper --features wasmtime_test --test apps_wasmtime`
-(all green) — the extra ground-truth gate ripgrep needs because it is the one
-preprocessed module with a committed wasmtime golden.
+Behaviour preservation is verified, not assumed: after adoption the libpcap / tree-sitter C-API cases and ripgrep's `rg_search` e2e were re-run, and ripgrep's wasmtime golden was re-checked via `cargo test -p dewasm-test-helper --features wasmtime_test --test apps_wasmtime` (all green) — the extra ground-truth gate ripgrep needs because it is the one preprocessed module with a committed wasmtime golden.
 
-Each preprocessed module's rebuild stamp is extended from `<source-sha256>` to
-`<source-sha256>\n<wasm-opt --version>`, compared whole. A wasm-opt upgrade
-therefore invalidates the cache and rebuilds the module, so its shipped shape
-always matches the installed optimizer. `wasm-opt` joins `zig`/`bison`/`flex`
-in each affected recipe's fail-loud prerequisite check ([ADR-15](15-tests-fail-not-skip.md)).
+Each preprocessed module's rebuild stamp is extended from `<source-sha256>` to `<source-sha256>\n<wasm-opt --version>`, compared whole. A wasm-opt upgrade therefore invalidates the cache and rebuilds the module, so its shipped shape always matches the installed optimizer. `wasm-opt` joins `zig`/`bison`/`flex` in each affected recipe's fail-loud prerequisite check ([ADR-15](15-tests-fail-not-skip.md)).
 
 ## Rejected alternatives
 
-- **Optimize every cached module, including downloaded artifacts.** Rewriting a
-  checksum-pinned upstream binary breaks the "the cache is exactly the pinned
-  artifact" contract (ADR-9) and would make the download's sha256 verification
-  meaningless. Downloaded modules are out of scope.
-- **Commit the pre-optimized `.wasm`.** Third-party artifacts are never
-  committed (ADR-9); the optimized output is derived from third-party source and
-  stays in the gitignored cache like everything else `fetch.sh` produces.
-- **`wasm-ctor-eval` / `-O3` / SIMD-enabled `-O2`.** More aggressive transforms
-  buy little for these modules and risk either behaviour changes (ctor-eval) or
-  out-of-scope constructs (SIMD) that the converter would then reject. `-O2` with
-  baseline features is the conservative floor that still wins big on size.
-- **Skip ripgrep.** ripgrep is a shipping app with a committed wasmtime golden,
-  so preprocessing it carries golden-drift risk. It is included only because
-  that golden is re-verifiable here (wasmtime installed); the rule stays "build
-  it ⇒ eligible, and re-verify."
+- **Optimize every cached module, including downloaded artifacts.** Rewriting a checksum-pinned upstream binary breaks the "the cache is exactly the pinned artifact" contract (ADR-9) and would make the download's sha256 verification meaningless. Downloaded modules are out of scope.
+- **Commit the pre-optimized `.wasm`.** Third-party artifacts are never committed (ADR-9); the optimized output is derived from third-party source and stays in the gitignored cache like everything else `fetch.sh` produces.
+- **`wasm-ctor-eval` / `-O3` / SIMD-enabled `-O2`.** More aggressive transforms buy little for these modules and risk either behaviour changes (ctor-eval) or out-of-scope constructs (SIMD) that the converter would then reject. `-O2` with baseline features is the conservative floor that still wins big on size.
+- **Skip ripgrep.** ripgrep is a shipping app with a committed wasmtime golden, so preprocessing it carries golden-drift risk. It is included only because that golden is re-verifiable here (wasmtime installed); the rule stays "build it ⇒ eligible, and re-verify."
 
 ## Consequences
 
-- Positive: markedly smaller locally-built modules (faster conversion, less
-  cache footprint) and a cleaner audit verdict (pure baseline, no
-  reference-types encoding bit).
+- Positive: markedly smaller locally-built modules (faster conversion, less cache footprint) and a cleaner audit verdict (pure baseline, no reference-types encoding bit).
 - Positive: the version-stamped cache self-heals on a binaryen upgrade.
-- Negative: `wasm-opt` (binaryen) is a new build-time prerequisite for the three
-  affected recipes; absent, they fail loud rather than silently shipping
-  unoptimized modules.
-- Carry-over: only these three modules are preprocessed today. A future
-  locally-built app should adopt the same helper; a future *downloaded* app must
-  not.
+- Negative: `wasm-opt` (binaryen) is a new build-time prerequisite for the three affected recipes; absent, they fail loud rather than silently shipping unoptimized modules.
+- Carry-over: only these three modules are preprocessed today. A future locally-built app should adopt the same helper; a future *downloaded* app must not.

--- a/docs/adr/4-ruby-backend-lowering.md
+++ b/docs/adr/4-ruby-backend-lowering.md
@@ -1,105 +1,27 @@
 # ADR-4 — Ruby Backend Lowering Conventions
 
-Status: **Accepted, 2026-07-23.** Backfilled; implemented in
-`crates/dewasm-backend-ruby/src/lib.rs` + `runtime/ruby/`. Numeric
-conventions are ADR-2's; this ADR covers control flow and object shape.
-The multi-level-`br` and loop-`catch`-value decisions (and the flag-variable
-rejection) are superseded by [ADR-42](42-ruby-label-variable-cascade.md); the
-temps-hoisting decision stands, as does `call_indirect`'s structural
-type-symbol comparison — but its splat-array dispatch is amended by
-[ADR-44](44-ruby-call-indirect-arity.md) (fixed-arity `Table#callN`).
+Status: **Accepted, 2026-07-23.** Backfilled; implemented in `crates/dewasm-backend-ruby/src/lib.rs` + `runtime/ruby/`. Numeric conventions are ADR-2's; this ADR covers control flow and object shape. The multi-level-`br` and loop-`catch`-value decisions (and the flag-variable rejection) are superseded by [ADR-42](42-ruby-label-variable-cascade.md); the temps-hoisting decision stands, as does `call_indirect`'s structural type-symbol comparison — but its splat-array dispatch is amended by [ADR-44](44-ruby-call-indirect-arity.md) (fixed-arity `Table#callN`).
 
 ## Context
 
-Ruby has no labeled break/continue, creates a new variable scope inside
-`do ... end` blocks, and compares `call_indirect` targets by nothing —
-the backend must supply wasm's structural type check. These three
-language facts drove the lowering shape.
+Ruby has no labeled break/continue, creates a new variable scope inside `do ... end` blocks, and compares `call_indirect` targets by nothing — the backend must supply wasm's structural type check. These three language facts drove the lowering shape.
 
 ## Decision
 
-- **Multi-level `br` lowers to `catch`/`throw`.** *(Superseded by
-  [ADR-42](42-ruby-label-variable-cascade.md): the `__br` label-variable
-  cascade.)* A referenced block
-  label becomes `catch(:lN) do ... end`; `br` becomes result-slot
-  assignments followed by `throw :lN`. Unreferenced labels emit nothing
-  (ADR-1's `referenced` flag).
-- **Loops become `while true` wrapping a `catch` whose value picks
-  continue vs. exit**: *(Superseded by
-  [ADR-42](42-ruby-label-variable-cascade.md).)* the body falls through
-  to `true` (break the while)
-  and a back-edge `throw`s `false` (next iteration). One shape covers
-  branches to the loop head from any nesting depth.
-- **A `br`/`br_if`/`br_table` at the innermost capturing frame — depth 1
-  — lowers to a plain `break`/`next` instead of `throw`, and a frame every
-  one of whose incoming branches is depth-1 drops `catch`/`throw`
-  entirely** *(Superseded by
-  [ADR-42](42-ruby-label-variable-cascade.md), which drops `catch`/`throw`
-  for every frame, not only depth-1-only ones; the depth-1 `break`/`next`
-  fast path it keeps.)* (`Block` renders as `begin ... end while false`, `Loop` as a
-  bare `while true ... end` with an appended trailing `break` for
-  fallthrough). This was the Consequences section's candidate
-  optimization below, now adopted: `break`/`next` inside a `catch(...) do
-  ... end` block still terminates/short-circuits it exactly like a
-  `throw` would (Ruby block semantics), so the branch-site simplification
-  is correct regardless of whether the target frame kept its `catch`
-  wrapper — only frames with *zero* deeper incoming throws can drop the
-  wrapper itself. A per-function pre-pass
-  (`compute_break_only` in `crates/dewasm-backend-ruby/src/lib.rs`)
-  computes, per label, whether every branch to it is depth-1; `plain if`,
-  `br_if`'s wrapper `if`, and `br_table`'s `case` never capture, so they
-  don't count as a frame boundary for this analysis. Measured in
-  isolation (20M-iteration loop back-edge, MRI 4.0.4): `catch`/`throw`
-  2.59s vs. `break`/`next` 0.45s, ~5.7x; (5M-call block-exit, same
-  benchmark): `catch`/`throw` 0.69s vs. `begin...end while false` 0.17s,
-  ~4.1x. `catch` and `throw` are genuinely expensive in MRI — this is the
-  actual driver of hot-loop overhead in generated code, not incidental.
-- **All stack temps are hoisted to method scope** with a single
-  `s0 = s1 = ... = nil` line at function entry. First assignment inside a
-  Ruby block is block-local, so without hoisting, values assigned inside
-  `catch` blocks vanish at `end` (found by spec-harness NameErrors, not
-  foreseen).
-- **`call_indirect` compares structural type symbols**: the backend
-  renders each type index as a symbol interned from the type's shape
-  (e.g. `:"i32,i64->i32"`), both when populating the table and at call
-  sites. Wasm compares function types structurally, not by index — and
-  any module-local id (even a canonicalized index) breaks once a table
-  is shared across modules via an imported table, whose index spaces
-  differ. *(The dispatch used a splat: `@tT.call(index, type_sym,
-  *args)` re-splatting into `func.call(*args)`. Amended by
-  [ADR-44](44-ruby-call-indirect-arity.md): a per-arity `Table#callN`
-  drops both splats; the structural-symbol comparison here is unchanged.)*
-- **Module = one class**: imports resolved in `initialize` (`@ifN`
-  ivars), globals as `@gN`, exports in an `@exports` hash keyed by the
-  raw export name with `invoke(name, *args)` as the entry point (export
-  names need not be valid Ruby method names), memory exposed via
-  `attr_reader`. Data segments embed as hex strings decoded with
-  `pack("H*")` (no `require` needed, unlike base64).
+- **Multi-level `br` lowers to `catch`/`throw`.** *(Superseded by [ADR-42](42-ruby-label-variable-cascade.md): the `__br` label-variable cascade.)* A referenced block label becomes `catch(:lN) do ... end`; `br` becomes result-slot assignments followed by `throw :lN`. Unreferenced labels emit nothing (ADR-1's `referenced` flag).
+- **Loops become `while true` wrapping a `catch` whose value picks continue vs. exit**: *(Superseded by [ADR-42](42-ruby-label-variable-cascade.md).)* the body falls through to `true` (break the while) and a back-edge `throw`s `false` (next iteration). One shape covers branches to the loop head from any nesting depth.
+- **A `br`/`br_if`/`br_table` at the innermost capturing frame — depth 1 — lowers to a plain `break`/`next` instead of `throw`, and a frame every one of whose incoming branches is depth-1 drops `catch`/`throw` entirely** *(Superseded by [ADR-42](42-ruby-label-variable-cascade.md), which drops `catch`/`throw` for every frame, not only depth-1-only ones; the depth-1 `break`/`next` fast path it keeps.)* (`Block` renders as `begin ... end while false`, `Loop` as a bare `while true ... end` with an appended trailing `break` for fallthrough). This was the Consequences section's candidate optimization below, now adopted: `break`/`next` inside a `catch(...) do ... end` block still terminates/short-circuits it exactly like a `throw` would (Ruby block semantics), so the branch-site simplification is correct regardless of whether the target frame kept its `catch` wrapper — only frames with *zero* deeper incoming throws can drop the wrapper itself. A per-function pre-pass (`compute_break_only` in `crates/dewasm-backend-ruby/src/lib.rs`) computes, per label, whether every branch to it is depth-1; `plain if`, `br_if`'s wrapper `if`, and `br_table`'s `case` never capture, so they don't count as a frame boundary for this analysis. Measured in isolation (20M-iteration loop back-edge, MRI 4.0.4): `catch`/`throw` 2.59s vs. `break`/`next` 0.45s, ~5.7x; (5M-call block-exit, same benchmark): `catch`/`throw` 0.69s vs. `begin...end while false` 0.17s, ~4.1x. `catch` and `throw` are genuinely expensive in MRI — this is the actual driver of hot-loop overhead in generated code, not incidental.
+- **All stack temps are hoisted to method scope** with a single `s0 = s1 = ... = nil` line at function entry. First assignment inside a Ruby block is block-local, so without hoisting, values assigned inside `catch` blocks vanish at `end` (found by spec-harness NameErrors, not foreseen).
+- **`call_indirect` compares structural type symbols**: the backend renders each type index as a symbol interned from the type's shape (e.g. `:"i32,i64->i32"`), both when populating the table and at call sites. Wasm compares function types structurally, not by index — and any module-local id (even a canonicalized index) breaks once a table is shared across modules via an imported table, whose index spaces differ. *(The dispatch used a splat: `@tT.call(index, type_sym, *args)` re-splatting into `func.call(*args)`. Amended by [ADR-44](44-ruby-call-indirect-arity.md): a per-arity `Table#callN` drops both splats; the structural-symbol comparison here is unchanged.)*
+- **Module = one class**: imports resolved in `initialize` (`@ifN` ivars), globals as `@gN`, exports in an `@exports` hash keyed by the raw export name with `invoke(name, *args)` as the entry point (export names need not be valid Ruby method names), memory exposed via `attr_reader`. Data segments embed as hex strings decoded with `pack("H*")` (no `require` needed, unlike base64).
 
 ## Rejected alternatives
 
-- **Flag variables / state-machine dispatch for multi-level br** — both
-  obscure the code far more than catch/throw, and the state machine
-  costs a dispatch loop per block; catch/throw benchmarked acceptably and
-  maps 1:1 to label semantics. *(Reversed by
-  [ADR-42](42-ruby-label-variable-cascade.md): once result values are
-  decoupled from control — via the `assigns` slot-copies and hoisted
-  temps above — a control-only flag needs no per-block dispatch, and
-  `catch`/`throw`'s allocation cost turned out to dominate hot loops.)*
-- **`define_method` per export as the public API** — export names collide
-  with `Object` methods and Ruby keywords; a name-keyed hash plus
-  `invoke` is collision-free. Friendly named methods can be layered on
-  later.
+- **Flag variables / state-machine dispatch for multi-level br** — both obscure the code far more than catch/throw, and the state machine costs a dispatch loop per block; catch/throw benchmarked acceptably and maps 1:1 to label semantics. *(Reversed by [ADR-42](42-ruby-label-variable-cascade.md): once result values are decoupled from control — via the `assigns` slot-copies and hoisted temps above — a control-only flag needs no per-block dispatch, and `catch`/`throw`'s allocation cost turned out to dominate hot loops.)*
+- **`define_method` per export as the public API** — export names collide with `Object` methods and Ruby keywords; a name-keyed hash plus `invoke` is collision-free. Friendly named methods can be layered on later.
 
 ## Consequences
 
-- Positive: the whole control-flow story is three emission shapes; the
-  spec harness (ADR-3) is green including `br_table`, `unwind`, and
-  `labels`.
-- Negative: `catch` allocates and `throw` unwinds — hot loops pay for
-  labels they rarely take. Mitigated for the common depth-1 case (see
-  the `break`/`next` decision above); a multi-level `br` (depth > 1)
-  still pays the full `catch`/`throw` cost, unavoidably — Ruby has no
-  labeled `break`.
-- Deep wasm recursion maps to Ruby stack frames; `SystemStackError` is
-  the (accepted) analogue of "call stack exhausted".
+- Positive: the whole control-flow story is three emission shapes; the spec harness (ADR-3) is green including `br_table`, `unwind`, and `labels`.
+- Negative: `catch` allocates and `throw` unwinds — hot loops pay for labels they rarely take. Mitigated for the common depth-1 case (see the `break`/`next` decision above); a multi-level `br` (depth > 1) still pays the full `catch`/`throw` cost, unavoidably — Ruby has no labeled `break`.
+- Deep wasm recursion maps to Ruby stack frames; `SystemStackError` is the (accepted) analogue of "call stack exhausted".

--- a/docs/adr/40-wasi-p1-completion.md
+++ b/docs/adr/40-wasi-p1-completion.md
@@ -1,102 +1,30 @@
 # ADR-40 — WASI p1 Completion: Symlink Family, Enforced Per-Fd Rights, and the Conformance-Runner Environment
 
-Status: **Accepted, 2026-07-28.** Implemented across all five backends
-(`runtime/<lang>/units/wasi/`), the wasi-testsuite runner
-(`crates/dewasm-test-helper/src/{backend,wasi_testsuite}.rs`), and the five
-per-backend ledgers. The ledgers shrank from ~30 rows per backend to the
-honest residue listed under Consequences; `docs/support.md` now shows full
-WASI p1 columns for Ruby/Python/Go/Java and near-full for Bash.
+Status: **Accepted, 2026-07-28.** Implemented across all five backends (`runtime/<lang>/units/wasi/`), the wasi-testsuite runner (`crates/dewasm-test-helper/src/{backend,wasi_testsuite}.rs`), and the five per-backend ledgers. The ledgers shrank from ~30 rows per backend to the honest residue listed under Consequences; `docs/support.md` now shows full WASI p1 columns for Ruby/Python/Go/Java and near-full for Bash.
 
 ## Context
 
-ADR-36's conformance harness attributed every known failure to a declared
-gap. Three of those declarations were themselves decisions this ADR revisits:
-ADR-14 deferred the symlink-family syscalls (creating links widens the
-accepted TOCTOU surface) and the rights syscalls (reporting narrowed rights
-while enforcing nothing would mislead); ADR-34 capped Bash's external-command
-license at `mkdir`/`rmdir`/`rm`/`mv`; and ADR-36 rejected clearing the child
-environment for the count-exact `environ_*` trials. Filling the remaining
-gaps honestly meant deciding each one, not just coding it.
+ADR-36's conformance harness attributed every known failure to a declared gap. Three of those declarations were themselves decisions this ADR revisits: ADR-14 deferred the symlink-family syscalls (creating links widens the accepted TOCTOU surface) and the rights syscalls (reporting narrowed rights while enforcing nothing would mislead); ADR-34 capped Bash's external-command license at `mkdir`/`rmdir`/`rm`/`mv`; and ADR-36 rejected clearing the child environment for the count-exact `environ_*` trials. Filling the remaining gaps honestly meant deciding each one, not just coding it.
 
 ## Decision
 
-1. **The symlink family is implemented; containment moves from create-time to
-   follow-time.** `path_symlink` writes the guest's target string *verbatim*
-   — it is never pre-resolved, because a link pointing outside the sandbox is
-   legal until followed, and every follow already passes the realpath +
-   prefix-containment check (`resolve_path`, ADR-14). `path_readlink` and
-   `path_link` resolve the link itself with the NOFOLLOW shape; `path_link`
-   contains both endpoints. Criterion: *enforce at the operation that can
-   escape, not the operation that merely stores a name.* This deliberately
-   widens the surface ADR-14 passively accepted; the TOCTOU caveat itself is
-   unchanged (check-then-open, not `openat`-beneath).
-2. **Per-fd rights are tracked, reported, and enforced.** Each fd carries
-   `(rights_base, rights_inheriting, fdflags)` in a parallel meta table;
-   `path_open` grants `requested ∩ dirfd.inheriting` capped to per-filetype
-   masks (wasmtime's directory/regular-file sets); `fd_fdstat_get` reports the
-   stored values; `fd_fdstat_set_rights` narrows only; and
-   `fd_read`/`fd_write`/`fd_seek`/`fd_readdir`/`fd_filestat_set_size` return
-   `NOTCAPABLE` when the right is absent. Criterion (inverting ADR-14's
-   deferral for its own reason): *report only what is enforced.* APPEND lives
-   in the fdflags meta and is honored by `fd_write` seeking to end, so
-   `fd_fdstat_set_flags` can turn it off at runtime — which a kernel
-   `O_APPEND` handle cannot.
-3. **Bash's external-command license (ADR-34 D2) extends to `ln -s`, `ln`,
-   and `readlink`.** `ln`/`ln -s` are namespace mutations with no pure-Bash
-   form — D2's own criterion. `readlink` is a read, licensed under a
-   companion clause: *a deliberately added capability must be complete*
-   (creating links but not reading them back is incoherent). The line holds
-   against `stat` (dev/ino stays zeroed, D6) and `touch` (timestamps stay
-   ENOSYS — not namespace mutation).
-4. **The conformance runner clears the child environment** and sets exactly
-   the manifest env (`run_standalone_wasi`), reversing ADR-36's rejected
-   alternative: upstream's wasmtime adapter passes env solely via `--env`, so
-   a cleared child reproduces the same observable guest environment without
-   touching ADR-31's whole-env passthrough in generated programs. Two
-   consequences the first attempt surfaced: bare interpreter names must be
-   resolved against the *parent* PATH before spawning (an env-cleared exec
-   falls back to the OS default path and picks the system ruby 2.6 /
-   bash 3.2), and interpreted hosts inject environ entries past a cleared
-   environment (CoreFoundation's `__CF_USER_TEXT_ENCODING`, CPython's PEP 538
-   `LC_CTYPE`, bash's `PWD`/`SHLVL`/`_`) which the guest legitimately
-   observes — those rows stay ledgered, re-attributed to the injection.
+1. **The symlink family is implemented; containment moves from create-time to follow-time.** `path_symlink` writes the guest's target string *verbatim* — it is never pre-resolved, because a link pointing outside the sandbox is legal until followed, and every follow already passes the realpath + prefix-containment check (`resolve_path`, ADR-14). `path_readlink` and `path_link` resolve the link itself with the NOFOLLOW shape; `path_link` contains both endpoints. Criterion: *enforce at the operation that can escape, not the operation that merely stores a name.* This deliberately widens the surface ADR-14 passively accepted; the TOCTOU caveat itself is unchanged (check-then-open, not `openat`-beneath).
+2. **Per-fd rights are tracked, reported, and enforced.** Each fd carries `(rights_base, rights_inheriting, fdflags)` in a parallel meta table; `path_open` grants `requested ∩ dirfd.inheriting` capped to per-filetype masks (wasmtime's directory/regular-file sets); `fd_fdstat_get` reports the stored values; `fd_fdstat_set_rights` narrows only; and `fd_read`/`fd_write`/`fd_seek`/`fd_readdir`/`fd_filestat_set_size` return `NOTCAPABLE` when the right is absent. Criterion (inverting ADR-14's deferral for its own reason): *report only what is enforced.* APPEND lives in the fdflags meta and is honored by `fd_write` seeking to end, so `fd_fdstat_set_flags` can turn it off at runtime — which a kernel `O_APPEND` handle cannot.
+3. **Bash's external-command license (ADR-34 D2) extends to `ln -s`, `ln`, and `readlink`.** `ln`/`ln -s` are namespace mutations with no pure-Bash form — D2's own criterion. `readlink` is a read, licensed under a companion clause: *a deliberately added capability must be complete* (creating links but not reading them back is incoherent). The line holds against `stat` (dev/ino stays zeroed, D6) and `touch` (timestamps stay ENOSYS — not namespace mutation).
+4. **The conformance runner clears the child environment** and sets exactly the manifest env (`run_standalone_wasi`), reversing ADR-36's rejected alternative: upstream's wasmtime adapter passes env solely via `--env`, so a cleared child reproduces the same observable guest environment without touching ADR-31's whole-env passthrough in generated programs. Two consequences the first attempt surfaced: bare interpreter names must be resolved against the *parent* PATH before spawning (an env-cleared exec falls back to the OS default path and picks the system ruby 2.6 / bash 3.2), and interpreted hosts inject environ entries past a cleared environment (CoreFoundation's `__CF_USER_TEXT_ENCODING`, CPython's PEP 538 `LC_CTYPE`, bash's `PWD`/`SHLVL`/`_`) which the guest legitimately observes — those rows stay ledgered, re-attributed to the injection.
 
 ## Rejected alternatives
 
-- **Track-and-report rights without enforcement.** ADR-14's original
-  objection stands: it looks like a sandbox and isn't. Enforcement at five
-  syscall entry points is cheap (one mask test).
-- **Pre-resolving symlink targets at create time.** Breaks legal guests
-  (relative links into not-yet-mounted trees) and adds nothing: escape is
-  only possible at follow time, where the existing check already sits.
-- **Licensing `stat`/`touch` for Bash alongside `ln`.** Neither is required
-  by a capability this ADR adds; D6 already accepts zeroed dev/ino and
-  timestamp syscalls stay declared-ENOSYS on Bash.
-- **Keeping the environ rows attributed to ADR-31.** The interface passes the
-  env through faithfully; after the runner fix the remaining mismatch is host
-  injection, and blaming the interface would misdirect any future fix.
+- **Track-and-report rights without enforcement.** ADR-14's original objection stands: it looks like a sandbox and isn't. Enforcement at five syscall entry points is cheap (one mask test).
+- **Pre-resolving symlink targets at create time.** Breaks legal guests (relative links into not-yet-mounted trees) and adds nothing: escape is only possible at follow time, where the existing check already sits.
+- **Licensing `stat`/`touch` for Bash alongside `ln`.** Neither is required by a capability this ADR adds; D6 already accepts zeroed dev/ino and timestamp syscalls stay declared-ENOSYS on Bash.
+- **Keeping the environ rows attributed to ADR-31.** The interface passes the env through faithfully; after the runner fix the remaining mismatch is host injection, and blaming the interface would misdirect any future fix.
 
 ## Consequences
 
-- Positive: the five wasi-testsuite ledgers drop to their honest floor —
-  `sock_shutdown` ×2 everywhere (out of scope, ADR-24); `environ` ×3 on the
-  four interpreted backends (host injection; Go's compiled binaries pass);
-  Java `path_link` (hard-linking a dangling symlink needs `linkat(2)`
-  nofollow, inexpressible in NIO — Ruby reaches it via Fiddle, Go by
-  recreating the link); Go `rust/symlink_filestat` (no portable
-  build-tag-free `lutimes` in Go std); Bash's declared set (timestamps ×2
-  under D4, d_ino/dev-ino ×3 under D6, cross-fd read-back under D1, and
-  three file-symlink-follow ELOOP re-tags under D3).
-- Positive: real-app suites (SQLite, QuickJS, CPython, CRuby, ripgrep) stay
-  green under enforcement because preopens seed the canonical directory
-  rights with full inheriting sets.
-- Negative: the rights meta table adds a lookup to the hot `fd_read`/
-  `fd_write` paths on every backend; the Bash symlink units spawn licensed
-  external commands.
-- Carry-over: closing the TOCTOU gap for real (cap-std-style `openat`-
-  beneath) remains out of scope, as in ADR-14.
+- Positive: the five wasi-testsuite ledgers drop to their honest floor — `sock_shutdown` ×2 everywhere (out of scope, ADR-24); `environ` ×3 on the four interpreted backends (host injection; Go's compiled binaries pass); Java `path_link` (hard-linking a dangling symlink needs `linkat(2)` nofollow, inexpressible in NIO — Ruby reaches it via Fiddle, Go by recreating the link); Go `rust/symlink_filestat` (no portable build-tag-free `lutimes` in Go std); Bash's declared set (timestamps ×2 under D4, d_ino/dev-ino ×3 under D6, cross-fd read-back under D1, and three file-symlink-follow ELOOP re-tags under D3).
+- Positive: real-app suites (SQLite, QuickJS, CPython, CRuby, ripgrep) stay green under enforcement because preopens seed the canonical directory rights with full inheriting sets.
+- Negative: the rights meta table adds a lookup to the hot `fd_read`/ `fd_write` paths on every backend; the Bash symlink units spawn licensed external commands.
+- Carry-over: closing the TOCTOU gap for real (cap-std-style `openat`- beneath) remains out of scope, as in ADR-14.
 
-Revises: [ADR-14](14-ruby-wasi-filesystem.md) (rights + symlink deferrals),
-[ADR-34](34-bash-wasi-filesystem.md) (D2 license, carry-over list),
-[ADR-36](36-wasi-testsuite-conformance.md) (environment-clearing
-alternative).
+Revises: [ADR-14](14-ruby-wasi-filesystem.md) (rights + symlink deferrals), [ADR-34](34-bash-wasi-filesystem.md) (D2 license, carry-over list), [ADR-36](36-wasi-testsuite-conformance.md) (environment-clearing alternative).

--- a/docs/adr/41-adjacent-data-segment-merging.md
+++ b/docs/adr/41-adjacent-data-segment-merging.md
@@ -1,89 +1,32 @@
 # ADR-41 — Merge Adjacent Active Data Segments at Build Time
 
-Status: **Accepted, 2026-07-28.** A core pass collapses runs of consecutive,
-near-adjacent active data segments into single zero-filled blobs, always on and
-identical for every backend. Landed in
-`crates/dewasm-core/src/data_merge.rs`, run unconditionally at the end of
-`build_module_with_options`; no IR types change and no backend is touched.
+Status: **Accepted, 2026-07-28.** A core pass collapses runs of consecutive, near-adjacent active data segments into single zero-filled blobs, always on and identical for every backend. Landed in `crates/dewasm-core/src/data_merge.rs`, run unconditionally at the end of `build_module_with_options`; no IR types change and no backend is touched.
 
 ## Context
 
-Toolchains split a program's initialized data across many active segments — one
-per `.data`-like region — and every backend emits one initializer per active
-segment, index-keyed off `module.datas`. The extreme case in the app corpus is
-`ruby.wasm`: **7871 active segments**, each generating its own memory-init call
-and its own offset/length constants. Most of those segments sit a handful of
-bytes apart. Concatenating a run of them into one blob (zero-filling the small
-holes) cuts the initializer count by more than an order of magnitude, and
-because the reduction is on the shared `module.datas`, it composes with every
-backend for free — this is the follow-up ADR-37 flagged.
+Toolchains split a program's initialized data across many active segments — one per `.data`-like region — and every backend emits one initializer per active segment, index-keyed off `module.datas`. The extreme case in the app corpus is `ruby.wasm`: **7871 active segments**, each generating its own memory-init call and its own offset/length constants. Most of those segments sit a handful of bytes apart. Concatenating a run of them into one blob (zero-filling the small holes) cuts the initializer count by more than an order of magnitude, and because the reduction is on the shared `module.datas`, it composes with every backend for free — this is the follow-up ADR-37 flagged.
 
-The rewrite is only sound if it preserves the final memory image. wasm
-initializes active segments in declaration order, later writes winning on
-overlap; a passive segment writes nothing on its own (only `memory.init` does);
-and bulk-memory ops (`memory.init` / `data.drop`) name segments **by index**, so
-renumbering them silently corrupts a program. A merge must respect all three.
+The rewrite is only sound if it preserves the final memory image. wasm initializes active segments in declaration order, later writes winning on overlap; a passive segment writes nothing on its own (only `memory.init` does); and bulk-memory ops (`memory.init` / `data.drop`) name segments **by index**, so renumbering them silently corrupts a program. A merge must respect all three.
 
 ## Decision
 
-Add a crate-private pass, `merge_adjacent_data_segments`, over `module.datas`.
-It walks the segments in declaration order and merges a run of active
-`i32.const`-offset segments into one blob (offset = run start, bytes = the
-segments concatenated with each inter-segment hole zero-filled), guarded by
-three conditions — failing **any** bails the whole pass, leaving `module.datas`
-byte-for-byte as built:
+Add a crate-private pass, `merge_adjacent_data_segments`, over `module.datas`. It walks the segments in declaration order and merges a run of active `i32.const`-offset segments into one blob (offset = run start, bytes = the segments concatenated with each inter-segment hole zero-filled), guarded by three conditions — failing **any** bails the whole pass, leaving `module.datas` byte-for-byte as built:
 
-1. **No segment-by-index reference.** If any function body contains
-   `Stmt::MemoryInit` or `Stmt::DataDrop` (walked recursively through
-   `Block`/`Loop`/`If`), bail. Merging drops and renumbers indices; a bulk op
-   would then address the wrong (or a nonexistent) segment. Active segments are
-   valid `memory.init` sources too, so this is all-or-nothing, not per-segment.
-2. **Never reorder across a barrier.** Only segments already consecutive in
-   declaration order merge. A `global.get`-offset active segment writes to a
-   runtime-unknown address, so it is an opaque barrier that flushes the current
-   run and passes through unchanged, keeping its order against the constant
-   segments intact. A passive segment carries no standalone effect (guard 1 has
-   ruled out `memory.init`), so it passes through *without* closing the run —
-   the actives on either side still merge around it.
-3. **Zero-fill soundness.** Require the active `i32.const` segments to be
-   *globally* monotonically ascending and non-overlapping (each start ≥ the
-   running max end of all earlier ones); else bail. This proves that no other
-   constant-offset segment occupies a hole we zero-fill, so filling it cannot
-   erase a byte some other segment wrote.
+1. **No segment-by-index reference.** If any function body contains `Stmt::MemoryInit` or `Stmt::DataDrop` (walked recursively through `Block`/`Loop`/`If`), bail. Merging drops and renumbers indices; a bulk op would then address the wrong (or a nonexistent) segment. Active segments are valid `memory.init` sources too, so this is all-or-nothing, not per-segment.
+2. **Never reorder across a barrier.** Only segments already consecutive in declaration order merge. A `global.get`-offset active segment writes to a runtime-unknown address, so it is an opaque barrier that flushes the current run and passes through unchanged, keeping its order against the constant segments intact. A passive segment carries no standalone effect (guard 1 has ruled out `memory.init`), so it passes through *without* closing the run — the actives on either side still merge around it.
+3. **Zero-fill soundness.** Require the active `i32.const` segments to be *globally* monotonically ascending and non-overlapping (each start ≥ the running max end of all earlier ones); else bail. This proves that no other constant-offset segment occupies a hole we zero-fill, so filling it cannot erase a byte some other segment wrote.
 
-**Merge threshold.** Two consecutive active segments merge when
-`next.offset >= run_end && next.offset - run_end < 64` (u64 arithmetic). The
-64-byte bound is the discriminating rule: the fill bytes are emitted **inline by
-every backend unconditionally**, so the break-even is the always-on cost of a
-few zero bytes versus a second initializer's per-segment overhead — a small
-figure. wasm2go's analogous constant is 4096, but that is an *externalize-only*
-threshold (bytes moved to a sidecar, ADR-37), a different trade-off; and this
-pass lives in the core, which cannot see `GenOptions` and so cannot know whether
-externalization is even on. Tuning to the always-on inline cost is the only
-choice available here, and 64 captures the dense runs (`ruby.wasm`'s segments
-are packed far tighter than that) without inventing large stretches of zero.
+**Merge threshold.** Two consecutive active segments merge when `next.offset >= run_end && next.offset - run_end < 64` (u64 arithmetic). The 64-byte bound is the discriminating rule: the fill bytes are emitted **inline by every backend unconditionally**, so the break-even is the always-on cost of a few zero bytes versus a second initializer's per-segment overhead — a small figure. wasm2go's analogous constant is 4096, but that is an *externalize-only* threshold (bytes moved to a sidecar, ADR-37), a different trade-off; and this pass lives in the core, which cannot see `GenOptions` and so cannot know whether externalization is even on. Tuning to the always-on inline cost is the only choice available here, and 64 captures the dense runs (`ruby.wasm`'s segments are packed far tighter than that) without inventing large stretches of zero.
 
 ## Rejected alternatives
 
-- **Sort segments by offset, then merge.** Would merge more, but reordering
-  active segments changes which write wins on overlap and moves them relative to
-  `global.get` barriers whose targets are unknown. Declaration order is the only
-  order whose memory image is guaranteed; sorting trades a proven-correct pass
-  for an unprovable one.
-- **A backend-side merge during lowering.** Each backend already iterates
-  `module.datas`; merging there would multiply the delicate ordering/soundness
-  reasoning by the backend count and invite divergence. Doing it once on the
-  shared IR keeps a single audited implementation under one spec-harness gate.
-- **Merge regardless of gap size (bridge any hole).** A single pair of segments
-  straddling a multi-kilobyte hole would materialize kilobytes of zero bytes
-  inline in every backend, which is strictly worse than two initializers. The
-  threshold caps that blow-up.
+- **Sort segments by offset, then merge.** Would merge more, but reordering active segments changes which write wins on overlap and moves them relative to `global.get` barriers whose targets are unknown. Declaration order is the only order whose memory image is guaranteed; sorting trades a proven-correct pass for an unprovable one.
+- **A backend-side merge during lowering.** Each backend already iterates `module.datas`; merging there would multiply the delicate ordering/soundness reasoning by the backend count and invite divergence. Doing it once on the shared IR keeps a single audited implementation under one spec-harness gate.
+- **Merge regardless of gap size (bridge any hole).** A single pair of segments straddling a multi-kilobyte hole would materialize kilobytes of zero bytes inline in every backend, which is strictly worse than two initializers. The threshold caps that blow-up.
 
 ## Consequences
 
-- The active-segment count drops sharply for split-data modules, cutting the
-  per-segment initializer calls and offset/length constants every backend emits,
-  with no backend change. Measured (`module.datas.len()` before vs. after):
+- The active-segment count drops sharply for split-data modules, cutting the per-segment initializer calls and offset/length constants every backend emits, with no backend change. Measured (`module.datas.len()` before vs. after):
 
   | module | before | after |
   | --- | --- | --- |
@@ -91,18 +34,9 @@ are packed far tighter than that) without inventing large stretches of zero.
   | cpython.wasm | 2 | 1 |
   | qjs.wasm | 2 | 1 |
 
-  The flagship `ruby.wasm` collapses 7871 → 352 (a 22× reduction); the
-  code-dominated `cpython`/`qjs` have only two segments and merge to one.
-- Correctness is bound by the spec harness (ADR-3): the pass is always on, so
-  the full testsuite passing for every backend *is* the execution-equivalence
-  proof. Targeted IR-shape unit tests in `crates/dewasm-core/tests/data_merge.rs`
-  pin the merge, the zero-fill, the gap threshold, the barrier, and each bail.
-- Modules that use bulk data ops (`rg.wasm`, `libpcap.wasm`, treesitter) hit
-  guard 1 and are passed through untouched — the pass never regresses them.
-- Composes with ADR-37: `--data-file` externalizes the *merged* blobs, so the
-  sidecar carries fewer, larger segments and the source fewer prefix-sum
-  constants.
+The flagship `ruby.wasm` collapses 7871 → 352 (a 22× reduction); the code-dominated `cpython`/`qjs` have only two segments and merge to one.
+- Correctness is bound by the spec harness (ADR-3): the pass is always on, so the full testsuite passing for every backend *is* the execution-equivalence proof. Targeted IR-shape unit tests in `crates/dewasm-core/tests/data_merge.rs` pin the merge, the zero-fill, the gap threshold, the barrier, and each bail.
+- Modules that use bulk data ops (`rg.wasm`, `libpcap.wasm`, treesitter) hit guard 1 and are passed through untouched — the pass never regresses them.
+- Composes with ADR-37: `--data-file` externalizes the *merged* blobs, so the sidecar carries fewer, larger segments and the source fewer prefix-sum constants.
 
-Cross-refs: ADR-1 (semantics-preserving transforms belong in the core IR),
-ADR-3 (the harness binds), ADR-32 (the sibling always-on core pass, expression
-folding), ADR-37 (data-segment externalization, whose follow-up this is).
+Cross-refs: ADR-1 (semantics-preserving transforms belong in the core IR), ADR-3 (the harness binds), ADR-32 (the sibling always-on core pass, expression folding), ADR-37 (data-segment externalization, whose follow-up this is).

--- a/docs/adr/42-ruby-label-variable-cascade.md
+++ b/docs/adr/42-ruby-label-variable-cascade.md
@@ -1,90 +1,30 @@
 # ADR-42 — Ruby Backend: Label-Variable Cascade for Multi-Level `br`
 
-Status: **Accepted, 2026-07-28.** Implemented in
-`crates/dewasm-backend-ruby/src/lib.rs`; supersedes the multi-level-`br`
-and loop-`catch`-value decisions of [ADR-4](4-ruby-backend-lowering.md)
-(its temps-hoisting and `call_indirect` decisions stand).
+Status: **Accepted, 2026-07-28.** Implemented in `crates/dewasm-backend-ruby/src/lib.rs`; supersedes the multi-level-`br` and loop-`catch`-value decisions of [ADR-4](4-ruby-backend-lowering.md) (its temps-hoisting and `call_indirect` decisions stand).
 
 ## Context
 
-ADR-4 lowered a multi-level `br` to Ruby `catch`/`throw`: a referenced
-frame became `catch(:lN) do ... end` and the branch a `throw :lN`.
-`catch`/`throw` is expensive in MRI. Profiling the converted
-`sqlite3-shell` (a workload that ran 24.0s) put `Kernel#catch` at 31.4%
-and `Kernel#throw` at 5.1% of CPU; each `throw` allocates one `T_IMEMO`,
-which accounted for 63–70% of the run's ~8M object allocations and drove
-GC to 16.5% of CPU. A label-variable cascade micro-benchmarked 2.8x
-faster at 4 levels deep and 4.3x at 16.
+ADR-4 lowered a multi-level `br` to Ruby `catch`/`throw`: a referenced frame became `catch(:lN) do ... end` and the branch a `throw :lN`. `catch`/`throw` is expensive in MRI. Profiling the converted `sqlite3-shell` (a workload that ran 24.0s) put `Kernel#catch` at 31.4% and `Kernel#throw` at 5.1% of CPU; each `throw` allocates one `T_IMEMO`, which accounted for 63–70% of the run's ~8M object allocations and drove GC to 16.5% of CPU. A label-variable cascade micro-benchmarked 2.8x faster at 4 levels deep and 4.3x at 16.
 
-ADR-4 explicitly rejected flag variables as obscuring the code and
-needing a state-machine dispatch. That rejection predated ADR-4's own
-decoupling of result values from control: branch result values already
-travel through slot-copy `assigns` and method-scope-hoisted temps, never
-through the branch itself. So a control flag now carries *only* control —
-one method-local variable plus structured `break`/`next` is enough, and
-the per-block dispatch loop ADR-4 feared is unnecessary.
+ADR-4 explicitly rejected flag variables as obscuring the code and needing a state-machine dispatch. That rejection predated ADR-4's own decoupling of result values from control: branch result values already travel through slot-copy `assigns` and method-scope-hoisted temps, never through the branch itself. So a control flag now carries *only* control — one method-local variable plus structured `break`/`next` is enough, and the per-block dispatch loop ADR-4 feared is unnecessary.
 
 ## Decision
 
-- **A method-local `__br` holds the pending target label id** (`nil` =
-  none; label ids start at 0, so `nil` is an unambiguous sentinel).
-  It carries control only, hoisted with the temps when the function has
-  any crossed frame.
-- **Frames keep the lean shapes**: a `Block` or referenced-`If` is
-  `begin ... end while false`; a `Loop` is `while true`.
-- **Depth-1 fast path** — a `br` whose target is the innermost enclosing
-  frame leaves it directly: `break` a block/if, `next` an unwrapped
-  loop's back-edge.
-- **A multi-level `br` sets `__br` and `break`s** the innermost scope.
-  Every frame the branch crosses carries a land-or-relay epilogue,
-  emitted *after* its scope, so the `break` skips any code left in the
-  crossed body: if `__br` names this frame, clear it (the branch lands);
-  otherwise `break` again to relay outward. The discriminating rule for
-  needing an epilogue: a frame is *crossed* iff some outward `br` has it
-  on the inclusive stack path from the target up to and including the
-  branch's own innermost frame (whose bare `break` would otherwise land
-  mid-body in its parent).
-- **A loop targeted from a strictly nested frame is *wrapped***: its body
-  moves into an inner `begin ... end while false` so the relayed `break`
-  re-enters the loop head via `next` instead of exiting the `while`.
-  Loops not targeted from a nested frame stay unwrapped with a plain
-  `next` back-edge. A per-function pre-pass (`compute_frame_sets`)
-  computes the crossed and wrapped sets.
-- **The outermost frame omits its relay arm.** A bare `break` at
-  method-body scope is a Ruby `SyntaxError`, and a pending branch can
-  never target something outside the outermost frame, so that arm is dead
-  anyway.
+- **A method-local `__br` holds the pending target label id** (`nil` = none; label ids start at 0, so `nil` is an unambiguous sentinel). It carries control only, hoisted with the temps when the function has any crossed frame.
+- **Frames keep the lean shapes**: a `Block` or referenced-`If` is `begin ... end while false`; a `Loop` is `while true`.
+- **Depth-1 fast path** — a `br` whose target is the innermost enclosing frame leaves it directly: `break` a block/if, `next` an unwrapped loop's back-edge.
+- **A multi-level `br` sets `__br` and `break`s** the innermost scope. Every frame the branch crosses carries a land-or-relay epilogue, emitted *after* its scope, so the `break` skips any code left in the crossed body: if `__br` names this frame, clear it (the branch lands); otherwise `break` again to relay outward. The discriminating rule for needing an epilogue: a frame is *crossed* iff some outward `br` has it on the inclusive stack path from the target up to and including the branch's own innermost frame (whose bare `break` would otherwise land mid-body in its parent).
+- **A loop targeted from a strictly nested frame is *wrapped***: its body moves into an inner `begin ... end while false` so the relayed `break` re-enters the loop head via `next` instead of exiting the `while`. Loops not targeted from a nested frame stay unwrapped with a plain `next` back-edge. A per-function pre-pass (`compute_frame_sets`) computes the crossed and wrapped sets.
+- **The outermost frame omits its relay arm.** A bare `break` at method-body scope is a Ruby `SyntaxError`, and a pending branch can never target something outside the outermost frame, so that arm is dead anyway.
 
 ## Rejected alternatives
 
-- **Keep `catch`/`throw` (ADR-4).** The `T_IMEMO` allocation and stack
-  unwind dominate hot control flow — the 31%+5% CPU and 63–70% of
-  allocations above are the direct cost.
-- **Epilogue *inside* the scope, innermost frame excluded** (the first
-  cut of this design). Incorrect: a `break` out of a nested frame lands
-  mid-body in its parent, so any intervening parent code runs before the
-  epilogue is reached, and a bare inner `break` skips the epilogue that
-  should have relayed `__br`. The epilogue must sit after the scope, and
-  the branch's own innermost frame needs one too. `sqlite3-shell` and
-  hand-built mixed-depth `br_table` cases exercise this.
-- **Relooper-style state machine / per-statement guards.** More code
-  churn and a dispatch per block; the structured `break`/`next` cascade
-  maps directly onto wasm's already-structured labels.
+- **Keep `catch`/`throw` (ADR-4).** The `T_IMEMO` allocation and stack unwind dominate hot control flow — the 31%+5% CPU and 63–70% of allocations above are the direct cost.
+- **Epilogue *inside* the scope, innermost frame excluded** (the first cut of this design). Incorrect: a `break` out of a nested frame lands mid-body in its parent, so any intervening parent code runs before the epilogue is reached, and a bare inner `break` skips the epilogue that should have relayed `__br`. The epilogue must sit after the scope, and the branch's own innermost frame needs one too. `sqlite3-shell` and hand-built mixed-depth `br_table` cases exercise this.
+- **Relooper-style state machine / per-statement guards.** More code churn and a dispatch per block; the structured `break`/`next` cascade maps directly onto wasm's already-structured labels.
 
 ## Consequences
 
-- Positive: `catch`/`throw` is gone from generated Ruby. `sqlite3-shell`
-  on the benchmark workload dropped 24.0s → 6.95s (3.45x), byte-identical
-  output; GC fell from 16.5% to 11%, and a CPU profile's top frames are
-  now the work function and memory loads/stores, with no `Kernel#catch`
-  or `Kernel#throw`.
-- Negative: a *wrapped* loop's back-edge takes a `__br` assignment and a
-  compare instead of a plain `next`; the common loop+block idiom stays
-  unwrapped and keeps `next`. A multi-level `br` emits one small epilogue
-  per crossed frame — an output-size cost (epilogues sit at deep indents,
-  so they are emitted as single lines; measured on `sqlite3-shell`, the
-  multi-line first cut grew the output by 37%, mostly leading
-  whitespace).
-- The spec harness (ADR-3) binds correctness: it is green for the Ruby
-  backend under this lowering, including `br_table`, `unwind`, and
-  `labels`.
+- Positive: `catch`/`throw` is gone from generated Ruby. `sqlite3-shell` on the benchmark workload dropped 24.0s → 6.95s (3.45x), byte-identical output; GC fell from 16.5% to 11%, and a CPU profile's top frames are now the work function and memory loads/stores, with no `Kernel#catch` or `Kernel#throw`.
+- Negative: a *wrapped* loop's back-edge takes a `__br` assignment and a compare instead of a plain `next`; the common loop+block idiom stays unwrapped and keeps `next`. A multi-level `br` emits one small epilogue per crossed frame — an output-size cost (epilogues sit at deep indents, so they are emitted as single lines; measured on `sqlite3-shell`, the multi-line first cut grew the output by 37%, mostly leading whitespace).
+- The spec harness (ADR-3) binds correctness: it is green for the Ruby backend under this lowering, including `br_table`, `unwind`, and `labels`.

--- a/docs/adr/43-ruby-i64-mask-fast-path.md
+++ b/docs/adr/43-ruby-i64-mask-fast-path.md
@@ -1,83 +1,36 @@
 # ADR-43 — Ruby Backend: i64 Mask Fixnum Fast Path
 
-Status: **Accepted, 2026-07-28.** Implemented in
-`crates/dewasm-backend-ruby/src/lib.rs` and `runtime/ruby/units/rt/m64.rb`.
-Refines the masked-unsigned i64 lowering; the numeric conventions of
-[ADR-2](2-numeric-semantics.md) are unchanged.
+Status: **Accepted, 2026-07-28.** Implemented in `crates/dewasm-backend-ruby/src/lib.rs` and `runtime/ruby/units/rt/m64.rb`. Refines the masked-unsigned i64 lowering; the numeric conventions of [ADR-2](2-numeric-semantics.md) are unchanged.
 
 ## Context
 
-The Ruby backend stores i64 as a masked-unsigned integer in `0..2**64-1`
-(ADR-2). Wrapping arithmetic re-masks with `& 0xffff_ffff_ffff_ffff`. On
-a 64-bit MRI the mask literal `M64` is itself a `T_BIGNUM`: the `Integer#&`
-call therefore boxes a bignum on *every* i64 add/sub/mul/shift, even when
-the result fits a fixnum. Measured, `12345 & M64` allocates 1.00 objects
-per operation, whereas the 32-bit `12345 & M32` (a fixnum literal)
-allocates ≈0.
+The Ruby backend stores i64 as a masked-unsigned integer in `0..2**64-1` (ADR-2). Wrapping arithmetic re-masks with `& 0xffff_ffff_ffff_ffff`. On a 64-bit MRI the mask literal `M64` is itself a `T_BIGNUM`: the `Integer#&` call therefore boxes a bignum on *every* i64 add/sub/mul/shift, even when the result fits a fixnum. Measured, `12345 & M64` allocates 1.00 objects per operation, whereas the 32-bit `12345 & M32` (a fixnum literal) allocates ≈0.
 
-Profiling the converted `sqlite3-shell` on the benchmark workload put
-`T_BIGNUM` at 24.5% of ~8M object allocations (after the ADR-42 cascade
-removed the `T_IMEMO` churn). 91.9% of those bignums held fixnum-range
-values — allocated only because the `& M64` forces the bignum path.
+Profiling the converted `sqlite3-shell` on the benchmark workload put `T_BIGNUM` at 24.5% of ~8M object allocations (after the ADR-42 cascade removed the `T_IMEMO` churn). 91.9% of those bignums held fixnum-range values — allocated only because the `& M64` forces the bignum path.
 
-Two measured facts open a fast path: a comparison against a bignum literal
-(`x <= M64`) does *not* allocate, and the overwhelming majority of masked
-i64 values are already in range.
+Two measured facts open a fast path: a comparison against a bignum literal (`x <= M64`) does *not* allocate, and the overwhelming majority of masked i64 values are already in range.
 
 ## Decision
 
-- **A runtime helper `Rt.m64(x)` replaces the inline `& M64`** on the i64
-  arithmetic sites that can produce an out-of-range value:
+- **A runtime helper `Rt.m64(x)` replaces the inline `& M64`** on the i64 arithmetic sites that can produce an out-of-range value:
 
   ```ruby
   def m64(x) = (x >= 0 && x <= M64) ? x : (x & M64)
   ```
 
-  In-range values (the common case) return unboxed via two non-allocating
-  comparisons; genuine out-of-range values take the same `& M64` as before,
-  so the helper is allocation-neutral on real bignums and correct for every
-  input (`x & M64` still yields the low 64 bits for a negative or oversized
-  `x`).
-- **Applied to exactly the sites whose value can leave `0..2**64-1`**:
-  in `lib.rs`, `I64Add`/`I64Sub`/`I64Mul`/`I64Shl`/`I64ShrS`; in the runtime
-  units, `rt/i64_rotl`, `rt/i64_rotr`, `rt/i64_extend_i32_s`, `rt/i64_div_s`,
-  `rt/i64_rem_s`, `rt/i64_trunc_s`, `rt/i64_trunc_sat_s`, the signed i64
-  memory loads (`memory/i64_load{8,16,32}_s`), and the cold WASI offset
-  stores (`wasi/fd_seek`, `fd_tell`, `clock_time_get`).
-- **Mask-free ops stay mask-free.** `And`/`Or`/`Xor`, `I64ShrU`, `Const`,
-  `ExtendI32U`, and the unsigned loads already keep their operand in range
-  and are not touched. Sites where `M64` is a *bound argument* rather than a
-  top-level mask — `rt/i64_trunc_u`, `rt/i64_trunc_sat_u` (upper bound to
-  `trunc_checked`/`trunc_sat`) and `rt/i64_extend{8,16,32}_s` (mask arg into
-  the i32/i64-shared `rt/sext`) — are left as-is; routing them through an
-  i64-specific `m64` would mean restructuring a shared helper for no clear
-  win.
-- The helper is evaluated with its argument exactly once, so it composes
-  with the ADR-32 expression-folding/spill machinery unchanged.
+In-range values (the common case) return unboxed via two non-allocating comparisons; genuine out-of-range values take the same `& M64` as before, so the helper is allocation-neutral on real bignums and correct for every input (`x & M64` still yields the low 64 bits for a negative or oversized `x`).
+- **Applied to exactly the sites whose value can leave `0..2**64-1`**: in `lib.rs`, `I64Add`/`I64Sub`/`I64Mul`/`I64Shl`/`I64ShrS`; in the runtime units, `rt/i64_rotl`, `rt/i64_rotr`, `rt/i64_extend_i32_s`, `rt/i64_div_s`, `rt/i64_rem_s`, `rt/i64_trunc_s`, `rt/i64_trunc_sat_s`, the signed i64 memory loads (`memory/i64_load{8,16,32}_s`), and the cold WASI offset stores (`wasi/fd_seek`, `fd_tell`, `clock_time_get`).
+- **Mask-free ops stay mask-free.** `And`/`Or`/`Xor`, `I64ShrU`, `Const`, `ExtendI32U`, and the unsigned loads already keep their operand in range and are not touched. Sites where `M64` is a *bound argument* rather than a top-level mask — `rt/i64_trunc_u`, `rt/i64_trunc_sat_u` (upper bound to `trunc_checked`/`trunc_sat`) and `rt/i64_extend{8,16,32}_s` (mask arg into the i32/i64-shared `rt/sext`) — are left as-is; routing them through an i64-specific `m64` would mean restructuring a shared helper for no clear win.
+- The helper is evaluated with its argument exactly once, so it composes with the ADR-32 expression-folding/spill machinery unchanged.
 
 ## Rejected alternatives
 
-- **Inline shared-temp guard** (`(t = A + B) >= 0 && t <= M64 ? t : ...`
-  emitted at each site). Microbenchmarked slightly faster (69ns vs the
-  helper's 82ns) but expands every arithmetic site and needs a spill temp,
-  growing the already-large generated file instead of shrinking it. The
-  helper call `Rt.m64(A + B)` is *shorter* than `((A + B) & M64)`.
-- **Keep the inline `& M64`.** This is the status quo whose 24.5%-of-allocs
-  bignum churn the change targets; 1.00 obj/op on the hot i64 path.
-- **Drop the masked-unsigned representation** (store i64 signed, ADR-2). Out
-  of scope and a far larger change; ADR-2's conventions stand.
+- **Inline shared-temp guard** (`(t = A + B) >= 0 && t <= M64 ? t : ...` emitted at each site). Microbenchmarked slightly faster (69ns vs the helper's 82ns) but expands every arithmetic site and needs a spill temp, growing the already-large generated file instead of shrinking it. The helper call `Rt.m64(A + B)` is *shorter* than `((A + B) & M64)`.
+- **Keep the inline `& M64`.** This is the status quo whose 24.5%-of-allocs bignum churn the change targets; 1.00 obj/op on the hot i64 path.
+- **Drop the masked-unsigned representation** (store i64 signed, ADR-2). Out of scope and a far larger change; ADR-2's conventions stand.
 
 ## Consequences
 
-- Positive: on the `sqlite3-shell` benchmark, allocated objects dropped
-  2.40M → 0.62M (−74%) for byte-identical output; wall time stayed flat
-  (~6.2s, within noise). The generated `sqlite3-shell` shrank ~42 KB
-  (21,316,625 → 21,274,277 bytes) because `Rt.m64(...)` is shorter than the
-  inline mask.
-- Negative: rotates and other sites whose value is usually out of range pay
-  two extra comparisons before the same `& M64`; these are rare, and the
-  code-size and consistency win holds. One more runtime unit (`rt/m64`)
-  enters the bundle whenever any masked i64 op is emitted.
-- The spec harness (ADR-3) binds correctness and is green for the Ruby
-  backend under this lowering (257 trials); the numeric conventions of
-  ADR-2 are unchanged.
+- Positive: on the `sqlite3-shell` benchmark, allocated objects dropped 2.40M → 0.62M (−74%) for byte-identical output; wall time stayed flat (~6.2s, within noise). The generated `sqlite3-shell` shrank ~42 KB (21,316,625 → 21,274,277 bytes) because `Rt.m64(...)` is shorter than the inline mask.
+- Negative: rotates and other sites whose value is usually out of range pay two extra comparisons before the same `& M64`; these are rare, and the code-size and consistency win holds. One more runtime unit (`rt/m64`) enters the bundle whenever any masked i64 op is emitted.
+- The spec harness (ADR-3) binds correctness and is green for the Ruby backend under this lowering (257 trials); the numeric conventions of ADR-2 are unchanged.

--- a/docs/adr/44-ruby-call-indirect-arity.md
+++ b/docs/adr/44-ruby-call-indirect-arity.md
@@ -1,89 +1,37 @@
 # ADR-44 — Ruby Backend: Fixed-Arity `call_indirect` Dispatch
 
-Status: **Accepted, 2026-07-28.** Implemented in
-`crates/dewasm-backend-ruby/src/lib.rs` +
-`runtime/ruby/units/table/call{0..8}.rb`. Amends
-[ADR-4](4-ruby-backend-lowering.md)'s `call_indirect` bullet: the structural
-type-symbol comparison it fixed still binds; only the splat-array *dispatch*
-it used is superseded here.
+Status: **Accepted, 2026-07-28.** Implemented in `crates/dewasm-backend-ruby/src/lib.rs` + `runtime/ruby/units/table/call{0..8}.rb`. Amends [ADR-4](4-ruby-backend-lowering.md)'s `call_indirect` bullet: the structural type-symbol comparison it fixed still binds; only the splat-array *dispatch* it used is superseded here.
 
 ## Context
 
-ADR-4 renders `call_indirect` as `@tT.call(index, type_sym, *args)`, where
-`Table#call` re-splats the collected `*args` into the callee
-(`func.call(*args)`). Both splats allocate a fresh `T_ARRAY` per indirect
-call. SQLite's VDBE and virtual-table dispatch route almost everything
-through `call_indirect`: profiling the converted `sqlite3-shell` on the
-benchmark workload put `Rt::Table#call` at 3.7% of CPU, and its `*args`
-array at ~0.4M `T_ARRAY` allocations per run (5.2% of the run's objects).
+ADR-4 renders `call_indirect` as `@tT.call(index, type_sym, *args)`, where `Table#call` re-splats the collected `*args` into the callee (`func.call(*args)`). Both splats allocate a fresh `T_ARRAY` per indirect call. SQLite's VDBE and virtual-table dispatch route almost everything through `call_indirect`: profiling the converted `sqlite3-shell` on the benchmark workload put `Rt::Table#call` at 3.7% of CPU, and its `*args` array at ~0.4M `T_ARRAY` allocations per run (5.2% of the run's objects).
 
-The argument count is a static property of the call site's type signature,
-so the splat is avoidable — the arity is known at conversion time. Measuring
-the two `call_indirect`-heavy real-world apps confirms a small fixed ceiling
-covers every site (arity = signature parameter count):
+The argument count is a static property of the call site's type signature, so the splat is avoidable — the arity is known at conversion time. Measuring the two `call_indirect`-heavy real-world apps confirms a small fixed ceiling covers every site (arity = signature parameter count):
 
 | arity | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | >8 |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | sqlite3-shell (2018 sites) | 31 | 1390 | 184 | 166 | 183 | 29 | 35 | 0 | 0 | 0 |
 | qjs (1317 sites) | 0 | 522 | 524 | 239 | 13 | 8 | 7 | 1 | 3 | 0 |
 
-Arity 1 alone is 68.9% of sqlite's sites; qjs tops out at 8. A ceiling of 8
-covers 100% of both.
+Arity 1 alone is 68.9% of sqlite's sites; qjs tops out at 8. A ceiling of 8 covers 100% of both.
 
 ## Decision
 
-- **A per-arity `Table#callN` for `0 ≤ N ≤ MAX_FIXED_ARITY` (= 8)**, one
-  runtime unit each (`runtime/ruby/units/table/call0.rb` …
-  `call8.rb`). Each takes the index, the type symbol, and exactly `N`
-  positional parameters — no `*args` on the caller side — and invokes the
-  callee with a fixed argument list (`func.call(a0, a1)`), no splat on the
-  callee side either. The dispatch and trap contract is **identical** to
-  `call`: `undefined element` (out of bounds), `uninitialized element`
-  (null slot), `indirect call type mismatch` (structural symbol `!=`),
-  then the call.
-- **The backend emits `@tT.callN(index, type_sym, a0, …)`** when the site's
-  signature has `N ≤ MAX_FIXED_ARITY` args, and `use_unit`s only the
-  `callN` actually referenced — so a module bundles just the arities it
-  uses, matching the existing per-method unit granularity (ADR-6).
-- **The splat `call` stays as the fallback** for signatures wider than
-  `MAX_FIXED_ARITY`. No such site appears in the measured apps, but general
-  wasm permits any arity, so the path is kept for correctness.
-- **`MAX_FIXED_ARITY` is a single named constant** in the backend; the
-  `call{0..N}.rb` units must exist for the value chosen.
+- **A per-arity `Table#callN` for `0 ≤ N ≤ MAX_FIXED_ARITY` (= 8)**, one runtime unit each (`runtime/ruby/units/table/call0.rb` … `call8.rb`). Each takes the index, the type symbol, and exactly `N` positional parameters — no `*args` on the caller side — and invokes the callee with a fixed argument list (`func.call(a0, a1)`), no splat on the callee side either. The dispatch and trap contract is **identical** to `call`: `undefined element` (out of bounds), `uninitialized element` (null slot), `indirect call type mismatch` (structural symbol `!=`), then the call.
+- **The backend emits `@tT.callN(index, type_sym, a0, …)`** when the site's signature has `N ≤ MAX_FIXED_ARITY` args, and `use_unit`s only the `callN` actually referenced — so a module bundles just the arities it uses, matching the existing per-method unit granularity (ADR-6).
+- **The splat `call` stays as the fallback** for signatures wider than `MAX_FIXED_ARITY`. No such site appears in the measured apps, but general wasm permits any arity, so the path is kept for correctness.
+- **`MAX_FIXED_ARITY` is a single named constant** in the backend; the `call{0..N}.rb` units must exist for the value chosen.
 
-Semantics are unchanged: the same interned structural type symbols
-(`:"i32,i64->i32"`, ADR-4), the same `Rt.trap` on mismatch / null /
-out-of-bounds, and the same cross-module structural typing (a symbol
-interned from the type's *shape*, never a module-local index). Wasm 1.0
-returns (zero or one value) flow through `func.call`'s return exactly as
-before.
+Semantics are unchanged: the same interned structural type symbols (`:"i32,i64->i32"`, ADR-4), the same `Rt.trap` on mismatch / null / out-of-bounds, and the same cross-module structural typing (a symbol interned from the type's *shape*, never a module-local index). Wasm 1.0 returns (zero or one value) flow through `func.call`'s return exactly as before.
 
 ## Rejected alternatives
 
-- **One variadic `call` with `func.call(*args)` (ADR-4, status quo).**
-  Allocates two `T_ARRAY`s per indirect call; the 0.4M-array measurement
-  above is the direct cost on a `call_indirect`-saturated workload.
-- **A single `call` taking a splat but forwarding fixed via a `case
-  args.size` inside.** Removes the callee splat but not the caller one, and
-  adds a per-call branch; the caller-side array is the larger share and is
-  only removable by generating fixed positional arguments at the call site.
-- **Unbounded `callN` generation (a unit per distinct arity seen).** The
-  measured ceiling is 8; a fixed constant with a splat fallback is simpler
-  than threading the module's arity set into the runtime bundler, and the
-  fallback covers the (unobserved) tail with no correctness gap.
+- **One variadic `call` with `func.call(*args)` (ADR-4, status quo).** Allocates two `T_ARRAY`s per indirect call; the 0.4M-array measurement above is the direct cost on a `call_indirect`-saturated workload.
+- **A single `call` taking a splat but forwarding fixed via a `case args.size` inside.** Removes the callee splat but not the caller one, and adds a per-call branch; the caller-side array is the larger share and is only removable by generating fixed positional arguments at the call site.
+- **Unbounded `callN` generation (a unit per distinct arity seen).** The measured ceiling is 8; a fixed constant with a splat fallback is simpler than threading the module's arity set into the runtime bundler, and the fallback covers the (unobserved) tail with no correctness gap.
 
 ## Consequences
 
-- Positive: no `T_ARRAY` is built for any `call_indirect` at arity ≤ 8. On
-  the `sqlite3-shell` benchmark workload total object allocations fell
-  2,570,922 → 2,117,639 (−453,283, ~17.6%), byte-identical output. The
-  wall-clock gain is modest (~1% on this bench, which is dominated by other
-  work); the win is allocation/GC pressure, which the profile attributed to
-  the splat.
-- Negative: nine near-identical small units instead of one. They share the
-  trap contract by copy, so a change to that contract touches all nine (and
-  the fallback `call`); the units lint (ADR-6) keeps their `# requires:`
-  headers honest but does not dedupe the bodies.
-- The spec harness (ADR-3) binds correctness: it is green for the Ruby
-  backend under this lowering, `call_indirect.wast` included, and the
-  `qjs`/`sqlite3-shell` heavy e2e cases pass.
+- Positive: no `T_ARRAY` is built for any `call_indirect` at arity ≤ 8. On the `sqlite3-shell` benchmark workload total object allocations fell 2,570,922 → 2,117,639 (−453,283, ~17.6%), byte-identical output. The wall-clock gain is modest (~1% on this bench, which is dominated by other work); the win is allocation/GC pressure, which the profile attributed to the splat.
+- Negative: nine near-identical small units instead of one. They share the trap contract by copy, so a change to that contract touches all nine (and the fallback `call`); the units lint (ADR-6) keeps their `# requires:` headers honest but does not dedupe the bodies.
+- The spec harness (ADR-3) binds correctness: it is green for the Ruby backend under this lowering, `call_indirect.wast` included, and the `qjs`/`sqlite3-shell` heavy e2e cases pass.

--- a/docs/adr/45-rails-sqlite3-shim-example.md
+++ b/docs/adr/45-rails-sqlite3-shim-example.md
@@ -1,62 +1,25 @@
 # ADR-45 — Rails Demo via a sqlite3-Gem Shim over Converted libsqlite3
 
-Status: **Accepted, 2026-07-28.** `examples/rails` runs an unmodified Rails 8
-app on `libsqlite3.wasm` converted to Ruby; the sqlite3-gem-compatible shim,
-the extended `SQLITE_EXPORTS` list in `examples/apps/fetch.sh`, and the
-end-to-end `run.sh` all landed.
+Status: **Accepted, 2026-07-28.** `examples/rails` runs an unmodified Rails 8 app on `libsqlite3.wasm` converted to Ruby; the sqlite3-gem-compatible shim, the extended `SQLITE_EXPORTS` list in `examples/apps/fetch.sh`, and the end-to-end `run.sh` all landed.
 
 ## Context
 
-The Ruby backend's north-star demo (`docs/backends/ruby.md`) is real software
-using converted SQLite. Rails is the strongest form of that claim, but
-something must bridge ActiveRecord's SQLite3Adapter to the converted module's
-`invoke`/`Rt::Memory` interface — and the converted library cannot call back
-into arbitrary host Ruby (a guest function pointer cannot be conjured for a
-host lambda; only declared imports can, per ADR-7's provider table).
+The Ruby backend's north-star demo (`docs/backends/ruby.md`) is real software using converted SQLite. Rails is the strongest form of that claim, but something must bridge ActiveRecord's SQLite3Adapter to the converted module's `invoke`/`Rt::Memory` interface — and the converted library cannot call back into arbitrary host Ruby (a guest function pointer cannot be conjured for a host lambda; only declared imports can, per ADR-7's provider table).
 
 ## Decision
 
-Bridge at the **sqlite3 gem API layer**: a path gem named `sqlite3`
-(`examples/rails/sqlite3`) implements the surface Rails 8.1 actually calls —
-verified against the adapter and gem sources, not guessed — so Rails and
-ActiveRecord run unmodified. The criterion, reusable for future "run X on a
-converted library" work: **shim at the narrowest public API whose consumer
-you refuse to fork, and keep the guest callback-free** — every gem feature
-that would need a guest→host callback is re-expressed on guest-side
-primitives (`busy_handler_timeout=` → `sqlite3_busy_timeout`;
-`execute_batch2` → a prepare/`remainder` loop instead of `sqlite3_exec`).
+Bridge at the **sqlite3 gem API layer**: a path gem named `sqlite3` (`examples/rails/sqlite3`) implements the surface Rails 8.1 actually calls — verified against the adapter and gem sources, not guessed — so Rails and ActiveRecord run unmodified. The criterion, reusable for future "run X on a converted library" work: **shim at the narrowest public API whose consumer you refuse to fork, and keep the guest callback-free** — every gem feature that would need a guest→host callback is re-expressed on guest-side primitives (`busy_handler_timeout=` → `sqlite3_busy_timeout`; `execute_batch2` → a prepare/`remainder` loop instead of `sqlite3_exec`).
 
-Each `SQLite3::Database` instantiates its own wasm module (isolated heap;
-a mutex serializes entry), so a connection-pool entry is an isolated SQLite
-and thread-safety never depends on guest-global state. The C surface this
-requires is exported by extending `SQLITE_EXPORTS` in
-`examples/apps/fetch.sh` (stamp now covers the export lists, so edits
-retrigger the build).
+Each `SQLite3::Database` instantiates its own wasm module (isolated heap; a mutex serializes entry), so a connection-pool entry is an isolated SQLite and thread-safety never depends on guest-global state. The C surface this requires is exported by extending `SQLITE_EXPORTS` in `examples/apps/fetch.sh` (stamp now covers the export lists, so edits retrigger the build).
 
 ## Rejected alternatives
 
-- **Patch/replace the ActiveRecord adapter.** Chases Rails internals across
-  releases and weakens the demo ("Rails, if you modify it"). The gem API is
-  the narrower, slower-moving seam.
-- **Host-callback binding shape (`sqlite3-binding.wasm`, ADR-22).** Needs
-  bespoke C per feature and still cannot register runtime-chosen callbacks
-  (`busy_handler`, `create_function`); fine as a linking proof, wrong as a
-  compatibility layer.
-- **One shared wasm instance for all connections.** Smaller footprint, but
-  Ruby threads interleave at arbitrary points, so guest-global sqlite state
-  would need one big lock — serializing the whole pool and losing isolation.
+- **Patch/replace the ActiveRecord adapter.** Chases Rails internals across releases and weakens the demo ("Rails, if you modify it"). The gem API is the narrower, slower-moving seam.
+- **Host-callback binding shape (`sqlite3-binding.wasm`, ADR-22).** Needs bespoke C per feature and still cannot register runtime-chosen callbacks (`busy_handler`, `create_function`); fine as a linking proof, wrong as a compatibility layer.
+- **One shared wasm instance for all connections.** Smaller footprint, but Ruby threads interleave at arbitrary points, so guest-global sqlite state would need one big lock — serializing the whole pool and losing isolation.
 
 ## Consequences
 
-- Positive: `examples/rails/run.sh` proves wasm 1.0 + WASI p1 (ADR-40)
-  carries a real framework end-to-end; the shim doubles as a reference
-  embedding of a converted reactor library (ADR-14 preopens, ADR-2 i64
-  masking at the boundary).
-- Negative: the shim tracks the sqlite3 gem's Rails-facing surface and can
-  drift with new Rails releases; `strict:`, extensions, custom functions and
-  collations are unsupported (callback-free rule); WAL silently degrades to
-  rollback journal (no WASI shared memory) and cross-process locking is
-  absent — single-process embedding only.
-- Carry-over: performance work on converted SQLite (ADR-32/33/41–44)
-  directly improves this demo; a future backend can reuse the same shim
-  design against its own runtime.
+- Positive: `examples/rails/run.sh` proves wasm 1.0 + WASI p1 (ADR-40) carries a real framework end-to-end; the shim doubles as a reference embedding of a converted reactor library (ADR-14 preopens, ADR-2 i64 masking at the boundary).
+- Negative: the shim tracks the sqlite3 gem's Rails-facing surface and can drift with new Rails releases; `strict:`, extensions, custom functions and collations are unsupported (callback-free rule); WAL silently degrades to rollback journal (no WASI shared memory) and cross-process locking is absent — single-process embedding only.
+- Carry-over: performance work on converted SQLite (ADR-32/33/41–44) directly improves this demo; a future backend can reuse the same shim design against its own runtime.

--- a/docs/adr/46-host-scoped-wasi-ledgers.md
+++ b/docs/adr/46-host-scoped-wasi-ledgers.md
@@ -1,67 +1,30 @@
 # ADR-46 — Host-OS-Scoped Expected-Failure Ledgers for the WASI Testsuite Harness
 
-Status: **Accepted, 2026-07-29.** Implemented in
-`crates/dewasm-test-helper/src/wasi_testsuite.rs` (the
-`expected_failures_macos`/`expected_failures_linux` trait methods) together
-with the first scoped entries (Java, Ruby); the Java `path_link` entry was
-fixed outright instead of scoped.
+Status: **Accepted, 2026-07-29.** Implemented in `crates/dewasm-test-helper/src/wasi_testsuite.rs` (the `expected_failures_macos`/`expected_failures_linux` trait methods) together with the first scoped entries (Java, Ruby); the Java `path_link` entry was fixed outright instead of scoped.
 
 ## Context
 
-The wasi-testsuite ledgers ([ADR-8](8-latest-testsuite-support-matrix.md)
-discipline, [ADR-36](36-wasi-testsuite-conformance.md) harness) are checked both
-ways: a ledgered trial that *passes* is a hard failure. Every entry was
-written against a macOS development host. The first Linux CI run (issue #7)
-broke that assumption in both directions:
+The wasi-testsuite ledgers ([ADR-8](8-latest-testsuite-support-matrix.md) discipline, [ADR-36](36-wasi-testsuite-conformance.md) harness) are checked both ways: a ledgered trial that *passes* is a hard failure. Every entry was written against a macOS development host. The first Linux CI run (issue #7) broke that assumption in both directions:
 
-- Entries whose cause is macOS host behaviour — CoreFoundation injecting
-  `__CF_USER_TEXT_ENCODING` into the JVM/ruby environ — *pass* on Linux and
-  trip the unexpectedly-passing check.
-- A trial can fail on Linux only: the Linux JDK sets NOFOLLOW symlink times
-  through microsecond `lutimes`, truncating the ns `mtim` the suite
-  round-trips (`rust/symlink_filestat`), while macOS preserves ns.
+- Entries whose cause is macOS host behaviour — CoreFoundation injecting `__CF_USER_TEXT_ENCODING` into the JVM/ruby environ — *pass* on Linux and trip the unexpectedly-passing check.
+- A trial can fail on Linux only: the Linux JDK sets NOFOLLOW symlink times through microsecond `lutimes`, truncating the ns `mtim` the suite round-trips (`rust/symlink_filestat`), while macOS preserves ns.
 
-So a single flat ledger cannot be simultaneously green on both hosts, yet the
-both-ways check is worth keeping — it is what caught the Go `path_link` bug
-(#5) hiding behind host `link(2)` differences.
+So a single flat ledger cannot be simultaneously green on both hosts, yet the both-ways check is worth keeping — it is what caught the Go `path_link` bug (#5) hiding behind host `link(2)` differences.
 
 ## Decision
 
-Ledger entries may be scoped to the host OS. `WasiTestsuiteBackend` gains two
-default-empty methods, `expected_failures_macos()` and
-`expected_failures_linux()`; the harness merges the host-matching list into
-the base ledger before the (unchanged) both-ways check.
+Ledger entries may be scoped to the host OS. `WasiTestsuiteBackend` gains two default-empty methods, `expected_failures_macos()` and `expected_failures_linux()`; the harness merges the host-matching list into the base ledger before the (unchanged) both-ways check.
 
-The discriminating criterion: **an entry is host-scoped when its attributed
-cause is host-side behaviour outside the runtime's reach** (libc/interpreter
-environ injection, a host stdlib precision gap). If the cause is in the
-generated runtime, fix the unit instead — the Java `path_link` case was
-exactly that (the macOS `link(2)`-follows gap is emulated by recreating the
-symlink, mirroring the Go unit) and was removed from the ledger, not scoped.
-An entry that fails identically on both hosts stays in the base list.
+The discriminating criterion: **an entry is host-scoped when its attributed cause is host-side behaviour outside the runtime's reach** (libc/interpreter environ injection, a host stdlib precision gap). If the cause is in the generated runtime, fix the unit instead — the Java `path_link` case was exactly that (the macOS `link(2)`-follows gap is emulated by recreating the symlink, mirroring the Go unit) and was removed from the ledger, not scoped. An entry that fails identically on both hosts stays in the base list.
 
 ## Rejected alternatives
 
-- **Fix every host difference portably.** Not reachable: environ injection
-  (CoreFoundation, PEP 538) and the JDK's µs `lutimes` path are outside what
-  generated code can influence without FFI, which the backends deliberately
-  avoid.
-- **Relax the unexpectedly-passing check.** Would have silently absorbed the
-  ledger drift — the check is precisely what surfaced #5 as a real bug.
-- **`#[cfg]`-duplicated ledger arrays per backend.** Same effect, but each
-  backend re-states the shared entries twice and the harness API stays
-  ignorant of the semantics; the trait methods keep scoping explicit and
-  additive.
+- **Fix every host difference portably.** Not reachable: environ injection (CoreFoundation, PEP 538) and the JDK's µs `lutimes` path are outside what generated code can influence without FFI, which the backends deliberately avoid.
+- **Relax the unexpectedly-passing check.** Would have silently absorbed the ledger drift — the check is precisely what surfaced #5 as a real bug.
+- **`#[cfg]`-duplicated ledger arrays per backend.** Same effect, but each backend re-states the shared entries twice and the harness API stays ignorant of the semantics; the trait methods keep scoping explicit and additive.
 
 ## Consequences
 
-- CI on ubuntu-latest and local macOS runs are both green against one ledger
-  declaration, and each host still enforces the both-ways discipline for the
-  entries that apply to it.
-- A scoped entry is only ever *verified* on its own host: macOS entries are
-  exercised locally, Linux entries only by CI (and vice versa). A stale
-  scoped entry therefore surfaces one environment later, not never.
-- New backends state host-dependent gaps where they belong instead of
-  papering over them with the flat list; the spec harness ledger
-  ([ADR-8](8-latest-testsuite-support-matrix.md)) stays flat until it meets
-  the same problem.
+- CI on ubuntu-latest and local macOS runs are both green against one ledger declaration, and each host still enforces the both-ways discipline for the entries that apply to it.
+- A scoped entry is only ever *verified* on its own host: macOS entries are exercised locally, Linux entries only by CI (and vice versa). A stale scoped entry therefore surfaces one environment later, not never.
+- New backends state host-dependent gaps where they belong instead of papering over them with the flat list; the spec harness ledger ([ADR-8](8-latest-testsuite-support-matrix.md)) stays flat until it meets the same problem.

--- a/docs/adr/47-ruby-f64-sub-quiet-guard.md
+++ b/docs/adr/47-ruby-f64-sub-quiet-guard.md
@@ -1,29 +1,10 @@
 # ADR-47 — Inline Quiet-NaN Guard for Ruby f64.sub
 
-Status: **Accepted, 2026-07-29.** Implemented in the Ruby backend's binop
-lowering (`crates/dewasm-backend-ruby/src/lib.rs`, `F64Sub`), reusing the
-existing `rt/quiet_nan` unit.
+Status: **Accepted, 2026-07-29.** Implemented in the Ruby backend's binop lowering (`crates/dewasm-backend-ruby/src/lib.rs`, `F64Sub`), reusing the existing `rt/quiet_nan` unit.
 
 ## Context
 
-Wasm requires float arithmetic to return *arithmetic* (quiet-bit-set) NaNs.
-The Ruby lowering emitted plain `(a - b)` for `f64.sub` ([ADR-4](4-ruby-backend-lowering.md)),
-implicitly assuming the host FPU executes the subtraction and quietens a
-signaling-NaN operand. **GCC-built MRI** breaks that assumption: `a - b` with
-`b == +0.0` returns the LHS bits unquieted (a fresh Float, same bits) on every
-version probed (3.4.5, 3.4.10, 4.0.6, head), on every call shape, on both
-x86_64 and arm64 Linux; clang-built (macOS) rubies quieten correctly. The
-mechanism was isolated with a minimal C model: MRI's flonum decode
-(`rb_float_flonum_value`) special-cases the flonum encoding of +0.0 with a
-literal `return 0.0`, and GCC — MRI ships `-fno-fast-math` but not
-`-fsignaling-nans` — duplicates the subtraction into that branch and folds
-`a - 0.0 → a` (IEEE-valid once sNaNs are assumed away), skipping the FPU sub;
-clang performs no such fold. `x - (+0.0)` is the only affected identity:
-`x - (-0.0)` and `x + (±0.0)` are not foldable under signed zeros, and only
-+0.0 has the literal decode branch. Upstream, NaN payloads are explicitly not
-considered by Ruby (bugs.ruby-lang.org #20662), so this is behavior dewasm
-must own, not a bug fix to wait for. Caught by the first Linux CI runs
-(issue #11): f64.wast:742,746 and float_exprs.wast:76,2409.
+Wasm requires float arithmetic to return *arithmetic* (quiet-bit-set) NaNs. The Ruby lowering emitted plain `(a - b)` for `f64.sub` ([ADR-4](4-ruby-backend-lowering.md)), implicitly assuming the host FPU executes the subtraction and quietens a signaling-NaN operand. **GCC-built MRI** breaks that assumption: `a - b` with `b == +0.0` returns the LHS bits unquieted (a fresh Float, same bits) on every version probed (3.4.5, 3.4.10, 4.0.6, head), on every call shape, on both x86_64 and arm64 Linux; clang-built (macOS) rubies quieten correctly. The mechanism was isolated with a minimal C model: MRI's flonum decode (`rb_float_flonum_value`) special-cases the flonum encoding of +0.0 with a literal `return 0.0`, and GCC — MRI ships `-fno-fast-math` but not `-fsignaling-nans` — duplicates the subtraction into that branch and folds `a - 0.0 → a` (IEEE-valid once sNaNs are assumed away), skipping the FPU sub; clang performs no such fold. `x - (+0.0)` is the only affected identity: `x - (-0.0)` and `x + (±0.0)` are not foldable under signed zeros, and only +0.0 has the literal decode branch. Upstream, NaN payloads are explicitly not considered by Ruby (bugs.ruby-lang.org #20662), so this is behavior dewasm must own, not a bug fix to wait for. Caught by the first Linux CI runs (issue #11): f64.wast:742,746 and float_exprs.wast:76,2409.
 
 ## Decision
 
@@ -33,37 +14,18 @@ Lower `f64.sub` to an inline self-compare guard:
 ((r = a - b) == r ? r : Rt.quiet_nan(r))
 ```
 
-`r == r` is false only for NaN, so the common path adds one C-level compare —
-no method call, no allocation — matching the Ruby perf posture
-(ADR-32/33/42–44); the NaN path routes through the existing `rt/quiet_nan`
-(sign and payload preserved, hence still an arithmetic NaN).
+`r == r` is false only for NaN, so the common path adds one C-level compare — no method call, no allocation — matching the Ruby perf posture (ADR-32/33/42–44); the NaN path routes through the existing `rt/quiet_nan` (sign and payload preserved, hence still an arithmetic NaN).
 
-The criterion for guarding an op: **an op gets a quiet guard only when a real
-host was observed returning a signaling NaN from it.** Today that is `f64.sub`
-alone — `f32.sub` is already safe because the `Rt.f32` re-round's `pack("e")`
-narrowing quietens on every probed host, and add/mul/div quietened everywhere.
-The same criterion applies to other backends if they exhibit the class.
+The criterion for guarding an op: **an op gets a quiet guard only when a real host was observed returning a signaling NaN from it.** Today that is `f64.sub` alone — `f32.sub` is already safe because the `Rt.f32` re-round's `pack("e")` narrowing quietens on every probed host, and add/mul/div quietened everywhere. The same criterion applies to other backends if they exhibit the class.
 
 ## Rejected alternatives
 
-- **Guard every float binop defensively.** Pays the guard cost on ops no host
-  has been observed to break; the spec harness runs on both dev (macOS) and CI
-  (Linux) hosts, so a newly broken op surfaces as a red spec trial and gets
-  its guard then, with evidence.
-- **Pin the CI/dev Ruby to an unaffected build.** Every GCC-built MRI folds
-  (all probed versions, both architectures) — which in practice is every
-  Linux ruby — and generated code must be correct on whatever host ruby a
-  user runs.
-- **An `Rt.fsub` helper unit.** A method call per subtraction on the hot
-  path; the inline guard is both faster and no less clear.
+- **Guard every float binop defensively.** Pays the guard cost on ops no host has been observed to break; the spec harness runs on both dev (macOS) and CI (Linux) hosts, so a newly broken op surfaces as a red spec trial and gets its guard then, with evidence.
+- **Pin the CI/dev Ruby to an unaffected build.** Every GCC-built MRI folds (all probed versions, both architectures) — which in practice is every Linux ruby — and generated code must be correct on whatever host ruby a user runs.
+- **An `Rt.fsub` helper unit.** A method call per subtraction on the hot path; the inline guard is both faster and no less clear.
 
 ## Consequences
 
-- `f64.sub` output grows a temp-and-ternary wrapper; correctness outranks
-  generated-code readability ([ADR-1](1-ir-design.md)).
-- The `r` temp is written then immediately read within one expression, so
-  nested subs re-assign it only after the inner value is consumed; it cannot
-  collide with the generated `l*`/`s*` locals.
-- The quiet guard's absence elsewhere is a deliberate, evidence-driven gap:
-  a future host that folds another identity (e.g. `x + (-0.0)`) will fail the
-  spec harness loudly, not silently.
+- `f64.sub` output grows a temp-and-ternary wrapper; correctness outranks generated-code readability ([ADR-1](1-ir-design.md)).
+- The `r` temp is written then immediately read within one expression, so nested subs re-assign it only after the inner value is consumed; it cannot collide with the generated `l*`/`s*` locals.
+- The quiet guard's absence elsewhere is a deliberate, evidence-driven gap: a future host that folds another identity (e.g. `x + (-0.0)`) will fail the spec harness loudly, not silently.

--- a/docs/adr/48-slow-test-tiers.md
+++ b/docs/adr/48-slow-test-tiers.md
@@ -1,67 +1,29 @@
 # ADR-48 — Two-Tier Slow-Test Gating (slow_test / ultra_slow_test)
 
-Status: **Accepted, 2026-07-29.** Implemented across the backend crates'
-cargo features, the `dewasm-test-helper` case macros (`slow_tier_test!`), the
-spec harness's sweep gating, and the CI workflow's main-branch legs.
+Status: **Accepted, 2026-07-29.** Implemented across the backend crates' cargo features, the `dewasm-test-helper` case macros (`slow_tier_test!`), the spec harness's sweep gating, and the CI workflow's main-branch legs.
 
 ## Context
 
-The former single `heavy_test` feature marked every non-fast case, and CI's
-main-branch sweep ran them all via `cargo test -- --include-ignored`. The
-first such run (issues #22, #23) showed the tier conflates two classes: cases
-that are slow but CI-affordable (the java/ruby app legs passed in minutes),
-and cases that individually exceed about a minute on a 4-core runner — the
-bash QuickJS REPL pty case (no prompt within 180 s) and go's
-giant-generated-program builds, whose parallel `go build`s exhausted runner
-memory and got the job killed. Verifying those on every push costs more than
-it returns, but the fail-loud policy ([ADR-15](15-tests-fail-not-skip.md))
-rules out anything that silently skips. "Heavy" was also the wrong word: the
-gate has always been about wall time.
+The former single `heavy_test` feature marked every non-fast case, and CI's main-branch sweep ran them all via `cargo test -- --include-ignored`. The first such run (issues #22, #23) showed the tier conflates two classes: cases that are slow but CI-affordable (the java/ruby app legs passed in minutes), and cases that individually exceed about a minute on a 4-core runner — the bash QuickJS REPL pty case (no prompt within 180 s) and go's giant-generated-program builds, whose parallel `go build`s exhausted runner memory and got the job killed. Verifying those on every push costs more than it returns, but the fail-loud policy ([ADR-15](15-tests-fail-not-skip.md)) rules out anything that silently skips. "Heavy" was also the wrong word: the gate has always been about wall time.
 
 ## Decision
 
 Two explicit tiers, named for what they gate:
 
-- `slow_test` (renamed from `heavy_test`): cases CI verifies on every push to
-  main. The feature also un-ignores the spec harness's non-curated sweep, so
-  the CI switch from `--include-ignored` to `--features slow_test` drops
-  nothing unintended.
-- `ultra_slow_test = ["slow_test"]`: cases CI deliberately does not run.
-  **Criterion: roughly one minute per test on a CI runner** (observed, not
-  estimated — a case is promoted on evidence from a real run). The tier is
-  chosen per callsite in each backend's `tests/e2e.rs`, so the same case can
-  be ultra for go (compiling a CPython-sized program) and slow for java.
+- `slow_test` (renamed from `heavy_test`): cases CI verifies on every push to main. The feature also un-ignores the spec harness's non-curated sweep, so the CI switch from `--include-ignored` to `--features slow_test` drops nothing unintended.
+- `ultra_slow_test = ["slow_test"]`: cases CI deliberately does not run. **Criterion: roughly one minute per test on a CI runner** (observed, not estimated — a case is promoted on evidence from a real run). The tier is chosen per callsite in each backend's `tests/e2e.rs`, so the same case can be ultra for go (compiling a CPython-sized program) and slow for java.
 
-Local tiers: `cargo test` (fast gate) → `--features slow_test` (what CI's
-main sweep runs) → `--features ultra_slow_test` (everything);
-`-- --include-ignored` remains the feature-independent sledgehammer. The
-ultra tier is thereby *locally* verified — run it before declaring support or
-tagging a release — never silently skipped: the cases stay compiled (clippy
-runs `--all-features`) and visibly `ignored` in default output.
+Local tiers: `cargo test` (fast gate) → `--features slow_test` (what CI's main sweep runs) → `--features ultra_slow_test` (everything); `-- --include-ignored` remains the feature-independent sledgehammer. The ultra tier is thereby *locally* verified — run it before declaring support or tagging a release — never silently skipped: the cases stay compiled (clippy runs `--all-features`) and visibly `ignored` in default output.
 
 ## Rejected alternatives
 
-- **Keep `--include-ignored` and buy bigger runners.** Pays continuously for
-  cases that change rarely; the go memory exhaustion would need the largest
-  runners for a handful of tests.
-- **Runtime time-budget skipping** (skip when a case exceeds N seconds).
-  Nondeterministic pass/skip is exactly what ADR-15 forbids; a tier flip in
-  a reviewed diff is auditable, a runtime skip is not.
-- **A single tier with per-case CI excludes in the workflow.** Scatters the
-  test-selection policy into YAML `--skip` lists that nothing type-checks;
-  the feature keeps the policy next to the case and greppable.
-- **Keeping the `heavy` name.** The gate has never measured memory or size —
-  only time. Historical ADRs keep the old name; living docs and code use
-  `slow`.
+- **Keep `--include-ignored` and buy bigger runners.** Pays continuously for cases that change rarely; the go memory exhaustion would need the largest runners for a handful of tests.
+- **Runtime time-budget skipping** (skip when a case exceeds N seconds). Nondeterministic pass/skip is exactly what ADR-15 forbids; a tier flip in a reviewed diff is auditable, a runtime skip is not.
+- **A single tier with per-case CI excludes in the workflow.** Scatters the test-selection policy into YAML `--skip` lists that nothing type-checks; the feature keeps the policy next to the case and greppable.
+- **Keeping the `heavy` name.** The gate has never measured memory or size — only time. Historical ADRs keep the old name; living docs and code use `slow`.
 
 ## Consequences
 
-- CI main legs run `--features <backend>/slow_test` (the core job:
-  `dewasm-cli/slow_test,dewasm-test-helper/wasmtime_test`); #22 and #23 are
-  resolved by reclassification rather than tuning timeouts and thread counts.
-- The ultra tier's coverage now depends on the local pre-release habit the
-  criterion implies; the tier list is small (bash: 1 pty case, go: 8 builds)
-  and each entry cites the evidence that promoted it.
-- A future case is promoted (or demoted) by editing one callsite and citing a
-  CI run, mirroring the evidence-driven criterion of
-  [ADR-47](47-ruby-f64-sub-quiet-guard.md).
+- CI main legs run `--features <backend>/slow_test` (the core job: `dewasm-cli/slow_test,dewasm-test-helper/wasmtime_test`); #22 and #23 are resolved by reclassification rather than tuning timeouts and thread counts.
+- The ultra tier's coverage now depends on the local pre-release habit the criterion implies; the tier list is small (bash: 1 pty case, go: 8 builds) and each entry cites the evidence that promoted it.
+- A future case is promoted (or demoted) by editing one callsite and citing a CI run, mirroring the evidence-driven criterion of [ADR-47](47-ruby-f64-sub-quiet-guard.md).

--- a/docs/adr/49-spec-silent-follow-wasmtime.md
+++ b/docs/adr/49-spec-silent-follow-wasmtime.md
@@ -4,48 +4,22 @@ Status: **Accepted, 2026-07-29.** Implemented in PR #43 (issue #42).
 
 ## Context
 
-WASI p1 (and p2's `path-resolution.md`) says nothing about trailing-slash
-paths, and the shapes are inconsequential — a real program breaking on one of
-these errnos is astronomically unlikely. Still, each backend needs *some*
-answer; the first fix for issue #42 pinned POSIX, which contradicts wasmtime
-on a few shapes. The upstream wasi-testsuite's `assert_errno!` runs
-Permissive by default (the union of its per-OS arms) — how the divergences
-went unnoticed; setting one `ERRNO_MODE_*` is its intended strict usage.
+WASI p1 (and p2's `path-resolution.md`) says nothing about trailing-slash paths, and the shapes are inconsequential — a real program breaking on one of these errnos is astronomically unlikely. Still, each backend needs *some* answer; the first fix for issue #42 pinned POSIX, which contradicts wasmtime on a few shapes. The upstream wasi-testsuite's `assert_errno!` runs Permissive by default (the union of its per-OS arms) — how the divergences went unnoticed; setting one `ERRNO_MODE_*` is its intended strict usage.
 
-Survey (macOS; full table in PR #43): wasmer 7 can't run the mutation probes
-(its VFS denies them); WasmEdge 0.17 and Node 24 agree with wasmtime on the
-ENOTDIR resolution family but not on the quirks — `rmdir("dir/")` EINVAL and
-macOS O_CREAT-through-slash EINVAL are wasmtime alone. Noted for the record;
-it changed nothing.
+Survey (macOS; full table in PR #43): wasmer 7 can't run the mutation probes (its VFS denies them); WasmEdge 0.17 and Node 24 agree with wasmtime on the ENOTDIR resolution family but not on the quirks — `rmdir("dir/")` EINVAL and macOS O_CREAT-through-slash EINVAL are wasmtime alone. Noted for the record; it changed nothing.
 
 ## Decision
 
-**Where the WASI spec is silent, backends copy wasmtime's observed behavior**
-(currently 47), measured on both CI hosts: host-uniform values are
-implemented deterministically, host splits wasmtime inherits (unlink of a
-directory: EPERM/EISDIR) are reproduced per host, and one-host internal
-artifacts (its Linux-only nofollow-stat slash strip) stay unpinned, noted at
-the test site. wasmtime is the pick because the upstream testsuite encodes
-it, not because its behavior is better; where it is an outlier the value is
-arbitrary and not worth debating.
+**Where the WASI spec is silent, backends copy wasmtime's observed behavior** (currently 47), measured on both CI hosts: host-uniform values are implemented deterministically, host splits wasmtime inherits (unlink of a directory: EPERM/EISDIR) are reproduced per host, and one-host internal artifacts (its Linux-only nofollow-stat slash strip) stay unpinned, noted at the test site. wasmtime is the pick because the upstream testsuite encodes it, not because its behavior is better; where it is an outlier the value is arbitrary and not worth debating.
 
-The wasi-testsuite runner injects the host-matched strict errno mode
-(`ERRNO_MODE_MACOS`/`ERRNO_MODE_UNIX`) into the Rust suite's guest
-environment — a deliberate deviation from the manifest-only-env rule (commit
-02c5ef5), scoped to Rust because the C/assemblyscript suites assert exact
-environ contents.
+The wasi-testsuite runner injects the host-matched strict errno mode (`ERRNO_MODE_MACOS`/`ERRNO_MODE_UNIX`) into the Rust suite's guest environment — a deliberate deviation from the manifest-only-env rule (commit 02c5ef5), scoped to Rust because the C/assemblyscript suites assert exact environ contents.
 
 ## Rejected alternatives
 
-- **POSIX semantics** (this PR's first revision) — nothing tests against
-  POSIX; fails the strict suite on at least one host.
+- **POSIX semantics** (this PR's first revision) — nothing tests against POSIX; fails the strict suite on at least one host.
 - **Permissive errno modes** — hides real divergence.
-- **Majority vote across runtimes** — effort spent on shapes that don't
-  matter, with no canonical electorate.
+- **Majority vote across runtimes** — effort spent on shapes that don't matter, with no canonical electorate.
 
 ## Consequences
 
-Some units carry host-OS branches to reproduce wasmtime's splits; its quirks
-are copied as-is. A future wasmtime change to a spec-silent shape forces a
-re-measure. The PR #41 bash pins are re-based on this rule
-(`crates/dewasm-backend-bash/tests/wasi_fs_regressions.rs`).
+Some units carry host-OS branches to reproduce wasmtime's splits; its quirks are copied as-is. A future wasmtime change to a spec-silent shape forces a re-measure. The PR #41 bash pins are re-based on this rule (`crates/dewasm-backend-bash/tests/wasi_fs_regressions.rs`).

--- a/docs/adr/5-bash-softfloat.md
+++ b/docs/adr/5-bash-softfloat.md
@@ -1,55 +1,26 @@
 # ADR-5 — Bash Floats: Pure-Bash Softfloat
 
-Status: **Accepted, 2026-07-23.** Backfilled; the policy was fixed
-during initial planning. The implementation landed after the
-integers/memory/WASI milestones, with its conventions recorded in
-[ADR-13](13-bash-softfloat-conventions.md); the spec float files are
-green and real binaries run under bash.
+Status: **Accepted, 2026-07-23.** Backfilled; the policy was fixed during initial planning. The implementation landed after the integers/memory/WASI milestones, with its conventions recorded in [ADR-13](13-bash-softfloat-conventions.md); the spec float files are green and real binaries run under bash.
 
-**Revision, 2026-07-27:** the "dependency set is exactly a Bash interpreter"
-criterion is narrowly amended by [ADR-34](34-bash-wasi-filesystem.md) — the
-four WASI namespace-mutation syscalls may each call one POSIX command
-(`mkdir`/`rmdir`/`rm`/`mv`), which pure Bash cannot express.
+**Revision, 2026-07-27:** the "dependency set is exactly a Bash interpreter" criterion is narrowly amended by [ADR-34](34-bash-wasi-filesystem.md) — the four WASI namespace-mutation syscalls may each call one POSIX command (`mkdir`/`rmdir`/`rm`/`mv`), which pure Bash cannot express.
 
 ## Context
 
-Bash arithmetic (`$(( ))`) is signed 64-bit integers only; there is no
-float type. The Bash backend is the project's flagship demonstration
-(ADR-0): C/Rust tools running with no architecture-specific binary and no
-runtime dependency. f32/f64 support therefore needs an emulation
-strategy, and the choice decides whether that promise actually holds.
+Bash arithmetic (`$(( ))`) is signed 64-bit integers only; there is no float type. The Bash backend is the project's flagship demonstration (ADR-0): C/Rust tools running with no architecture-specific binary and no runtime dependency. f32/f64 support therefore needs an emulation strategy, and the choice decides whether that promise actually holds.
 
 ## Decision
 
-Implement IEEE 754 f32/f64 as a **softfloat library written in pure Bash**,
-operating on i64 bit patterns with integer arithmetic (add/sub/mul/div/
-sqrt, comparisons, roundings, int↔float conversions). Criterion: *the
-generated program's dependency set must be exactly "a Bash interpreter"* —
-the same property that makes the backend interesting — and the
-implementation must be able to pass the spec testsuite's float files
-(ADR-3), including NaN patterns and rounding modes.
+Implement IEEE 754 f32/f64 as a **softfloat library written in pure Bash**, operating on i64 bit patterns with integer arithmetic (add/sub/mul/div/ sqrt, comparisons, roundings, int↔float conversions). Criterion: *the generated program's dependency set must be exactly "a Bash interpreter"* — the same property that makes the backend interesting — and the implementation must be able to pass the spec testsuite's float files (ADR-3), including NaN patterns and rounding modes.
 
-Sequencing: the Bash backend ships integer/memory/control-flow/WASI
-support first; float-using modules fail with a clear conversion-time
-error until softfloat lands (consistent with ADR-0's unsupported-feature
-contract).
+Sequencing: the Bash backend ships integer/memory/control-flow/WASI support first; float-using modules fail with a clear conversion-time error until softfloat lands (consistent with ADR-0's unsupported-feature contract).
 
 ## Rejected alternatives
 
-- **Delegating to `awk` / `bc`** — adds external-command dependencies
-  (portability loss, huge per-call fork cost) and neither implements
-  IEEE 754 semantics bit-exactly (NaN payloads, −0.0, round-to-nearest-
-  even at the format boundary); the spec testsuite would not pass.
-- **Integer-only forever** — leaves the flagship demo unable to run most
-  real Rust/C programs (`std` formatting paths alone pull in floats).
+- **Delegating to `awk` / `bc`** — adds external-command dependencies (portability loss, huge per-call fork cost) and neither implements IEEE 754 semantics bit-exactly (NaN payloads, −0.0, round-to-nearest- even at the format boundary); the spec testsuite would not pass.
+- **Integer-only forever** — leaves the flagship demo unable to run most real Rust/C programs (`std` formatting paths alone pull in floats).
 
 ## Consequences
 
-- Positive: "runs anywhere Bash runs" stays literally true; softfloat in
-  ~pure shell is also simply a compelling artifact.
-- Negative: large implementation cost and dire performance — floats in
-  Bash will be orders of magnitude slower than integers, which are
-  already slow. Accepted: the Bash backend's value is existence, not
-  speed (stated in the README).
-- The softfloat routines live in `runtime/bash/` like any other embedded
-  runtime; the spec float files become the acceptance test.
+- Positive: "runs anywhere Bash runs" stays literally true; softfloat in ~pure shell is also simply a compelling artifact.
+- Negative: large implementation cost and dire performance — floats in Bash will be orders of magnitude slower than integers, which are already slow. Accepted: the Bash backend's value is existence, not speed (stated in the README).
+- The softfloat routines live in `runtime/bash/` like any other embedded runtime; the spec float files become the acceptance test.

--- a/docs/adr/6-runtime-units.md
+++ b/docs/adr/6-runtime-units.md
@@ -1,77 +1,32 @@
 # ADR-6 — Runtime as Per-Method Units with Selectable Linkage
 
-Status: **Accepted, 2026-07-23.** Implemented for Ruby: the runtime lives
-in `runtime/ruby/units/` (118 units), the generic bundler in
-`crates/dewasm-backend/src/lib.rs` (`RuntimeBundler`), and generated
-code references the runtime via the relative name `Rt`. The external/gem
-linkage is designed for but not shipped.
+Status: **Accepted, 2026-07-23.** Implemented for Ruby: the runtime lives in `runtime/ruby/units/` (118 units), the generic bundler in `crates/dewasm-backend/src/lib.rs` (`RuntimeBundler`), and generated code references the runtime via the relative name `Rt`. The external/gem linkage is designed for but not shipped.
 
 ## Context
 
-The runtime was two monolithic files (`runtime.rb`, `wasi.rb`) embedded
-wholesale into every generated program. Three pressures broke that:
-the Bash backend's softfloat (ADR-5) will be ~1000 lines a float-free
-program must not carry (shells parse the whole file at startup); WASI
-keeps growing but a module's imports name exactly which syscalls it can
-ever call; and two generated files loaded into one Ruby process both
-reopened the global `Dewasmify` module — colliding constants and,
-worse, silently mixing runtimes from different dewasmify versions.
+The runtime was two monolithic files (`runtime.rb`, `wasi.rb`) embedded wholesale into every generated program. Three pressures broke that: the Bash backend's softfloat (ADR-5) will be ~1000 lines a float-free program must not carry (shells parse the whole file at startup); WASI keeps growing but a module's imports name exactly which syscalls it can ever call; and two generated files loaded into one Ruby process both reopened the global `Dewasmify` module — colliding constants and, worse, silently mixing runtimes from different dewasmify versions.
 
 ## Decision
 
 Two orthogonal mechanisms:
 
-- **Per-method runtime units, bundled on demand.** One file per runtime
-  method under `runtime/<lang>/units/<scope>/<name>`, dependencies
-  declared in `# requires:` header lines, inseparable class skeletons as
-  `_class`/`_module` prelude units. Code generation records every helper
-  it references; the build bundles only that closure. Criterion: *the
-  generated artifact carries only code the module can reach.*
-- **Runtime linkage behind one name.** Generated code and units refer to
-  the runtime only as `Rt`; `RuntimeLinkage` decides where `Rt` lives:
-  `Embedded` nests `module Rt` inside the generated class (self-contained
-  file, `A::Rt` and `B::Rt` fully independent — naive multi-require is
-  safe), `Alias(path)` emits one `Rt = <path>` line for a shared bundle
-  (the spec harness) or, later, a `dewasm-runtime` gem dependency for
-  programs using many modules. Criterion: *the runtime's location must be
-  a one-line concern of the generated code.* Ruby's lexical constant
-  resolution makes the same unit source work in every placement.
+- **Per-method runtime units, bundled on demand.** One file per runtime method under `runtime/<lang>/units/<scope>/<name>`, dependencies declared in `# requires:` header lines, inseparable class skeletons as `_class`/`_module` prelude units. Code generation records every helper it references; the build bundles only that closure. Criterion: *the generated artifact carries only code the module can reach.*
+- **Runtime linkage behind one name.** Generated code and units refer to the runtime only as `Rt`; `RuntimeLinkage` decides where `Rt` lives: `Embedded` nests `module Rt` inside the generated class (self-contained file, `A::Rt` and `B::Rt` fully independent — naive multi-require is safe), `Alias(path)` emits one `Rt = <path>` line for a shared bundle (the spec harness) or, later, a `dewasm-runtime` gem dependency for programs using many modules. Criterion: *the runtime's location must be a one-line concern of the generated code.* Ruby's lexical constant resolution makes the same unit source work in every placement.
 
-The declared-dependency drift risk (edit the code, forget the header) is
-mitigated twice: a lint test (a `#[cfg(test)] mod units` at the bottom of
-`crates/dewasm-backend-ruby/src/lib.rs`) extracts `Rt.x` / `Rt::X` /
-`@memory.x` / bare sibling-call references
-from unit bodies and checks them against the header, and the spec harness
-runs its 19k assertions against minimal bundles, so an undeclared
-dependency fails as a NoMethodError at the exact assertion.
+The declared-dependency drift risk (edit the code, forget the header) is mitigated twice: a lint test (a `#[cfg(test)] mod units` at the bottom of `crates/dewasm-backend-ruby/src/lib.rs`) extracts `Rt.x` / `Rt::X` / `@memory.x` / bare sibling-call references from unit bodies and checks them against the header, and the spec harness runs its 19k assertions against minimal bundles, so an undeclared dependency fails as a NoMethodError at the exact assertion.
 
 ## Rejected alternatives
 
-- **Keep the monolith** — unacceptable output cost once Bash softfloat
-  exists, and no answer to multi-artifact collisions.
-- **Coarse feature groups** (memory / floats / wasi) — most of the
-  machinery for a fraction of the precision; any float instruction would
-  still drag the whole float group into Bash output.
-- **A fixed global namespace for the embedded runtime** — multi-module
-  programs collide; version skew between artifacts goes undetected.
-- **Runtime `require` of shared files at run time** — breaks the
-  single-file, no-dependency output contract (ADR-0); dependency-based
-  distribution is instead the future gem linkage, chosen explicitly at
-  build time.
+- **Keep the monolith** — unacceptable output cost once Bash softfloat exists, and no answer to multi-artifact collisions.
+- **Coarse feature groups** (memory / floats / wasi) — most of the machinery for a fraction of the precision; any float instruction would still drag the whole float group into Bash output.
+- **A fixed global namespace for the embedded runtime** — multi-module programs collide; version skew between artifacts goes undetected.
+- **Runtime `require` of shared files at run time** — breaks the single-file, no-dependency output contract (ADR-0); dependency-based distribution is instead the future gem linkage, chosen explicitly at build time.
 
 ## Consequences
 
-- Positive: float-free WASI programs shrank (hello: 430 → 160 lines);
-  generated files coexist in one process; WASI syscalls are bundled by
-  import name, so unimplemented ones cost a stub lambda, not code; the
-  bundler and the unit convention are language-agnostic and ready for
-  `runtime/bash/units/`.
-- Negative: 118 small files instead of two readable ones, and the
-  `requires:` headers are hand-maintained (residual risk: a parenless
-  bare call the lint cannot see — the harness net catches those).
-- Carry-over: gem packaging (`Alias` pointing at an installed runtime,
-  version compatibility checking) is a future ADR once a second consumer
-  of the shared linkage exists.
+- Positive: float-free WASI programs shrank (hello: 430 → 160 lines); generated files coexist in one process; WASI syscalls are bundled by import name, so unimplemented ones cost a stub lambda, not code; the bundler and the unit convention are language-agnostic and ready for `runtime/bash/units/`.
+- Negative: 118 small files instead of two readable ones, and the `requires:` headers are hand-maintained (residual risk: a parenless bare call the lint cannot see — the harness net catches those).
+- Carry-over: gem packaging (`Alias` pointing at an installed runtime, version compatibility checking) is a future ADR once a second consumer of the shared linkage exists.
 
 ## Relationship to other ADRs
 

--- a/docs/adr/7-import-providers.md
+++ b/docs/adr/7-import-providers.md
@@ -1,86 +1,35 @@
 # ADR-7 — Import Providers and the Default WASI Fallback
 
-Status: **Accepted, 2026-07-23.** Implemented for Ruby: the provider
-protocol and resolution order in generated `initialize`
-(`crates/dewasm-backend-ruby/src/lib.rs`), `Rt.resolve_import`
-(`runtime/ruby/units/rt/resolve_import.rb`), and `Rt::WASI` implementing
-the protocol itself (`runtime/ruby/units/wasi/_class.rb`). Generalized to
-non-function imports and to generated classes implementing the protocol
-themselves by [ADR-16](16-ruby-wasm1-completion.md).
+Status: **Accepted, 2026-07-23.** Implemented for Ruby: the provider protocol and resolution order in generated `initialize` (`crates/dewasm-backend-ruby/src/lib.rs`), `Rt.resolve_import` (`runtime/ruby/units/rt/resolve_import.rb`), and `Rt::WASI` implementing the protocol itself (`runtime/ruby/units/wasi/_class.rb`). Generalized to non-function imports and to generated classes implementing the protocol themselves by [ADR-16](16-ruby-wasm1-completion.md).
 
 ## Context
 
-Imports could only be supplied as a Hash of per-function callables, which
-made a whole-runtime replacement impractical: a WASI implementation is
-coupled to the guest memory, but the memory exists only after `new`
-returns while imports must go *into* `new` — the classic instantiation
-circularity. Library mode also refused to instantiate WASI-importing
-modules at all unless the embedder hand-implemented preview 1.
+Imports could only be supplied as a Hash of per-function callables, which made a whole-runtime replacement impractical: a WASI implementation is coupled to the guest memory, but the memory exists only after `new` returns while imports must go *into* `new` — the classic instantiation circularity. Library mode also refused to instantiate WASI-importing modules at all unless the embedder hand-implemented preview 1.
 
 Survey of how real systems break the circularity:
 
-- **Node.js `node:wasi`**: a WASI object yields the import object;
-  `wasi.start(instance)` binds the exported memory before execution — a
-  provider with a bind step.
-- **wasm2c / w2c2** (source translators): every embedder-implemented
-  import receives the module instance as its first argument
-  (`u32 w2c_host_fill_buf(w2c_host* instance, ...)`) — per-call context.
-- **wasmtime / wazero / Chicory**: host functions receive a per-call
-  context (Caller / api.Module / Instance) and fetch memory from it.
+- **Node.js `node:wasi`**: a WASI object yields the import object; `wasi.start(instance)` binds the exported memory before execution — a provider with a bind step.
+- **wasm2c / w2c2** (source translators): every embedder-implemented import receives the module instance as its first argument (`u32 w2c_host_fill_buf(w2c_host* instance, ...)`) — per-call context.
+- **wasmtime / wazero / Chicory**: host functions receive a per-call context (Caller / api.Module / Instance) and fetch memory from it.
 
 ## Decision
 
-- **Provider protocol.** A value in the imports table is either a Hash
-  (name → callable, unchanged) or a *provider*: an object with
-  `import(name) → callable | nil` and optionally `attach(instance)`.
-  Generated `initialize` calls `attach` once the instance is fully
-  constructed, before the start function (and thus before any wasm code
-  can invoke an import). Passing the *instance* rather than just the
-  memory is Node's bind step generalized to cover wasm2c's power
-  (providers can reach exports too).
-- **Resolution order per imported function**: explicit entry from the
-  embedder → bundled WASI (for `wasi_snapshot_preview1`, when enabled) →
-  ENOSYS stub for syscalls dewasmify has not implemented; non-WASI
-  imports remain mandatory (`Rt::LinkError`, as is a present import of
-  the wrong kind).
-- **The bundled WASI is constructed only when needed**: the first
-  fallback resolution runs `@wasi ||= Rt::WASI.new(args:, env:)`. If the
-  embedder covers every WASI import, no instance is created and its side
-  effects (stdio `binmode`) never happen. Unimplemented syscalls resolve
-  to stubs at generation time, so they cannot trigger construction.
-- `Rt::WASI` implements the provider protocol itself, so a custom WASI
-  runtime is two methods away from a wholesale swap, and the standalone
-  main collapses to `Klass.new({}, args:, env:)` + `invoke("_start")`.
-- `--no-default-wasi` (library mode only) disables the fallback for
-  embedders that want zero ambient authority; `proc_exit` in library
-  mode surfaces as `Klass::Rt::Exit` for the embedder to rescue.
+- **Provider protocol.** A value in the imports table is either a Hash (name → callable, unchanged) or a *provider*: an object with `import(name) → callable | nil` and optionally `attach(instance)`. Generated `initialize` calls `attach` once the instance is fully constructed, before the start function (and thus before any wasm code can invoke an import). Passing the *instance* rather than just the memory is Node's bind step generalized to cover wasm2c's power (providers can reach exports too).
+- **Resolution order per imported function**: explicit entry from the embedder → bundled WASI (for `wasi_snapshot_preview1`, when enabled) → ENOSYS stub for syscalls dewasmify has not implemented; non-WASI imports remain mandatory (`Rt::LinkError`, as is a present import of the wrong kind).
+- **The bundled WASI is constructed only when needed**: the first fallback resolution runs `@wasi ||= Rt::WASI.new(args:, env:)`. If the embedder covers every WASI import, no instance is created and its side effects (stdio `binmode`) never happen. Unimplemented syscalls resolve to stubs at generation time, so they cannot trigger construction.
+- `Rt::WASI` implements the provider protocol itself, so a custom WASI runtime is two methods away from a wholesale swap, and the standalone main collapses to `Klass.new({}, args:, env:)` + `invoke("_start")`.
+- `--no-default-wasi` (library mode only) disables the fallback for embedders that want zero ambient authority; `proc_exit` in library mode surfaces as `Klass::Rt::Exit` for the embedder to rescue.
 
 ## Rejected alternatives
 
-- **Per-call context argument on every import callable** (wasm2c style) —
-  taxes the common case (plain lambdas, the spectest harness) with a
-  changed signature; Ruby closures plus `attach` reach the same power.
-- **Strict imports only (status quo)** — makes WASI-importing modules
-  unusable as libraries in practice.
-- **Memory-name binding only** (Node's `start` looks up `exports.memory`)
-  — `attach(instance)` is a superset and needs no export-name contract.
-- **Unconditional eager construction of the bundled WASI** — pays the
-  `binmode` side effect and an object even when the embedder provided
-  everything.
-- **Deferring construction to the first syscall invocation** — extra
-  lambda indirection for little gain over construction-time laziness
-  (user call).
+- **Per-call context argument on every import callable** (wasm2c style) — taxes the common case (plain lambdas, the spectest harness) with a changed signature; Ruby closures plus `attach` reach the same power.
+- **Strict imports only (status quo)** — makes WASI-importing modules unusable as libraries in practice.
+- **Memory-name binding only** (Node's `start` looks up `exports.memory`) — `attach(instance)` is a superset and needs no export-name contract.
+- **Unconditional eager construction of the bundled WASI** — pays the `binmode` side effect and an object even when the embedder provided everything.
+- **Deferring construction to the first syscall invocation** — extra lambda indirection for little gain over construction-time laziness (user call).
 
 ## Consequences
 
-- Positive: `Hello.new` works out of the box for WASI programs in
-  library mode; custom runtimes swap in wholesale; spec harness needed no
-  changes (Hash path untouched).
-- Negative / caveat: with minimal Embedded bundles, `instance.memory`
-  only carries the typed accessors the module itself uses; the stable
-  surface a provider may rely on is `memory.bytes` (a mutable binary
-  String). A fuller guaranteed API is a carry-over for the shared/gem
-  linkage (ADR-6).
-- The provider protocol is intentionally not WASI-specific: any import
-  namespace (e.g. an emscripten-style `env`) can be served by a provider
-  with instance access.
+- Positive: `Hello.new` works out of the box for WASI programs in library mode; custom runtimes swap in wholesale; spec harness needed no changes (Hash path untouched).
+- Negative / caveat: with minimal Embedded bundles, `instance.memory` only carries the typed accessors the module itself uses; the stable surface a provider may rely on is `memory.bytes` (a mutable binary String). A fuller guaranteed API is a carry-over for the shared/gem linkage (ADR-6).
+- The provider protocol is intentionally not WASI-specific: any import namespace (e.g. an emscripten-style `env`) can be served by a provider with instance access.

--- a/docs/adr/8-latest-testsuite-support-matrix.md
+++ b/docs/adr/8-latest-testsuite-support-matrix.md
@@ -1,70 +1,27 @@
 # ADR-8 — Track the Latest Testsuite; Attribute Skips to a Support Matrix
 
-Status: **Accepted, 2026-07-23.** Implemented: `Feature` +
-`UnsupportedError` (`crates/dewasm-core/src/feature.rs`), attribution
-in the harness (`crates/dewasm-test-helper/src/spec.rs`, now running every
-top-level `.wast`), and the generated matrix (`docs/support.md`, gated by
-the `support_docs` test). Revises ADR-3's skip policy.
+Status: **Accepted, 2026-07-23.** Implemented: `Feature` + `UnsupportedError` (`crates/dewasm-core/src/feature.rs`), attribution in the harness (`crates/dewasm-test-helper/src/spec.rs`, now running every top-level `.wast`), and the generated matrix (`docs/support.md`, gated by the `support_docs` test). Revises ADR-3's skip policy.
 
 ## Context
 
-The upstream testsuite tracks the latest spec (Wasm 3.0), while
-dewasmify's first-release scope is Wasm 1.0 plus a few extensions.
-Curated file lists plus bare skip counts made the numbers meaningless:
-894 skips mixed "declared out of scope" with "whatever else", a curated
-list silently excluded 200 files, and any real breakage could hide inside
-a skip. Pinning an old testsuite was considered and rejected by the user
-— upgrades would pile up into one big bang — and no historical snapshot
-matches our scope anyway (`wg-1.0` uses directives the modern wast crate
-cannot parse and lacks the extensions; bulk memory merged into the spec
-together with reference types, so a "bulk without reftypes" suite never
-existed).
+The upstream testsuite tracks the latest spec (Wasm 3.0), while dewasmify's first-release scope is Wasm 1.0 plus a few extensions. Curated file lists plus bare skip counts made the numbers meaningless: 894 skips mixed "declared out of scope" with "whatever else", a curated list silently excluded 200 files, and any real breakage could hide inside a skip. Pinning an old testsuite was considered and rejected by the user — upgrades would pile up into one big bang — and no historical snapshot matches our scope anyway (`wg-1.0` uses directives the modern wast crate cannot parse and lacks the extensions; bulk memory merged into the spec together with reference types, so a "bulk without reftypes" suite never existed).
 
 ## Decision
 
-- **The testsuite submodule tracks upstream latest**; updating it is a
-  routine, deliberate commit, not a migration.
-- **Every conversion refusal is attributed.** The converter's rejections
-  carry an `UnsupportedError` naming `Feature`s (typed bails in IR
-  building; for validation failures, a probe re-validates with known
-  proposals' feature bits and keeps the minimal set that makes the module
-  valid). Wasm 1.0 gaps (imported globals/memories/tables, multiple
-  tables, bulk table ops) are Features too — declared debt, not silence.
-- **The harness only tolerates attributable skips.** Criterion: *a skip
-  must be a consequence of a declaration; an unattributable failure is a
-  regression.* Unattributed conversion errors fail the suite. Assertion-
-  level known failures live in an expected-failures ledger, each entry
-  attributed (currently all `linking`). Validation failures beyond every
-  proposal this toolchain knows are reported as `unknown-proposal` but
-  tolerated — the converter refused cleanly, which is ADR-0's contract.
-- **Backends declare their support** (`Backend::feature_status`,
-  `baseline`). Flipping a feature to `Supported` makes its remaining
-  skips hard failures until the tests actually pass — the declaration and
-  the tests cannot drift apart.
-- **`docs/support.md` is generated from those declarations** (features ×
-  backends, plus the WASI preview 1 table derived from the runtime
-  units), gated by a golden-file test; regenerate with
-  `DEWASM_UPDATE_DOCS=1 cargo test -p dewasm-cli --test support_docs`.
+- **The testsuite submodule tracks upstream latest**; updating it is a routine, deliberate commit, not a migration.
+- **Every conversion refusal is attributed.** The converter's rejections carry an `UnsupportedError` naming `Feature`s (typed bails in IR building; for validation failures, a probe re-validates with known proposals' feature bits and keeps the minimal set that makes the module valid). Wasm 1.0 gaps (imported globals/memories/tables, multiple tables, bulk table ops) are Features too — declared debt, not silence.
+- **The harness only tolerates attributable skips.** Criterion: *a skip must be a consequence of a declaration; an unattributable failure is a regression.* Unattributed conversion errors fail the suite. Assertion- level known failures live in an expected-failures ledger, each entry attributed (currently all `linking`). Validation failures beyond every proposal this toolchain knows are reported as `unknown-proposal` but tolerated — the converter refused cleanly, which is ADR-0's contract.
+- **Backends declare their support** (`Backend::feature_status`, `baseline`). Flipping a feature to `Supported` makes its remaining skips hard failures until the tests actually pass — the declaration and the tests cannot drift apart.
+- **`docs/support.md` is generated from those declarations** (features × backends, plus the WASI preview 1 table derived from the runtime units), gated by a golden-file test; regenerate with `DEWASM_UPDATE_DOCS=1 cargo test -p dewasm-cli --test support_docs`.
 
 ## Rejected alternatives
 
-- **Pinning an old testsuite commit** — see Context; also loses upstream
-  assertion fixes and turns every update into an event.
-- **Curated file lists** — drift, and unknown breakage hides in the
-  excluded set; running everything with attribution costs ~14 s.
-- **Bare expected-failure/skip counts** — numbers without meaning rot;
-  attribution is what makes an update reviewable ("simd +120" vs. "??").
+- **Pinning an old testsuite commit** — see Context; also loses upstream assertion fixes and turns every update into an event.
+- **Curated file lists** — drift, and unknown breakage hides in the excluded set; running everything with attribution costs ~14 s.
+- **Bare expected-failure/skip counts** — numbers without meaning rot; attribution is what makes an update reviewable ("simd +120" vs. "??").
 
 ## Consequences
 
-- Positive: the whole 257-file suite runs (pass 19,446 → 24,338 just
-  from previously-excluded files); `fail=23` are all linking-attributed;
-  all 33k skips carry a feature id; the roadmap is literally the
-  `unsupported:` table sorted by count.
-- Negative / caveats: `names.wast` is rejected wholesale by the wast
-  crate's confusing-unicode policy (counted `unknown-proposal`);
-  attribution of *validation* failures depends on wasmparser knowing the
-  proposal, so a brand-new proposal reports as `unknown-proposal` until
-  the toolchain updates.
-- ADR-3 remains the testing strategy; its "curated FILES + skip"
-  mechanics are superseded by this ADR.
+- Positive: the whole 257-file suite runs (pass 19,446 → 24,338 just from previously-excluded files); `fail=23` are all linking-attributed; all 33k skips carry a feature id; the roadmap is literally the `unsupported:` table sorted by count.
+- Negative / caveats: `names.wast` is rejected wholesale by the wast crate's confusing-unicode policy (counted `unknown-proposal`); attribution of *validation* failures depends on wasmparser knowing the proposal, so a brand-new proposal reports as `unknown-proposal` until the toolchain updates.
+- ADR-3 remains the testing strategy; its "curated FILES + skip" mechanics are superseded by this ADR.

--- a/docs/adr/9-example-apps-from-registry.md
+++ b/docs/adr/9-example-apps-from-registry.md
@@ -1,75 +1,24 @@
 # ADR-9 — Example Apps Fetched from Upstream, Never Committed
 
-Status: **Accepted, 2026-07-23.** Implemented: `examples/apps/fetch.sh`
-(version-pinned, sha256-verified downloads into the gitignored
-`examples/apps/cache/`) and the `apps` cases of the `e2e` test
-(`crates/dewasm-test-helper/src/apps.rs`) comparing converted output
-against a golden reference (originally a live `wasmtime` diff; ADR-15
-replaced that with golden files checked into `examples/apps/golden/`,
-dropping the `wasmtime` dependency — the fetch/pin/checksum decision
-below is unaffected). Initial apps: cowsay and QuickJS, both from the
-Wasmer registry; QuickJS later moved to quickjs-ng's own GitHub release
-(a standalone WASI CLI asset) once that became available upstream —
-the decision below was never registry-specific, only per-app source
-diversity was added.
+Status: **Accepted, 2026-07-23.** Implemented: `examples/apps/fetch.sh` (version-pinned, sha256-verified downloads into the gitignored `examples/apps/cache/`) and the `apps` cases of the `e2e` test (`crates/dewasm-test-helper/src/apps.rs`) comparing converted output against a golden reference (originally a live `wasmtime` diff; ADR-15 replaced that with golden files checked into `examples/apps/golden/`, dropping the `wasmtime` dependency — the fetch/pin/checksum decision below is unaffected). Initial apps: cowsay and QuickJS, both from the Wasmer registry; QuickJS later moved to quickjs-ng's own GitHub release (a standalone WASI CLI asset) once that became available upstream — the decision below was never registry-specific, only per-app source diversity was added.
 
 ## Context
 
-Real applications (cowsay, a JavaScript engine) are the most convincing
-demos and the best end-to-end regression tests beyond the spec suite.
-But committing third-party wasm binaries into this repository means
-*redistributing* them — a licensing question per app (the registry often
-carries no license metadata at all) plus permanent repository bloat.
+Real applications (cowsay, a JavaScript engine) are the most convincing demos and the best end-to-end regression tests beyond the spec suite. But committing third-party wasm binaries into this repository means *redistributing* them — a licensing question per app (the registry often carries no license metadata at all) plus permanent repository bloat.
 
 ## Decision
 
-Third-party artifacts are **never committed**. `examples/apps/fetch.sh`
-downloads each app from **its own upstream** — a registry CDN (Wasmer)
-or a project's own release asset (quickjs-ng's GitHub releases), whichever
-actually publishes a standalone WASI binary for it — at **pinned versions
-with sha256 verification**, into a gitignored cache, and documents each
-app's upstream in `examples/apps/README.md`. Criterion: *distribution
-stays upstream's; the repository holds only references (URL + hash),
-which raise no license questions and keep the supply chain auditable* —
-this criterion never named a specific registry, so per-app source
-diversity (fetch.sh's data shape supports both a tarball-with-inner-path
-and a bare `.wasm` release asset) is a refinement, not a reversal. Not
-every upstream qualifies: sqlite.org's own "WebAssembly" download is an
-Emscripten browser/Node.js bundle, not something `wasmtime run` can
-execute, so sqlite stays on the Wasmer registry build. Per ADR-15, the
-e2e test *fails* rather than skips when the cache is absent — `cargo
-test` itself stays hermetic (no network access during a normal run),
-but reaching that state requires the one-time, explicit `fetch.sh` step
-first.
+Third-party artifacts are **never committed**. `examples/apps/fetch.sh` downloads each app from **its own upstream** — a registry CDN (Wasmer) or a project's own release asset (quickjs-ng's GitHub releases), whichever actually publishes a standalone WASI binary for it — at **pinned versions with sha256 verification**, into a gitignored cache, and documents each app's upstream in `examples/apps/README.md`. Criterion: *distribution stays upstream's; the repository holds only references (URL + hash), which raise no license questions and keep the supply chain auditable* — this criterion never named a specific registry, so per-app source diversity (fetch.sh's data shape supports both a tarball-with-inner-path and a bare `.wasm` release asset) is a refinement, not a reversal. Not every upstream qualifies: sqlite.org's own "WebAssembly" download is an Emscripten browser/Node.js bundle, not something `wasmtime run` can execute, so sqlite stays on the Wasmer registry build. Per ADR-15, the e2e test *fails* rather than skips when the cache is absent — `cargo test` itself stays hermetic (no network access during a normal run), but reaching that state requires the one-time, explicit `fetch.sh` step first.
 
-App selection is constrained by the declared WASI surface
-(docs/support.md) — originally stdio/args/environ/clock/random only;
-WASI filesystem support (ADR-14) later widened this for Ruby. `wasi_unstable`
-(snapshot 0) is accepted as an alias of preview 1 for the implemented
-functions — the original Wasmer-registry QuickJS build (since replaced)
-needed it (known simplification: snapshot 0's fd_seek whence encoding
-differs; none of the current apps seek).
+App selection is constrained by the declared WASI surface (docs/support.md) — originally stdio/args/environ/clock/random only; WASI filesystem support (ADR-14) later widened this for Ruby. `wasi_unstable` (snapshot 0) is accepted as an alias of preview 1 for the implemented functions — the original Wasmer-registry QuickJS build (since replaced) needed it (known simplification: snapshot 0's fd_seek whence encoding differs; none of the current apps seek).
 
 ## Rejected alternatives
 
-- **Committing the wasm binaries** — redistribution licensing per app,
-  registry packages often lack license metadata, and megabytes of
-  history bloat.
-- **Building from crates.io sources at test time** — works for Rust
-  apps but demands local toolchains (wasi-sdk for C apps like QuickJS)
-  and long builds; the registry serves exactly the prebuilt artifact
-  users would run (user's call).
+- **Committing the wasm binaries** — redistribution licensing per app, registry packages often lack license metadata, and megabytes of history bloat.
+- **Building from crates.io sources at test time** — works for Rust apps but demands local toolchains (wasi-sdk for C apps like QuickJS) and long builds; the registry serves exactly the prebuilt artifact users would run (user's call).
 
 ## Consequences
 
-- Positive: QuickJS — a complete C-built JS engine — converts to a
-  ~25 MB Ruby file and produces wasmtime-identical output in about a
-  second; the demo story ("a JS engine on plain Ruby") costs one script
-  run.
-- Negative: the `apps` cases fail (per ADR-15) rather than passing
-  vacuously in a fresh clone until the explicit `fetch.sh` step runs;
-  CI needs that step (or a cached fetch job) before `cargo test` is
-  green. Upstream availability is a fetch-time dependency, mitigated by
-  pinning and checksums.
-- Adding an app = one line in `fetch.sh` + a case in
-  `crates/dewasm-test-helper/src/apps.rs` + a row in the README table.
+- Positive: QuickJS — a complete C-built JS engine — converts to a ~25 MB Ruby file and produces wasmtime-identical output in about a second; the demo story ("a JS engine on plain Ruby") costs one script run.
+- Negative: the `apps` cases fail (per ADR-15) rather than passing vacuously in a fresh clone until the explicit `fetch.sh` step runs; CI needs that step (or a cached fetch job) before `cargo test` is green. Upstream availability is a fetch-time dependency, mitigated by pinning and checksums.
+- Adding an app = one line in `fetch.sh` + a case in `crates/dewasm-test-helper/src/apps.rs` + a row in the README table.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,21 +1,13 @@
 # Architecture Decision Records
 
-This directory contains the Architecture Decision Records (ADRs) for
-dewasm. Each document captures a significant design decision: its
-context, the decision with its rationale, the rejected alternatives, and
-the consequences.
+This directory contains the Architecture Decision Records (ADRs) for dewasm. Each document captures a significant design decision: its context, the decision with its rationale, the rejected alternatives, and the consequences.
 
 ## How to read
 
-- **ADR-0** is the foundation document — start there for the project's
-  goal, scope, and architecture.
+- **ADR-0** is the foundation document — start there for the project's goal, scope, and architecture.
 - Higher-numbered ADRs build on it and can be read as needed.
-- Each ADR opens with a **Status** paragraph: `Accepted`, `Proposed`, or
-  `Superseded`, with a date and a one-paragraph "what landed / what
-  remains" summary. Accepted ADRs whose implementation is still pending
-  carry a parenthetical note (e.g. *not yet implemented*).
-- ADR-0 through ADR-5 were backfilled on 2026-07-23 from decisions made
-  during initial planning and implementation.
+- Each ADR opens with a **Status** paragraph: `Accepted`, `Proposed`, or `Superseded`, with a date and a one-paragraph "what landed / what remains" summary. Accepted ADRs whose implementation is still pending carry a parenthetical note (e.g. *not yet implemented*).
+- ADR-0 through ADR-5 were backfilled on 2026-07-23 from decisions made during initial planning and implementation.
 
 ## Index
 
@@ -77,38 +69,21 @@ the consequences.
 When a decision with real alternatives is made:
 
 1. Take the next free number and create `docs/adr/<N>-<slug>.md`.
-2. Follow the structural contract: an opening **Status** paragraph
-   (state, date, what landed / what remains), then **Context**,
-   **Decision**, **Rejected alternatives**, **Consequences**.
+2. Follow the structural contract: an opening **Status** paragraph (state, date, what landed / what remains), then **Context**, **Decision**, **Rejected alternatives**, **Consequences**.
 3. Add a row to the index table above, in ascending order.
-4. Cross-reference: link related ADRs, and cite the ADR from `AGENTS.md`
-   or code comments where the rule is enforced.
+4. Cross-reference: link related ADRs, and cite the ADR from `AGENTS.md` or code comments where the rule is enforced.
 
 Quality bar:
 
-- An ADR records a **decision with rationale and rejected alternatives**,
-  or a standing policy. State the *criterion* that discriminated between
-  the options as a reusable rule, not just "we picked B".
-- A mechanical change with no live alternatives does not need an ADR —
-  the commit message is enough.
-- **Length tracks stakes.** The common failure mode is writing too much,
-  not too little. Move research material (surveys, comparison tables)
-  out of the ADR and cite it; keep the ADR the decision, not the
-  research.
-- Anchor claims to real code (`crates/.../file.rs`, `runtime/<lang>/`)
-  where possible.
-- The spec testsuite binds behaviour (ADR-3); an ADR records *why*, never
-  a normative description that the harness already enforces.
+- An ADR records a **decision with rationale and rejected alternatives**, or a standing policy. State the *criterion* that discriminated between the options as a reusable rule, not just "we picked B".
+- A mechanical change with no live alternatives does not need an ADR — the commit message is enough.
+- **Length tracks stakes.** The common failure mode is writing too much, not too little. Move research material (surveys, comparison tables) out of the ADR and cite it; keep the ADR the decision, not the research.
+- Anchor claims to real code (`crates/.../file.rs`, `runtime/<lang>/`) where possible.
+- The spec testsuite binds behaviour (ADR-3); an ADR records *why*, never a normative description that the harness already enforces.
 
 ## Relationship to other documents
 
-- **`AGENTS.md`** — the development contract for agents (and humans)
-  working in this repository; cites ADRs where a rule needs its why.
-- **`README.md`** — user-facing overview; links here for design
-  rationale.
-- **`docs/getting-started.md`** and **`docs/backends/`** — the user tutorial
-  and per-target reference; they link to the lowering ADRs (4/11–13/28/29/30)
-  for design rationale rather than restating it.
-- **`docs/docs-policy.md`** — the doc taxonomy (which file each kind of
-  content belongs in, and why `docs/support.md` is generated, never
-  hand-edited).
+- **`AGENTS.md`** — the development contract for agents (and humans) working in this repository; cites ADRs where a rule needs its why.
+- **`README.md`** — user-facing overview; links here for design rationale.
+- **`docs/getting-started.md`** and **`docs/backends/`** — the user tutorial and per-target reference; they link to the lowering ADRs (4/11–13/28/29/30) for design rationale rather than restating it.
+- **`docs/docs-policy.md`** — the doc taxonomy (which file each kind of content belongs in, and why `docs/support.md` is generated, never hand-edited).

--- a/docs/apps-audit.md
+++ b/docs/apps-audit.md
@@ -6,11 +6,7 @@ The ADR-24 gate: before an app binary becomes a conversion target, run
 cargo run -p dewasm-core --bin feature-audit -- examples/apps/cache/*.wasm
 ```
 
-and record the verdict here. An app that needs a proposal outside the 0.1
-scope (wasm 1.0 + the universal baseline: sign extension, saturating
-float-to-int, multi-value, bulk memory, mutable globals) is **deferred**,
-not worked around; the entry stays here so it is revisited if the feature
-returns.
+and record the verdict here. An app that needs a proposal outside the 0.1 scope (wasm 1.0 + the universal baseline: sign extension, saturating float-to-int, multi-value, bulk memory, mutable globals) is **deferred**, not worked around; the entry stays here so it is revisited if the feature returns.
 
 ## Verdicts (audited 2026-07-26)
 
@@ -29,290 +25,74 @@ returns.
 | libpcap 1.10.6 (BPF filter compiler) | pinned-source zig reactor build in `fetch.sh` | none (baseline after ADR-39 wasm-opt)¹¹ | ✅ in scope (shipping, C-API on Ruby + Python + Go⁸) |
 | tree-sitter 0.26.11 + tree-sitter-json 0.24.8 | pinned-source zig reactor build in `fetch.sh` | none (baseline after ADR-39 wasm-opt)¹¹ | ✅ in scope (shipping, C-API on Ruby + Python + Go¹⁰) |
 
-¹ **Reference-types encoding tolerance.** LLVM-based toolchains
-(clang/wasi-sdk, zig, rustc) emit `call_indirect` type/table-index
-immediates as padded, overlong LEBs when the `reference-types` target
-feature is enabled — the default since LLVM 19. Such binaries *validate*
-only with the reference-types feature bit even though they use **no
-construct** from the proposal (the audit tool verifies this and prints
-"encoding only"). The converter therefore keeps the validator bit enabled
-as a pure encoding relaxation while rejecting every actual
-reference-types construct at conversion time. Real-world wasip1 binaries
-would otherwise be uniformly rejected, which would defeat the project.
+¹ **Reference-types encoding tolerance.** LLVM-based toolchains (clang/wasi-sdk, zig, rustc) emit `call_indirect` type/table-index immediates as padded, overlong LEBs when the `reference-types` target feature is enabled — the default since LLVM 19. Such binaries *validate* only with the reference-types feature bit even though they use **no construct** from the proposal (the audit tool verifies this and prints "encoding only"). The converter therefore keeps the validator bit enabled as a pure encoding relaxation while rejecting every actual reference-types construct at conversion time. Real-world wasip1 binaries would otherwise be uniformly rejected, which would defeat the project.
 
-² Apps we compile ourselves get their feature surface from our own build
-flags; run the audit on the built artifact before wiring its e2e case.
+² Apps we compile ourselves get their feature surface from our own build flags; run the audit on the built artifact before wiring its e2e case.
 
-³ **QuickJS deepened (Phase 5a).** Beyond the one-shot `-e` eval case, two
-e2e cases now exercise real WASI filesystem use against a preopened scratch
-dir, both byte-identical to `wasmtime --dir`. Originally Ruby-only (ADR-14);
-Python (`qjs_file_io_python`, `qjs_repl_python`, ADR-28), Go
-(`qjs_file_io_go`, `qjs_repl_go`, ADR-29's third milestone), and Java
-(`qjs_file_io_java`, `qjs_repl_java`, ADR-30's third milestone, all adopting
-ADR-14's fs model) now mirror both against the same fixtures and goldens,
-gated behind the `slow_test` cargo feature in each crate (`#[ignore]`d
-otherwise; run with `--features slow_test` or `-- --include-ignored`):
+³ **QuickJS deepened (Phase 5a).** Beyond the one-shot `-e` eval case, two e2e cases now exercise real WASI filesystem use against a preopened scratch dir, both byte-identical to `wasmtime --dir`. Originally Ruby-only (ADR-14); Python (`qjs_file_io_python`, `qjs_repl_python`, ADR-28), Go (`qjs_file_io_go`, `qjs_repl_go`, ADR-29's third milestone), and Java (`qjs_file_io_java`, `qjs_repl_java`, ADR-30's third milestone, all adopting ADR-14's fs model) now mirror both against the same fixtures and goldens, gated behind the `slow_test` cargo feature in each crate (`#[ignore]`d otherwise; run with `--features slow_test` or `-- --include-ignored`):
 
-- *File I/O* (`qjs_file_io_ruby`): the `qjs:std` module writes a file,
-  reads it back, and prints it; the test asserts the guest stdout golden
-  **and** the host-side file content. Fixture:
-  `examples/apps/fixtures/qjs_file_io.js`.
-- *REPL* (`qjs_repl_ruby`): **ground-truth finding — QuickJS's built-in
-  interactive REPL is not byte-stable over a pipe.** Under `wasmtime`, piping a
-  scripted session (`1+2\n\q`) into bare `qjs` or `qjs -i` drives a
-  terminal line editor: it emits ANSI escape sequences (cursor moves,
-  syntax-highlight colors), mis-parses `1+2\q` as one line, and never
-  terminates on stdin EOF over a pipe (it hangs until a timeout). A
-  scripted read-eval-print *fixture*
-  (`examples/apps/fixtures/qjs_repl.js`) reading lines from `std.in` and
-  printing `std.evalScript` results exercises the same stdin-read + eval
-  path minus the tty-only line editor, and needs nothing beyond `fd_read`
-  and the ADR-14 filesystem stack.
+- *File I/O* (`qjs_file_io_ruby`): the `qjs:std` module writes a file, reads it back, and prints it; the test asserts the guest stdout golden **and** the host-side file content. Fixture: `examples/apps/fixtures/qjs_file_io.js`.
+- *REPL* (`qjs_repl_ruby`): **ground-truth finding — QuickJS's built-in interactive REPL is not byte-stable over a pipe.** Under `wasmtime`, piping a scripted session (`1+2\n\q`) into bare `qjs` or `qjs -i` drives a terminal line editor: it emits ANSI escape sequences (cursor moves, syntax-highlight colors), mis-parses `1+2\q` as one line, and never terminates on stdin EOF over a pipe (it hangs until a timeout). A scripted read-eval-print *fixture* (`examples/apps/fixtures/qjs_repl.js`) reading lines from `std.in` and printing `std.evalScript` results exercises the same stdin-read + eval path minus the tty-only line editor, and needs nothing beyond `fd_read` and the ADR-14 filesystem stack.
 
-  The *interactive* REPL (bare `qjs`, its actual line editor) is a
-  separate matter: after each prompt it blocks in `poll_oneoff` on an
-  fd_read subscription over stdin, so with `poll_oneoff` resolving to
-  ENOSYS the event loop collapsed and the program exited immediately —
-  the fixture above was a workaround, not the end state. `poll_oneoff` is
-  now implemented (ADR-14 revision; Ruby/Python/Go/Java, Bash deferred),
-  and over a pipe the converted REPL now blocks on stdin, reads input, and
-  evaluates it (the line editor still echoes ANSI escapes over a pipe, as
-  it does under wasmtime). The interactive REPL is now verified
-  **byte-identical to wasmtime under a real pty** on all four
-  poll_oneoff backends (Ruby, Python, Go, Java): the `qjs_repl_pty` case
-  (`qjs_repl_pty_e2e!`, gated on the `slow_test` feature) converts bare qjs to a
-  standalone program, drives the scripted session
-  `1+2⏎[3,1,2].sort()⏎Math.max(4,9)⏎\q⏎` under an 80x24 pty
-  (`crates/dewasm-test-helper/src/pty.rs`, `portable-pty`), and compares the
-  transcript — ANSI escapes and all — to
-  `examples/apps/golden/qjs_repl_interactive.transcript` (2089 bytes, captured
-  from wasmtime and re-checked by the `wasmtime_test`-gated
-  `qjs_repl_interactive_golden` freshness test). Getting Ruby and Python
-  green required one fix: their `fd_read` used a buffered read that blocks
-  until the full requested length or EOF, which deadlocks a line-buffered tty
-  that never sends EOF — stdin now uses a short read (`IO#readpartial` /
-  `os.read`), the WASI semantics wasmtime already follows.
+The *interactive* REPL (bare `qjs`, its actual line editor) is a separate matter: after each prompt it blocks in `poll_oneoff` on an fd_read subscription over stdin, so with `poll_oneoff` resolving to ENOSYS the event loop collapsed and the program exited immediately — the fixture above was a workaround, not the end state. `poll_oneoff` is now implemented (ADR-14 revision; Ruby/Python/Go/Java, Bash deferred), and over a pipe the converted REPL now blocks on stdin, reads input, and evaluates it (the line editor still echoes ANSI escapes over a pipe, as it does under wasmtime). The interactive REPL is now verified **byte-identical to wasmtime under a real pty** on all four poll_oneoff backends (Ruby, Python, Go, Java): the `qjs_repl_pty` case (`qjs_repl_pty_e2e!`, gated on the `slow_test` feature) converts bare qjs to a standalone program, drives the scripted session `1+2⏎[3,1,2].sort()⏎Math.max(4,9)⏎\q⏎` under an 80x24 pty (`crates/dewasm-test-helper/src/pty.rs`, `portable-pty`), and compares the transcript — ANSI escapes and all — to `examples/apps/golden/qjs_repl_interactive.transcript` (2089 bytes, captured from wasmtime and re-checked by the `wasmtime_test`-gated `qjs_repl_interactive_golden` freshness test). Getting Ruby and Python green required one fix: their `fd_read` used a buffered read that blocks until the full requested length or EOF, which deadlocks a line-buffered tty that never sends EOF — stdin now uses a short read (`IO#readpartial` / `os.read`), the WASI semantics wasmtime already follows.
 
-⁴ **sqlite3 deepened (Phase 5a).** The pinned source now yields **three**
-artifacts (ADR-22); the DB-*file* lifecycle and a guest→host callback are
-now covered on the existing ADR-14 syscall set (no new WASI unit). The
-shell DB-file case is also mirrored under Python (`sqlite3_shell_dbfile_python`),
-Go (`sqlite3_shell_dbfile_go`), and Java (`sqlite3_shell_dbfile_java`), same
-fixture/golden, `slow_test`-feature-gated;
-the C-API/callback cases stay Ruby-only (they exercise Ruby's provider/guest-
-memory idioms, not new WASI fs):
+⁴ **sqlite3 deepened (Phase 5a).** The pinned source now yields **three** artifacts (ADR-22); the DB-*file* lifecycle and a guest→host callback are now covered on the existing ADR-14 syscall set (no new WASI unit). The shell DB-file case is also mirrored under Python (`sqlite3_shell_dbfile_python`), Go (`sqlite3_shell_dbfile_go`), and Java (`sqlite3_shell_dbfile_java`), same fixture/golden, `slow_test`-feature-gated; the C-API/callback cases stay Ruby-only (they exercise Ruby's provider/guest- memory idioms, not new WASI fs):
 
-- *Shell DB file* (`sqlite3_shell_dbfile_ruby`): one invocation creates
-  and populates `/db/test.db`, a second reopens it and SELECTs; asserts
-  the second run's stdout (golden vs. `wasmtime --dir`) and a nonzero DB
-  file on the host.
-- *Library DB file* (`sqlite3_file_c_api_ruby`): the same file
-  create/close/reopen/select through the sqlite3 C API, proving the C-API
-  path hits the same fs stack (fixed-string expectation — a C-API flow
-  `wasmtime` cannot drive).
-- *Callback binding* (`sqlite3_callback_binding_ruby`): the new
-  `sqlite3-binding.wasm` (our own `examples/apps/src/sqlite3_binding.c`)
-  exports `run_query`, which calls `sqlite3_exec` with a C callback
-  forwarding each row to an imported `env.host_row`; the Ruby side
-  provides `host_row` via the ADR-7 import-provider mechanism and collects
-  the rows (fixed-string expectation).
+- *Shell DB file* (`sqlite3_shell_dbfile_ruby`): one invocation creates and populates `/db/test.db`, a second reopens it and SELECTs; asserts the second run's stdout (golden vs. `wasmtime --dir`) and a nonzero DB file on the host.
+- *Library DB file* (`sqlite3_file_c_api_ruby`): the same file create/close/reopen/select through the sqlite3 C API, proving the C-API path hits the same fs stack (fixed-string expectation — a C-API flow `wasmtime` cannot drive).
+- *Callback binding* (`sqlite3_callback_binding_ruby`): the new `sqlite3-binding.wasm` (our own `examples/apps/src/sqlite3_binding.c`) exports `run_query`, which calls `sqlite3_exec` with a C callback forwarding each row to an imported `env.host_row`; the Ruby side provides `host_row` via the ADR-7 import-provider mechanism and collects the rows (fixed-string expectation).
 
-⁵ **CPython / CRuby executed across backends (Phase 5b; multi-backend as of
-the ADR-27 revision).** Both language-runtime binaries are converted *and run*,
-each reading its stdlib from a preopened directory (`fetch.sh` extracts the
-trees: `cache/cpython-lib/lib/python3.14`, `cache/ruby-lib/usr/local/lib/ruby`).
-They are now shared per-case consts (`CPYTHON_HELLO`, `CRUBY_HELLO`, driven by
-`cpython_hello_e2e!`/`cruby_hello_e2e!`) — the stdlib trees mount straight from
-the app cache via the case's `cache_preopens` field (never copied), and each is
-ground-truthed against `wasmtime --dir`. The
-feature audit reports both as baseline-only (in scope). No new WASI unit was
-needed: the wide import lists below include functions no backend implements
-(CPython imports `poll_oneoff`/`path_link`/`path_symlink`/`path_readlink`/
-`sock_*`; CRuby imports `fd_renumber`/`poll_oneoff`/`path_readlink`), but none
-is *called* on the interpreter boot + one-liner path, so the ADR-14 syscall set
-suffices (measured by running to success).
+⁵ **CPython / CRuby executed across backends (Phase 5b; multi-backend as of the ADR-27 revision).** Both language-runtime binaries are converted *and run*, each reading its stdlib from a preopened directory (`fetch.sh` extracts the trees: `cache/cpython-lib/lib/python3.14`, `cache/ruby-lib/usr/local/lib/ruby`). They are now shared per-case consts (`CPYTHON_HELLO`, `CRUBY_HELLO`, driven by `cpython_hello_e2e!`/`cruby_hello_e2e!`) — the stdlib trees mount straight from the app cache via the case's `cache_preopens` field (never copied), and each is ground-truthed against `wasmtime --dir`. The feature audit reports both as baseline-only (in scope). No new WASI unit was needed: the wide import lists below include functions no backend implements (CPython imports `poll_oneoff`/`path_link`/`path_symlink`/`path_readlink`/ `sock_*`; CRuby imports `fd_renumber`/`poll_oneoff`/`path_readlink`), but none is *called* on the interpreter boot + one-liner path, so the ADR-14 syscall set suffices (measured by running to success).
 
-Measured on the dev machine (Apple Silicon), convert + (compile, compiled
-backends) + run:
+Measured on the dev machine (Apple Silicon), convert + (compile, compiled backends) + run:
 
 | App | wasm | Ruby | Python | Go | Java |
 | --- | --- | --- | --- | --- | --- |
 | CPython 3.14.6 | 30 MB | ~1.4 s + ~12 s ✅ | ~6 s + ~31 s ✅ | ~1.4 s + `go build` ~84 s + ~1 s ✅ | ⛔ excluded |
 | CRuby 3.4 | 35 MB | ~2.8 s + ~60 s ✅ | ~3 s + ~107 s ✅ | ⛔ excluded | ⛔ excluded |
 
-Exclusions are measured, not guessed, and encoded (ADR-27 revision) as a backend
-simply not invoking that case's macro, the reason kept as a comment at the
-callsite:
+Exclusions are measured, not guessed, and encoded (ADR-27 revision) as a backend simply not invoking that case's macro, the reason kept as a comment at the callsite:
 
-- **Java (both):** a single generated interpreter method overflows the JVM's
-  64 KB per-method bytecode limit (`javac`: *code too large* on CPython) and,
-  on CRuby, the element-segment `Elem` class also overflows the 64 K
-  constant-pool limit (*too many constants*). Hard limits the ADR-30
-  class-splitter partitions classes — but not oversized individual methods or a
-  single huge element segment — against.
-- **Go (CRuby only):** the ~35 MB wasm's ~242 MB Go source exceeds the ADR-24
-  ~5-minute `go build` bar (measured >6 min). CPython, the smaller binary,
-  clears it (~84 s).
+- **Java (both):** a single generated interpreter method overflows the JVM's 64 KB per-method bytecode limit (`javac`: *code too large* on CPython) and, on CRuby, the element-segment `Elem` class also overflows the 64 K constant-pool limit (*too many constants*). Hard limits the ADR-30 class-splitter partitions classes — but not oversized individual methods or a single huge element segment — against.
+- **Go (CRuby only):** the ~35 MB wasm's ~242 MB Go source exceeds the ADR-24 ~5-minute `go build` bar (measured >6 min). CPython, the smaller binary, clears it (~84 s).
 
-Where included, each is comfortably under the ADR-24 ~5-minute bar, so it
-genuinely executes rather than being a conversion-only smoke. Because the
-heavy source and RSS on *every* `cargo test` is too costly for the default
-gate, both cases (like all filesystem-app cases) are gated behind the
-`slow_test` cargo feature —
-the same deliberate perf opt-out the slow `apps` cases use (ADR-15's
-documented scope: a perf gate, not a missing-environment skip). CRuby on Ruby
-is the "Ruby on Ruby" north-star demo.
+Where included, each is comfortably under the ADR-24 ~5-minute bar, so it genuinely executes rather than being a conversion-only smoke. Because the heavy source and RSS on *every* `cargo test` is too costly for the default gate, both cases (like all filesystem-app cases) are gated behind the `slow_test` cargo feature — the same deliberate perf opt-out the slow `apps` cases use (ADR-15's documented scope: a perf gate, not a missing-environment skip). CRuby on Ruby is the "Ruby on Ruby" north-star demo.
 
-⁶ **ripgrep (Phase 5b).** ripgrep 14.1.1 built from the pinned source
-release with `cargo build --release --target wasm32-wasip1` (default
-features — which already exclude pcre2; no tweaks needed). Audit: baseline only
-after the ADR-39 `wasm-opt` pass¹¹, in scope. A recursive directory search over
-the committed fixture tree (`examples/apps/fixtures/rg/`) staged into a scratch
-dir and preopened at `/work`, asserting the guest stdout is byte-identical to
-the `wasmtime --dir` golden. `--sort path` forces ripgrep's otherwise-parallel
-walk into a single deterministic order (without it the file order varies
-run-to-run). ripgrep imports `poll_oneoff`/`path_readlink` but does not call
-them on this path, so no new WASI unit was needed. Ruby (`rg_search_ruby`):
-convert ~1.4 s, run ~1.7 s. Python (`rg_search_python`), Go
-(`rg_search_go`, ADR-29), and Java (`rg_search_java`, ADR-30) now mirror it
-against the same fixture/golden, `slow_test`-feature-gated: Python ~10 s
-convert+run for the 22 MB wasm; Go convert+`go build`+run cold likewise
-dominated by the compile. Java is the class-split stress case: rg's ~7300
-functions and ~4900-entry function table overflow a single class's 65535-entry
-constant pool, so its functions are partitioned across five nested `P{k}`
-classes and the table is built in a nested `Elem` class (ADR-30), each with its
-own pool; convert ~2 s, `javac` ~10 s, run warm.
+⁶ **ripgrep (Phase 5b).** ripgrep 14.1.1 built from the pinned source release with `cargo build --release --target wasm32-wasip1` (default features — which already exclude pcre2; no tweaks needed). Audit: baseline only after the ADR-39 `wasm-opt` pass¹¹, in scope. A recursive directory search over the committed fixture tree (`examples/apps/fixtures/rg/`) staged into a scratch dir and preopened at `/work`, asserting the guest stdout is byte-identical to the `wasmtime --dir` golden. `--sort path` forces ripgrep's otherwise-parallel walk into a single deterministic order (without it the file order varies run-to-run). ripgrep imports `poll_oneoff`/`path_readlink` but does not call them on this path, so no new WASI unit was needed. Ruby (`rg_search_ruby`): convert ~1.4 s, run ~1.7 s. Python (`rg_search_python`), Go (`rg_search_go`, ADR-29), and Java (`rg_search_java`, ADR-30) now mirror it against the same fixture/golden, `slow_test`-feature-gated: Python ~10 s convert+run for the 22 MB wasm; Go convert+`go build`+run cold likewise dominated by the compile. Java is the class-split stress case: rg's ~7300 functions and ~4900-entry function table overflow a single class's 65535-entry constant pool, so its functions are partitioned across five nested `P{k}` classes and the table is built in a nested `Elem` class (ADR-30), each with its own pool; convert ~2 s, `javac` ~10 s, run warm.
 
-⁷ **minigzip / zlib (Phase 5b compression CLI).** zlib 1.3.1's `minigzip`
-built from the pinned source release with `zig cc -target wasm32-wasi` (the
-zlib translation units + `test/minigzip.c`; `-DZ_HAVE_UNISTD_H` so the
-shipped `zconf.h` declares `lseek`). Integer-only and tiny, with **binary**
-stdin/stdout — the byte-exact-stdio stress that runs under **all five**
-backends (`run_gzip_cases`, wired via `gzip_e2e!` in the Ruby, Bash,
-Python, Go, and Java crates; Go and Java — the compiled backends — prove the
-byte-stdio path is exact through compiled output too, ADR-29/ADR-30). Two cases:
-*compress*
-(stdin text → gz stdout byte-identical to the `wasmtime` golden
-`examples/apps/golden/minigzip_compress.gz`) and *round trip* (compress then
-`-d` decompress → original, self-checking). zlib's gz stream is deterministic
-here — mtime 0, OS byte 3 — so wasmtime and every backend agree byte-for-byte.
-Not marked slow: no softfloat, so Bash runs it too (compress ~0.9 s + round
-trip ~0.3 s under Bash). The binary stdin/golden cannot travel through the
-`&str`/`include_str!` `APP_CASES` path, so these live in a dedicated
-`run_gzip_cases` (bytes-capable `run_bytes`/`run_command_bytes` helpers) that
-each backend calls.
+⁷ **minigzip / zlib (Phase 5b compression CLI).** zlib 1.3.1's `minigzip` built from the pinned source release with `zig cc -target wasm32-wasi` (the zlib translation units + `test/minigzip.c`; `-DZ_HAVE_UNISTD_H` so the shipped `zconf.h` declares `lseek`). Integer-only and tiny, with **binary** stdin/stdout — the byte-exact-stdio stress that runs under **all five** backends (`run_gzip_cases`, wired via `gzip_e2e!` in the Ruby, Bash, Python, Go, and Java crates; Go and Java — the compiled backends — prove the byte-stdio path is exact through compiled output too, ADR-29/ADR-30). Two cases: *compress* (stdin text → gz stdout byte-identical to the `wasmtime` golden `examples/apps/golden/minigzip_compress.gz`) and *round trip* (compress then `-d` decompress → original, self-checking). zlib's gz stream is deterministic here — mtime 0, OS byte 3 — so wasmtime and every backend agree byte-for-byte. Not marked slow: no softfloat, so Bash runs it too (compress ~0.9 s + round trip ~0.3 s under Bash). The binary stdin/golden cannot travel through the `&str`/`include_str!` `APP_CASES` path, so these live in a dedicated `run_gzip_cases` (bytes-capable `run_bytes`/`run_command_bytes` helpers) that each backend calls.
 
-⁸ **libpcap (Track A).** libpcap 1.10.6 built from the pinned upstream release
-with `zig cc -target wasm32-wasi -mexec-model=reactor` as a C-API library. Only
-the platform-independent BPF-filter-compilation translation units are compiled
-(no capture backend); the parser is regenerated with bison/flex (1.10.x no
-longer ships pre-generated `grammar.c`/`scanner.c`). Audit: baseline only after
-the ADR-39 `wasm-opt` pass¹¹ (which re-encodes the overlong `call_indirect`
-immediates), in scope. Our own `examples/apps/src/pcap_binding.c` exports
-`compile_filter`, which runs `pcap_compile_nopcap` and serializes the resulting
-BPF program (`[u32 bf_len][bf_len × {u16 code; u8 jt; u8 jf; u32 k}]`) into
-guest memory; the C-API case (`pcap_compile`, `pcap_compile_e2e!`) drives
-`compile_filter("tcp port 80", DLT_EN10MB, 65535)` on Ruby, Python, and Go and
-pins the canonical tcp-port-80 program (deterministic — BPF holds
-offsets/constants only). Like the other reactor-library C-API cases it is
-`slow_test`-gated (a ~2 MB artifact reconverted per run). Bash does not
-participate: no host-language C API to plumb a pointer-returning binding
-through (ADR-12). *Shim caveat:* wasip1 has no `./configure` host, no
-`socket()`, and no baseline `setjmp`/`longjmp`, so a first-party
-`examples/apps/src/pcap_config.h`⁹ stands in for the generated `config.h` — see
-its header comment.
+⁸ **libpcap (Track A).** libpcap 1.10.6 built from the pinned upstream release with `zig cc -target wasm32-wasi -mexec-model=reactor` as a C-API library. Only the platform-independent BPF-filter-compilation translation units are compiled (no capture backend); the parser is regenerated with bison/flex (1.10.x no longer ships pre-generated `grammar.c`/`scanner.c`). Audit: baseline only after the ADR-39 `wasm-opt` pass¹¹ (which re-encodes the overlong `call_indirect` immediates), in scope. Our own `examples/apps/src/pcap_binding.c` exports `compile_filter`, which runs `pcap_compile_nopcap` and serializes the resulting BPF program (`[u32 bf_len][bf_len × {u16 code; u8 jt; u8 jf; u32 k}]`) into guest memory; the C-API case (`pcap_compile`, `pcap_compile_e2e!`) drives `compile_filter("tcp port 80", DLT_EN10MB, 65535)` on Ruby, Python, and Go and pins the canonical tcp-port-80 program (deterministic — BPF holds offsets/constants only). Like the other reactor-library C-API cases it is `slow_test`-gated (a ~2 MB artifact reconverted per run). Bash does not participate: no host-language C API to plumb a pointer-returning binding through (ADR-12). *Shim caveat:* wasip1 has no `./configure` host, no `socket()`, and no baseline `setjmp`/`longjmp`, so a first-party `examples/apps/src/pcap_config.h`⁹ stands in for the generated `config.h` — see its header comment.
 
-⁹ **The `pcap_config.h` shim** collapses three wasip1 gaps: the `./configure`
-feature macros the filter compiler reads; placeholders (`socket()`,
-`SIOCGIF*`) that let the never-reached, wasm-ld-GC'd `pcap_lookupnet` compile;
-and a baseline-wasm `setjmp`→0 / `longjmp`→trap stand-in (libpcap reports
-filter *syntax errors* via `longjmp`, which wasip1's `<setjmp.h>` refuses to
-compile without the out-of-scope wasm exception-handling proposal). A valid
-filter — the only kind this demo compiles — never takes the error path, so the
-stand-in is transparent; an invalid filter would trap rather than return an
-error. Name-based filters (`host example.com`) are likewise out of scope:
-`pcap_binding.c` stubs the missing `getaddrinfo`/`getnetbyname`/`getprotobyname`
-to report "not found".
+⁹ **The `pcap_config.h` shim** collapses three wasip1 gaps: the `./configure` feature macros the filter compiler reads; placeholders (`socket()`, `SIOCGIF*`) that let the never-reached, wasm-ld-GC'd `pcap_lookupnet` compile; and a baseline-wasm `setjmp`→0 / `longjmp`→trap stand-in (libpcap reports filter *syntax errors* via `longjmp`, which wasip1's `<setjmp.h>` refuses to compile without the out-of-scope wasm exception-handling proposal). A valid filter — the only kind this demo compiles — never takes the error path, so the stand-in is transparent; an invalid filter would trap rather than return an error. Name-based filters (`host example.com`) are likewise out of scope: `pcap_binding.c` stubs the missing `getaddrinfo`/`getnetbyname`/`getprotobyname` to report "not found".
 
-¹⁰ **tree-sitter (Track A).** The tree-sitter incremental-parsing runtime
-0.26.11 (single-TU amalgamation `lib/src/lib.c`) plus the pre-generated
-tree-sitter-json 0.24.8 grammar (`src/parser.c`), built from the pinned
-upstream releases with `zig cc -mexec-model=reactor` as a C-API library. Audit:
-baseline only after the ADR-39 `wasm-opt` pass¹¹, in scope — unlike libpcap, the
-runtime needs no shim (no `setjmp`, no host lookups). Our own
-`examples/apps/src/treesitter_binding.c` exports `parse_source`, which parses a
-source string and returns the parse tree's S-expression (`ts_node_string`, a
-malloc'd C string) into guest memory. The C-API case (`treesitter_parse`,
-`treesitter_parse_e2e!`) parses the fixed snippet `{"key": [1, true, null]}` on
-Ruby, Python, and Go and pins the S-expression `(document (object (pair key:
-(string (string_content)) value: (array (number) (true) (null)))))`
-(deterministic — tree-sitter's node naming is fixed by the pinned grammar).
-`slow_test`-gated like the other reactor-library C-API cases; Bash does not
-participate (ADR-12).
+¹⁰ **tree-sitter (Track A).** The tree-sitter incremental-parsing runtime 0.26.11 (single-TU amalgamation `lib/src/lib.c`) plus the pre-generated tree-sitter-json 0.24.8 grammar (`src/parser.c`), built from the pinned upstream releases with `zig cc -mexec-model=reactor` as a C-API library. Audit: baseline only after the ADR-39 `wasm-opt` pass¹¹, in scope — unlike libpcap, the runtime needs no shim (no `setjmp`, no host lookups). Our own `examples/apps/src/treesitter_binding.c` exports `parse_source`, which parses a source string and returns the parse tree's S-expression (`ts_node_string`, a malloc'd C string) into guest memory. The C-API case (`treesitter_parse`, `treesitter_parse_e2e!`) parses the fixed snippet `{"key": [1, true, null]}` on Ruby, Python, and Go and pins the S-expression `(document (object (pair key: (string (string_content)) value: (array (number) (true) (null)))))` (deterministic — tree-sitter's node naming is fixed by the pinned grammar). `slow_test`-gated like the other reactor-library C-API cases; Bash does not participate (ADR-12).
 
-¹¹ **ADR-39 `wasm-opt` preprocessing.** The three modules `fetch.sh` builds
-locally (libpcap, tree-sitter, ripgrep) are run through `wasm-opt -O2` (baseline
-features only, no ctor-eval) before caching — see
-[ADR-39](adr/39-wasm-opt-preprocessing.md). Besides shrinking them, `wasm-opt`
-re-encodes the overlong `call_indirect` immediates the LLVM toolchain emits, so
-these modules audit as *pure* baseline rather than baseline + the
-reference-types encoding bit¹ the downloaded/unoptimized artifacts carry.
+¹¹ **ADR-39 `wasm-opt` preprocessing.** The three modules `fetch.sh` builds locally (libpcap, tree-sitter, ripgrep) are run through `wasm-opt -O2` (baseline features only, no ctor-eval) before caching — see [ADR-39](adr/39-wasm-opt-preprocessing.md). Besides shrinking them, `wasm-opt` re-encodes the overlong `call_indirect` immediates the LLVM toolchain emits, so these modules audit as *pure* baseline rather than baseline + the reference-types encoding bit¹ the downloaded/unoptimized artifacts carry.
 
 ## Deferred: pandoc
 
-- Source: https://haskell-wasm.github.io/pandoc-wasm/pandoc.wasm
-  (gh-pages of `haskell-wasm/pandoc-wasm`, unversioned — record the
-  serving commit when pinning; audited copy: commit `ed18ae6e337d`,
-  sha256 `48d9ceed3ef805f6acc28e6f58c2439cdeb1f71864244fffcc155e2c045aa7fc`, 53 MB).
-- Audit: **needs simd** (first offense: a v128 operation at offset
-  0x24723a). Notably it does *not* need tail calls or exception handling
-  — the GHC 9.12 wasm backend output is otherwise baseline-shaped — so
-  SIMD support alone would unblock it.
-- Revisit when/if SIMD enters scope; the binary is otherwise a pure
-  wasip1 stdio converter and would make a strong demo.
+- Source: https://haskell-wasm.github.io/pandoc-wasm/pandoc.wasm (gh-pages of `haskell-wasm/pandoc-wasm`, unversioned — record the serving commit when pinning; audited copy: commit `ed18ae6e337d`, sha256 `48d9ceed3ef805f6acc28e6f58c2439cdeb1f71864244fffcc155e2c045aa7fc`, 53 MB).
+- Audit: **needs simd** (first offense: a v128 operation at offset 0x24723a). Notably it does *not* need tail calls or exception handling — the GHC 9.12 wasm backend output is otherwise baseline-shaped — so SIMD support alone would unblock it.
+- Revisit when/if SIMD enters scope; the binary is otherwise a pure wasip1 stdio converter and would make a strong demo.
 
 ## Deferred: zeroperl
 
-- Source: [github.com/6over3/zeroperl](https://github.com/6over3/zeroperl) —
-  a WASI reactor build of Perl 5.42. A prebuilt artifact is redistributed
-  in [github.com/lbe/go-exiftool-wasm](https://github.com/lbe/go-exiftool-wasm)
-  as `internal/zeroperl/zeroperl.wasm` (pin the serving commit + sha256 when
-  it is promoted).
-- Audit: **not blocked on a wasm feature** — the blocker is host shims. The
-  build relies on binaryen **asyncify** plus a custom **setjmp/longjmp** shim
-  and an imported `env.call_host_function`, none of which the runtime provides.
-  This is an ABI/host-environment gap, not a proposal outside the 0.1 scope.
-- Revisit when a setjmp/asyncify story exists (a general asyncify unwinding
-  shim plus the `call_host_function` host glue); Perl 5 would be a marquee
-  scripting-language demo alongside CPython and CRuby.
+- Source: [github.com/6over3/zeroperl](https://github.com/6over3/zeroperl) — a WASI reactor build of Perl 5.42. A prebuilt artifact is redistributed in [github.com/lbe/go-exiftool-wasm](https://github.com/lbe/go-exiftool-wasm) as `internal/zeroperl/zeroperl.wasm` (pin the serving commit + sha256 when it is promoted).
+- Audit: **not blocked on a wasm feature** — the blocker is host shims. The build relies on binaryen **asyncify** plus a custom **setjmp/longjmp** shim and an imported `env.call_host_function`, none of which the runtime provides. This is an ABI/host-environment gap, not a proposal outside the 0.1 scope.
+- Revisit when a setjmp/asyncify story exists (a general asyncify unwinding shim plus the `call_host_function` host glue); Perl 5 would be a marquee scripting-language demo alongside CPython and CRuby.
 
 ## Deferred: LightningCSS
 
-- Source: [github.com/pgaskin/go-lightningcss](https://github.com/pgaskin/go-lightningcss)
-  — a Rust **reactor** build of LightningCSS (the CSS parser/transformer),
-  produced via a **pgaskin/wasm2go fork** of the build tooling; the published
-  artifact is therefore unverified against an upstream release.
-- Audit: **not yet run** — deferred pending audit. The fork-built artifact is
-  not trustworthy enough to promote as-is.
-- Revisit by pinning the build (a reproducible from-source recipe, not the
-  fork's prebuilt wasm) and running the feature-audit on the resulting binary
-  before promoting it in scope.
+- Source: [github.com/pgaskin/go-lightningcss](https://github.com/pgaskin/go-lightningcss) — a Rust **reactor** build of LightningCSS (the CSS parser/transformer), produced via a **pgaskin/wasm2go fork** of the build tooling; the published artifact is therefore unverified against an upstream release.
+- Audit: **not yet run** — deferred pending audit. The fork-built artifact is not trustworthy enough to promote as-is.
+- Revisit by pinning the build (a reproducible from-source recipe, not the fork's prebuilt wasm) and running the feature-audit on the resulting binary before promoting it in scope.
 
 ## WASI p1 import surfaces (for the Phase 5 wiring)
 
-The audit also prints each binary's imported WASI functions; the widest
-candidates are:
+The audit also prints each binary's imported WASI functions; the widest candidates are:
 
-- **CPython**: 42 functions — the full p1 surface including `fd_pread`/
-  `fd_pwrite`/`fd_tell`/`fd_advise`/`fd_datasync`, `path_link`/`path_rename`/
-  `path_symlink`, `sched_yield`, and the four `sock_*` functions.
-- **CRuby**: 37 functions — CPython's list minus the `sock_*` family,
-  `sched_yield`, and `fd_filestat_set_times`, plus `fd_renumber`.
+- **CPython**: 42 functions — the full p1 surface including `fd_pread`/ `fd_pwrite`/`fd_tell`/`fd_advise`/`fd_datasync`, `path_link`/`path_rename`/ `path_symlink`, `sched_yield`, and the four `sock_*` functions.
+- **CRuby**: 37 functions — CPython's list minus the `sock_*` family, `sched_yield`, and `fd_filestat_set_times`, plus `fd_renumber`.
 
-Importing is not calling: the out-of-scope `sock_*` imports still resolve to
-the ENOSYS stub, but a runtime implementation is not required for scripts
-that never open sockets — confirmed by running both to success (footnote ⁵).
-Both runtimes read their stdlib trees from a preopened directory at startup;
-`fetch.sh` now extracts those trees (`cache/cpython-lib/lib/python3.14`,
-`cache/ruby-lib/usr/local/lib/ruby`) and the e2e cases preopen them at guest
-`/lib` and `/usr` respectively.
+Importing is not calling: the out-of-scope `sock_*` imports still resolve to the ENOSYS stub, but a runtime implementation is not required for scripts that never open sockets — confirmed by running both to success (footnote ⁵). Both runtimes read their stdlib trees from a preopened directory at startup; `fetch.sh` now extracts those trees (`cache/cpython-lib/lib/python3.14`, `cache/ruby-lib/usr/local/lib/ruby`) and the e2e cases preopen them at guest `/lib` and `/usr` respectively.

--- a/docs/backends/bash.md
+++ b/docs/backends/bash.md
@@ -1,69 +1,37 @@
 # Bash backend
 
-`--target bash`. The flagship "runs where the only dependency is a shell"
-target: C/Rust tools converted to a script with no external commands.
+`--target bash`. The flagship "runs where the only dependency is a shell" target: C/Rust tools converted to a script with no external commands.
 
 ## Output shape
 
-A single sourceable `.sh` script: the runtime is a set of flat
-`rt_*`/`mem_*` functions and the module's functions are prefixed per
-generation so multiple modules can coexist in one shell. Imports resolve from
-the caller's `IMPORTS` associative array (`[module.name]=function`). Control
-flow maps onto `while :; do ...; break; done` wrappers with `break N` /
-`continue N`. See [ADR-11](../adr/11-bash-backend-lowering.md) for lowering,
-[ADR-12](../adr/12-bash-wasi.md) for WASI conventions, and
-[ADR-13](../adr/13-bash-softfloat-conventions.md) for the softfloat.
+A single sourceable `.sh` script: the runtime is a set of flat `rt_*`/`mem_*` functions and the module's functions are prefixed per generation so multiple modules can coexist in one shell. Imports resolve from the caller's `IMPORTS` associative array (`[module.name]=function`). Control flow maps onto `while :; do ...; break; done` wrappers with `break N` / `continue N`. See [ADR-11](../adr/11-bash-backend-lowering.md) for lowering, [ADR-12](../adr/12-bash-wasi.md) for WASI conventions, and [ADR-13](../adr/13-bash-softfloat-conventions.md) for the softfloat.
 
 ## Requirements
 
-`bash` **5 or newer** (associative arrays and namerefs; macOS's system
-`/bin/bash` is 3.2 and does **not** qualify — `brew install bash`). No other
-external commands: floats run on a pure-Bash IEEE-754 softfloat, so there is
-no dependency on `bc`, `awk`, `python`, etc.
+`bash` **5 or newer** (associative arrays and namerefs; macOS's system `/bin/bash` is 3.2 and does **not** qualify — `brew install bash`). No other external commands: floats run on a pure-Bash IEEE-754 softfloat, so there is no dependency on `bc`, `awk`, `python`, etc.
 
 ```console
 $ dewasm prog.wasm --target bash --mode standalone -o prog.sh
 $ bash prog.sh arg1 arg2      # a bash 5+ on PATH
 ```
 
-Standalone programs follow the shared runtime interface (argv, env, exit/trap):
-[docs/standalone-interface.md](../standalone-interface.md). Bash has no
-filesystem support, so `--dir` is rejected with a clear error rather than
-silently ignored.
+Standalone programs follow the shared runtime interface (argv, env, exit/trap): [docs/standalone-interface.md](../standalone-interface.md). Bash has no filesystem support, so `--dir` is rejected with a clear error rather than silently ignored.
 
 ## Capabilities
 
-Wasm core 1.0 plus the universal baseline, with f32/f64 on the pure-Bash
-softfloat. Deliberately the narrowest backend:
+Wasm core 1.0 plus the universal baseline, with f32/f64 on the pure-Bash softfloat. Deliberately the narrowest backend:
 
-- **No WASI filesystem** — WASI core only (stdio, args, environ, clocks,
-  random, proc_exit, byte-wise binary stdio). See [docs/support.md](../support.md).
-- **Non-function imports, multiple tables, and table bulk ops are rejected**
-  at conversion time with a clear error (a plain associative-array import
-  table has no object model for them).
+- **No WASI filesystem** — WASI core only (stdio, args, environ, clocks, random, proc_exit, byte-wise binary stdio). See [docs/support.md](../support.md).
+- **Non-function imports, multiple tables, and table bulk ops are rejected** at conversion time with a clear error (a plain associative-array import table has no object model for them).
 
-`proc_exit` propagates as status 133; traps set `TRAP_MSG` and propagate
-status 134 through `|| return $?` chains.
+`proc_exit` propagates as status 133; traps set `TRAP_MSG` and propagate status 134 through `|| return $?` chains.
 
 ## Providers and library usage
 
-The import table is the `IMPORTS` associative array keyed `module.name`; there
-is no duck-typed provider *object* as on Ruby/Python. Set an entry to a shell
-function name to override an import; unset entries fall back to the bundled
-WASI. The e2e override glue
-(`crates/dewasm-backend-bash/tests/e2e.rs`) is the worked reference.
+The import table is the `IMPORTS` associative array keyed `module.name`; there is no duck-typed provider *object* as on Ruby/Python. Set an entry to a shell function name to override an import; unset entries fall back to the bundled WASI. The e2e override glue (`crates/dewasm-backend-bash/tests/e2e.rs`) is the worked reference.
 
 ## Caveats
 
-- **Speed.** Bash arithmetic is signed-64 only, and every float operation is
-  softfloat integer arithmetic, so float-heavy programs are slow — the slow
-  apps (QuickJS, SQLite) are `#[ignore]`d for Bash by default and run only
-  under the `slow_test` cargo feature (or `cargo test -- --include-ignored`);
-  the interactive qjs REPL pty case is slower still and sits at the
-  `ultra_slow_test` tier ([ADR-48](../adr/48-slow-test-tiers.md), kept out of CI).
-  Integer-only programs (cowsay, minigzip) run fine.
-- Every generated function ends with an explicit `return 0`; a trailing
-  arithmetic statement would otherwise leak status 1 (the units lint enforces
-  this — [ADR-11](../adr/11-bash-backend-lowering.md)).
-- Floats are their bit patterns (u32 / signed-64), not shell floats; reads of
-  the output should expect softfloat, not native, arithmetic.
+- **Speed.** Bash arithmetic is signed-64 only, and every float operation is softfloat integer arithmetic, so float-heavy programs are slow — the slow apps (QuickJS, SQLite) are `#[ignore]`d for Bash by default and run only under the `slow_test` cargo feature (or `cargo test -- --include-ignored`); the interactive qjs REPL pty case is slower still and sits at the `ultra_slow_test` tier ([ADR-48](../adr/48-slow-test-tiers.md), kept out of CI). Integer-only programs (cowsay, minigzip) run fine.
+- Every generated function ends with an explicit `return 0`; a trailing arithmetic statement would otherwise leak status 1 (the units lint enforces this — [ADR-11](../adr/11-bash-backend-lowering.md)).
+- Floats are their bit patterns (u32 / signed-64), not shell floats; reads of the output should expect softfloat, not native, arithmetic.

--- a/docs/backends/go.md
+++ b/docs/backends/go.md
@@ -1,22 +1,14 @@
 # Go backend
 
-`--target go`. One self-contained Go source file, compiled with the Go
-toolchain.
+`--target go`. One self-contained Go source file, compiled with the Go toolchain.
 
 ## Output shape
 
-A single `.go` file: `package main` plus a bundled runtime referenced as
-`Rt.<name>` (methods on a zero-size receiver). Integers are native
-`uint32`/`uint64` (wrapping arithmetic makes masking free) and floats are
-native `float32`/`float64`, so f32 re-rounding and trap-free division need no
-helper. Control flow maps onto Go's labeled loops. Because unused labels and
-locals are Go compile errors, the backend emits them only when referenced. See
-[ADR-29](../adr/29-go-backend-lowering.md).
+A single `.go` file: `package main` plus a bundled runtime referenced as `Rt.<name>` (methods on a zero-size receiver). Integers are native `uint32`/`uint64` (wrapping arithmetic makes masking free) and floats are native `float32`/`float64`, so f32 re-rounding and trap-free division need no helper. Control flow maps onto Go's labeled loops. Because unused labels and locals are Go compile errors, the backend emits them only when referenced. See [ADR-29](../adr/29-go-backend-lowering.md).
 
 ## Requirements
 
-`go` on `PATH` (or `$DEWASM_GO`), **1.18 or newer** (the runtime uses
-generics). The output is a normal Go program — `go run` or `go build` it.
+`go` on `PATH` (or `$DEWASM_GO`), **1.18 or newer** (the runtime uses generics). The output is a normal Go program — `go run` or `go build` it.
 
 ## Running it
 
@@ -25,12 +17,9 @@ $ dewasm prog.wasm --target go --mode standalone -o prog.go
 $ go build -o prog prog.go && ./prog --dir ./data::/data arg1 arg2
 ```
 
-Standalone programs follow the shared runtime interface (argv, `--dir` preopens,
-env, exit/trap): [docs/standalone-interface.md](../standalone-interface.md).
+Standalone programs follow the shared runtime interface (argv, `--dir` preopens, env, exit/trap): [docs/standalone-interface.md](../standalone-interface.md).
 
-Library mode: the generated file is `package main`, so add your own `func main`
-in the same package (the file already imports `fmt`). Constructor arguments are
-`(imports, argv, env, preopens)`; exports are typed callables in `Exports`:
+Library mode: the generated file is `package main`, so add your own `func main` in the same package (the file already imports `fmt`). Constructor arguments are `(imports, argv, env, preopens)`; exports are typed callables in `Exports`:
 
 ```go
 func main() {
@@ -43,16 +32,11 @@ func main() {
 
 ## Capabilities
 
-Full wasm core 1.0 plus the universal baseline, and **full WASI preview 1
-including the filesystem**. Non-function imports, multiple tables, and table
-bulk ops are supported. Authoritative matrix: [docs/support.md](../support.md).
+Full wasm core 1.0 plus the universal baseline, and **full WASI preview 1 including the filesystem**. Non-function imports, multiple tables, and table bulk ops are supported. Authoritative matrix: [docs/support.md](../support.md).
 
 ## Providers and library usage
 
-Any unprovided WASI import falls back to a bundled WASI. Override imports by
-passing an `Imports` map to the constructor (`map[module]map[name]func`);
-preopen directories via the fourth constructor argument. The e2e override glue
-in `crates/dewasm-backend-go/tests/e2e.rs`:
+Any unprovided WASI import falls back to a bundled WASI. Override imports by passing an `Imports` map to the constructor (`map[module]map[name]func`); preopen directories via the fourth constructor argument. The e2e override glue in `crates/dewasm-backend-go/tests/e2e.rs`:
 
 ```go
 inst = NewProg(Imports{"wasi_snapshot_preview1": {"fd_write": fdWrite}}, nil, nil, nil)
@@ -61,9 +45,5 @@ inst.Exports["_start"].(func())()   // random_get falls back to the bundled WASI
 
 ## Caveats
 
-- **Build cost dominates.** Being compiled, the first `go build`/`go run` of a
-  large generated file is the slow step (ripgrep's ~22 MB wasm is dominated by
-  the compile, not the run). The e2e suite compiles to a content-addressed
-  cache binary to pay this once.
-- Native floats mean IEEE semantics come for free, but Go's strict no-FMA
-  contraction is what keeps f32/f64 bit-exact ([ADR-29](../adr/29-go-backend-lowering.md)).
+- **Build cost dominates.** Being compiled, the first `go build`/`go run` of a large generated file is the slow step (ripgrep's ~22 MB wasm is dominated by the compile, not the run). The e2e suite compiles to a content-addressed cache binary to pay this once.
+- Native floats mean IEEE semantics come for free, but Go's strict no-FMA contraction is what keeps f32/f64 bit-exact ([ADR-29](../adr/29-go-backend-lowering.md)).

--- a/docs/backends/java.md
+++ b/docs/backends/java.md
@@ -1,24 +1,14 @@
 # Java backend
 
-`--target java`. One `.java` source file compiled with `javac` and run on the
-JVM; splits very large modules across multiple classes.
+`--target java`. One `.java` source file compiled with `javac` and run on the JVM; splits very large modules across multiple classes.
 
 ## Output shape
 
-A single `.java` file: a set of package-private runtime classes
-(`Rt`/`Memory`/`Table`/`WASI`) plus the generated module class named after the
-input stem. In **standalone** mode the entry point is always a `public class
-Main` with `public static void main`, so name the output `Main.java`. In
-**library** mode the module class is package-private, so put your own `public
-class Main` (or other public entry) in the *same* file. Integers are native
-`int`/`long` as bit patterns; unsigned ops use `Integer.*`/`Long.*`. Control
-flow uses a per-function branch register `_br`. See
-[ADR-30](../adr/30-java-backend-lowering.md).
+A single `.java` file: a set of package-private runtime classes (`Rt`/`Memory`/`Table`/`WASI`) plus the generated module class named after the input stem. In **standalone** mode the entry point is always a `public class Main` with `public static void main`, so name the output `Main.java`. In **library** mode the module class is package-private, so put your own `public class Main` (or other public entry) in the *same* file. Integers are native `int`/`long` as bit patterns; unsigned ops use `Integer.*`/`Long.*`. Control flow uses a per-function branch register `_br`. See [ADR-30](../adr/30-java-backend-lowering.md).
 
 ## Requirements
 
-`java` and `javac` on `PATH` (or `$DEWASM_JAVA`/`$DEWASM_JAVAC`), **JDK 11 or
-newer** (standard APIs only).
+`java` and `javac` on `PATH` (or `$DEWASM_JAVA`/`$DEWASM_JAVAC`), **JDK 11 or newer** (standard APIs only).
 
 ## Running it
 
@@ -29,14 +19,9 @@ $ dewasm prog.wasm --target java --mode standalone -o Main.java
 $ javac Main.java && java Main --dir ./data::/data arg1 arg2
 ```
 
-Standalone programs follow the shared runtime interface (argv, `--dir` preopens,
-env, exit/trap): [docs/standalone-interface.md](../standalone-interface.md). Java
-is the one deviation on `argv[0]`: the JVM does not pass the launched file name
-to `main`, so it uses the module class name.
+Standalone programs follow the shared runtime interface (argv, `--dir` preopens, env, exit/trap): [docs/standalone-interface.md](../standalone-interface.md). Java is the one deviation on `argv[0]`: the JVM does not pass the launched file name to `main`, so it uses the module class name.
 
-Library (append your `public class Main` to the generated file). Constructor
-arguments are `(imports, argv, env, preopens)`; exports are `Rt.Fn` values in
-the `Exports` map:
+Library (append your `public class Main` to the generated file). Constructor arguments are `(imports, argv, env, preopens)`; exports are `Rt.Fn` values in the `Exports` map:
 
 ```java
 Add inst = new Add(null, null, null, null);
@@ -52,28 +37,13 @@ $ javac Main.java && java Main   # after appending the class above
 
 ## Capabilities
 
-Full wasm core 1.0 plus the universal baseline, and **full WASI preview 1
-including the filesystem** (adopting the Ruby fs model,
-[ADR-14](../adr/14-ruby-wasi-filesystem.md)). Non-function imports, multiple
-tables, and table bulk ops are supported. Authoritative matrix:
-[docs/support.md](../support.md).
+Full wasm core 1.0 plus the universal baseline, and **full WASI preview 1 including the filesystem** (adopting the Ruby fs model, [ADR-14](../adr/14-ruby-wasi-filesystem.md)). Non-function imports, multiple tables, and table bulk ops are supported. Authoritative matrix: [docs/support.md](../support.md).
 
 ## Providers and library usage
 
-Any unprovided WASI import falls back to a bundled WASI. Override imports by
-passing a `Map<String, Map<String, Object>>` to the constructor; preopen
-directories via the fourth argument (`Map.of(guest, host)`). The e2e override
-glue in `crates/dewasm-backend-java/tests/e2e.rs` is the worked reference.
+Any unprovided WASI import falls back to a bundled WASI. Override imports by passing a `Map<String, Map<String, Object>>` to the constructor; preopen directories via the fourth argument (`Map.of(guest, host)`). The e2e override glue in `crates/dewasm-backend-java/tests/e2e.rs` is the worked reference.
 
 ## Caveats
 
-- **Class splitting at scale.** The JVM caps a method at 64 KB of bytecode, a
-  class's constant pool at 65535 entries, and a string literal at 64 KB.
-  dewasm handles all three automatically — large functions are split into
-  numbered `part` methods over a per-call frame object, huge modules are
-  partitioned across nested `P{k}` classes (ripgrep's ~7300 functions span
-  five), and oversized data segments are emitted as chunked Base64. This is
-  transparent but explains why one binary yields many classes
-  ([ADR-30](../adr/30-java-backend-lowering.md)).
-- **Compile cost** is the slow step for large modules (like Go); the e2e suite
-  compiles to a content-addressed class-dir cache to pay `javac` once.
+- **Class splitting at scale.** The JVM caps a method at 64 KB of bytecode, a class's constant pool at 65535 entries, and a string literal at 64 KB. dewasm handles all three automatically — large functions are split into numbered `part` methods over a per-call frame object, huge modules are partitioned across nested `P{k}` classes (ripgrep's ~7300 functions span five), and oversized data segments are emitted as chunked Base64. This is transparent but explains why one binary yields many classes ([ADR-30](../adr/30-java-backend-lowering.md)).
+- **Compile cost** is the slow step for large modules (like Go); the e2e suite compiles to a content-addressed class-dir cache to pay `javac` once.

--- a/docs/backends/python.md
+++ b/docs/backends/python.md
@@ -1,22 +1,14 @@
 # Python backend
 
-`--target python`. A plain importable module with the full WASI preview 1
-surface.
+`--target python`. A plain importable module with the full WASI preview 1 surface.
 
 ## Output shape
 
-A single `.py` module: the generated module as a class named after the input
-stem (override with `--module-name`), with the runtime at **module top level**
-under the name `Rt` (Python method scopes cannot see an enclosing class scope,
-so the runtime cannot nest inside the class as it does for Ruby). Only wasm
-loops become real `while True`; forward branches use a per-function branch
-register `_br` to stay within Python's static-nesting limits. See
-[ADR-28](../adr/28-python-backend-lowering.md).
+A single `.py` module: the generated module as a class named after the input stem (override with `--module-name`), with the runtime at **module top level** under the name `Rt` (Python method scopes cannot see an enclosing class scope, so the runtime cannot nest inside the class as it does for Ruby). Only wasm loops become real `while True`; forward branches use a per-function branch register `_br` to stay within Python's static-nesting limits. See [ADR-28](../adr/28-python-backend-lowering.md).
 
 ## Requirements
 
-`python3` **3.9 or newer** on `PATH` (or `$DEWASM_PYTHON`). No third-party
-packages — the output uses only the standard library.
+`python3` **3.9 or newer** on `PATH` (or `$DEWASM_PYTHON`). No third-party packages — the output uses only the standard library.
 
 ## Running it
 
@@ -25,8 +17,7 @@ $ dewasm prog.wasm --target python --mode standalone -o prog.py
 $ python3 prog.py --dir ./data::/data arg1 arg2
 ```
 
-Standalone programs follow the shared runtime interface (argv, `--dir` preopens,
-env, exit/trap): [docs/standalone-interface.md](../standalone-interface.md).
+Standalone programs follow the shared runtime interface (argv, `--dir` preopens, env, exit/trap): [docs/standalone-interface.md](../standalone-interface.md).
 
 Library mode:
 
@@ -37,22 +28,15 @@ print(inst.invoke("add", 2, 3))   # 5
 inst.memory                       # linear memory
 ```
 
-`proc_exit` raises `Rt.Exit` (with `.code`); catch it around
-`invoke("_start")` in library mode.
+`proc_exit` raises `Rt.Exit` (with `.code`); catch it around `invoke("_start")` in library mode.
 
 ## Capabilities
 
-Full wasm core 1.0 plus the universal baseline, and **full WASI preview 1
-including the filesystem** (adopting the Ruby fs model,
-[ADR-14](../adr/14-ruby-wasi-filesystem.md)). Non-function imports, multiple
-tables, and table bulk ops are supported. Authoritative matrix:
-[docs/support.md](../support.md).
+Full wasm core 1.0 plus the universal baseline, and **full WASI preview 1 including the filesystem** (adopting the Ruby fs model, [ADR-14](../adr/14-ruby-wasi-filesystem.md)). Non-function imports, multiple tables, and table bulk ops are supported. Authoritative matrix: [docs/support.md](../support.md).
 
 ## Providers and library usage
 
-Any unprovided WASI import falls back to a bundled WASI (disable with
-`--no-default-wasi`). Override an import by passing an imports table to the
-constructor; unprovided entries still fall back:
+Any unprovided WASI import falls back to a bundled WASI (disable with `--no-default-wasi`). Override an import by passing an imports table to the constructor; unprovided entries still fall back:
 
 ```python
 _captured = bytearray()
@@ -71,16 +55,10 @@ _holder["inst"] = inst
 inst.invoke("_start")   # random_get falls back to the bundled WASI
 ```
 
-Preopen host directories for filesystem access via the constructor's
-`preopens` argument. The e2e glue in
-`crates/dewasm-backend-python/tests/e2e.rs` is the worked reference.
+Preopen host directories for filesystem access via the constructor's `preopens` argument. The e2e glue in `crates/dewasm-backend-python/tests/e2e.rs` is the worked reference.
 
 ## Caveats
 
-- **Recursion / thread-stack depth.** Deeply recursive wasm (or deep call
-  chains) can hit Python's recursion limit; raising it (`sys.setrecursionlimit`)
-  and the thread stack size may be necessary for heavy programs.
-- Float division goes through `Rt.fdiv` because Python raises on `x / 0.0`
-  ([ADR-28](../adr/28-python-backend-lowering.md)).
-- Numeric conventions are the shared masked-unsigned model
-  ([ADR-2](../adr/2-numeric-semantics.md)).
+- **Recursion / thread-stack depth.** Deeply recursive wasm (or deep call chains) can hit Python's recursion limit; raising it (`sys.setrecursionlimit`) and the thread stack size may be necessary for heavy programs.
+- Float division goes through `Rt.fdiv` because Python raises on `x / 0.0` ([ADR-28](../adr/28-python-backend-lowering.md)).
+- Numeric conventions are the shared masked-unsigned model ([ADR-2](../adr/2-numeric-semantics.md)).

--- a/docs/backends/ruby.md
+++ b/docs/backends/ruby.md
@@ -1,28 +1,14 @@
 # Ruby backend
 
-`--target ruby` (the default). The most complete backend and the host for the
-SQLite and CRuby north-star demos — up to and including Rails running on the
-converted SQLite ([`examples/rails`](../../examples/rails/README.md),
-[ADR-45](../adr/45-rails-sqlite3-shim-example.md)).
+`--target ruby` (the default). The most complete backend and the host for the SQLite and CRuby north-star demos — up to and including Rails running on the converted SQLite ([`examples/rails`](../../examples/rails/README.md), [ADR-45](../adr/45-rails-sqlite3-shim-example.md)).
 
 ## Output shape
 
-A single `.rb` file: the generated module as a Ruby **class** named after the
-input file stem (override with `--module-name`), with the lightweight runtime
-bundled inside it under the relative name `Rt`. Nesting the runtime in the
-class lets several generated files coexist in one process without collision.
-The default name can still clash with a constant MRI already defines — most
-notably `ruby.wasm` defaults to `class Ruby`, which collides with Ruby 4.0's
-built-in `Ruby` module and fails at load time with "Ruby is not a class
-(TypeError)". That is working as designed (the stem is just a default); pass
-`--module-name` to pick a free constant.
-See [ADR-4](../adr/4-ruby-backend-lowering.md) for the lowering conventions and
-[ADR-6](../adr/6-runtime-units.md) for the runtime-unit model.
+A single `.rb` file: the generated module as a Ruby **class** named after the input file stem (override with `--module-name`), with the lightweight runtime bundled inside it under the relative name `Rt`. Nesting the runtime in the class lets several generated files coexist in one process without collision. The default name can still clash with a constant MRI already defines — most notably `ruby.wasm` defaults to `class Ruby`, which collides with Ruby 4.0's built-in `Ruby` module and fails at load time with "Ruby is not a class (TypeError)". That is working as designed (the stem is just a default); pass `--module-name` to pick a free constant. See [ADR-4](../adr/4-ruby-backend-lowering.md) for the lowering conventions and [ADR-6](../adr/6-runtime-units.md) for the runtime-unit model.
 
 ## Requirements
 
-`ruby` on `PATH`. No specific version is required and no gems are needed — the
-output is self-contained.
+`ruby` on `PATH`. No specific version is required and no gems are needed — the output is self-contained.
 
 ## Running it
 
@@ -33,8 +19,7 @@ $ dewasm prog.wasm --target ruby --mode standalone -o prog.rb
 $ ruby prog.rb --dir ./data::/data arg1 arg2
 ```
 
-Standalone programs follow the shared runtime interface (argv, `--dir` preopens,
-env, exit/trap): [docs/standalone-interface.md](../standalone-interface.md).
+Standalone programs follow the shared runtime interface (argv, `--dir` preopens, env, exit/trap): [docs/standalone-interface.md](../standalone-interface.md).
 
 Library mode exposes the exports:
 
@@ -45,25 +30,15 @@ inst.invoke("add", 2, 3)       # => 5
 inst.memory                    # linear memory (bytes is a binary String)
 ```
 
-`proc_exit` raises `<Class>::Rt::Exit` (with `#code`); rescue it around
-`invoke("_start")` in library mode.
+`proc_exit` raises `<Class>::Rt::Exit` (with `#code`); rescue it around `invoke("_start")` in library mode.
 
 ## Capabilities
 
-Full wasm core 1.0 plus the universal baseline, and **full WASI preview 1
-including the filesystem** — the only backend with filesystem support besides
-none. Non-function imports, multiple tables, and table bulk ops are all
-supported. The authoritative matrix is [docs/support.md](../support.md); the
-filesystem model (the `preopens:` provider kwarg, the fd-table, the accepted
-TOCTOU/symlink sandboxing caveat) is [ADR-14](../adr/14-ruby-wasi-filesystem.md).
+Full wasm core 1.0 plus the universal baseline, and **full WASI preview 1 including the filesystem** — the only backend with filesystem support besides none. Non-function imports, multiple tables, and table bulk ops are all supported. The authoritative matrix is [docs/support.md](../support.md); the filesystem model (the `preopens:` provider kwarg, the fd-table, the accepted TOCTOU/symlink sandboxing caveat) is [ADR-14](../adr/14-ruby-wasi-filesystem.md).
 
 ## Providers and library usage
 
-Any WASI import the embedder does not supply falls back to a bundled WASI
-implementation (built only if used; disable with `--no-default-wasi`). Override
-a single import with a callable, or replace a whole namespace with a *provider
-object* — `import(name)` resolves functions and `attach(instance)` binds the
-memory before wasm runs ([ADR-7](../adr/7-import-providers.md)):
+Any WASI import the embedder does not supply falls back to a bundled WASI implementation (built only if used; disable with `--no-default-wasi`). Override a single import with a callable, or replace a whole namespace with a *provider object* — `import(name)` resolves functions and `attach(instance)` binds the memory before wasm runs ([ADR-7](../adr/7-import-providers.md)):
 
 ```ruby
 class MyWasi
@@ -82,16 +57,10 @@ Filesystem access is granted by preopening host directories:
 inst = Prog.new({}, preopens: { "/work" => "/path/on/host" })
 ```
 
-A single-import override (capturing `fd_write`, everything else falling back to
-the bundled WASI) is walked through in
-[docs/getting-started.md](../getting-started.md#4-overriding-an-import-provider).
+A single-import override (capturing `fd_write`, everything else falling back to the bundled WASI) is walked through in [docs/getting-started.md](../getting-started.md#4-overriding-an-import-provider).
 
 ## Caveats
 
-- Maturity: this is the most exercised backend, but the whole project is early
-  development — treat generated output as tested, not battle-hardened.
-- Numeric conventions ([ADR-2](../adr/2-numeric-semantics.md)): i32/i64 are
-  masked-unsigned `Integer`s; signed views appear only where an instruction
-  needs them, so reading the output requires knowing this.
-- Large modules produce large files (CRuby is ~335 MB of Ruby); loading and
-  running them costs proportional time and memory.
+- Maturity: this is the most exercised backend, but the whole project is early development — treat generated output as tested, not battle-hardened.
+- Numeric conventions ([ADR-2](../adr/2-numeric-semantics.md)): i32/i64 are masked-unsigned `Integer`s; signed views appear only where an instruction needs them, so reading the output requires knowing this.
+- Large modules produce large files (CRuby is ~335 MB of Ruby); loading and running them costs proportional time and memory.

--- a/docs/docs-policy.md
+++ b/docs/docs-policy.md
@@ -1,7 +1,6 @@
 # Documentation policy
 
-The taxonomy of dewasm's docs, so new content lands in one obvious place and
-nothing is duplicated. All docs are written in English.
+The taxonomy of dewasm's docs, so new content lands in one obvious place and nothing is duplicated. All docs are written in English.
 
 | Doc | Role | Audience | Editable |
 | --- | --- | --- | --- |
@@ -17,22 +16,13 @@ nothing is duplicated. All docs are written in English.
 
 ## Rules
 
-- **`docs/support.md` is generated** from the backend declarations. Never edit
-  it by hand; regenerate with `cargo xtask update-support-docs`
-  (`cargo test -p dewasm-cli --test support_docs` fails while the file is
-  stale). Everywhere else, **link** to it rather than copying the matrix.
-- **Decisions go in an ADR, not in prose docs.** Anything with real
-  alternatives is recorded under `docs/adr/` (the `adr-author` skill carries
-  the procedure). Other docs *link* to the ADR for the "why"; they do not
-  restate it.
-- **Tutorial commands must be verified by running them.** getting-started and
-  the backend docs claim exact output; keep them true.
+- **`docs/support.md` is generated** from the backend declarations. Never edit it by hand; regenerate with `cargo xtask update-support-docs` (`cargo test -p dewasm-cli --test support_docs` fails while the file is stale). Everywhere else, **link** to it rather than copying the matrix.
+- **Decisions go in an ADR, not in prose docs.** Anything with real alternatives is recorded under `docs/adr/` (the `adr-author` skill carries the procedure). Other docs *link* to the ADR for the "why"; they do not restate it.
+- **Tutorial commands must be verified by running them.** getting-started and the backend docs claim exact output; keep them true.
 
 ## Where new content goes
 
-- A user-facing capability or a new target → a line in the README table, a
-  page under `docs/backends/`, and (if it needs a walkthrough) a section in
-  getting-started.
+- A user-facing capability or a new target → a line in the README table, a page under `docs/backends/`, and (if it needs a walkthrough) a section in getting-started.
 - A contributor-facing setup requirement → `docs/testing.md`.
 - A design decision → a new ADR (see [docs/adr/README.md](adr/README.md)).
 - A new real-world app target → an audited row in `docs/apps-audit.md`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,17 +1,10 @@
 # Getting started
 
-A hands-on tour of dewasm: convert a wasm module to a real language, run it
-standalone, then call it as a library and override one of its imports. Every
-command here is verified against the repository; the `dewasm` binary is built
-with `cargo build --release` (`target/release/dewasm`) or run in place with
-`cargo run -p dewasm-cli --`.
+A hands-on tour of dewasm: convert a wasm module to a real language, run it standalone, then call it as a library and override one of its imports. Every command here is verified against the repository; the `dewasm` binary is built with `cargo build --release` (`target/release/dewasm`) or run in place with `cargo run -p dewasm-cli --`.
 
 ## 1. A binary to convert
 
-You can point dewasm at any `wasm32-wasip1` binary, but the repository ships
-small `.wat` examples so you need no toolchain to follow along. We will use
-[`examples/wat/hello.wat`](../examples/wat/hello.wat), which writes a line via
-WASI's `fd_write` and exits:
+You can point dewasm at any `wasm32-wasip1` binary, but the repository ships small `.wat` examples so you need no toolchain to follow along. We will use [`examples/wat/hello.wat`](../examples/wat/hello.wat), which writes a line via WASI's `fd_write` and exits:
 
 ```wat
 (module
@@ -31,8 +24,7 @@ dewasm accepts `.wat` text directly, so no separate assembler step is needed.
 
 ## 2. Standalone mode: run the program
 
-`--mode standalone` wires up WASI and runs the module's `_start`. Pick a
-target with `--target`:
+`--mode standalone` wires up WASI and runs the module's `_start`. Pick a target with `--target`:
 
 ```console
 $ dewasm examples/wat/hello.wat --target python --mode standalone -o hello.py
@@ -62,8 +54,7 @@ $ go run hello.go
 Hello, WASI!
 ```
 
-Java's standalone entry point is always a `public class Main`, so name the
-output `Main.java`:
+Java's standalone entry point is always a `public class Main`, so name the output `Main.java`:
 
 ```console
 $ dewasm examples/wat/hello.wat --target java --mode standalone -o Main.java
@@ -71,8 +62,7 @@ $ javac Main.java && java Main
 Hello, WASI!
 ```
 
-A real binary works the same way. If you have run `examples/apps/fetch.sh`,
-try the cowsay showpiece:
+A real binary works the same way. If you have run `examples/apps/fetch.sh`, try the cowsay showpiece:
 
 ```console
 $ dewasm examples/apps/cache/cowsay.wasm --target bash --mode standalone -o cowsay.sh
@@ -87,13 +77,7 @@ $ echo "moo" | bash cowsay.sh
                 ||     ||
 ```
 
-Standalone programs share one runtime interface across every backend, modelled
-on wasmtime's CLI: pass the guest arguments after the program, and mount host
-directories with repeatable `--dir HOST::GUEST` flags (on the
-filesystem-capable backends). A `proc_exit(N)` becomes exit code `N`, and a trap
-prints to stderr and exits 134. The full reference — argv, env, exit/trap, and
-per-backend runner lines — is
-[docs/standalone-interface.md](standalone-interface.md).
+Standalone programs share one runtime interface across every backend, modelled on wasmtime's CLI: pass the guest arguments after the program, and mount host directories with repeatable `--dir HOST::GUEST` flags (on the filesystem-capable backends). A `proc_exit(N)` becomes exit code `N`, and a trap prints to stderr and exits 134. The full reference — argv, env, exit/trap, and per-backend runner lines — is [docs/standalone-interface.md](standalone-interface.md).
 
 ```console
 $ dewasm examples/wat/wasi_standalone_dir.wat --target ruby --mode standalone -o rt.rb
@@ -104,10 +88,7 @@ hello, wasi fs!
 
 ## 3. Library mode: call the exports
 
-`--mode library` (the default) exposes the module's exports to the host
-language instead of running `_start`. We will use
-[`examples/wat/add.wat`](../examples/wat/add.wat), which exports `add` and a
-recursive `fib`.
+`--mode library` (the default) exposes the module's exports to the host language instead of running `_start`. We will use [`examples/wat/add.wat`](../examples/wat/add.wat), which exports `add` and a recursive `fib`.
 
 ### Ruby
 
@@ -139,8 +120,7 @@ print(inst.invoke("fib", 10))     # 55
 
 ### Go
 
-The generated file is `package main`; add a `func main` in the same package
-(the file already imports `fmt`). Exports are typed callables in `Exports`:
+The generated file is `package main`; add a `func main` in the same package (the file already imports `fmt`). Exports are typed callables in `Exports`:
 
 ```go
 func main() {
@@ -157,8 +137,7 @@ $ go run add.go        # after appending the func main above
 
 ### Java
 
-The generated module class is package-private, so put your `public class Main`
-in the *same* `.java` file (generate with `--module-name Add`, then append):
+The generated module class is package-private, so put your `public class Main` in the *same* `.java` file (generate with `--module-name Add`, then append):
 
 ```java
 public class Main {
@@ -175,19 +154,13 @@ $ dewasm examples/wat/add.wat --target java --mode library --module-name Add -o 
 $ javac Main.java && java Main   # after appending the class above
 ```
 
-The constructor arguments are `(imports, argv, env, preopens)` for the
-compiled backends (`nil`/`null` for none); Ruby and Python take the imports
-table as the first positional argument and `preopens:` as a keyword. See
-[docs/backends/](backends/) for the exact per-language shape.
+The constructor arguments are `(imports, argv, env, preopens)` for the compiled backends (`nil`/`null` for none); Ruby and Python take the imports table as the first positional argument and `preopens:` as a keyword. See [docs/backends/](backends/) for the exact per-language shape.
 
 ## 4. Overriding an import (provider)
 
-In library mode any WASI import the embedder does not provide falls back to a
-bundled WASI implementation. You can intercept individual imports — useful for
-capturing output, sandboxing, or supplying host functions the module imports.
+In library mode any WASI import the embedder does not provide falls back to a bundled WASI implementation. You can intercept individual imports — useful for capturing output, sandboxing, or supplying host functions the module imports.
 
-Convert `hello.wat` as a library and provide our own `fd_write`, letting
-`proc_exit` fall back to the bundled WASI (which raises `Rt::Exit`):
+Convert `hello.wat` as a library and provide our own `fd_write`, letting `proc_exit` fall back to the bundled WASI (which raises `Rt::Exit`):
 
 ```console
 $ dewasm examples/wat/hello.wat --target ruby --mode library --module-name Hello -o hello_lib.rb
@@ -217,19 +190,11 @@ end
 print "captured: ", captured   # captured: Hello, WASI!
 ```
 
-An imports-table value can also be a whole *provider object* (implement
-`import(name)` and optionally `attach(instance)`) to replace an entire
-namespace — for example a custom WASI. The mechanism and its fallback rules
-are [ADR-7](adr/7-import-providers.md); every backend's provider snippet is in
-[docs/backends/](backends/).
+An imports-table value can also be a whole *provider object* (implement `import(name)` and optionally `attach(instance)`) to replace an entire namespace — for example a custom WASI. The mechanism and its fallback rules are [ADR-7](adr/7-import-providers.md); every backend's provider snippet is in [docs/backends/](backends/).
 
 ## Where to go next
 
-- [docs/backends/](backends/) — output shape, requirements, and idioms per
-  target language.
-- [docs/standalone-interface.md](standalone-interface.md) — the standalone
-  runtime interface (argv, `--dir`, env, exit/trap) shared by every backend.
-- [docs/support.md](support.md) — which features and WASI calls each backend
-  supports.
-- [README](../README.md#what-it-can-convert) — the real-world apps dewasm
-  converts and how to fetch them.
+- [docs/backends/](backends/) — output shape, requirements, and idioms per target language.
+- [docs/standalone-interface.md](standalone-interface.md) — the standalone runtime interface (argv, `--dir`, env, exit/trap) shared by every backend.
+- [docs/support.md](support.md) — which features and WASI calls each backend supports.
+- [README](../README.md#what-it-can-convert) — the real-world apps dewasm converts and how to fetch them.

--- a/docs/related-work.md
+++ b/docs/related-work.md
@@ -1,13 +1,10 @@
 # Related Work
 
-dewasm translates WebAssembly into **source code** of many languages
-from **one shared IR**. Its neighbors each hold one piece of that
-sentence; none holds all of it. They fall into three groups.
+dewasm translates WebAssembly into **source code** of many languages from **one shared IR**. Its neighbors each hold one piece of that sentence; none holds all of it. They fall into three groups.
 
 ## Source-to-source translators — single target each
 
-The closest relatives. Every one of them targets exactly one language,
-with its own IR, runtime, and test rig.
+The closest relatives. Every one of them targets exactly one language, with its own IR, runtime, and test rig.
 
 | Project | Target | Notes |
 | --- | --- | --- |
@@ -20,8 +17,7 @@ with its own IR, runtime, and test rig.
 
 ## Bytecode compilers — managed runtimes, but not source
 
-These remove the wasm engine like dewasm does, but emit **bytecode
-for one VM**, not source code.
+These remove the wasm engine like dewasm does, but emit **bytecode for one VM**, not source code.
 
 | Project | Output | Notes |
 | --- | --- | --- |
@@ -29,46 +25,18 @@ for one VM**, not source code.
 | [Chicory build-time compiler](https://chicory.dev/docs/usage/build-time-compiler/) | JVM bytecode | Active; part of the pure-Java Chicory runtime. |
 | [wasm2cil](https://github.com/ericsink/wasm2cil) | .NET CIL assemblies | WASI support; work-in-progress, but notably ran SQLite and a raytracer on the CLR — prior art for "SQLite on a managed runtime via wasm", which dewasm pursues at the source level on Ruby (README north-star). Also why the C# backend ([ADR-10](adr/10-csharp-target.md)) still has an open niche: CIL is not C# source. |
 
-Bytecode output is invisible to the target ecosystem's humans and
-tooling: it cannot be read, reviewed, patched, stepped through as
-ordinary code, or vendored into a codebase as a plain file — and it
-only exists where the VM has a bytecode story at all (there is none for
-Bash, and none for shipping a plain `.rb`/`.py` file).
+Bytecode output is invisible to the target ecosystem's humans and tooling: it cannot be read, reviewed, patched, stepped through as ordinary code, or vendored into a codebase as a plain file — and it only exists where the VM has a bytecode story at all (there is none for Bash, and none for shipping a plain `.rb`/`.py` file).
 
 ## Runtimes — a different answer to the same question
 
-wasmtime, wasmer, wazero, wasm3, Chicory's interpreter, and browser
-engines all *embed an engine* next to your program. dewasm's premise
-is to need no engine at run time: the translated program is native
-source in the host language, with a small runtime bundled inside it
-([ADR-6](adr/6-runtime-units.md)).
+wasmtime, wasmer, wazero, wasm3, Chicory's interpreter, and browser engines all *embed an engine* next to your program. dewasm's premise is to need no engine at run time: the translated program is native source in the host language, with a small runtime bundled inside it ([ADR-6](adr/6-runtime-units.md)).
 
 ## What dewasm adds
 
-1. **One IR, many targets** ([ADR-0](adr/0-foundation.md),
-   [ADR-1](adr/1-ir-design.md)). Every translator above is
-   single-target. Here, adding a language is a lowering table plus
-   runtime units plus turning the shared spec harness green
-   ([ADR-3](adr/3-testing-strategy.md)) — the semantics knowledge
-   (numerics, NaN bit-exactness, trap points) is paid for once
-   ([ADR-2](adr/2-numeric-semantics.md)).
-2. **Source output, deliberately.** Readable, reviewable, debuggable,
-   vendorable as a file; no build toolchain or VM contract at the run
-   site.
-3. **Targets that cannot run wasm any other way.** The flagship is
-   Bash ([ADR-5](adr/5-bash-softfloat.md)): C/Rust tools running where
-   the only dependency is a shell.
-4. **Deployment-grade output, not demo output.** Minimal runtime
-   bundling per module and collision-free coexistence of generated
-   artifacts ([ADR-6](adr/6-runtime-units.md)); a library mode with
-   import providers and a default WASI fallback
-   ([ADR-7](adr/7-import-providers.md)).
-5. **Declared, enforced fidelity.** The official testsuite runs on the
-   real target interpreters, and every skipped test must be attributable
-   to a feature declared unsupported in the generated
-   [support matrix](support.md) ([ADR-8](adr/8-latest-testsuite-support-matrix.md)).
+1. **One IR, many targets** ([ADR-0](adr/0-foundation.md), [ADR-1](adr/1-ir-design.md)). Every translator above is single-target. Here, adding a language is a lowering table plus runtime units plus turning the shared spec harness green ([ADR-3](adr/3-testing-strategy.md)) — the semantics knowledge (numerics, NaN bit-exactness, trap points) is paid for once ([ADR-2](adr/2-numeric-semantics.md)).
+2. **Source output, deliberately.** Readable, reviewable, debuggable, vendorable as a file; no build toolchain or VM contract at the run site.
+3. **Targets that cannot run wasm any other way.** The flagship is Bash ([ADR-5](adr/5-bash-softfloat.md)): C/Rust tools running where the only dependency is a shell.
+4. **Deployment-grade output, not demo output.** Minimal runtime bundling per module and collision-free coexistence of generated artifacts ([ADR-6](adr/6-runtime-units.md)); a library mode with import providers and a default WASI fallback ([ADR-7](adr/7-import-providers.md)).
+5. **Declared, enforced fidelity.** The official testsuite runs on the real target interpreters, and every skipped test must be attributable to a feature declared unsupported in the generated [support matrix](support.md) ([ADR-8](adr/8-latest-testsuite-support-matrix.md)).
 
-dewasm stands on this prior work: wasm2c's translation scheme, w2c2's
-proof that spec-level fidelity is reachable, and the import-binding
-designs of Node's WASI, wasm2c, and the major runtimes are all cited in
-the ADRs above.
+dewasm stands on this prior work: wasm2c's translation scheme, w2c2's proof that spec-level fidelity is reachable, and the import-binding designs of Node's WASI, wasm2c, and the major runtimes are all cited in the ADRs above.

--- a/docs/standalone-interface.md
+++ b/docs/standalone-interface.md
@@ -1,11 +1,6 @@
 # Standalone runtime interface
 
-A program converted with `--mode standalone` is a self-contained CLI: the
-generated `main` supplies the WASI guest its argv, environment, and filesystem
-preopens, and translates the guest's exit/trap into a process exit code. That
-interface is uniform across every backend and modelled on wasmtime's CLI, so a
-converted program behaves like the `.wasm` it came from. The decision and its
-rationale are [ADR-31](adr/31-standalone-runtime-interface.md).
+A program converted with `--mode standalone` is a self-contained CLI: the generated `main` supplies the WASI guest its argv, environment, and filesystem preopens, and translates the guest's exit/trap into a process exit code. That interface is uniform across every backend and modelled on wasmtime's CLI, so a converted program behaves like the `.wasm` it came from. The decision and its rationale are [ADR-31](adr/31-standalone-runtime-interface.md).
 
 ## Invocation
 
@@ -13,22 +8,13 @@ rationale are [ADR-31](adr/31-standalone-runtime-interface.md).
 <runner> <program> [--dir HOST::GUEST]... [--] [guest args...]
 ```
 
-The generated `main` consumes a **leading run of `--dir` flags** and hands
-everything after them to the guest as `argv[1..]`:
+The generated `main` consumes a **leading run of `--dir` flags** and hands everything after them to the guest as `argv[1..]`:
 
-- `--dir HOST::GUEST` (repeatable) preopens host directory `HOST` at guest path
-  `GUEST`, exactly like `wasmtime run --dir`. Both `--dir X` and `--dir=X` are
-  accepted. A value with no `::` mounts the same path on both sides
-  (`--dir /data` = `--dir /data::/data`).
-- `--` ends flag parsing; every following token is a guest argument (use it to
-  pass a guest a literal `--dir`).
-- The first token that is not a `--dir` flag also ends parsing; it and the rest
-  are guest arguments.
+- `--dir HOST::GUEST` (repeatable) preopens host directory `HOST` at guest path `GUEST`, exactly like `wasmtime run --dir`. Both `--dir X` and `--dir=X` are accepted. A value with no `::` mounts the same path on both sides (`--dir /data` = `--dir /data::/data`).
+- `--` ends flag parsing; every following token is a guest argument (use it to pass a guest a literal `--dir`).
+- The first token that is not a `--dir` flag also ends parsing; it and the rest are guest arguments.
 
-`<runner>` is the per-backend way to launch the program (below). `--dir` is a
-shim parsed *inside the generated program*, not a flag of the interpreter — so
-it comes after `<program>`, whereas wasmtime consumes its own `--dir` before the
-`.wasm`.
+`<runner>` is the per-backend way to launch the program (below). `--dir` is a shim parsed *inside the generated program*, not a flag of the interpreter — so it comes after `<program>`, whereas wasmtime consumes its own `--dir` before the `.wasm`.
 
 ### Per-backend runner lines
 
@@ -53,11 +39,7 @@ it comes after `<program>`, whereas wasmtime consumes its own `--dir` before the
 
 ## Bash `--dir`
 
-The Bash backend honors `--dir` with real WASI filesystem support
-([ADR-34](adr/34-bash-wasi-filesystem.md)); a missing `--dir` argument fails
-loudly with exit 2. Bash reaches the same exit/trap surface as the other
-backends through its status-cascade protocol (133 = `proc_exit`, 134 = trap;
-[ADR-11](adr/11-bash-backend-lowering.md)/[ADR-12](adr/12-bash-wasi.md)).
+The Bash backend honors `--dir` with real WASI filesystem support ([ADR-34](adr/34-bash-wasi-filesystem.md)); a missing `--dir` argument fails loudly with exit 2. Bash reaches the same exit/trap surface as the other backends through its status-cascade protocol (133 = `proc_exit`, 134 = trap; [ADR-11](adr/11-bash-backend-lowering.md)/[ADR-12](adr/12-bash-wasi.md)).
 
 ## Example
 
@@ -70,7 +52,4 @@ $ cat /tmp/work/hello.txt
 hello, wasi fs!
 ```
 
-The same command under wasmtime — `wasmtime run --dir /tmp/work::/
-wasi_standalone_dir.wat` — produces identical output; the shared
-`wasi_standalone_dir` e2e case runs it on every filesystem backend and re-runs
-it under wasmtime as ground truth ([ADR-27](adr/27-test-helper-crate.md)).
+The same command under wasmtime — `wasmtime run --dir /tmp/work::/ wasi_standalone_dir.wat` — produces identical output; the shared `wasi_standalone_dir` e2e case runs it on every filesystem backend and re-runs it under wasmtime as ground truth ([ADR-27](adr/27-test-helper-crate.md)).

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,17 +1,12 @@
 # Backend Support Matrix
 
-<!-- AUTO-GENERATED from the backend declarations; do not edit by hand.
-     Regenerate: cargo xtask update-support-docs -->
+<!-- AUTO-GENERATED from the backend declarations; do not edit by hand. Regenerate: cargo xtask update-support-docs -->
 
-The spec harness only tolerates test skips attributable to a feature that is
-not `Supported` here ([ADR-8](adr/8-latest-testsuite-support-matrix.md)); an
-unattributable failure is treated as a bug. Flipping a feature to supported
-turns its remaining skips into hard failures until the tests pass.
+The spec harness only tolerates test skips attributable to a feature that is not `Supported` here ([ADR-8](adr/8-latest-testsuite-support-matrix.md)); an unattributable failure is treated as a bug. Flipping a feature to supported turns its remaining skips into hard failures until the tests pass.
 
 ## Features
 
-The wasm 1.0 features a backend can meaningfully differ on ([ADR-25](adr/25-retire-support-tiers.md));
-every other `Feature` variant is rejected by the core for every backend ([ADR-24](adr/24-01-scope-reset.md)).
+The wasm 1.0 features a backend can meaningfully differ on ([ADR-25](adr/25-retire-support-tiers.md)); every other `Feature` variant is rejected by the core for every backend ([ADR-24](adr/24-01-scope-reset.md)).
 
 | Feature | ruby | bash | python | go | java |
 | --- | --- | --- | --- | --- | --- |
@@ -24,10 +19,7 @@ every other `Feature` variant is rejected by the core for every backend ([ADR-24
 
 ## WASI preview 1
 
-Derived from the runtime units; unimplemented syscalls resolve to an ENOSYS
-stub ([ADR-7](adr/7-import-providers.md), bash conventions in
-[ADR-12](adr/12-bash-wasi.md)). `—` marks the out-of-scope surface (sockets,
-`proc_raise`) no toolchain output exercises (ADR-25).
+Derived from the runtime units; unimplemented syscalls resolve to an ENOSYS stub ([ADR-7](adr/7-import-providers.md), bash conventions in [ADR-12](adr/12-bash-wasi.md)). `—` marks the out-of-scope surface (sockets, `proc_raise`) no toolchain output exercises (ADR-25).
 
 | Function | ruby | bash | python | go | java |
 | --- | --- | --- | --- | --- | --- |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -4,140 +4,40 @@ What `cargo test` actually needs, and what happens when it's missing.
 
 ## The policy: fail loud, never skip
 
-Per [ADR-15](adr/15-tests-fail-not-skip.md), a test whose required tool
-or setup step is missing **fails**, with a message pointing back to this
-file — it does not silently skip and report success. If you see a
-passing `cargo test`, every test in it actually ran. Every failure
-message below is something this document explains how to fix.
+Per [ADR-15](adr/15-tests-fail-not-skip.md), a test whose required tool or setup step is missing **fails**, with a message pointing back to this file — it does not silently skip and report success. If you see a passing `cargo test`, every test in it actually ran. Every failure message below is something this document explains how to fix.
 
 ## Required environment
 
-- **Rust toolchain**: pinned by `rust-toolchain.toml`; plain `cargo`
-  commands pick it up automatically.
-- **`git submodule update --init`**: fetches the two upstream testsuite
-  submodules (never edit either) — the wasm spec testsuite into `tests/spec/`
-  and the official WASI p1 conformance suite
-  ([`WebAssembly/wasi-testsuite`](https://github.com/WebAssembly/wasi-testsuite),
-  branch `prod/testsuite-base`) into `tests/wasi-testsuite/`. Without the
-  former the spec harness (`cargo test -p dewasm-backend-ruby --test spec`, and
-  likewise `-p dewasm-backend-bash` / `-p dewasm-backend-python`) fails
-  immediately; without the latter the WASI-testsuite harness
-  (`cargo test -p dewasm-backend-<lang> --test wasi_testsuite`, ADR-36) does.
-  Initialize just one with `git submodule update --init tests/wasi-testsuite`.
-- **`ruby` >= 3.4 on `PATH`**: needed by the spec harness and most of the
-  `e2e` test (both the Ruby backend's own tests and, indirectly, anything
-  comparing Ruby's output). The 3.4 floor is the generated runtime's
-  `IO::Buffer`-backed memory (see docs/adr/33-ruby-io-buffer-memory.md).
-- **`python3` >= 3.9 on `PATH` (or `$DEWASM_PYTHON`)**: needed by the
-  Python backend's spec/e2e tests. Like Bash, the Python spec harness runs
-  a curated `.wast` subset by default; add `-- --include-ignored` to run
-  every file. Note: the slow qjs-scale generated modules (deep loop nesting)
-  need **python >= 3.12.4** — 3.12.0–3.12.3 hit a static-block limit that
-  breaks that generated code (issue #21), so CI pins 3.13.
-- **`bash` >= 5 on `PATH`, `$DEWASM_BASH`, or a common Homebrew
-  install path**: needed by the Bash backend's spec/e2e/softfloat tests.
-  macOS's system `/bin/bash` is 3.2 and does not qualify (no associative
-  arrays / namerefs); install a newer one (e.g. `brew install bash`) and
-  either put it on `PATH` ahead of the system one or point
-  `$DEWASM_BASH` at it directly.
-- **`go` on `PATH` (or `$DEWASM_GO`)**: needed by the Go backend's spec, e2e,
-  and units tests. Go is compiled, so those tests `go build` the generated code
-  (to a content-addressed cache binary) and run the binary; a units test also
-  `go build`s the whole runtime bundle. The spec harness compiles one program
-  per `.wast` file, so it defaults to a curated list (like bash/python);
-  `-- --include-ignored` sweeps every file. Any recent Go (generics, i.e. >= 1.18)
-  qualifies.
-- **`java` and `javac` on `PATH` (or `$DEWASM_JAVA`/`$DEWASM_JAVAC`)**: needed by
-  the Java backend's spec, e2e, and units tests. Java is compiled, so those tests
-  `javac` the generated `Main.java` (to a content-addressed class-dir cache) and
-  run `java -cp <dir> Main`; a units test also `javac`s the whole runtime bundle.
-  JDK 11+ qualifies (the backend uses only standard APIs). The spec harness
-  compiles one `Main.java` per `.wast` file, so it defaults to a curated list
-  (like bash/python/go); `-- --include-ignored` sweeps every file.
+- **Rust toolchain**: pinned by `rust-toolchain.toml`; plain `cargo` commands pick it up automatically.
+- **`git submodule update --init`**: fetches the two upstream testsuite submodules (never edit either) — the wasm spec testsuite into `tests/spec/` and the official WASI p1 conformance suite ([`WebAssembly/wasi-testsuite`](https://github.com/WebAssembly/wasi-testsuite), branch `prod/testsuite-base`) into `tests/wasi-testsuite/`. Without the former the spec harness (`cargo test -p dewasm-backend-ruby --test spec`, and likewise `-p dewasm-backend-bash` / `-p dewasm-backend-python`) fails immediately; without the latter the WASI-testsuite harness (`cargo test -p dewasm-backend-<lang> --test wasi_testsuite`, ADR-36) does. Initialize just one with `git submodule update --init tests/wasi-testsuite`.
+- **`ruby` >= 3.4 on `PATH`**: needed by the spec harness and most of the `e2e` test (both the Ruby backend's own tests and, indirectly, anything comparing Ruby's output). The 3.4 floor is the generated runtime's `IO::Buffer`-backed memory (see docs/adr/33-ruby-io-buffer-memory.md).
+- **`python3` >= 3.9 on `PATH` (or `$DEWASM_PYTHON`)**: needed by the Python backend's spec/e2e tests. Like Bash, the Python spec harness runs a curated `.wast` subset by default; add `-- --include-ignored` to run every file. Note: the slow qjs-scale generated modules (deep loop nesting) need **python >= 3.12.4** — 3.12.0–3.12.3 hit a static-block limit that breaks that generated code (issue #21), so CI pins 3.13.
+- **`bash` >= 5 on `PATH`, `$DEWASM_BASH`, or a common Homebrew install path**: needed by the Bash backend's spec/e2e/softfloat tests. macOS's system `/bin/bash` is 3.2 and does not qualify (no associative arrays / namerefs); install a newer one (e.g. `brew install bash`) and either put it on `PATH` ahead of the system one or point `$DEWASM_BASH` at it directly.
+- **`go` on `PATH` (or `$DEWASM_GO`)**: needed by the Go backend's spec, e2e, and units tests. Go is compiled, so those tests `go build` the generated code (to a content-addressed cache binary) and run the binary; a units test also `go build`s the whole runtime bundle. The spec harness compiles one program per `.wast` file, so it defaults to a curated list (like bash/python); `-- --include-ignored` sweeps every file. Any recent Go (generics, i.e. >= 1.18) qualifies.
+- **`java` and `javac` on `PATH` (or `$DEWASM_JAVA`/`$DEWASM_JAVAC`)**: needed by the Java backend's spec, e2e, and units tests. Java is compiled, so those tests `javac` the generated `Main.java` (to a content-addressed class-dir cache) and run `java -cp <dir> Main`; a units test also `javac`s the whole runtime bundle. JDK 11+ qualifies (the backend uses only standard APIs). The spec harness compiles one `Main.java` per `.wast` file, so it defaults to a curated list (like bash/python/go); `-- --include-ignored` sweeps every file.
 
-Nothing else is required for `cargo test` to pass in full, **except** for
-the `apps` cases specifically — see below.
+Nothing else is required for `cargo test` to pass in full, **except** for the `apps` cases specifically — see below.
 
 ## The `apps` end-to-end cases
 
-The `apps` case table (`crates/dewasm-test-helper/src/apps.rs`, run per
-backend as `cargo test -p dewasm-backend-<lang> --test e2e apps`) converts
-real-world wasm binaries (cowsay, quickjs-ng, SQLite) and checks the output
-against a golden reference. Two things distinguish it from the rest of the
-suite:
+The `apps` case table (`crates/dewasm-test-helper/src/apps.rs`, run per backend as `cargo test -p dewasm-backend-<lang> --test e2e apps`) converts real-world wasm binaries (cowsay, quickjs-ng, SQLite) and checks the output against a golden reference. Two things distinguish it from the rest of the suite:
 
-- **The binaries themselves are fetched, not committed** ([ADR-9](adr/9-example-apps-from-registry.md)):
-  run `examples/apps/fetch.sh` once (needs network access) to populate
-  the gitignored `examples/apps/cache/`. Per ADR-15 this is a hard
-  prerequisite, not an optional extra — the `apps` tests fail with a
-  message naming the missing file until you run it. Several apps are built
-  locally from pinned source, so `fetch.sh` needs a few extra tools on PATH
-  (only for `fetch.sh` — `cargo test` itself never needs them once the cache
-  exists):
-    - the three sqlite3 shapes and `minigzip` (zlib) need **`zig`** and
-      **`unzip`** ([ADR-22](adr/22-sqlite3-built-from-source.md); `minigzip`
-      is `zig cc`'d from the pinned zlib 1.3.1 source, the byte-exact-stdio
-      compression CLI that runs under both backends);
-    - **ripgrep** is built with `cargo build --release --target
-      wasm32-wasip1` from the pinned 14.1.1 source, so it needs the
-      **`wasm32-wasip1`** rustup target (`rustup target add wasm32-wasip1`);
-      `fetch.sh` fails loudly if the target is not installed;
-    - **CPython** and **CRuby** are downloaded prebuilt (official
-      wasm32-wasip1 releases); `fetch.sh` additionally extracts each one's
-      stdlib tree (`cache/cpython-lib/lib/python3.14`,
-      `cache/ruby-lib/usr/local/lib/ruby`) that the interpreters read at
-      startup, which the heavy e2e cases preopen.
-- **The filesystem-exercising app cases are shared** across every fs-capable
-  backend (ADR-27 revision): the QuickJS file-I/O and scripted-REPL cases, the
-  sqlite3 DB-file case, ripgrep, and the CPython/CRuby runtime demos are `pub
-  const` cases in `crates/dewasm-test-helper/src/apps_fs.rs`, each driven by its
-  own per-case macro (`qjs_file_io_e2e!` … `cruby_hello_e2e!`); the sqlite3 C-API
-  / callback drives live in `apps_capi.rs`, run via `libsqlite3_c_api_e2e!` and
-  friends. Each backend supplies only a named glue string constant per case
-  (class name, argv, env, and preopen *guest* paths written literally; the
-  runtime host paths substituted from `{scratch}`/`{cache}` placeholders). A
-  backend that cannot run a case does not invoke that case's macro; the reason is
-  a comment at the (absent) callsite, with the measured numbers in
-  `docs/apps-audit.md` (e.g. CPython/CRuby on Java, CRuby on Go). The committed
-  driver fixtures (the `.js` scripts) live in `examples/apps/fixtures/`; the
-  filesystem-app goldens are still captured from `wasmtime` (the C-API drives
-  have no wasmtime golden — results live in guest memory — so each pins a fixed
-  string).
-- **No `wasmtime` install is needed to run these tests.** They used to
-  diff live against `wasmtime run`; that comparison's result is fixed
-  for a pinned binary and fixed input, so it's captured once and checked
-  into `examples/apps/golden/*.stdout`, compiled into the test binary via
-  `include_str!`. `wasmtime` is only needed for the opt-in check below,
-  or if you're re-pinning an app's version and must regenerate its
-  golden file.
+- **The binaries themselves are fetched, not committed** ([ADR-9](adr/9-example-apps-from-registry.md)): run `examples/apps/fetch.sh` once (needs network access) to populate the gitignored `examples/apps/cache/`. Per ADR-15 this is a hard prerequisite, not an optional extra — the `apps` tests fail with a message naming the missing file until you run it. Several apps are built locally from pinned source, so `fetch.sh` needs a few extra tools on PATH (only for `fetch.sh` — `cargo test` itself never needs them once the cache exists):
+    - the three sqlite3 shapes and `minigzip` (zlib) need **`zig`** and **`unzip`** ([ADR-22](adr/22-sqlite3-built-from-source.md); `minigzip` is `zig cc`'d from the pinned zlib 1.3.1 source, the byte-exact-stdio compression CLI that runs under both backends);
+    - **ripgrep** is built with `cargo build --release --target wasm32-wasip1` from the pinned 14.1.1 source, so it needs the **`wasm32-wasip1`** rustup target (`rustup target add wasm32-wasip1`); `fetch.sh` fails loudly if the target is not installed;
+    - **CPython** and **CRuby** are downloaded prebuilt (official wasm32-wasip1 releases); `fetch.sh` additionally extracts each one's stdlib tree (`cache/cpython-lib/lib/python3.14`, `cache/ruby-lib/usr/local/lib/ruby`) that the interpreters read at startup, which the heavy e2e cases preopen.
+- **The filesystem-exercising app cases are shared** across every fs-capable backend (ADR-27 revision): the QuickJS file-I/O and scripted-REPL cases, the sqlite3 DB-file case, ripgrep, and the CPython/CRuby runtime demos are `pub const` cases in `crates/dewasm-test-helper/src/apps_fs.rs`, each driven by its own per-case macro (`qjs_file_io_e2e!` … `cruby_hello_e2e!`); the sqlite3 C-API / callback drives live in `apps_capi.rs`, run via `libsqlite3_c_api_e2e!` and friends. Each backend supplies only a named glue string constant per case (class name, argv, env, and preopen *guest* paths written literally; the runtime host paths substituted from `{scratch}`/`{cache}` placeholders). A backend that cannot run a case does not invoke that case's macro; the reason is a comment at the (absent) callsite, with the measured numbers in `docs/apps-audit.md` (e.g. CPython/CRuby on Java, CRuby on Go). The committed driver fixtures (the `.js` scripts) live in `examples/apps/fixtures/`; the filesystem-app goldens are still captured from `wasmtime` (the C-API drives have no wasmtime golden — results live in guest memory — so each pins a fixed string).
+- **No `wasmtime` install is needed to run these tests.** They used to diff live against `wasmtime run`; that comparison's result is fixed for a pinned binary and fixed input, so it's captured once and checked into `examples/apps/golden/*.stdout`, compiled into the test binary via `include_str!`. `wasmtime` is only needed for the opt-in check below, or if you're re-pinning an app's version and must regenerate its golden file.
 
 ### Checking the golden files are still accurate
 
-A golden file is a claim ("this is what `wasmtime run` produces") that
-can go stale — a re-pinned app version, or a hand-edit mistake. Since
-`wasmtime` isn't a required tool for the default suite (previous
-section), this check is opt-in: behind the `wasmtime_test` Cargo
-feature, and `#[ignore]`d when that feature is off, so a plain
-`cargo test` never needs `wasmtime` but a deliberate check can still
-run it:
+A golden file is a claim ("this is what `wasmtime run` produces") that can go stale — a re-pinned app version, or a hand-edit mistake. Since `wasmtime` isn't a required tool for the default suite (previous section), this check is opt-in: behind the `wasmtime_test` Cargo feature, and `#[ignore]`d when that feature is off, so a plain `cargo test` never needs `wasmtime` but a deliberate check can still run it:
 
 ```console
 $ cargo test -p dewasm-test-helper --features wasmtime_test --test apps_wasmtime
 ```
 
-This runs wasmtime as a `BackendUnderTest` (`crates/dewasm-test-helper/tests/apps_wasmtime.rs`)
-through the *same* shared `apps`, `gzip`, and `fs_apps` runners the real
-backends use: for each case it execs `wasmtime run` (with `--dir`/`--env` for
-the filesystem cases) on the cached binary and compares the output against the
-checked-in golden file (independent of whether dewasm's own generated output
-also matches — the always-on per-backend `apps` tests already cover that half).
-The `fs_apps` cases drive `wasmtime --dir <scratch>::<guest>` — QuickJS file I/O
-(`--dir <scratch>::/work`, arg `/work/qjs_file_io.js`), the QuickJS scripted
-REPL (same, `qjs_repl.js`, the scripted session on stdin), the sqlite3 shell
-writing then reopening a DB file (`--dir <scratch>::/db`, two invocations), and
-ripgrep over a staged tree. Run this whenever
-you doubt a golden file, or as part of regenerating one after bumping a
-pin in `examples/apps/fetch.sh`:
+This runs wasmtime as a `BackendUnderTest` (`crates/dewasm-test-helper/tests/apps_wasmtime.rs`) through the *same* shared `apps`, `gzip`, and `fs_apps` runners the real backends use: for each case it execs `wasmtime run` (with `--dir`/`--env` for the filesystem cases) on the cached binary and compares the output against the checked-in golden file (independent of whether dewasm's own generated output also matches — the always-on per-backend `apps` tests already cover that half). The `fs_apps` cases drive `wasmtime --dir <scratch>::<guest>` — QuickJS file I/O (`--dir <scratch>::/work`, arg `/work/qjs_file_io.js`), the QuickJS scripted REPL (same, `qjs_repl.js`, the scripted session on stdin), the sqlite3 shell writing then reopening a DB file (`--dir <scratch>::/db`, two invocations), and ripgrep over a staged tree. Run this whenever you doubt a golden file, or as part of regenerating one after bumping a pin in `examples/apps/fetch.sh`:
 
 ```console
 $ examples/apps/fetch.sh   # fetch the newly-pinned binary
@@ -145,98 +45,31 @@ $ wasmtime run examples/apps/cache/<name>.wasm <args...> < <stdin-fixture> \
     > examples/apps/golden/<case>.stdout
 ```
 
-Then update the matching `AppCase` in `crates/dewasm-test-helper/src/apps.rs`
-(`expect_code` too, if the exit status changed), and confirm with the
-`wasmtime_test` command above before running the normal per-backend
-`cargo test -p dewasm-backend-<lang> --test e2e`.
+Then update the matching `AppCase` in `crates/dewasm-test-helper/src/apps.rs` (`expect_code` too, if the exit status changed), and confirm with the `wasmtime_test` command above before running the normal per-backend `cargo test -p dewasm-backend-<lang> --test e2e`.
 
 ## Test layout
 
-Tests live with the one backend they exercise; only a test that needs *every*
-backend lives centrally (ADR-27). The shared harness, case tables, and the
-per-feature test macros are in `crates/dewasm-test-helper`, which depends only
-on `dewasm-core` + `dewasm-backend` (never on a concrete backend).
+Tests live with the one backend they exercise; only a test that needs *every* backend lives centrally (ADR-27). The shared harness, case tables, and the per-feature test macros are in `crates/dewasm-test-helper`, which depends only on `dewasm-core` + `dewasm-backend` (never on a concrete backend).
 
-- **`crates/dewasm-backend-<lang>/tests/spec.rs`** — that backend's spec
-  conformance suite: its `SpecBackend` impl, its `EXPECTED_FAILURES` ledger
-  (and, for bash, the curated file list), wired up with `spec_suite!`. Run it
-  with `cargo test -p dewasm-backend-<lang> --test spec`.
-- **`crates/dewasm-backend-<lang>/tests/e2e.rs`** — that backend's suites,
-  declared by invoking the shared macros. The zero-glue aggregate macros
-  (`gzip_e2e!`, `qjs_repl_pty_e2e!`, `wasi_suite!(Stdio/ArgsEnv/ClockRandom/Poll)`)
-  take just the backend; the per-case macros (the library cases, the apps
-  `cowsay_args_e2e!`/`cowsay_stdin_e2e!`/`qjs_eval_e2e!`/`sqlite3_shell_e2e!`,
-  the filesystem apps `qjs_file_io_e2e!` … `cruby_hello_e2e!`, the C-API
-  `libsqlite3_c_api_e2e!` …, the multi-module
-  `shared_table_e2e!`/`embedded_coexist_e2e!`, `wasi_root_containment_e2e!`) take
-  no glue (the apps macros) or one named glue-string constant as their only
-  glue argument; the WASI-filesystem template `wasi_suite!(Fs, …)` likewise
-  takes one glue constant. `qjs_eval_e2e!`/`sqlite3_shell_e2e!` are slow —
-  the macro expands their generated `#[test]` as `#[ignore]`d unless the
-  expanding backend crate's `slow_test` feature is enabled (run it with
-  `--features slow_test`, or run everything including the ultra tier with a
-  single `cargo test -- --include-ignored`); a callsite may pass a trailing
-  `ultra` tier token ([ADR-48](adr/48-slow-test-tiers.md)). Per the ADR-27
-  revision this file
-  contains **only** the `BackendUnderTest` impl, named glue string constants
-  (library glue, the WASI-filesystem template, the filesystem-app instantiation
-  glue, the C-API driver glue, the multi-module driver glue, and the
-  `compose_modules` impl), and macro invocations — no backend-specific `#[test]`
-  function, no glue-returning function or `match` on a case name. Which macros a
-  backend invokes is the capability declaration; a case a backend cannot run is
-  simply not invoked, with the reason as a comment at the callsite. Runtime paths
-  a glue const cannot know statically are `{scratch}`/`{cache}`/`{guest}`/`{host}`
-  placeholders the runner fills (`glue::fill`).
-- **The interactive-REPL pty case (`qjs_repl_pty`).** `qjs_repl_pty_e2e!`
-  drives the *bare* QuickJS REPL (no script arg → interactive line editor)
-  under a real pty (`crates/dewasm-test-helper/src/pty.rs`, `portable-pty`) and
-  requires its transcript — ANSI escapes and all — to be byte-identical to the
-  one wasmtime produces. A pty is required because qjs only enters that path
-  when `fd_fdstat_get` on stdin reports a character device; a pipe does not.
-  The scripted session is *prompt-driven*: each line is sent only after the
-  `qjs > ` prompt reappears, so the transcript is stable regardless of how long
-  a backend takes to start (Ruby parses a ~200 MB source first). Slow: like
-  the other slow per-case macros, `qjs_repl_pty_e2e!`'s generated `#[test]`
-  is `#[ignore]`d unless the expanding backend crate's `slow_test` feature is
-  enabled (perf opt-out, ADR-15). For bash it is promoted to the ultra tier
-  (`ultra_slow_test`) because it timed out on CI
-  ([ADR-48](adr/48-slow-test-tiers.md), #22); the golden lives at
-  `examples/apps/golden/qjs_repl_interactive.transcript`.
-- The units lint (`declared_requires_cover_references`, `all_units_bundle`, and
-  the go/java whole-bundle compile checks) lives as `#[cfg(test)] mod units`
-  unit tests at the bottom of each backend's `src/lib.rs`, run with
-  `cargo test -p dewasm-backend-<lang> --lib`. **`softfloat.rs`** (bash) is the
-  one remaining backend-local integration oracle, unchanged.
-- **`crates/dewasm-cli/tests/`** — only `support_docs.rs` (the
-  `docs/support.md` golden gate over all backends).
-- **`crates/dewasm-test-helper/tests/apps_wasmtime.rs`** — wasmtime as a
-  `BackendUnderTest`: the `apps`/`gzip`/`fs_apps` golden-freshness checks run
-  through the shared runners, plus `qjs_repl_interactive_golden`, which
-  re-captures the bare qjs REPL under a pty from a live wasmtime and compares it
-  to the checked-in transcript (compare-only; regenerate with
-  `cargo xtask update-repl-golden`). All behind the `wasmtime_test` feature,
-  named for a future engine such as wasmer/wasmedge joining it.
+- **`crates/dewasm-backend-<lang>/tests/spec.rs`** — that backend's spec conformance suite: its `SpecBackend` impl, its `EXPECTED_FAILURES` ledger (and, for bash, the curated file list), wired up with `spec_suite!`. Run it with `cargo test -p dewasm-backend-<lang> --test spec`.
+- **`crates/dewasm-backend-<lang>/tests/e2e.rs`** — that backend's suites, declared by invoking the shared macros. The zero-glue aggregate macros (`gzip_e2e!`, `qjs_repl_pty_e2e!`, `wasi_suite!(Stdio/ArgsEnv/ClockRandom/Poll)`) take just the backend; the per-case macros (the library cases, the apps `cowsay_args_e2e!`/`cowsay_stdin_e2e!`/`qjs_eval_e2e!`/`sqlite3_shell_e2e!`, the filesystem apps `qjs_file_io_e2e!` … `cruby_hello_e2e!`, the C-API `libsqlite3_c_api_e2e!` …, the multi-module `shared_table_e2e!`/`embedded_coexist_e2e!`, `wasi_root_containment_e2e!`) take no glue (the apps macros) or one named glue-string constant as their only glue argument; the WASI-filesystem template `wasi_suite!(Fs, …)` likewise takes one glue constant. `qjs_eval_e2e!`/`sqlite3_shell_e2e!` are slow — the macro expands their generated `#[test]` as `#[ignore]`d unless the expanding backend crate's `slow_test` feature is enabled (run it with `--features slow_test`, or run everything including the ultra tier with a single `cargo test -- --include-ignored`); a callsite may pass a trailing `ultra` tier token ([ADR-48](adr/48-slow-test-tiers.md)). Per the ADR-27 revision this file contains **only** the `BackendUnderTest` impl, named glue string constants (library glue, the WASI-filesystem template, the filesystem-app instantiation glue, the C-API driver glue, the multi-module driver glue, and the `compose_modules` impl), and macro invocations — no backend-specific `#[test]` function, no glue-returning function or `match` on a case name. Which macros a backend invokes is the capability declaration; a case a backend cannot run is simply not invoked, with the reason as a comment at the callsite. Runtime paths a glue const cannot know statically are `{scratch}`/`{cache}`/`{guest}`/`{host}` placeholders the runner fills (`glue::fill`).
+- **The interactive-REPL pty case (`qjs_repl_pty`).** `qjs_repl_pty_e2e!` drives the *bare* QuickJS REPL (no script arg → interactive line editor) under a real pty (`crates/dewasm-test-helper/src/pty.rs`, `portable-pty`) and requires its transcript — ANSI escapes and all — to be byte-identical to the one wasmtime produces. A pty is required because qjs only enters that path when `fd_fdstat_get` on stdin reports a character device; a pipe does not. The scripted session is *prompt-driven*: each line is sent only after the `qjs > ` prompt reappears, so the transcript is stable regardless of how long a backend takes to start (Ruby parses a ~200 MB source first). Slow: like the other slow per-case macros, `qjs_repl_pty_e2e!`'s generated `#[test]` is `#[ignore]`d unless the expanding backend crate's `slow_test` feature is enabled (perf opt-out, ADR-15). For bash it is promoted to the ultra tier (`ultra_slow_test`) because it timed out on CI ([ADR-48](adr/48-slow-test-tiers.md), #22); the golden lives at `examples/apps/golden/qjs_repl_interactive.transcript`.
+- The units lint (`declared_requires_cover_references`, `all_units_bundle`, and the go/java whole-bundle compile checks) lives as `#[cfg(test)] mod units` unit tests at the bottom of each backend's `src/lib.rs`, run with `cargo test -p dewasm-backend-<lang> --lib`. **`softfloat.rs`** (bash) is the one remaining backend-local integration oracle, unchanged.
+- **`crates/dewasm-cli/tests/`** — only `support_docs.rs` (the `docs/support.md` golden gate over all backends).
+- **`crates/dewasm-test-helper/tests/apps_wasmtime.rs`** — wasmtime as a `BackendUnderTest`: the `apps`/`gzip`/`fs_apps` golden-freshness checks run through the shared runners, plus `qjs_repl_interactive_golden`, which re-captures the bare qjs REPL under a pty from a live wasmtime and compares it to the checked-in transcript (compare-only; regenerate with `cargo xtask update-repl-golden`). All behind the `wasmtime_test` feature, named for a future engine such as wasmer/wasmedge joining it.
 
-Onboarding a new backend to the e2e suites is: implement `BackendUnderTest`
-(and `SpecBackend` for the spec harness) in the new crate, then invoke the
-macros for the suites it participates in.
+Onboarding a new backend to the e2e suites is: implement `BackendUnderTest` (and `SpecBackend` for the spec harness) in the new crate, then invoke the macros for the suites it participates in.
 
 ## Regenerating golden files
 
-Two golden files are code-derived rather than hand-written, and each has a
-compare-only test that fails with the exact command to regenerate it — no
-env-var modes:
+Two golden files are code-derived rather than hand-written, and each has a compare-only test that fails with the exact command to regenerate it — no env-var modes:
 
 | Golden | Regenerate with | Compare-only test |
 | --- | --- | --- |
 | `docs/support.md` | `cargo xtask update-support-docs` | `cargo test -p dewasm-cli --test support_docs` |
 | `examples/apps/golden/qjs_repl_interactive.transcript` | `cargo xtask update-repl-golden` | `cargo test -p dewasm-test-helper --features wasmtime_test --test apps_wasmtime` |
 
-`update-repl-golden` needs `wasmtime` on `PATH` and the qjs app cached
-(`examples/apps/fetch.sh`) — the same requirements as the freshness test it
-feeds. `cargo xtask` is aliased in `.cargo/config.toml` to
-`cargo run -p xtask --`; run `cargo xtask` with no arguments (or `--help`) for
-the command list.
+`update-repl-golden` needs `wasmtime` on `PATH` and the qjs app cached (`examples/apps/fetch.sh`) — the same requirements as the freshness test it feeds. `cargo xtask` is aliased in `.cargo/config.toml` to `cargo run -p xtask --`; run `cargo xtask` with no arguments (or `--help`) for the command list.
 
 ## Useful environment variables
 
@@ -247,76 +80,29 @@ the command list.
 
 ## The spec harness (libtest-mimic)
 
-Each backend's spec integration test (`crates/dewasm-backend-<lang>/tests/spec.rs`)
-is a [libtest-mimic](https://crates.io/crates/libtest-mimic) harness
-(`harness = false`): every upstream `.wast` file becomes one named trial (the
-file stem is the trial name), enumerated at runtime from the `tests/spec`
-submodule. This replaces the former `DEWASM_SPEC`/`DEWASM_SPEC_ALL` environment
-variables with cargo's own test UX:
+Each backend's spec integration test (`crates/dewasm-backend-<lang>/tests/spec.rs`) is a [libtest-mimic](https://crates.io/crates/libtest-mimic) harness (`harness = false`): every upstream `.wast` file becomes one named trial (the file stem is the trial name), enumerated at runtime from the `tests/spec` submodule. This replaces the former `DEWASM_SPEC`/`DEWASM_SPEC_ALL` environment variables with cargo's own test UX:
 
-- **Select files by name** with cargo's built-in filter:
-  `cargo test -p dewasm-backend-ruby --test spec i32` runs every trial whose
-  name contains `i32` (add `-- --exact i32` for that one file).
-- **Curated vs. full sweep** is the ignore mechanism: files outside a backend's
-  curated list are `#[ignore]`d trials, so a plain `cargo test` runs the curated
-  set (Ruby is fast enough to curate nothing — it runs all files), and
-  `-- --include-ignored` (or `-- --ignored` for only the non-curated ones)
-  sweeps the whole testsuite. The `slow_test` feature also runs the full sweep
-  (nothing is marked ignored), so CI's main leg — `--features slow_test` — covers
-  every `.wast` file ([ADR-48](adr/48-slow-test-tiers.md)).
-- **Trials run in parallel** on libtest-mimic's thread pool; each trial owns its
-  per-file state, so the sweeps parallelize across cores (control the thread
-  count with `-- --test-threads=N`).
+- **Select files by name** with cargo's built-in filter: `cargo test -p dewasm-backend-ruby --test spec i32` runs every trial whose name contains `i32` (add `-- --exact i32` for that one file).
+- **Curated vs. full sweep** is the ignore mechanism: files outside a backend's curated list are `#[ignore]`d trials, so a plain `cargo test` runs the curated set (Ruby is fast enough to curate nothing — it runs all files), and `-- --include-ignored` (or `-- --ignored` for only the non-curated ones) sweeps the whole testsuite. The `slow_test` feature also runs the full sweep (nothing is marked ignored), so CI's main leg — `--features slow_test` — covers every `.wast` file ([ADR-48](adr/48-slow-test-tiers.md)).
+- **Trials run in parallel** on libtest-mimic's thread pool; each trial owns its per-file state, so the sweeps parallelize across cores (control the thread count with `-- --test-threads=N`).
 
-A passing trial is quiet; a failing one carries that file's `pass/fail/skip`
-summary plus the failing assertion lines. The former aggregate cross-backend
-`TOTAL: pass=… fail=…` line is gone — the per-file trial results supersede it.
-Per-file failure counts are still gated against each backend's
-`EXPECTED_FAILURES` ledger (ADR-8) inside the trial.
+A passing trial is quiet; a failing one carries that file's `pass/fail/skip` summary plus the failing assertion lines. The former aggregate cross-backend `TOTAL: pass=… fail=…` line is gone — the per-file trial results supersede it. Per-file failure counts are still gated against each backend's `EXPECTED_FAILURES` ledger (ADR-8) inside the trial.
 
-The slow app cases (QuickJS, SQLite, the filesystem apps, the C-API cases,
-the interactive-REPL pty case) run in two tiers gated by cargo features rather
-than an environment variable ([ADR-48](adr/48-slow-test-tiers.md)):
+The slow app cases (QuickJS, SQLite, the filesystem apps, the C-API cases, the interactive-REPL pty case) run in two tiers gated by cargo features rather than an environment variable ([ADR-48](adr/48-slow-test-tiers.md)):
 
-- **`slow_test`** — CI's main sweep. Each backend crate declares it; the
-  per-case macros expand their generated `#[test]` as `#[ignore]`d unless it is
-  enabled, and it also runs the full spec-testsuite sweep. Run one backend's
-  slow tier with `--features slow_test` (e.g.
-  `cargo test -p dewasm-backend-bash --features slow_test --test e2e`).
-- **`ultra_slow_test`** (implies `slow_test`) — the cases measured at roughly a
-  minute or more on a CI runner: the interactive qjs REPL pty case (bash timed
-  out >180s, #22) and go's giant-generated-program `go build`s (which
-  collectively exhausted a 4-core runner's memory, #23). These are pinned per
-  callsite and **deliberately kept out of CI** — run them only in local
-  pre-release verification with `--features ultra_slow_test` or the
-  everything-included `cargo test -- --include-ignored`.
+- **`slow_test`** — CI's main sweep. Each backend crate declares it; the per-case macros expand their generated `#[test]` as `#[ignore]`d unless it is enabled, and it also runs the full spec-testsuite sweep. Run one backend's slow tier with `--features slow_test` (e.g. `cargo test -p dewasm-backend-bash --features slow_test --test e2e`).
+- **`ultra_slow_test`** (implies `slow_test`) — the cases measured at roughly a minute or more on a CI runner: the interactive qjs REPL pty case (bash timed out >180s, #22) and go's giant-generated-program `go build`s (which collectively exhausted a 4-core runner's memory, #23). These are pinned per callsite and **deliberately kept out of CI** — run them only in local pre-release verification with `--features ultra_slow_test` or the everything-included `cargo test -- --include-ignored`.
 
-This is a deliberate perf-based opt-out, not a missing-environment one — see
-ADR-15's scope; the ultra tier is not CI-verified.
+This is a deliberate perf-based opt-out, not a missing-environment one — see ADR-15's scope; the ultra tier is not CI-verified.
 
 See `AGENTS.md`'s Common commands table for the exact invocations.
 
 ## The WASI-testsuite harness (libtest-mimic)
 
-Alongside the spec harness, each backend has a second libtest-mimic suite
-(`crates/dewasm-backend-<lang>/tests/wasi_testsuite.rs`, `harness = false`,
-`main` from `wasi_testsuite_suite!`) that runs the official WASI p1 conformance
-modules from the `tests/wasi-testsuite` submodule (ADR-36). It converts each
-prebuilt `.wasm` in `--mode standalone` and executes it through the ADR-31
-interface — the co-located `<name>.json` manifest's `args`/`env`/`root` become
-guest argv / child env / a `--dir <root>::/` preopen (from a fresh temp copy, so
-trials are hermetic), and the trial asserts the process exit code and, when
-pinned, stdout. Run one backend with:
+Alongside the spec harness, each backend has a second libtest-mimic suite (`crates/dewasm-backend-<lang>/tests/wasi_testsuite.rs`, `harness = false`, `main` from `wasi_testsuite_suite!`) that runs the official WASI p1 conformance modules from the `tests/wasi-testsuite` submodule (ADR-36). It converts each prebuilt `.wasm` in `--mode standalone` and executes it through the ADR-31 interface — the co-located `<name>.json` manifest's `args`/`env`/`root` become guest argv / child env / a `--dir <root>::/` preopen (from a fresh temp copy, so trials are hermetic), and the trial asserts the process exit code and, when pinned, stdout. Run one backend with:
 
 ```console
 $ cargo test -p dewasm-backend-ruby --test wasi_testsuite   # or bash/python/go/java
 ```
 
-The c + rust + assemblyscript `wasm32-wasip1` suites run (the Rust `wasm32-wasip3`
-tree is excluded — preview 3 is component-model territory, ADR-24). Each backend
-carries its own `WASI_TESTSUITE_EXPECTED_FAILURES` ledger (ADR-8): every known
-failure is attributed to a declared ENOSYS gap (docs/support.md), a
-semantics-precision gap on a supported syscall, or the ADR-31 whole-environment
-passthrough. As in the spec harness the ledger is checked both ways — a ledgered
-trial that unexpectedly *passes* is a hard failure, so filling a gap forces the
-entry to be removed.
+The c + rust + assemblyscript `wasm32-wasip1` suites run (the Rust `wasm32-wasip3` tree is excluded — preview 3 is component-model territory, ADR-24). Each backend carries its own `WASI_TESTSUITE_EXPECTED_FAILURES` ledger (ADR-8): every known failure is attributed to a declared ENOSYS gap (docs/support.md), a semantics-precision gap on a supported syscall, or the ADR-31 whole-environment passthrough. As in the spec harness the ledger is checked both ways — a ledgered trial that unexpectedly *passes* is a hard failure, so filling a gap forces the entry to be removed.


### PR DESCRIPTION
## Summary
- Stop hard-wrapping docs/ADRs/comments at ~80 columns (one line per paragraph/list item); regenerate `docs/support.md` from its now-unwrapped generator strings instead of hand-editing it.
- Rewrite the README intro with three worked examples (cowsay → Bash, QuickJS-NG → Ruby, `add.wat` as a library, pointing to `examples/rails` for the SQLite/Rails demo) plus a short feature summary, replacing the old feature-dump intro.
- Consolidate the former duplicate Install/Usage sections into single Installation/Usage/Copyright sections, and trim the CLI's `--help` doc comments to match (drop ADR citations/long asides that belong in docs/, not the terminal).

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (full gate, run before the README/CLI-help commit)
- [x] Manually converted/ran `cowsay`, `qjs`, and `add.wat` per the new README examples to verify the shown output

🤖 Generated with [Claude Code](https://claude.com/claude-code)