### PR TITLE
Inline linear-memory loads and stores in the bash emitter

### DIFF
--- a/crates/dewasm-backend-bash/src/lib.rs
+++ b/crates/dewasm-backend-bash/src/lib.rs
@@ -739,16 +739,15 @@ impl<'a> Gen<'a> {
                 value,
                 offset,
             } => {
-                let a = self.addr(w, addr, *offset);
-                let v = self.value(w, value);
                 let method = store_method(*op);
-                self.use_unit(&format!("mem/{method}"));
-                w.line(format!(
-                    "mem_{method} {} {} {} || return $?",
-                    self.prefix,
-                    cmd_arg(&a),
-                    cmd_arg(&v)
-                ));
+                let ea = self.eff_addr(w, addr, *offset);
+                let vfrag = self.value(w, value);
+                let v = self.as_var(w, &vfrag);
+                self.mem_bounds(w, &ea, access_bytes(method));
+                let mem = format!("{}mem", self.prefix);
+                for line in store_inline_stmts(method, &mem, &ea, &v) {
+                    w.line(line);
+                }
             }
             Stmt::Block { label, body } => {
                 if label.referenced {
@@ -1050,18 +1049,47 @@ impl<'a> Gen<'a> {
         }
     }
 
-    /// Memory address fragment with the static offset folded in.
-    fn addr(&self, w: &mut CodeWriter, addr: &Expr, offset: u64) -> String {
+    /// Effective-address var for an inline mem access: the load/store address
+    /// with the static offset folded in (base+offset in the unsigned 33-bit
+    /// range fits bash's signed 64), snapshotted into a plain var so the bounds
+    /// check and every byte subscript share one canonical decimal key source.
+    fn eff_addr(&self, w: &mut CodeWriter, addr: &Expr, offset: u64) -> String {
         let a = self.value(w, addr);
-        if offset == 0 {
+        let frag = if offset == 0 {
             a
         } else {
-            format!("(({a}) + {offset})")
-        }
+            format!("({a}) + {offset}")
+        };
+        self.as_var(w, &frag)
+    }
+
+    /// Inline out-of-bounds check preserving the trap protocol (ADR-11):
+    /// compare the effective address against `pages * 65536` (a nameref read
+    /// for imported memory, so `memory.grow` on the owner is reflected) and
+    /// cascade status 134 on failure.
+    fn mem_bounds(&self, w: &mut CodeWriter, ea: &str, n: u32) {
+        self.use_unit("rt/trap");
+        let p = self.prefix;
+        w.line(format!(
+            "if (( {ea} + {n} > {p}pages * 65536 )); then rt_trap 'out of bounds memory access'; return $?; fi"
+        ));
+    }
+
+    /// Emit an inline load (address snapshot + bounds check), returning the
+    /// arithmetic fragment that composes its value directly from memory.
+    fn inline_load(&self, w: &mut CodeWriter, op: LoadOp, addr: &Expr, offset: u64) -> String {
+        let method = load_method(op);
+        let ea = self.eff_addr(w, addr, offset);
+        self.mem_bounds(w, &ea, access_bytes(method));
+        load_inline_expr(method, &format!("{}mem", self.prefix), &ea)
     }
 
     fn emit_assign(&self, w: &mut CodeWriter, dst: &str, expr: &Expr) {
         if let Some(frag) = self.arith(expr) {
+            w.line(format!("(( {dst} = {frag} ))"));
+        } else if let Expr::Load { op, addr, offset } = expr {
+            // Load straight into the destination, skipping the R0 hop.
+            let frag = self.inline_load(w, *op, addr, *offset);
             w.line(format!("(( {dst} = {frag} ))"));
         } else if self.emit_command(w, expr) {
             w.line(format!("(( {dst} = R0 ))"));
@@ -1098,15 +1126,10 @@ impl<'a> Gen<'a> {
                 self.grab_r0(w)
             }
             Expr::Load { op, addr, offset } => {
-                let a = self.addr(w, addr, *offset);
-                let method = load_method(*op);
-                self.use_unit(&format!("mem/{method}"));
-                w.line(format!(
-                    "mem_{method} {} {} || return $?",
-                    self.prefix,
-                    cmd_arg(&a)
-                ));
-                self.grab_r0(w)
+                // Snapshot the composed value into a scratch var so callers
+                // that repeat the operand don't re-read memory.
+                let frag = self.inline_load(w, *op, addr, *offset);
+                self.as_var(w, &frag)
             }
             Expr::Select { cond, then, els } => {
                 let c = self.value(w, cond);
@@ -1139,24 +1162,8 @@ impl<'a> Gen<'a> {
                 self.rt_cmd(w, bin_helper(*op), &[cmd_arg(&a), cmd_arg(&b)]);
                 true
             }
-            Expr::Load { op, addr, offset } => {
-                let Some(a) = self.arith(addr) else {
-                    return false;
-                };
-                let a = if *offset == 0 {
-                    a
-                } else {
-                    format!("(({a}) + {offset})")
-                };
-                let method = load_method(*op);
-                self.use_unit(&format!("mem/{method}"));
-                w.line(format!(
-                    "mem_{method} {} {} || return $?",
-                    self.prefix,
-                    cmd_arg(&a)
-                ));
-                true
-            }
+            // Loads inline directly into their destination via emit_assign /
+            // value(); they never take the R0 command path.
             _ => false,
         }
     }
@@ -1252,6 +1259,83 @@ fn s32_view(x: &str) -> String {
 
 fn u64_flip(x: &str) -> String {
     format!("(({x}) ^ (1 << 63))")
+}
+
+/// Bytes a load/store method touches, for the inline bounds check.
+fn access_bytes(method: &str) -> u32 {
+    match method {
+        "i32_load8_s" | "i32_load8_u" | "i64_load8_s" | "i64_load8_u" | "i32_store8"
+        | "i64_store8" => 1,
+        "i32_load16_s" | "i32_load16_u" | "i64_load16_s" | "i64_load16_u" | "i32_store16"
+        | "i64_store16" => 2,
+        "i32_load" | "i64_load32_s" | "i64_load32_u" | "i32_store" | "i64_store32" => 4,
+        "i64_load" | "i64_store" => 8,
+        _ => unreachable!("unknown mem method {method}"),
+    }
+}
+
+/// One little-endian byte cell of `<mem>` at effective address `ea` (already a
+/// plain integer var): `<mem>[$ea]` for byte 0, `<mem>[$((ea+k))]` for k>0 —
+/// the pre-expanded canonical-decimal key the assoc representation needs so it
+/// stays on bash's fast subscript path (ADR-51).
+fn mem_byte(mem: &str, ea: &str, k: u32) -> String {
+    if k == 0 {
+        format!("{mem}[${ea}]")
+    } else {
+        format!("{mem}[$(({ea}+{k}))]")
+    }
+}
+
+/// Little-endian composition of `n` bytes at `ea`: `b0 | b1<<8 | ...`.
+fn le_compose(mem: &str, ea: &str, n: u32) -> String {
+    (0..n)
+        .map(|k| match k {
+            0 => mem_byte(mem, ea, 0),
+            _ => format!("{}<<{}", mem_byte(mem, ea, k), k * 8),
+        })
+        .collect::<Vec<_>>()
+        .join(" | ")
+}
+
+/// Inline arithmetic reproducing a `mem_<method>` load body: little-endian
+/// byte composition with the unit's exact sign-extension form. The i64 top
+/// byte `<<56` wraps into the sign bit, which is the signed-64 bit pattern of
+/// i64 (ADR-11); narrow signed loads xor/sub the sign bit, and the i32 ones
+/// remask to masked-unsigned (ADR-2).
+fn load_inline_expr(method: &str, mem: &str, ea: &str) -> String {
+    match method {
+        "i32_load" => le_compose(mem, ea, 4),
+        "i64_load" => le_compose(mem, ea, 8),
+        "i32_load8_u" | "i64_load8_u" => mem_byte(mem, ea, 0),
+        "i32_load16_u" | "i64_load16_u" => le_compose(mem, ea, 2),
+        "i64_load32_u" => le_compose(mem, ea, 4),
+        "i32_load8_s" => format!("(({} ^ 0x80) - 0x80) & 0xffffffff", mem_byte(mem, ea, 0)),
+        "i32_load16_s" => format!(
+            "((({}) ^ 0x8000) - 0x8000) & 0xffffffff",
+            le_compose(mem, ea, 2)
+        ),
+        "i64_load8_s" => format!("({} ^ 0x80) - 0x80", mem_byte(mem, ea, 0)),
+        "i64_load16_s" => format!("((({}) ^ 0x8000) - 0x8000)", le_compose(mem, ea, 2)),
+        "i64_load32_s" => format!("((({}) ^ 0x80000000) - 0x80000000)", le_compose(mem, ea, 4)),
+        _ => unreachable!("unknown load method {method}"),
+    }
+}
+
+/// Inline byte-store statements reproducing a `mem_<method>` store body: low
+/// byte first, `v >> 8*k & 0xff` per cell. The arithmetic right shift on a
+/// negative i64 pattern is harmless — `& 0xff` masks the dragged-in sign bits
+/// (ADR-11).
+fn store_inline_stmts(method: &str, mem: &str, ea: &str, v: &str) -> Vec<String> {
+    (0..access_bytes(method))
+        .map(|k| {
+            let rhs = if k == 0 {
+                format!("{v} & 0xff")
+            } else {
+                format!("{v} >> {} & 0xff", k * 8)
+            };
+            format!("{}=$(( {rhs} ))", mem_byte(mem, ea, k))
+        })
+        .collect()
 }
 
 /// Inline arithmetic lowering for a unary op, if it has one.

--- a/docs/adr/52-bash-inline-memops.md
+++ b/docs/adr/52-bash-inline-memops.md
@@ -1,0 +1,27 @@
+# ADR-52 — Bash Emitter Inlines Linear-Memory Loads and Stores
+
+Status: **Accepted, 2026-07-30.** The Bash emitter generates per-instruction loads/stores as inline arithmetic on the module's memory array instead of `mem_*` unit calls; the units remain for WASI and bulk/rare ops. DOOM's tick dropped 87s → 34s (2.5x) and initGame 198s → 103s on top of ADR-51's representation change, with identical framebuffer checksums and the full gate green (spec 257/257).
+
+## Context
+
+After ADR-51 made random access O(1), the next cost class is bash function-call overhead: a call-based i32 load measured ~41k ops/sec while the same composition inlined measured ~85k. Every generated load also paid a second call (`mem_check`) and an R0-hop into its destination. ADR-1's ordering applies: this changes emitted shape, not semantics, and the spec harness gates it.
+
+## Decision
+
+Inline the 16 integer load/store variants and the memory-access half of f32/f64 (bit-conversion stays in Rt): snapshot the effective address (base + folded static offset, computed in the unsigned-33-bit range that fits bash's signed 64) into one var, emit the ADR-11-conforming bounds check `if (( ea + N > <p>pages * 65536 )); then rt_trap 'out of bounds memory access'; return $?; fi`, then compose the value with arithmetic-expanded subscripts `M[$((ea+k))]` — measured faster (85k vs 73k ops/sec) than hoisting per-byte key temps, and the pre-expansion keeps ADR-51's canonical-decimal-key invariant. Loads assign straight into their destination, eliminating the `R0` hop; stores are one short assignment per byte (comma-chaining assoc writes inside one `(( ))` is impossible, and giant single `(( ))` statements measure slower anyway). Criterion, extending ADR-51's: *emitted-shape choices are settled by microbenchmark at representative scale before the emitter changes* — intuition inverted twice here (temp-key hoisting lost; a `declare -gn` memory alias lost to the direct array name).
+
+Memory naming needs no new machinery: generated code references `<p>mem`/`<p>pages` literally — a 0-hop direct array for local memory, and the depth-1 nameref that `<p>_init` already establishes for imported memory (ADR-35), through which stores write and `memory.grow` on the owner is reflected (verified, and exercised by the spec linking tests).
+
+`mem_copy`/`fill`/`init`/`grow`/`size` stay unit calls (bulk or rare), and the `mem_*` load/store units themselves remain — WASI units and cross-module paths still call them, and the units lint keeps binding them.
+
+## Rejected alternatives
+
+- **Per-module `declare -gn` memory alias** (the design's initial sketch): adds a nameref hop to the dominant local-memory case, measured ~72k vs 85k ops/sec — slower than just naming the array.
+- **Pre-computed temp keys per byte** (`a1=$((ea+1)); M[$a1]`): the ADR-51 unit idiom, but at emit sites the inline `$((ea+k))` form is both faster and shorter; units keep the temp-key style for readability where the call overhead already dominates.
+- **Inlining WASI/bulk paths too**: destroys the unit structure (ADR-6) for paths where per-call overhead is amortized over many bytes; no measured win to justify it.
+
+## Consequences
+
+- Positive: DOOM tick 2.5x, initGame 1.9x; every converted module's hot loops shed two function calls plus an R0 copy per memory access. Remaining bash cost is arithmetic/control-flow, not call overhead.
+- Negative: generated files grow (DOOM: 16.7MB → 19.1MB, +14%; source time +7.6%); load/store semantics now exist in two places (units and emitter helpers) — the spec suite is the guard against drift.
+- Carry-over: word-packed cells (ADR-51's rejected alternative) remain the next representation-level lever if ever needed; the function-return `R0` hop for value-returning bodies is untouched (it is the return mechanism, not load overhead).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -65,6 +65,7 @@ This directory contains the Architecture Decision Records (ADRs) for dewasm. Eac
 | ADR-49 | [Where the WASI Spec Is Silent, Follow wasmtime; Host-Pinned Errno Modes for wasi-testsuite](49-spec-silent-follow-wasmtime.md) | Accepted |
 | ADR-50 | [DOOM Demo: One Wasm Binary, Per-Language Native Frontends](50-doom-example-shape.md) | Accepted |
 | ADR-51 | [Bash Linear Memory as an Associative Array](51-bash-assoc-memory.md) | Accepted |
+| ADR-52 | [Bash Emitter Inlines Linear-Memory Loads and Stores](52-bash-inline-memops.md) | Accepted |
 
 ## Adding a new ADR
 


### PR DESCRIPTION
Stacked on #52 (base: `bash-assoc-memory`; retargets to `main` when it merges). Adds ADR-52.

With ADR-51's hash-table memory in place, the per-access cost left was bash function-call overhead: every load paid a `mem_*` call, a nested `mem_check` call, and an `R0` hop. The emitter now generates the 16 integer load/store variants (plus the memory half of f32/f64) inline: one effective-address snapshot, an inline ADR-11-conforming bounds check (exact trap message and status-134 cascade preserved), arithmetic-expanded subscripts, and direct assignment into the destination. The `mem_*` units stay — WASI and bulk/cross-module paths still call them.

DOOM (headless, stub imports), cumulative over the two PRs:

| phase | indexed (2 days ago) | assoc (#52) | inline (this PR) |
| --- | --- | --- | --- |
| initGame | >3 CPU-hours, never completed | 198s | **103s** |
| tickGame | never reached | ~87s | **~34s** |

Framebuffer sample checksums identical across all three representations — semantics preserved. Costs: generated DOOM grows 16.7→19.1MB (+14%), source time +7.6%.

Verified (agent run + orchestrator re-run of the fast gate): fast gate green, `--features slow_test` sweep green (**full spec 257/257**, QuickJS/sqlite e2e), fmt/clippy clean, workspace `cargo test` green, cowsay standalone WASI run correct. Microbench-driven design decisions (direct array name over a `declare -gn` alias; inline `$((ea+k))` subscripts over hoisted temp keys; per-byte store statements over one giant `(( ))`) are recorded in ADR-52 with numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)