### PR TITLE
Derive branch-target free sets bottom-up in python and java

### DIFF
--- a/crates/dewasm-backend-java/src/lib.rs
+++ b/crates/dewasm-backend-java/src/lib.rs
@@ -1205,8 +1205,9 @@ impl<'a> Gen<'a> {
                 w.line(format!("{ret_ty} _ret = {ret_init};"));
             }
             let mut guarded = false;
+            let mut free = BTreeSet::new();
             for stmt in &func.body {
-                self.emit_stmt(w, stmt, &mut guarded);
+                self.emit_stmt(w, stmt, &mut guarded, &mut free);
             }
             if has_result {
                 w.line("return _ret;");
@@ -1283,26 +1284,35 @@ impl<'a> Gen<'a> {
     }
 
     /// Emit a statement sequence as the body of a construct (loop/if/block body or the function entry): inline when small, or split into chained `part` methods when the function is split and the sub-body is large.
-    fn emit_body(&self, w: &mut CodeWriter, stmts: &[Stmt], guarded_in: bool) {
+    ///
+    /// Returns the sequence's *free* branch targets: the label ids it branches to that are not bound within it. The caller unions that set upward (minus the label it binds itself), so the information is derived once bottom-up; re-deriving it top-down at every enclosing block made conversion quadratic in nesting depth.
+    fn emit_body(&self, w: &mut CodeWriter, stmts: &[Stmt], guarded_in: bool) -> BTreeSet<u32> {
+        let mut free = BTreeSet::new();
         if self.split.get() && seq_cost(stmts) > SPLIT_THRESHOLD {
             let part_args = if self.partitioned.get() {
                 "inst, f"
             } else {
                 "f"
             };
-            for name in self.emit_parts(stmts, guarded_in) {
+            for name in self.emit_parts(stmts, guarded_in, &mut free) {
                 w.line(format!("{name}({part_args});"));
             }
         } else {
             let mut guarded = guarded_in;
             for stmt in stmts {
-                self.emit_stmt(w, stmt, &mut guarded);
+                self.emit_stmt(w, stmt, &mut guarded, &mut free);
             }
         }
+        free
     }
 
     /// Split `stmts` into consecutive `part` methods (each below the threshold), threading the `guarded` flag across the boundaries. Parts are called unconditionally in order: control flow is carried by the `f.br` register and each part self-guards, so an escaped branch simply no-ops the rest.
-    fn emit_parts(&self, stmts: &[Stmt], guarded_in: bool) -> Vec<String> {
+    fn emit_parts(
+        &self,
+        stmts: &[Stmt],
+        guarded_in: bool,
+        free: &mut BTreeSet<u32>,
+    ) -> Vec<String> {
         let mut names = Vec::new();
         let mut w = CodeWriter::new("    ");
         let mut guarded = guarded_in;
@@ -1316,7 +1326,7 @@ impl<'a> Gen<'a> {
                 w = CodeWriter::new("    ");
                 cost = 0;
             }
-            self.emit_stmt(&mut w, stmt, &mut guarded);
+            self.emit_stmt(&mut w, stmt, &mut guarded, free);
             cost += c;
         }
         let name = self.new_part();
@@ -1325,19 +1335,28 @@ impl<'a> Gen<'a> {
         names
     }
 
-    fn emit_stmt(&self, w: &mut CodeWriter, stmt: &Stmt, guarded: &mut bool) {
+    /// Emit one statement, adding its free branch targets to `free` (see `emit_body`).
+    fn emit_stmt(
+        &self,
+        w: &mut CodeWriter,
+        stmt: &Stmt,
+        guarded: &mut bool,
+        free: &mut BTreeSet<u32>,
+    ) {
         match stmt {
             Stmt::Block { label, body } => {
-                self.emit_body(w, body, *guarded);
+                let mut inner = self.emit_body(w, body, *guarded);
                 self.reset_marker(w, label);
-                *guarded = *guarded || !stmt_free_targets(stmt).is_empty();
+                inner.remove(&label.id);
+                *guarded = *guarded || !inner.is_empty();
+                free.extend(inner);
             }
             Stmt::Loop { label, body } => {
                 if label.referenced {
                     let before = *guarded;
                     w.line("while (true) {");
                     w.indent();
-                    self.emit_body(w, body, before);
+                    let mut inner = self.emit_body(w, body, before);
                     w.line(format!(
                         "if ({0} == {1}) {{ {0} = 0; continue; }}",
                         self.br(),
@@ -1346,10 +1365,14 @@ impl<'a> Gen<'a> {
                     w.line("break;");
                     w.dedent();
                     w.line("}");
-                    *guarded = before || !stmt_free_targets(stmt).is_empty();
+                    inner.remove(&label.id);
+                    *guarded = before || !inner.is_empty();
+                    free.extend(inner);
                 } else {
-                    self.emit_body(w, body, *guarded);
-                    *guarded = *guarded || !stmt_free_targets(stmt).is_empty();
+                    let mut inner = self.emit_body(w, body, *guarded);
+                    inner.remove(&label.id);
+                    *guarded = *guarded || !inner.is_empty();
+                    free.extend(inner);
                 }
             }
             Stmt::If {
@@ -1358,9 +1381,11 @@ impl<'a> Gen<'a> {
                 then,
                 els,
             } => {
-                self.emit_if(w, *guarded, cond, then, els);
+                let mut inner = self.emit_if(w, *guarded, cond, then, els);
                 self.reset_marker(w, label);
-                *guarded = *guarded || !stmt_free_targets(stmt).is_empty();
+                inner.remove(&label.id);
+                *guarded = *guarded || !inner.is_empty();
+                free.extend(inner);
             }
             // REASON: DWARF source-line markers are out of scope for Java (ADR-38) — drop them here (not via the `_br` guard) so the guard state and emitted output stay byte-identical to a non-`--dwarf-line` build.
             Stmt::SourceLine(_) => {}
@@ -1374,7 +1399,7 @@ impl<'a> Gen<'a> {
                 } else {
                     self.simple_stmt(w, stmt);
                 }
-                if !stmt_free_targets(stmt).is_empty() {
+                if collect_leaf_free_targets(stmt, free) {
                     *guarded = true;
                 }
             }
@@ -1391,7 +1416,15 @@ impl<'a> Gen<'a> {
         }
     }
 
-    fn emit_if(&self, w: &mut CodeWriter, guarded: bool, cond: &Expr, then: &[Stmt], els: &[Stmt]) {
+    /// Emit an `if`, returning the free branch targets of both arms (the `if`'s own label is removed by the caller).
+    fn emit_if(
+        &self,
+        w: &mut CodeWriter,
+        guarded: bool,
+        cond: &Expr,
+        then: &[Stmt],
+        els: &[Stmt],
+    ) -> BTreeSet<u32> {
         let cond_s = self.expr(cond);
         if guarded {
             // `_br == 0 &&` short-circuits, so `cond` is not evaluated (and cannot trap) while a branch is pending.
@@ -1400,23 +1433,24 @@ impl<'a> Gen<'a> {
             w.line(format!("if (({cond_s}) != 0) {{"));
         }
         w.indent();
-        self.emit_body(w, then, guarded);
+        let mut free = self.emit_body(w, then, guarded);
         w.dedent();
         if els.is_empty() {
             w.line("}");
         } else if guarded {
             w.line(format!("}} else if ({} == 0) {{", self.br()));
             w.indent();
-            self.emit_body(w, els, guarded);
+            free.extend(self.emit_body(w, els, guarded));
             w.dedent();
             w.line("}");
         } else {
             w.line("} else {");
             w.indent();
-            self.emit_body(w, els, guarded);
+            free.extend(self.emit_body(w, els, guarded));
             w.dedent();
             w.line("}");
         }
+        free
     }
 
     fn simple_stmt(&self, w: &mut CodeWriter, stmt: &Stmt) {
@@ -2018,60 +2052,39 @@ fn store_method(op: StoreOp) -> &'static str {
 
 // --- branch-target free sets (drive the `_br` guard placement) --------------
 
-/// The set of label ids a statement branches to that are *not* bound within it (a `Return` contributes the RETURN sentinel). Non-empty means the statement may leave `_br` set on fall-through, so following siblings must be guarded (ADR-28/ADR-30).
-fn stmt_free_targets(stmt: &Stmt) -> BTreeSet<u32> {
+/// Add the label ids a non-structured statement branches to into `free` (a `Return` contributes the RETURN sentinel), returning whether it has any. Non-empty means the statement may leave `_br` set on fall-through, so following siblings must be guarded (ADR-28/ADR-30). Structured statements get their free set from `emit_body`, which builds it bottom-up as it emits.
+fn collect_leaf_free_targets(stmt: &Stmt, free: &mut BTreeSet<u32>) -> bool {
     match stmt {
-        Stmt::Br(t) | Stmt::BrIf { target: t, .. } => target_free(t),
+        Stmt::Br(t) | Stmt::BrIf { target: t, .. } => {
+            collect_target_free(t, free);
+            true
+        }
         Stmt::BrTable {
             targets, default, ..
         } => {
-            let mut s = target_free(default);
+            collect_target_free(default, free);
             for t in targets {
-                s.extend(target_free(t));
+                collect_target_free(t, free);
             }
-            s
+            true
         }
         Stmt::Return { .. } => {
-            let mut s = BTreeSet::new();
-            s.insert(RETURN_SENTINEL);
-            s
+            free.insert(RETURN_SENTINEL);
+            true
         }
-        Stmt::Block { label, body } | Stmt::Loop { label, body } => {
-            let mut s = seq_free_targets(body);
-            s.remove(&label.id);
-            s
-        }
-        Stmt::If {
-            label, then, els, ..
-        } => {
-            let mut s = seq_free_targets(then);
-            s.extend(seq_free_targets(els));
-            s.remove(&label.id);
-            s
-        }
-        _ => BTreeSet::new(),
+        _ => false,
     }
 }
 
-fn seq_free_targets(stmts: &[Stmt]) -> BTreeSet<u32> {
-    let mut s = BTreeSet::new();
-    for stmt in stmts {
-        s.extend(stmt_free_targets(stmt));
-    }
-    s
-}
-
-fn target_free(t: &BrTarget) -> BTreeSet<u32> {
-    let mut s = BTreeSet::new();
+fn collect_target_free(t: &BrTarget, free: &mut BTreeSet<u32>) {
     match t {
         BrTarget::Return { .. } => {
-            s.insert(RETURN_SENTINEL);
+            free.insert(RETURN_SENTINEL);
         }
         BrTarget::Label { label, .. } => {
-            s.insert(*label);
+            free.insert(*label);
         }
     }
-    s
 }
 
 // --- cost estimate (drives the 64KB method split) ---------------------------

--- a/crates/dewasm-backend-python/src/lib.rs
+++ b/crates/dewasm-backend-python/src/lib.rs
@@ -878,27 +878,32 @@ impl<'a> Gen<'a> {
     }
 
     /// Emit a statement sequence, threading the compile-time `guarded` flag (whether a preceding statement may have left a branch pending in `_br`). Block/Loop bodies are spliced inline so block nesting adds no Python nesting; only real loops become `while` (ADR-28).
-    fn emit_seq(&self, w: &mut CodeWriter, stmts: &[Stmt], guarded: &mut bool) {
+    ///
+    /// Returns the sequence's *free* branch targets: the label ids it branches to that are not bound within it. The caller unions that set upward (minus the label it binds itself), so the information is derived once bottom-up; re-deriving it top-down at every enclosing block made conversion quadratic in nesting depth.
+    fn emit_seq(&self, w: &mut CodeWriter, stmts: &[Stmt], guarded: &mut bool) -> BTreeSet<u32> {
+        let mut free = BTreeSet::new();
         for stmt in stmts {
             match stmt {
                 Stmt::Block { label, body } => {
                     let before = *guarded;
-                    self.emit_seq(w, body, guarded);
+                    let mut inner = self.emit_seq(w, body, guarded);
                     if label.referenced {
                         w.line(format!("if _br == {}:", label.id));
                         w.indent();
                         w.line("_br = 0");
                         w.dedent();
                     }
-                    *guarded = before || !stmt_free_targets(stmt).is_empty();
+                    inner.remove(&label.id);
+                    *guarded = before || !inner.is_empty();
+                    free.extend(inner);
                 }
                 Stmt::Loop { label, body } => {
                     if label.referenced {
                         let before = *guarded;
                         w.line("while True:");
                         w.indent();
-                        let mut inner = before;
-                        self.emit_seq(w, body, &mut inner);
+                        let mut inner_guarded = before;
+                        let mut inner = self.emit_seq(w, body, &mut inner_guarded);
                         w.line(format!("if _br == {}:", label.id));
                         w.indent();
                         w.line("_br = 0");
@@ -906,10 +911,14 @@ impl<'a> Gen<'a> {
                         w.dedent();
                         w.line("break");
                         w.dedent();
-                        *guarded = before || !stmt_free_targets(stmt).is_empty();
+                        inner.remove(&label.id);
+                        *guarded = before || !inner.is_empty();
+                        free.extend(inner);
                     } else {
                         // No br targets this loop, so it never repeats.
-                        self.emit_seq(w, body, guarded);
+                        let mut inner = self.emit_seq(w, body, guarded);
+                        inner.remove(&label.id);
+                        free.extend(inner);
                     }
                 }
                 Stmt::If {
@@ -919,14 +928,16 @@ impl<'a> Gen<'a> {
                     els,
                 } => {
                     let before = *guarded;
-                    self.emit_if(w, before, cond, then, els);
+                    let mut inner = self.emit_if(w, before, cond, then, els);
                     if label.referenced {
                         w.line(format!("if _br == {}:", label.id));
                         w.indent();
                         w.line("_br = 0");
                         w.dedent();
                     }
-                    *guarded = before || !stmt_free_targets(stmt).is_empty();
+                    inner.remove(&label.id);
+                    *guarded = before || !inner.is_empty();
+                    free.extend(inner);
                 }
                 Stmt::SourceLine(_) => {
                     // A comment carries no runtime effect, so render it outside the `_br == 0` guard: a lone comment under an indented guard block would be an empty suite Python rejects, and the guard state must stay exactly as the surrounding statements left it (ADR-38).
@@ -941,15 +952,24 @@ impl<'a> Gen<'a> {
                     } else {
                         self.simple_stmt(w, stmt);
                     }
-                    if !stmt_free_targets(stmt).is_empty() {
+                    if collect_leaf_free_targets(stmt, &mut free) {
                         *guarded = true;
                     }
                 }
             }
         }
+        free
     }
 
-    fn emit_if(&self, w: &mut CodeWriter, guarded: bool, cond: &Expr, then: &[Stmt], els: &[Stmt]) {
+    /// Emit an `if`, returning the free branch targets of both arms (the `if`'s own label is removed by the caller).
+    fn emit_if(
+        &self,
+        w: &mut CodeWriter,
+        guarded: bool,
+        cond: &Expr,
+        then: &[Stmt],
+        els: &[Stmt],
+    ) -> BTreeSet<u32> {
         let cond_s = self.expr(cond);
         // When guarded, `_br == 0 and ...` short-circuits so `cond` (which may trap on a load) is not evaluated while a branch is pending.
         if guarded {
@@ -958,11 +978,12 @@ impl<'a> Gen<'a> {
             w.line(format!("if ({cond_s}) != 0:"));
         }
         w.indent();
+        let mut free = BTreeSet::new();
         if then.is_empty() {
             w.line("pass");
         } else {
             let mut it = false;
-            self.emit_seq(w, then, &mut it);
+            free = self.emit_seq(w, then, &mut it);
         }
         w.dedent();
         if !els.is_empty() {
@@ -973,9 +994,10 @@ impl<'a> Gen<'a> {
             }
             w.indent();
             let mut ie = false;
-            self.emit_seq(w, els, &mut ie);
+            free.extend(self.emit_seq(w, els, &mut ie));
             w.dedent();
         }
+        free
     }
 
     fn simple_stmt(&self, w: &mut CodeWriter, stmt: &Stmt) {
@@ -1386,51 +1408,29 @@ fn stmt_has_label_branch(stmt: &Stmt) -> bool {
     }
 }
 
-/// The set of label ids a statement branches to that are *not* bound within it. Non-empty means the statement may leave `_br` set on fall-through, so following siblings must be guarded (ADR-28).
-fn stmt_free_targets(stmt: &Stmt) -> BTreeSet<u32> {
+/// Add the label ids a non-structured statement branches to into `free`, returning whether it has any. Non-empty means the statement may leave `_br` set on fall-through, so following siblings must be guarded (ADR-28). Structured statements get their free set from `emit_seq`, which builds it bottom-up as it emits.
+fn collect_leaf_free_targets(stmt: &Stmt, free: &mut BTreeSet<u32>) -> bool {
     match stmt {
-        Stmt::Br(t) | Stmt::BrIf { target: t, .. } => target_free(t),
+        Stmt::Br(t) | Stmt::BrIf { target: t, .. } => collect_target_free(t, free),
         Stmt::BrTable {
             targets, default, ..
         } => {
-            let mut s = target_free(default);
+            let mut any = collect_target_free(default, free);
             for t in targets {
-                s.extend(target_free(t));
+                any |= collect_target_free(t, free);
             }
-            s
+            any
         }
-        Stmt::Block { label, body } | Stmt::Loop { label, body } => {
-            let mut s = seq_free_targets(body);
-            s.remove(&label.id);
-            s
-        }
-        Stmt::If {
-            label, then, els, ..
-        } => {
-            let mut s = seq_free_targets(then);
-            s.extend(seq_free_targets(els));
-            s.remove(&label.id);
-            s
-        }
-        _ => BTreeSet::new(),
+        _ => false,
     }
 }
 
-fn seq_free_targets(stmts: &[Stmt]) -> BTreeSet<u32> {
-    let mut s = BTreeSet::new();
-    for stmt in stmts {
-        s.extend(stmt_free_targets(stmt));
-    }
-    s
-}
-
-fn target_free(t: &BrTarget) -> BTreeSet<u32> {
+fn collect_target_free(t: &BrTarget, free: &mut BTreeSet<u32>) -> bool {
     match t {
-        BrTarget::Return { .. } => BTreeSet::new(),
+        BrTarget::Return { .. } => false,
         BrTarget::Label { label, .. } => {
-            let mut s = BTreeSet::new();
-            s.insert(*label);
-            s
+            free.insert(*label);
+            true
         }
     }
 }


### PR DESCRIPTION
Closes #59.

## The bug

The `_br` fall-through guard ([ADR-28](docs/adr/28-python-backend-lowering.md)) asks, after emitting a structured statement, whether that statement can leave a branch pending — and answered it by re-walking the subtree it had just emitted (`stmt_free_targets`). Every ancestor did the same, so each IR node was visited once per enclosing structured block, with a fresh `BTreeSet<u32>` allocated and unioned at every visit, all to ask `.is_empty()`.

Cost is O(nodes x nesting depth). Invisible on ordinary modules, brutal on a deep one: `cpython.wasm`'s `_PyUnicode_InitStaticStrings` is a 778-level `block` staircase (59,131 wasm instrs, 3,112 blocks, 21,785 IR statements), giving a 737x re-walk that accounted for 178.2M of the module's 183.6M total work units — 97% of the conversion. Size was never the driver: `ruby.wasm` has 2.7x more IR nodes than cpython and 7.7x less work. Ruby/Bash/Go were unaffected because they have no such query — it exists only for the two backends using the `_br` scheme (Ruby uses throw/catch, Go labeled break, Bash the status cascade).

## The fix

The emit walk now *returns* the free-target set of the sequence it just emitted; each construct removes the label it binds and unions the rest upward. The sets are built once, bottom-up, as a by-product of emitting, and the separate top-down recursion is deleted. Python: `emit_seq`/`emit_if` return the set. Java: `emit_body`/`emit_if` return it and `emit_parts` takes an accumulator (it splits output into named parts, so a return value would have been awkward).

## Measurements (dev profile, `dewasm <wasm> -t <be> --mode standalone -o /dev/null`)

| app | backend | before | after | speedup |
| --- | --- | --- | --- | --- |
| qjs | python | 0.8 s | 0.6 s | 1.3x |
| qjs | java | 1.2 s | 1.1 s | 1.1x |
| libsqlite3 | python | 3.7 s | 0.6 s | 6.2x |
| libsqlite3 | java | 4.2 s | 1.1 s | 3.8x |
| rg | python | 1.7 s | 1.3 s | 1.3x |
| rg | java | 2.6 s | 2.2 s | 1.2x |
| cpython | python | 101.1 s | 2.9 s | 35x |
| cpython | java | 80.4 s | 7.4 s | 11x |
| ruby | python | 13.3 s | 7.6 s | 1.8x |
| ruby | java | 19.3 s | 18.0 s | 1.1x |

cpython is no longer an outlier — python's 2.9 s now beats ruby/bash/go's ~4.5 s.

## Verification

- **Byte-identical output**, the point of the change: sha256 of generated source for 13 cached apps x {python, java} = 26 pairs, plus `--mode library` and `--dwarf-line` variants (16 more pairs), all unchanged.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` — green.
- Full spec sweeps `--test spec -- --include-ignored`: python 257 passed / 0 failed, java 257 passed / 0 failed.

## Follow-up (not in this PR)

Java's remaining cpython cost is the same class of bug in a different query: `seq_cost`/`stmt_cost` (driving the 64 KB method split) is re-walked top-down from every `emit_body` and per-child in `emit_parts`, so it is also O(n x depth). That is what keeps java at 7.4 s vs python's 2.9 s; it needs a different fix (the cost must be known *before* emitting). Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
