### PR TITLE
Add zeroperl to the apps cache and retract its deferred verdict

### DIFF
--- a/crates/dewasm-backend-ruby/tests/e2e.rs
+++ b/crates/dewasm-backend-ruby/tests/e2e.rs
@@ -11,7 +11,8 @@ use dewasm_test_helper::{
     qjs_file_io_e2e, qjs_repl_e2e, qjs_repl_pty_e2e, rg_search_e2e, shared_table_e2e,
     sqlite3_callback_binding_e2e, sqlite3_file_c_api_e2e, sqlite3_shell_dbfile_e2e,
     sqlite3_shell_e2e, standalone_dir_e2e, stdio_capture_e2e, treesitter_parse_e2e,
-    wasi_import_override_e2e, wasi_root_containment_e2e, wasi_suite, BackendUnderTest,
+    wasi_import_override_e2e, wasi_root_containment_e2e, wasi_suite, zeroperl_eval_e2e,
+    BackendUnderTest,
 };
 
 pub struct Ruby;
@@ -413,6 +414,36 @@ inst.invoke("free", r)
 puts "TS-OK"
 "##;
 
+/// zeroperl Perl-5.42 eval (issue #67): instantiate the reactor with a
+/// zero-returning `env.call_host_function` import stub (only invoked when the
+/// guest registers host callbacks — this program registers none) and a
+/// `/dev/null` preopen (`zeroperl_init` returns 1 without it), then
+/// `_initialize` → `zeroperl_init` → `malloc` + copy a Perl program into guest
+/// memory → `zeroperl_eval` → `zeroperl_flush`. The program is a regex capture
+/// + `printf`, so its stdout is deterministic.
+const RUBY_ZEROPERL_EVAL: &str = r##"
+inst = Zeroperl.new(
+  { "env" => { "call_host_function" => ->(_, _, _) { 0 } } },
+  preopens: { "/dev/null" => "/dev/null" },
+)
+inst.invoke("_initialize")
+rc = inst.invoke("zeroperl_init")
+raise "zeroperl_init rc=#{rc}" unless rc.zero?
+mem = inst.memory
+
+prog = <<~'PERL'
+my $s = "hello world 42";
+if ($s =~ /(\w+)\s+(\w+)\s+(\d+)/) {
+  printf("m=%s|%s|%d sum=%d\n", $1, $2, $3, $3 + 8);
+}
+PERL
+bytes = "#{prog}\0"
+ptr = inst.invoke("malloc", bytes.bytesize)
+mem.init(ptr, bytes, 0, bytes.bytesize)
+inst.invoke("zeroperl_eval", ptr, 0, 0, 0)
+inst.invoke("zeroperl_flush")
+"##;
+
 // --------------------------------------------------------------------- Multi-module drive glue.
 
 /// Driver for the shared-table case: instantiate the exporter and the importer linked against it, then print `call0` (call_indirect through the shared table -> 42).
@@ -500,6 +531,7 @@ sqlite3_file_c_api_e2e!(Ruby, RUBY_LIBSQLITE3_FILE);
 sqlite3_callback_binding_e2e!(Ruby, RUBY_SQLITE3_CALLBACK);
 pcap_compile_e2e!(Ruby, RUBY_PCAP_COMPILE);
 treesitter_parse_e2e!(Ruby, RUBY_TREESITTER_PARSE);
+zeroperl_eval_e2e!(Ruby, RUBY_ZEROPERL_EVAL);
 
 doom_frame_e2e!(Ruby, RUBY_DOOM_FRAME_GLUE);
 

--- a/crates/dewasm-test-helper/src/apps_capi.rs
+++ b/crates/dewasm-test-helper/src/apps_capi.rs
@@ -87,6 +87,27 @@ pub const TREESITTER_PARSE: CApiCase = CApiCase {
     assert_host: assert_none,
 };
 
+/// zeroperl Perl-5.42 eval (ADR-54 retraction, issue #67): the prebuilt
+/// `@6over3/zeroperl-ts` reactor exposes an embedding C API; the glue drives it
+/// `_initialize` → `zeroperl_init` → `malloc` + copy a Perl program into guest
+/// memory → `zeroperl_eval` → `zeroperl_flush`. Two host-environment pieces the
+/// deferred verdict presumed were blockers are supplied entirely from the glue,
+/// not the runtime: the imported `env.call_host_function` is a zero-returning
+/// stub (only ever called when the guest registers host callbacks, which this
+/// program does not), and `zeroperl_init` needs `/dev/null` resolvable so the
+/// glue preopens it (mapped guest→host `/dev/null`; without it init returns 1).
+/// The asyncify and setjmp/longjmp machinery the verdict also cited is
+/// module-internal (binaryen transforms; the setjmp is a port of ruby.wasm's
+/// `rb_wasm_setjmp`) and needs nothing from us. The pinned output is a regex +
+/// `printf` line — deterministic, exercising a real slice of the Perl core.
+pub const ZEROPERL_EVAL: CApiCase = CApiCase {
+    name: "zeroperl_eval",
+    wasm: "zeroperl",
+    class: "Zeroperl",
+    expect_stdout: "m=hello|world|42 sum=50\n",
+    assert_host: assert_none,
+};
+
 /// Run one [`CApiCase`] for `lang` with its per-language `glue` unconditionally (the perf opt-out lives at the macro/feature level, see the module docs). Fills `{scratch}` in `glue` with a fresh scratch dir (the file-backed case's preopen; unused by the in-memory cases).
 pub fn run_capi_case(lang: &dyn BackendUnderTest, case: &CApiCase, glue: &str) {
     let cache = apps_cache_dir();

--- a/crates/dewasm-test-helper/src/apps_convert.rs
+++ b/crates/dewasm-test-helper/src/apps_convert.rs
@@ -40,10 +40,11 @@ struct AppConvert {
     mode: Mode,
     /// Heavy: dev-profile conversion exceeds ~2 s on every backend, measurably
     /// slowing the fast gate, so the trial is `#[ignore]`d unless the backend
-    /// crate's `slow_test` feature is on. Measured, not guessed: only the two
-    /// giant interpreter artifacts — `ruby` (~7–13 s) and `cpython` (~2.6–5 s)
-    /// — cross the line; the next-slowest, `rg`, stays ~1.1–2.1 s in the same
-    /// cluster as the sqlite cases and is left in the fast gate (ADR-54).
+    /// crate's `slow_test` feature is on. Measured, not guessed: only the three
+    /// giant artifacts — `ruby` (~7–13 s), `cpython` (~2.6–5 s), and the 25 MB
+    /// `zeroperl` (Perl 5.42, ~4–5 s on Ruby and Python) — cross the line; the
+    /// next-slowest, `rg`, stays ~1.1–2.1 s in the same cluster as the sqlite
+    /// cases and is left in the fast gate (ADR-54).
     heavy: bool,
 }
 
@@ -119,6 +120,11 @@ const MANIFEST: &[AppConvert] = &[
         stem: "treesitter",
         mode: Mode::Library,
         heavy: false,
+    },
+    AppConvert {
+        stem: "zeroperl",
+        mode: Mode::Library,
+        heavy: true,
     },
 ];
 

--- a/crates/dewasm-test-helper/src/lib.rs
+++ b/crates/dewasm-test-helper/src/lib.rs
@@ -23,7 +23,7 @@ pub use apps::{
 };
 pub use apps_capi::{
     run_capi_case, CApiCase, LIBSQLITE3_C_API, PCAP_COMPILE, SQLITE3_CALLBACK_BINDING,
-    SQLITE3_FILE_C_API, TREESITTER_PARSE,
+    SQLITE3_FILE_C_API, TREESITTER_PARSE, ZEROPERL_EVAL,
 };
 pub use apps_convert::{apps_convert_main, apps_convert_trials};
 pub use apps_fs::{
@@ -484,6 +484,22 @@ macro_rules! treesitter_parse_e2e {
             #[test]
             fn treesitter_parse() {
                 $crate::run_capi_case(&$lang, &$crate::TREESITTER_PARSE, $glue);
+            }
+        }
+    };
+}
+
+/// See [`libsqlite3_c_api_e2e!`]. Runs the zeroperl Perl-5.42 eval case [`ZEROPERL_EVAL`](crate::ZEROPERL_EVAL): drives the embedding C API to evaluate a Perl program and pins its stdout. Slow (a 25 MB reactor artifact reconverted to a ~120 MB / ~1M-line program per run), so gated like the other C-API cases.
+#[macro_export]
+macro_rules! zeroperl_eval_e2e {
+    ($lang:expr, $glue:expr) => {
+        $crate::zeroperl_eval_e2e!($lang, $glue, slow);
+    };
+    ($lang:expr, $glue:expr, $tier:tt) => {
+        $crate::slow_tier_test! { $tier,
+            #[test]
+            fn zeroperl_eval() {
+                $crate::run_capi_case(&$lang, &$crate::ZEROPERL_EVAL, $glue);
             }
         }
     };

--- a/docs/apps-audit.md
+++ b/docs/apps-audit.md
@@ -18,7 +18,7 @@ and record the verdict here. An app that needs a proposal outside the 0.1 scope 
 | CPython 3.14.6 | pinned in `fetch-and-build.sh` | none | ✅ in scope (shipping, **executes on Ruby/Python/Go**⁵) |
 | CRuby 3.4 (ruby.wasm 2.9.4) | pinned in `fetch-and-build.sh` | none | ✅ in scope (shipping, **executes on Ruby/Python**⁵) |
 | pandoc | see below | **simd** | ⛔ deferred |
-| zeroperl (Perl 5.42) | see below | none (host-shim blocked) | ⛔ deferred |
+| zeroperl (Perl 5.42) | [6over3/zeroperl](https://github.com/6over3/zeroperl) via the `@6over3/zeroperl-ts` npm pin in `scripts/zeroperl.sh` | none | ✅ in scope (shipping, **executes on Ruby**¹²) |
 | LightningCSS | see below | unaudited (unverified fork build) | ⛔ deferred |
 | ripgrep 14.1.1 | pinned-source cargo build in `fetch-and-build.sh` | none (baseline after ADR-39 wasm-opt)¹¹ | ✅ in scope (shipping, Ruby + Python + Go + Java fs⁶) |
 | minigzip (zlib 1.3.1) | pinned-source zig build in `fetch-and-build.sh` | none (baseline after ADR-39 wasm-opt)¹¹ | ✅ in scope (shipping, **all five backends**⁷) |
@@ -70,17 +70,13 @@ Where included, each is comfortably under the ADR-24 ~5-minute bar, so it genuin
 
 ¹¹ **ADR-39 `wasm-opt` preprocessing.** Every module `fetch-and-build.sh` builds from source (the three sqlite3 shapes, minigzip, libpcap, tree-sitter, ripgrep — but not the DWARF fixture, which keeps its debug info) is run through `wasm-opt -O2` (baseline features only, no ctor-eval) before caching — see [ADR-39](adr/39-wasm-opt-preprocessing.md). Besides shrinking them, `wasm-opt` re-encodes the overlong `call_indirect` immediates the LLVM toolchain emits, so these modules audit as *pure* baseline rather than baseline + the reference-types encoding bit¹ the downloaded artifacts (cowsay, qjs, CPython, CRuby) still carry.
 
+¹² **zeroperl retraction (audited 2026-08-01, issue #67).** This entry was previously *deferred* on three presumed host-environment blockers; converting and running the module proved all three were misreadings, so the verdict is retracted. (1) **asyncify** and the **setjmp/longjmp** shim are module-internal — asyncify is a binaryen transform baked into the wasm, and the setjmp implementation is a port of ruby.wasm's `rb_wasm_setjmp` that lowers to ordinary baseline instructions; neither asks anything of the runtime. (2) The imported **`env.call_host_function`** is only invoked when the guest registers a host callback, which the eval path never does, so a `->(_,_,_){0}` stub as an ADR-7 import provider satisfies the link with no host glue. (3) No **stdlib preopen** is needed — the Perl core is embedded in the module as an "SFS" blob served from guest memory; the only preopen `zeroperl_init` requires is `/dev/null` (mapped guest→host `/dev/null`; without it init returns 1). The prebuilt reactor exposes an embedding C API, so it is driven exactly like the other reactor-library C-API cases (footnotes ⁸/¹⁰): the `zeroperl_eval` case (`zeroperl_eval_e2e!`, `slow_test`-gated — the 25 MB module converts to a ~120 MB / ~1M-line Ruby program) evaluates a regex + `printf` Perl program and pins its stdout. Ruby only for now (it exercises Ruby's provider/guest-memory idioms, not a new WASI unit); Perl 5 joins CPython and CRuby as a marquee scripting-language demo. The pinnable distribution is the `@6over3/zeroperl-ts` npm wrapper (the `6over3/zeroperl` source repo — the org renamed from `uswriting` — cuts no releases); MIT source, Apache-2.0 npm wrapper.
+
 ## Deferred: pandoc
 
 - Source: https://haskell-wasm.github.io/pandoc-wasm/pandoc.wasm (gh-pages of `haskell-wasm/pandoc-wasm`, unversioned — record the serving commit when pinning; audited copy: commit `ed18ae6e337d`, sha256 `48d9ceed3ef805f6acc28e6f58c2439cdeb1f71864244fffcc155e2c045aa7fc`, 53 MB).
 - Audit: **needs simd** (first offense: a v128 operation at offset 0x24723a). Notably it does *not* need tail calls or exception handling — the GHC 9.12 wasm backend output is otherwise baseline-shaped — so SIMD support alone would unblock it.
 - Revisit when/if SIMD enters scope; the binary is otherwise a pure wasip1 stdio converter and would make a strong demo.
-
-## Deferred: zeroperl
-
-- Source: [github.com/6over3/zeroperl](https://github.com/6over3/zeroperl) — a WASI reactor build of Perl 5.42. A prebuilt artifact is redistributed in [github.com/lbe/go-exiftool-wasm](https://github.com/lbe/go-exiftool-wasm) as `internal/zeroperl/zeroperl.wasm` (pin the serving commit + sha256 when it is promoted).
-- Audit: **not blocked on a wasm feature** — the blocker is host shims. The build relies on binaryen **asyncify** plus a custom **setjmp/longjmp** shim and an imported `env.call_host_function`, none of which the runtime provides. This is an ABI/host-environment gap, not a proposal outside the 0.1 scope.
-- Revisit when a setjmp/asyncify story exists (a general asyncify unwinding shim plus the `call_host_function` host glue); Perl 5 would be a marquee scripting-language demo alongside CPython and CRuby.
 
 ## Deferred: LightningCSS
 

--- a/examples/apps/README.md
+++ b/examples/apps/README.md
@@ -31,6 +31,7 @@ boilerplate in `scripts/common.sh`); run one directly — e.g.
 | ruby (CRuby) | [ruby.wasm 2.9.4](https://github.com/ruby/ruby.wasm/releases/tag/2.9.4) full build (official prebuilt) | CRuby 3.4 executed on the Ruby backend — the "Ruby on Ruby" north-star demo (Ruby + Python, heavy; Phase 5b) |
 | libpcap | [libpcap 1.10.6](https://www.tcpdump.org/release/libpcap-1.10.6.tar.gz), built from source with `zig` (reactor) | libpcap's BPF filter compiler as a C-API library: `compile_filter("tcp port 80")` returns a serialized BPF program from guest memory, driven on Ruby + Python + Go (heavy) |
 | treesitter | [tree-sitter 0.26.11](https://github.com/tree-sitter/tree-sitter/releases/tag/v0.26.11) + [tree-sitter-json 0.24.8](https://github.com/tree-sitter/tree-sitter-json/releases/tag/v0.24.8), built from source with `zig` (reactor) | the tree-sitter parsing runtime as a C-API library: `parse_source("{...}")` returns the JSON parse tree's S-expression, driven on Ruby + Python + Go (heavy) |
+| zeroperl | [6over3/zeroperl](https://github.com/6over3/zeroperl) (Perl 5.42), prebuilt wasm from the [`@6over3/zeroperl-ts`](https://www.npmjs.com/package/@6over3/zeroperl-ts) npm package | the Perl 5 interpreter (25 MB reactor) driven through its embedding C API: `zeroperl_eval` runs a Perl program and prints its output on Ruby (heavy) |
 
 ```console
 $ ./fetch-and-build.sh

--- a/examples/apps/scripts/zeroperl.sh
+++ b/examples/apps/scripts/zeroperl.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# shellcheck source-path=SCRIPTDIR
+# shellcheck source=common.sh
+
+# zeroperl: a WASI reactor build of Perl 5.42 (6over3/zeroperl — the org
+# renamed from uswriting). The source repo cuts no releases/tags, so the
+# pinnable distribution is the npm wrapper `@6over3/zeroperl-ts`, which ships
+# the prebuilt zeroperl.wasm under dist/esm/. Licensing: the zeroperl source
+# (github.com/6over3/zeroperl) is MIT; the zeroperl-ts npm package that
+# redistributes the wasm is Apache-2.0.
+#
+# fetch_app verifies the tarball sha and extracts the inner wasm, but not the
+# extracted file's own sha; we add that check here (a 25 MB device where a
+# silent partial extract would be an inscrutable convert failure downstream).
+
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
+fetch_app zeroperl \
+  "https://registry.npmjs.org/@6over3/zeroperl-ts/-/zeroperl-ts-1.0.10.tgz" \
+  c46c5ffff4f2c2216137a6b34b4eb03f5554e17a2b88979463c5f61dffb36fed \
+  package/dist/esm/zeroperl.wasm
+
+echo "a6ae97f184fabc444b0b70d77c3d16475bfb3de16ebfb58ab8b2fbf98a53835e  cache/zeroperl.wasm" \
+  | shasum -a 256 -c - >/dev/null


### PR DESCRIPTION
Closes #67.

docs/apps-audit.md deferred zeroperl on three presumed host-environment blockers (asyncify host shims, a setjmp/longjmp shim, `env.call_host_function` glue). Converting and running the module shows all three were misreadings: asyncify and the setjmp machinery (a port of ruby.wasm's `rb_wasm_setjmp`) are module-internal binaryen transforms, the `env.call_host_function` import is only invoked when the guest registers host callbacks (a zero-returning ADR-7 provider stub links cleanly), and the Perl core is embedded in-module as an SFS blob so no stdlib preopen is needed — the only requirement is a `/dev/null` preopen (verified empirically: without it `zeroperl_init` returns 1; guest→host `/dev/null` direct mapping is the tightest shape that works).

- `examples/apps/scripts/zeroperl.sh`: pinned fetch from the `@6over3/zeroperl-ts@1.0.10` npm tarball (the `6over3/zeroperl` source repo cuts no releases; org renamed from `uswriting`), with two checksum layers — the whole-tarball sha256 via `fetch_app` plus the inner `zeroperl.wasm`'s own sha256. Idempotent on re-run via the stamp file.
- Convert suite (ADR-54): `zeroperl` row, `Mode::Library`, `heavy: true` (measured: Ruby ~4.97 s, Python ~4.01 s dev-profile conversion — both convert clean).
- New `zeroperl_eval` e2e case (`slow_test` tier, Ruby glue): `_initialize` → `zeroperl_init` → `malloc` + copy a Perl regex+printf program into guest memory → `zeroperl_eval` → `zeroperl_flush`, pinned stdout. Measured 8.4 s including loading the ~120 MB / ~1M-line generated Ruby.
- apps-audit retraction footnote ¹² + README app-table row.

Gates: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (fast gate) all green; heavy/slow trials verified explicitly with `--features slow_test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)