### PR TITLE
Add full WASI p1 and the app e2e suites to the Perl backend

### DIFF
--- a/crates/dewasm-backend-perl/Cargo.toml
+++ b/crates/dewasm-backend-perl/Cargo.toml
@@ -15,6 +15,10 @@ workspace = true
 # revision) as active `#[test]`s instead of `#[ignore]`d ones, and runs the
 # full spec testsuite sweep — CI's main sweep tier. See docs/testing.md.
 slow_test = []
+# The ultra tier (ADR-48): cases measured at ~1 minute or more on a CI
+# runner (the CRuby-hello run, ~57s locally), kept out of CI and run only
+# in local pre-release verification.
+ultra_slow_test = ["slow_test"]
 
 [dependencies]
 anyhow.workspace = true
@@ -31,6 +35,13 @@ dewasm-test-helper.workspace = true
 # `.wast` file, so `harness = false` and its `main` comes from `spec_suite!`.
 [[test]]
 name = "spec"
+harness = false
+
+# The WASI-testsuite integration test (ADR-36) is likewise a
+# libtest-mimic harness: one trial per prebuilt `.wasm`, `harness = false`,
+# `main` from `wasi_testsuite_suite!`.
+[[test]]
+name = "wasi_testsuite"
 harness = false
 
 # The whole-cache convert suite (ADR-54) is likewise a libtest-mimic

--- a/crates/dewasm-backend-perl/src/lib.rs
+++ b/crates/dewasm-backend-perl/src/lib.rs
@@ -57,12 +57,11 @@ pub fn bundler() -> &'static RuntimeBundler {
                     close: "",
                     prelude: Some("global/_package"),
                 },
-                // WASI preview 1 lands with the follow-up issue; the scope is declared so its units slot in without bundler changes.
                 RuntimeScope {
                     prefix: "wasi",
                     open: "package Rt::WASI;",
                     close: "",
-                    prelude: None,
+                    prelude: Some("wasi/_package"),
                 },
             ],
             UNIT_SOURCES,
@@ -252,10 +251,44 @@ impl Backend for PerlBackend {
                 RuntimeLinkage::Embedded => format!("{package_name}::Rt"),
                 RuntimeLinkage::Alias(_) => "Rt".to_string(),
             };
+            let wasi = wasi_bundled(module, opts.default_wasi);
             w.line("");
             w.line("package main;");
             w.line("");
-            w.line(format!("my $_inst = {package_name}->new({{}});"));
+            if wasi {
+                // The standalone runtime interface (ADR-31): a leading run of `--dir HOST::GUEST` flags mounts host directories at guest paths (wasmtime-style), stopping at `--` or the first non-flag token; the rest is the guest's argv[1..].
+                w.line("use File::Basename ();");
+                w.line("");
+                w.line("my %_preopens;");
+                w.line("my @_guest_args = @ARGV;");
+                w.line("while (@_guest_args) {");
+                w.indent();
+                w.line("my $_a = $_guest_args[0];");
+                w.line("if ($_a eq '--') { shift @_guest_args; last; }");
+                w.line("if ($_a ne '--dir' && rindex($_a, '--dir=', 0) != 0) { last; }");
+                w.line("shift @_guest_args;");
+                w.line("my $_spec;");
+                w.line("if ($_a eq '--dir') {");
+                w.indent();
+                w.line("if (!@_guest_args) { print STDERR \"--dir requires a HOST::GUEST argument\\n\"; exit(1); }");
+                w.line("$_spec = shift @_guest_args;");
+                w.dedent();
+                w.line("} else {");
+                w.indent();
+                w.line("$_spec = substr($_a, 6);");
+                w.dedent();
+                w.line("}");
+                w.line("my $_sep = index($_spec, '::');");
+                w.line("if ($_sep >= 0) { $_preopens{substr($_spec, $_sep + 2)} = substr($_spec, 0, $_sep); }");
+                w.line("else { $_preopens{$_spec} = $_spec; }");
+                w.dedent();
+                w.line("}");
+                w.line(format!(
+                    "my $_inst = {package_name}->new({{}}, args => [File::Basename::basename($0), @_guest_args], env => {{ %ENV }}, preopens => \\%_preopens);"
+                ));
+            } else {
+                w.line(format!("my $_inst = {package_name}->new({{}});"));
+            }
             w.line("eval { $_inst->invoke('_start'); };");
             w.line("if (my $_e = $@) {");
             w.indent();
@@ -344,6 +377,15 @@ const WASI_MODULES: &[&str] = &["wasi_snapshot_preview1", "wasi_unstable"];
 
 fn is_wasi_module(name: &str) -> bool {
     WASI_MODULES.contains(&name)
+}
+
+/// Whether the generated package will carry the bundled WASI fallback (and so its constructor takes the `args`/`env`/`preopens` options and the standalone main parses `--dir`): any WASI import the runtime has a unit for, with `default_wasi` on.
+fn wasi_bundled(module: &Module, default_wasi: bool) -> bool {
+    default_wasi
+        && module
+            .imported_funcs
+            .iter()
+            .any(|f| is_wasi_module(&f.module) && bundler().has_unit(&format!("wasi/{}", f.name)))
 }
 
 pub use dewasm_backend::WASI_PREVIEW1_FUNCTIONS;
@@ -473,11 +515,22 @@ impl<'a> Gen<'a> {
 
     fn initialize(&self, w: &mut CodeWriter) {
         let m = self.module;
+        let wasi_fallback = wasi_bundled(m, self.default_wasi);
         w.line("sub new {");
         w.indent();
-        w.line("my ($class, $imports) = @_;");
+        if wasi_fallback {
+            w.line("my ($class, $imports, %opts) = @_;");
+        } else {
+            w.line("my ($class, $imports) = @_;");
+        }
         w.line("$imports = {} unless defined $imports;");
         w.line("my $self = bless({}, $class);");
+        if wasi_fallback {
+            w.line("$self->{_wasi} = undef;");
+            w.line("$self->{_wasi_args} = $opts{args} // [];");
+            w.line("$self->{_wasi_env} = $opts{env} // {};");
+            w.line("$self->{_wasi_preopens} = $opts{preopens} // {};");
+        }
 
         if let Some(import) = &m.imported_memory {
             w.line(format!(
@@ -529,6 +582,7 @@ impl<'a> Gen<'a> {
                 let unit = format!("wasi/{}", import.name);
                 if bundler().has_unit(&unit) {
                     self.use_unit(&unit);
+                    self.use_unit("wasi/_package");
                     format!("$self->_wasi_import({})", perl_string(&import.name))
                 } else {
                     "sub { return 52 }".to_string() // ENOSYS: not implemented yet
@@ -632,6 +686,19 @@ impl<'a> Gen<'a> {
             export_entries.join(", ")
         ));
 
+        // Let import providers bind to the fully-constructed instance (ADR-7).
+        if !m.imported_funcs.is_empty() {
+            w.line("for my $_p (values %$imports) {");
+            w.indent();
+            w.line("my $_r = ref($_p);");
+            w.line("$_p->attach($self) if $_r && $_r ne 'HASH' && $_r ne 'ARRAY' && $_r ne 'CODE' && $_p->can('attach');");
+            w.dedent();
+            w.line("}");
+        }
+        if wasi_fallback {
+            w.line("$self->{_wasi}->attach($self) if defined $self->{_wasi};");
+        }
+
         if let Some(start) = m.start {
             w.line(format!("{};", self.call_string(start, &[])));
         }
@@ -691,6 +758,22 @@ impl<'a> Gen<'a> {
         ));
         w.dedent();
         w.line("}");
+        if wasi_bundled(self.module, self.default_wasi) {
+            // The bundled-WASI fallback (ADR-7): constructed lazily on the first unresolved WASI import, so a provider that covers every import keeps it unbuilt.
+            w.line("");
+            w.line("sub _wasi_import {");
+            w.indent();
+            w.line("my ($self, $name) = @_;");
+            w.line(format!(
+                "$self->{{_wasi}} = {}::WASI->new(args => $self->{{_wasi_args}}, env => $self->{{_wasi_env}}, preopens => $self->{{_wasi_preopens}}) unless defined $self->{{_wasi}};",
+                self.rt_name
+            ));
+            w.line("my $wasi = $self->{_wasi};");
+            w.line("my $method = \"wasi_$name\";");
+            w.line("return sub { return $wasi->$method(@_); };");
+            w.dedent();
+            w.line("}");
+        }
     }
 
     fn func_type_symbol(&self, func_idx: u32) -> String {

--- a/crates/dewasm-backend-perl/tests/e2e.rs
+++ b/crates/dewasm-backend-perl/tests/e2e.rs
@@ -1,0 +1,467 @@
+//! Perl end-to-end suites (ADR-27): the shared case consts (`dewasm-test-helper`) wired up for the Perl backend. Per the ADR-27 revision this file holds ONLY the [`BackendUnderTest`] impl, named glue string constants, and per-case macro invocations. Perl covers full WASI preview 1 incl. the filesystem (ADR-55/issue #69), so it wires every WASI kind, the slow-tier `apps`/`fs_apps`/`capi` suites, and both multi-module cases (the Embedded runtime is prefix-namespaced per package, so two artifacts coexist).
+
+use std::path::PathBuf;
+
+use dewasm_backend::{Backend, Mode, RuntimeLinkage};
+use dewasm_backend_perl::{find_perl, PerlBackend};
+use dewasm_test_helper::{
+    convert, cowsay_args_e2e, cowsay_stdin_e2e, cpython_hello_e2e, cruby_hello_e2e,
+    custom_wasi_provider_e2e, deep_recursion_e2e, embedded_coexist_e2e, examples_dir, gzip_e2e,
+    library_add_e2e, libsqlite3_c_api_e2e, partial_override_e2e, pcap_compile_e2e, qjs_eval_e2e,
+    qjs_file_io_e2e, qjs_repl_e2e, rg_search_e2e, shared_table_e2e, sqlite3_callback_binding_e2e,
+    sqlite3_file_c_api_e2e, sqlite3_shell_dbfile_e2e, sqlite3_shell_e2e, standalone_dir_e2e,
+    stdio_capture_e2e, treesitter_parse_e2e, wasi_import_override_e2e, wasi_root_containment_e2e,
+    wasi_suite, BackendUnderTest,
+};
+
+pub struct Perl;
+
+impl BackendUnderTest for Perl {
+    fn name(&self) -> &'static str {
+        "perl"
+    }
+
+    fn backend(&self) -> &'static (dyn Backend + Sync) {
+        &PerlBackend
+    }
+
+    fn interpreter(&self) -> PathBuf {
+        find_perl()
+            .expect("perl >= 5.26 with 64-bit IVs/NVs not found on PATH — see docs/testing.md")
+    }
+
+    /// Compose several `.wat` modules. `shared_runtime` emits each against one top-level `Rt` (Alias linkage) plus a single bundled runtime, so an imported table crosses modules; otherwise it concatenates independent Embedded conversions (each carrying its own `<Package>::Rt`).
+    fn compose_modules(&self, modules: &[(&str, &str)], shared_runtime: bool) -> String {
+        if shared_runtime {
+            let mut units = std::collections::BTreeSet::new();
+            let mut pkgs = Vec::new();
+            for (wat, name) in modules {
+                let bytes = wat::parse_file(examples_dir().join(wat)).expect("parse wat");
+                let module = dewasm_core::build_module(&bytes).expect("build IR");
+                let (src, u) = dewasm_backend_perl::generate_package_with_units(
+                    &module,
+                    name,
+                    &RuntimeLinkage::Alias("Rt".to_string()),
+                    false,
+                )
+                .expect("generate");
+                units.extend(u);
+                pkgs.push(src);
+            }
+            format!(
+                "{}\n{}",
+                dewasm_backend_perl::shared_runtime(&units).expect("bundle runtime"),
+                pkgs.join("\n")
+            )
+        } else {
+            modules
+                .iter()
+                .map(|(wat, name)| {
+                    convert(&PerlBackend, &examples_dir().join(wat), Mode::Library, name)
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        }
+    }
+}
+
+// --------------------------------------------------------------------- Library-case glue.
+
+/// `add.wat`: call the exported functions and print each result.
+const PERL_ADD_GLUE: &str = r#"my $inst = Add->new({});
+print $inst->invoke('add', 2, 3), "\n";
+print $inst->invoke('add', 0xffffffff, 1), "\n";
+print $inst->invoke('fib', 10), "\n";
+"#;
+
+/// The ADR-7 override/fallback glue: fd_write intercepted, random_get falls back to the bundled WASI. Prints the actual bytes written.
+const PERL_OVERRIDE_GLUE: &str = r#"my $inst;
+my $captured = '';
+my $fd_write = sub {
+    my ($fd, $iovs, $iovs_len, $out_ptr) = @_;
+    my $mem = $inst->{memory};
+    my $ptr = $mem->i32_load($iovs);
+    my $len = $mem->i32_load($iovs + 4);
+    $captured .= $mem->read_string($ptr, $len);
+    $mem->i32_store($out_ptr, $len);
+    return 0;
+};
+$inst = Prog->new({ 'wasi_snapshot_preview1' => { 'fd_write' => $fd_write } });
+$inst->invoke('_start');  # random_get falls back to the bundled WASI
+print $captured;
+"#;
+
+/// The `custom_wasi_provider` glue: a provider *object* (`wasm_import`/`attach`, the Perl analog of Python's provider) covers every import, so the bundled WASI (`_wasi`) is never lazily constructed.
+const PERL_CUSTOM_PROVIDER_GLUE: &str = r#"package MyWasi {
+    sub new { return bless({ out => '' }, shift); }
+    sub wasm_import {
+        my ($self, $name) = @_;
+        return sub { return $self->fd_write(@_); } if $name eq 'fd_write';
+        return sub { return 0; } if $name eq 'random_get';
+        return undef;
+    }
+    sub attach {
+        my ($self, $instance) = @_;
+        $self->{memory} = $instance->{memory};
+    }
+    sub fd_write {
+        my ($self, $fd, $iovs, $iovs_len, $out_ptr) = @_;
+        my $ptr = $self->{memory}->i32_load($iovs);
+        my $len = $self->{memory}->i32_load($iovs + 4);
+        $self->{out} .= $self->{memory}->read_string($ptr, $len);
+        $self->{memory}->i32_store($out_ptr, $len);
+        return 0;
+    }
+}
+my $wasi = MyWasi->new();
+my $inst = Prog->new({ 'wasi_snapshot_preview1' => $wasi });
+$inst->invoke('_start');
+print $wasi->{out};
+print 'bundled wasi constructed: ', (defined $inst->{_wasi} ? 'true' : 'false'), "\n";
+"#;
+
+/// The `partial_override_falls_back_to_bundled_wasi` glue: fd_write intercepted, random_get falls back — so the bundled WASI *was* lazily constructed.
+const PERL_PARTIAL_OVERRIDE_GLUE: &str = r#"my $inst;
+my $captured = '';
+my $fd_write = sub {
+    my ($fd, $iovs, $iovs_len, $out_ptr) = @_;
+    my $mem = $inst->{memory};
+    my $ptr = $mem->i32_load($iovs);
+    my $len = $mem->i32_load($iovs + 4);
+    $captured .= $mem->read_string($ptr, $len);
+    $mem->i32_store($out_ptr, $len);
+    return 0;
+};
+$inst = Prog->new({ 'wasi_snapshot_preview1' => { 'fd_write' => $fd_write } });
+$inst->invoke('_start');  # random_get falls back to the bundled WASI
+print $captured;
+print 'bundled wasi constructed: ', (defined $inst->{_wasi} ? 'true' : 'false'), "\n";
+"#;
+
+/// The `wasi_stdio_capture` glue: redirect STDOUT's file descriptor to an anonymous (unlinked) temp file — perl's native embedder-controlled sink that still supports the runtime's raw syswrite — run, restore, then print the captured bytes to the real stdout.
+const PERL_STDIO_CAPTURE_GLUE: &str = r#"open(my $cap, '+>', undef) or die "capture: $!";
+open(my $saved, '>&', \*STDOUT) or die "dup: $!";
+open(STDOUT, '>&', $cap) or die "redirect: $!";
+eval {
+    my $inst = Prog->new({});
+    $inst->invoke('_start');
+};
+my $err = $@;
+open(STDOUT, '>&', $saved) or die "restore: $!";
+die $err if $err && !(ref($err) && $err->isa('Prog::Rt::Exit'));
+sysseek($cap, 0, 0);
+my $data = '';
+1 while sysread($cap, $data, 65536, length($data));
+binmode(STDOUT);
+print $data;
+"#;
+
+// --------------------------------------------------------------------- WASI filesystem glue.
+
+/// The shared filesystem template: preopen the scratch dir (`{host}`) at guest `{guest}` (always `/`), run `_start`, and surface a `proc_exit` code as a trailing decimal line.
+const PERL_FS_GLUE: &str = r#"my $inst = Prog->new({}, preopens => { '{guest}' => '{host}' });
+eval { $inst->invoke('_start'); };
+if (my $e = $@) {
+    die $e unless ref($e) && $e->isa('Prog::Rt::Exit');
+    print $e->{code}, "\n";
+}
+"#;
+
+/// The root-preopen containment probe: call the WASI resolver directly with a `"/" => "/"` preopen (no guest run) and normalize the outcome to `contained`.
+const PERL_CONTAINMENT_GLUE: &str = r#"my $wasi = Prog::Rt::WASI->new(preopens => { '/' => '/' });
+my ($path, $err) = $wasi->resolve_path(3, 'etc');
+print defined $err ? "rejected\n" : "contained\n";
+"#;
+
+// --------------------------------------------------------------------- Filesystem app glue: package/argv/env/preopen-guest-paths are literals; only the host scratch/cache dirs come through {scratch}/{cache}.
+
+const PERL_QJS_FILE_IO_GLUE: &str = r#"my $inst = Qjs->new({}, args => ['qjs', '/work/qjs_file_io.js'], env => {}, preopens => { '/work' => '{scratch}' });
+eval { $inst->invoke('_start'); };
+die $@ if $@ && !(ref($@) && $@->isa('Qjs::Rt::Exit'));
+"#;
+
+const PERL_QJS_REPL_GLUE: &str = r#"my $inst = Qjs->new({}, args => ['qjs', '/work/qjs_repl.js'], env => {}, preopens => { '/work' => '{scratch}' });
+eval { $inst->invoke('_start'); };
+die $@ if $@ && !(ref($@) && $@->isa('Qjs::Rt::Exit'));
+"#;
+
+const PERL_SQLITE3_SHELL_GLUE: &str = r#"my $inst = Sqlite3Shell->new({}, args => ['sqlite3'], env => {}, preopens => { '/db' => '{scratch}' });
+eval { $inst->invoke('_start'); };
+die $@ if $@ && !(ref($@) && $@->isa('Sqlite3Shell::Rt::Exit'));
+"#;
+
+const PERL_RG_SEARCH_GLUE: &str = r#"my $inst = Rg->new({}, args => ['rg', '--sort', 'path', 'needle', '/work'], env => {}, preopens => { '/work' => '{scratch}' });
+eval { $inst->invoke('_start'); };
+die $@ if $@ && !(ref($@) && $@->isa('Rg::Rt::Exit'));
+"#;
+
+const PERL_CPYTHON_GLUE: &str = r#"my $inst = Cpython->new({}, args => ['python', '-c', "print('hello from cpython', 6 * 7)"], env => { 'PYTHONHOME' => '/', 'PYTHONPATH' => '/lib/python3.14' }, preopens => { '/lib' => '{cache}/cpython-lib/lib' });
+eval { $inst->invoke('_start'); };
+die $@ if $@ && !(ref($@) && $@->isa('Cpython::Rt::Exit'));
+"#;
+
+const PERL_CRUBY_GLUE: &str = r#"my $inst = Cruby->new({}, args => ['ruby', '-e', 'puts "hello from cruby #{6*7}"'], env => {}, preopens => { '/usr' => '{cache}/ruby-lib/usr' });
+eval { $inst->invoke('_start'); };
+die $@ if $@ && !(ref($@) && $@->isa('Cruby::Rt::Exit'));
+"#;
+
+// --------------------------------------------------------------------- C-API drive glue (sqlite3): malloc/pointer plumbing via the memory object. Only the file-backed case uses {scratch}.
+
+const PERL_LIBSQLITE3_MEM: &str = r#"
+my $db = Libsqlite3->new({});
+$db->invoke('_initialize');
+my $mem = $db->{memory};
+
+my $read_cstr = sub {
+    my ($ptr) = @_;
+    return undef if $ptr == 0;
+    my $end = index($mem->{data}, "\0", $ptr);
+    return $mem->read_string($ptr, $end - $ptr);
+};
+
+my $cstr = sub {
+    my ($s) = @_;
+    my $b = $s . "\0";
+    my $p = $db->invoke('sqlite3_malloc', length($b));
+    $mem->init($p, $b, 0, length($b));
+    return $p;
+};
+
+print 'version: ', $read_cstr->($db->invoke('sqlite3_libversion')), "\n";
+
+my $pp_db = $db->invoke('sqlite3_malloc', 4);
+my $rc = $db->invoke('sqlite3_open', $cstr->(':memory:'), $pp_db);
+die "open rc=$rc" unless $rc == 0;
+my $dbh = $mem->i32_load($pp_db);
+
+$rc = $db->invoke('sqlite3_exec', $dbh, $cstr->("create table t(a,b); insert into t values (1,'x'),(2,'y');"), 0, 0, 0);
+die 'exec rc=' . $rc . ': ' . $read_cstr->($db->invoke('sqlite3_errmsg', $dbh)) unless $rc == 0;
+
+my $pp_stmt = $db->invoke('sqlite3_malloc', 4);
+$rc = $db->invoke('sqlite3_prepare_v2', $dbh, $cstr->('select a*10, b from t order by a desc'), 0xffffffff, $pp_stmt, 0);
+die "prepare rc=$rc" unless $rc == 0;
+my $stmt = $mem->i32_load($pp_stmt);
+
+while ($db->invoke('sqlite3_step', $stmt) == 100) {
+    my $n = $db->invoke('sqlite3_column_count', $stmt);
+    print join('|', map { $read_cstr->($db->invoke('sqlite3_column_text', $stmt, $_)) } 0 .. $n - 1), "\n";
+}
+$db->invoke('sqlite3_finalize', $stmt);
+$db->invoke('sqlite3_close', $dbh);
+print "C-API-OK\n";
+"#;
+
+const PERL_LIBSQLITE3_FILE: &str = r#"
+my $db = Libsqlite3->new({}, preopens => { '/db' => '{scratch}' });
+$db->invoke('_initialize');
+my $mem = $db->{memory};
+
+my $read_cstr = sub {
+    my ($ptr) = @_;
+    return undef if $ptr == 0;
+    my $end = index($mem->{data}, "\0", $ptr);
+    return $mem->read_string($ptr, $end - $ptr);
+};
+
+my $cstr = sub {
+    my ($s) = @_;
+    my $b = $s . "\0";
+    my $p = $db->invoke('sqlite3_malloc', length($b));
+    $mem->init($p, $b, 0, length($b));
+    return $p;
+};
+
+my $open_db = sub {
+    my ($path) = @_;
+    my $pp = $db->invoke('sqlite3_malloc', 4);
+    my $rc = $db->invoke('sqlite3_open', $cstr->($path), $pp);
+    die "open rc=$rc" unless $rc == 0;
+    return $mem->i32_load($pp);
+};
+
+my $dbh = $open_db->('/db/data.db');
+my $rc = $db->invoke('sqlite3_exec', $dbh, $cstr->("create table t(a,b); insert into t values (1,'x'),(2,'y');"), 0, 0, 0);
+die 'exec rc=' . $rc . ': ' . $read_cstr->($db->invoke('sqlite3_errmsg', $dbh)) unless $rc == 0;
+$db->invoke('sqlite3_close', $dbh);
+
+$dbh = $open_db->('/db/data.db');
+my $pp_stmt = $db->invoke('sqlite3_malloc', 4);
+$rc = $db->invoke('sqlite3_prepare_v2', $dbh, $cstr->('select a*10, b from t order by a'), 0xffffffff, $pp_stmt, 0);
+die "prepare rc=$rc" unless $rc == 0;
+my $stmt = $mem->i32_load($pp_stmt);
+while ($db->invoke('sqlite3_step', $stmt) == 100) {
+    my $n = $db->invoke('sqlite3_column_count', $stmt);
+    print join('|', map { $read_cstr->($db->invoke('sqlite3_column_text', $stmt, $_)) } 0 .. $n - 1), "\n";
+}
+$db->invoke('sqlite3_finalize', $stmt);
+$db->invoke('sqlite3_close', $dbh);
+print "FILE-OK\n";
+"#;
+
+const PERL_SQLITE3_CALLBACK: &str = r#"
+my @rows;
+my $mem;
+my $host_row = sub {
+    my ($argc, $argv_ptr) = @_;
+    my @row;
+    for my $i (0 .. $argc - 1) {
+        my $p = $mem->i32_load($argv_ptr + $i * 4);
+        if ($p == 0) {
+            push @row, undef;
+        } else {
+            my $end = index($mem->{data}, "\0", $p);
+            push @row, $mem->read_string($p, $end - $p);
+        }
+    }
+    push @rows, \@row;
+    return 0;
+};
+
+my $db = Sqlite3Binding->new({ 'env' => { 'host_row' => $host_row } });
+$db->invoke('_initialize');
+$mem = $db->{memory};
+
+my $read_cstr = sub {
+    my ($ptr) = @_;
+    return undef if $ptr == 0;
+    my $end = index($mem->{data}, "\0", $ptr);
+    return $mem->read_string($ptr, $end - $ptr);
+};
+
+my $cstr = sub {
+    my ($s) = @_;
+    my $b = $s . "\0";
+    my $p = $db->invoke('sqlite3_malloc', length($b));
+    $mem->init($p, $b, 0, length($b));
+    return $p;
+};
+
+my $pp_db = $db->invoke('sqlite3_malloc', 4);
+my $rc = $db->invoke('sqlite3_open', $cstr->(':memory:'), $pp_db);
+die "open rc=$rc" unless $rc == 0;
+my $dbh = $mem->i32_load($pp_db);
+
+$rc = $db->invoke('sqlite3_exec', $dbh, $cstr->("create table t(a,b); insert into t values (1,'x'),(2,'y'),(3,'z');"), 0, 0, 0);
+die 'exec rc=' . $rc . ': ' . $read_cstr->($db->invoke('sqlite3_errmsg', $dbh)) unless $rc == 0;
+
+$rc = $db->invoke('run_query', $dbh, $cstr->('select a, b from t where a >= 2 order by a'));
+die "run_query rc=$rc" unless $rc == 0;
+$db->invoke('sqlite3_close', $dbh);
+
+print 'row: ', join('|', @$_), "\n" for @rows;
+print "CALLBACK-OK\n";
+"#;
+
+/// libpcap BPF filter compilation: drive `compile_filter` on "tcp port 80" (DLT_EN10MB, snaplen 65535), then walk the serialized program `[u32 bf_len][bf_len x {u16 code; u8 jt; u8 jf; u32 k}]` in guest memory, printing each instruction as `code jt jf k`.
+const PERL_PCAP_COMPILE: &str = r#"
+my $inst = Libpcap->new({});
+$inst->invoke('_initialize');
+my $mem = $inst->{memory};
+
+my $cstr = sub {
+    my ($s) = @_;
+    my $b = $s . "\0";
+    my $p = $inst->invoke('malloc', length($b));
+    $mem->init($p, $b, 0, length($b));
+    return $p;
+};
+
+my $prog = $inst->invoke('compile_filter', $cstr->('tcp port 80'), 1, 65535);
+die 'compile failed' unless $prog != 0;
+my $n = $mem->i32_load($prog);
+for my $i (0 .. $n - 1) {
+    my $base = $prog + 4 + $i * 8;
+    my $code = unpack('v', substr($mem->{data}, $base, 2));
+    my $jt = unpack('C', substr($mem->{data}, $base + 2, 1));
+    my $jf = unpack('C', substr($mem->{data}, $base + 3, 1));
+    my $k = $mem->i32_load($base + 4);
+    print "$code $jt $jf $k\n";
+}
+$inst->invoke('free', $prog);
+print "BPF-OK\n";
+"#;
+
+/// tree-sitter JSON parse: drive `parse_source` on the fixed snippet `{"key": [1, true, null]}` and print the parse tree's S-expression (a malloc'd NUL-terminated C string) from guest memory.
+const PERL_TREESITTER_PARSE: &str = r#"
+my $inst = Treesitter->new({});
+$inst->invoke('_initialize');
+my $mem = $inst->{memory};
+
+my $cstr = sub {
+    my ($s) = @_;
+    my $b = $s . "\0";
+    my $p = $inst->invoke('malloc', length($b));
+    $mem->init($p, $b, 0, length($b));
+    return $p;
+};
+
+my $src = '{"key": [1, true, null]}';
+my $r = $inst->invoke('parse_source', $cstr->($src), length($src));
+die 'parse failed' unless $r != 0;
+my $end = index($mem->{data}, "\0", $r);
+print $mem->read_string($r, $end - $r), "\n";
+$inst->invoke('free', $r);
+print "TS-OK\n";
+"#;
+
+// --------------------------------------------------------------------- Multi-module drive glue.
+
+/// Driver for the shared-table case: instantiate the exporter and the importer linked against it, then print `call0` (call_indirect through the shared table -> 42).
+const PERL_SHARED_TABLE_GLUE: &str = r#"my $a = TableExp->new({});
+my $b = TableImp->new({ 'a' => $a });
+print $b->invoke('call0'), "\n";
+"#;
+
+/// Driver for the Embedded-coexistence case: two independently converted packages, each with its own prefix-namespaced runtime (`Alpha::Rt`, `Beta::Rt`), living in one interpreter. The trap raised by one must be its own runtime's class, not the other's.
+const PERL_EMBEDDED_COEXIST_GLUE: &str = r#"my $a = Alpha->new({});
+my $b = Beta->new({});
+print $a->invoke('div', 7, 2), "\n";
+print $b->invoke('div', 0xfffffff9, 2), "\n";
+eval { $a->invoke('div', 1, 0); };
+my $e = $@;
+print((ref($e) && $e->isa('Alpha::Rt::Trap') && !$e->isa('Beta::Rt::Trap')) ? 'distinct-rt' : 'same-rt', "\n");
+print "trapped\n" if ref($e) && $e->isa('Alpha::Rt::Trap');
+"#;
+
+// --------------------------------------------------------------------- Suite wiring (ADR-27): each per-case macro invocation declares participation.
+
+library_add_e2e!(Perl, PERL_ADD_GLUE);
+wasi_import_override_e2e!(Perl, PERL_OVERRIDE_GLUE);
+custom_wasi_provider_e2e!(Perl, PERL_CUSTOM_PROVIDER_GLUE);
+partial_override_e2e!(Perl, PERL_PARTIAL_OVERRIDE_GLUE);
+stdio_capture_e2e!(Perl, PERL_STDIO_CAPTURE_GLUE);
+
+wasi_suite!(Perl, Stdio);
+wasi_suite!(Perl, ArgsEnv);
+wasi_suite!(Perl, Poll);
+wasi_suite!(Perl, Fs, PERL_FS_GLUE);
+wasi_root_containment_e2e!(Perl, PERL_CONTAINMENT_GLUE);
+standalone_dir_e2e!(Perl);
+// Perl recursion is heap-allocated (no host stack to overflow, ADR-55); the case pins that the entrypoint still surfaces proc_exit(42) through deep guest recursion.
+deep_recursion_e2e!(Perl);
+
+cowsay_args_e2e!(Perl);
+cowsay_stdin_e2e!(Perl);
+qjs_eval_e2e!(Perl);
+sqlite3_shell_e2e!(Perl);
+gzip_e2e!(Perl);
+
+qjs_file_io_e2e!(Perl, PERL_QJS_FILE_IO_GLUE);
+qjs_repl_e2e!(Perl, PERL_QJS_REPL_GLUE);
+sqlite3_shell_dbfile_e2e!(Perl, PERL_SQLITE3_SHELL_GLUE);
+rg_search_e2e!(Perl, PERL_RG_SEARCH_GLUE);
+cpython_hello_e2e!(Perl, PERL_CPYTHON_GLUE);
+// Ultra tier (ADR-48): measured ~57s locally (CRuby-on-Perl), which crosses the ~1-minute CI-runner line the other backends' cruby cases stay under.
+cruby_hello_e2e!(Perl, PERL_CRUBY_GLUE, ultra);
+// qjs_repl_pty_e2e!: not invoked — the interactive-REPL pty case is deferred with DOOM to a follow-up (issue #69 scope note); the file-driven qjs_repl case above covers the REPL loop itself.
+
+libsqlite3_c_api_e2e!(Perl, PERL_LIBSQLITE3_MEM);
+sqlite3_file_c_api_e2e!(Perl, PERL_LIBSQLITE3_FILE);
+sqlite3_callback_binding_e2e!(Perl, PERL_SQLITE3_CALLBACK);
+pcap_compile_e2e!(Perl, PERL_PCAP_COMPILE);
+treesitter_parse_e2e!(Perl, PERL_TREESITTER_PARSE);
+
+// doom_frame_e2e!: not invoked — DOOM is deferred to a follow-up (issue #69 scope note).
+
+shared_table_e2e!(Perl, PERL_SHARED_TABLE_GLUE);
+embedded_coexist_e2e!(Perl, PERL_EMBEDDED_COEXIST_GLUE);

--- a/crates/dewasm-backend-perl/tests/wasi_testsuite.rs
+++ b/crates/dewasm-backend-perl/tests/wasi_testsuite.rs
@@ -1,0 +1,53 @@
+//! Perl side of the official WASI p1 conformance harness (ADR-36): drives the prebuilt `WebAssembly/wasi-testsuite` modules through the Perl backend's standalone interface. The generic harness lives in `dewasm-test-helper`.
+
+use std::path::PathBuf;
+
+use dewasm_backend::Backend;
+use dewasm_backend_perl::PerlBackend;
+use dewasm_test_helper::{wasi_testsuite_suite, BackendUnderTest, WasiTestsuiteBackend};
+
+/// Known trial failures with their attribution (ADR-8, policy in ADR-36): `(trial, tag)` — the out-of-scope `sock_shutdown` syscall (docs/support.md), like Ruby/Python. Unlike the Ruby/Python hosts, perl injects no environ entries of its own, so the `environ_*` trials pass without host-scoped entries.
+const WASI_TESTSUITE_EXPECTED_FAILURES: &[(&str, &str)] = &[
+    // Declared out-of-scope syscall (docs/support.md).
+    ("c/sock_shutdown-invalid_fd", "sock_shutdown (out of scope)"),
+    ("c/sock_shutdown-not_sock", "sock_shutdown (out of scope)"),
+    // Core perl's only sub-second file-time APIs (Time::HiRes utime/stat) pass NV seconds, whose resolution at the current epoch is ~400ns — the suite's set-then-get of `mtim - 100` nanoseconds cannot round-trip exactly (the runtime unit comments carry the same attribution).
+    (
+        "rust/fd_filestat_set",
+        "filestat times: perl NV-seconds utime caps precision below ns",
+    ),
+    (
+        "rust/path_filestat",
+        "filestat times: perl NV-seconds utime caps precision below ns",
+    ),
+    // Core perl has no lutimes/utimensat(AT_SYMLINK_NOFOLLOW): a final-component symlink cannot carry its own times, so the suite's set-then-lstat on the link itself cannot hold (the Linux JDK ledger has the microsecond analog of this gap).
+    (
+        "rust/symlink_filestat",
+        "path_filestat_set_times NOFOLLOW: core perl lacks lutimes/utimensat",
+    ),
+];
+
+struct PerlWasi;
+
+impl BackendUnderTest for PerlWasi {
+    fn name(&self) -> &'static str {
+        "perl"
+    }
+
+    fn backend(&self) -> &'static (dyn Backend + Sync) {
+        &PerlBackend
+    }
+
+    fn interpreter(&self) -> PathBuf {
+        dewasm_backend_perl::find_perl()
+            .expect("perl >= 5.26 with 64-bit IVs/NVs not found on PATH — see docs/testing.md")
+    }
+}
+
+impl WasiTestsuiteBackend for PerlWasi {
+    fn expected_failures(&self) -> &'static [(&'static str, &'static str)] {
+        WASI_TESTSUITE_EXPECTED_FAILURES
+    }
+}
+
+wasi_testsuite_suite!(PerlWasi);

--- a/crates/dewasm-cli/tests/data_file.rs
+++ b/crates/dewasm-cli/tests/data_file.rs
@@ -1,4 +1,4 @@
-//! End-to-end coverage for `--data-file` data-segment externalization (ADR-37). For Ruby, Go, Python and Java: convert a module both embedded and with a sidecar, run each generated program, and assert byte-identical stdout/exit plus a smaller source file. Also pins the loud rejections (the bash target, `-o -`).
+//! End-to-end coverage for `--data-file` data-segment externalization (ADR-37). For Ruby, Go, Python, Perl and Java: convert a module both embedded and with a sidecar, run each generated program, and assert byte-identical stdout/exit plus a smaller source file. Also pins the loud rejections (the bash target, `-o -`).
 //!
 //! The inline fixture carries an active segment, a passive segment initialized via `memory.init` + `data.drop`, and a bulky third segment so the sidecar form provably shrinks the source. The slow real-app cases (`qjs.wasm`) are `#[ignore]`d unless the `slow_test` feature is on, matching the project's tier convention (ADR-48) for cases that pay a multi-second `go build` / interpreter startup (run with `--features slow_test` or `--include-ignored`).
 
@@ -7,6 +7,7 @@ use std::process::{Command, Output};
 
 use dewasm_backend_go::find_go;
 use dewasm_backend_java::{find_java, find_javac};
+use dewasm_backend_perl::find_perl;
 use dewasm_backend_python::find_python;
 use dewasm_backend_ruby::find_ruby;
 
@@ -118,6 +119,19 @@ fn run_python(prog: &Path, args: &[&str]) -> (Vec<u8>, i32) {
         .current_dir(prog.parent().unwrap())
         .output()
         .expect("spawn python");
+    (out.stdout, out.status.code().unwrap_or(-1))
+}
+
+/// Run a Perl program from its own directory (so the sidecar, resolved via `File::Basename::dirname(__FILE__)`, is found), returning (stdout, exit code).
+fn run_perl(prog: &Path, args: &[&str]) -> (Vec<u8>, i32) {
+    let perl = find_perl()
+        .expect("perl >= 5.26 with 64-bit IVs/NVs not found on PATH — see docs/testing.md");
+    let out = Command::new(perl)
+        .arg(prog)
+        .args(args)
+        .current_dir(prog.parent().unwrap())
+        .output()
+        .expect("spawn perl");
     (out.stdout, out.status.code().unwrap_or(-1))
 }
 
@@ -335,6 +349,67 @@ fn python_data_file_matches_embedded() {
 
     let (out_e, code_e) = run_python(&embedded, &[]);
     let (out_x, code_x) = run_python(&ext, &[]);
+    assert_eq!(out_e, FIXTURE_STDOUT.as_bytes());
+    assert_eq!(
+        out_e, out_x,
+        "stdout differs between embedded and externalized"
+    );
+    assert_eq!(code_e, 0);
+    assert_eq!(code_e, code_x);
+}
+
+#[test]
+fn perl_data_file_matches_embedded() {
+    let dir = tempdir("perl");
+    let wat = dir.join("mod.wat");
+    write(&wat, &fixture_wat());
+    let watp = wat.to_str().unwrap();
+
+    let embedded = dir.join("embedded.pl");
+    let ext = dir.join("ext.pl");
+    let sidecar = dir.join("ext.bin");
+
+    let e = run_dewasm(&[
+        watp,
+        "-t",
+        "perl",
+        "-m",
+        "standalone",
+        "-o",
+        embedded.to_str().unwrap(),
+    ]);
+    assert!(
+        e.status.success(),
+        "embedded convert: {}",
+        String::from_utf8_lossy(&e.stderr)
+    );
+    let x = run_dewasm(&[
+        watp,
+        "-t",
+        "perl",
+        "-m",
+        "standalone",
+        "-o",
+        ext.to_str().unwrap(),
+        "--data-file",
+        sidecar.to_str().unwrap(),
+    ]);
+    assert!(
+        x.status.success(),
+        "data-file convert: {}",
+        String::from_utf8_lossy(&x.stderr)
+    );
+
+    assert_eq!(std::fs::metadata(&sidecar).unwrap().len(), FIXTURE_DATA_LEN);
+    let src_embedded = std::fs::metadata(&embedded).unwrap().len();
+    let src_ext = std::fs::metadata(&ext).unwrap().len();
+    assert!(
+        src_ext < src_embedded,
+        "externalized .pl ({src_ext} B) should be smaller than embedded ({src_embedded} B)"
+    );
+
+    let (out_e, code_e) = run_perl(&embedded, &[]);
+    let (out_x, code_x) = run_perl(&ext, &[]);
     assert_eq!(out_e, FIXTURE_STDOUT.as_bytes());
     assert_eq!(
         out_e, out_x,

--- a/docs/backends/perl.md
+++ b/docs/backends/perl.md
@@ -1,6 +1,6 @@
 # Perl backend
 
-`--target perl`. A plain `require`-able package covering wasm core 1.0; WASI preview 1 is follow-up work (issue #69), so `_start`-shaped programs convert but WASI syscalls stub to `ENOSYS` for now.
+`--target perl`. A plain `require`-able package covering wasm core 1.0 plus full WASI preview 1 (the fd-table/preopens model of ADR-14/ADR-40, `sock_*` excepted — see [docs/support.md](../support.md)).
 
 ## Output shape
 
@@ -8,16 +8,16 @@ A single `.pl` file: the generated module as a `package` named after the input s
 
 ## Requirements
 
-`perl` **5.26 or newer** on `PATH` (or `$DEWASM_PERL`), built with 64-bit integers and IEEE doubles (`ivsize=8`, `nvsize=8` — any stock perl on a 64-bit OS). No CPAN modules — the output uses only core modules (`POSIX`, `Config`, `File::Basename`). The generated prelude verifies the integer/double sizes at load time and dies loudly otherwise (ADR-15).
+`perl` **5.26 or newer** on `PATH` (or `$DEWASM_PERL`), built with 64-bit integers and IEEE doubles (`ivsize=8`, `nvsize=8` — any stock perl on a 64-bit OS). No CPAN modules — the output uses only core modules (`POSIX`, `Config`, `Cwd`, `Errno`, `Fcntl`, `Time::HiRes`, `File::Basename`, `IO::Handle`). The generated prelude verifies the integer/double sizes at load time and dies loudly otherwise (ADR-15).
 
 ## Running it
 
 ```console
 $ dewasm prog.wasm --target perl --mode standalone -o prog.pl
-$ perl prog.pl
+$ perl prog.pl --dir .::/ input.txt
 ```
 
-Standalone programs follow the shared runtime interface for exit codes (`proc_exit` maps to the process exit code once WASI lands; a trap prints `trap: <message>` and exits 134): [docs/standalone-interface.md](../standalone-interface.md).
+Standalone programs follow the shared runtime interface ([docs/standalone-interface.md](../standalone-interface.md)): a leading run of `--dir HOST::GUEST` flags mounts host directories at guest paths, the rest becomes the guest's argv, `proc_exit` maps to the process exit code, and a trap prints `trap: <message>` and exits 134.
 
 Library mode (the file ends in a true value, so plain `require` works):
 
@@ -28,14 +28,22 @@ print $inst->invoke('add', 2, 3), "\n";   # 5
 $inst->{memory};                          # linear memory (Add::Rt::Memory)
 ```
 
-Imports are a hashref of module name to either a hashref (name to value) or a provider object with a `wasm_import($name)` method — another generated instance qualifies directly (ADR-7). Function imports are coderefs; globals/tables/memories are the runtime's boxed objects (`global_export`/`table_export` hand them out).
+A WASI module's constructor additionally takes `args`, `env`, and `preopens` options:
+
+```perl
+my $inst = Prog->new({}, args => ['prog', 'input.txt'], env => { LANG => 'C' }, preopens => { '/work' => './scratch' });
+$inst->invoke('_start');   # proc_exit dies a Prog::Rt::Exit carrying {code}
+```
+
+Imports are a hashref of module name to either a hashref (name to value) or a provider object with a `wasm_import($name)` method (an optional `attach($instance)` is called after construction) — another generated instance qualifies directly (ADR-7). Function imports are coderefs; globals/tables/memories are the runtime's boxed objects (`global_export`/`table_export` hand them out). An explicit WASI import overrides the bundled runtime per function; unhandled ones fall back to it, constructed lazily.
 
 ## Capabilities
 
-Full wasm core 1.0 plus the universal baseline: non-function imports, multiple tables, and table bulk ops are supported. **No WASI yet** (issue #69). Authoritative matrix: [docs/support.md](../support.md).
+Full wasm core 1.0 plus the universal baseline: non-function imports, multiple tables, and table bulk ops are supported. Full WASI preview 1 (`sock_*` out of scope), verified against the official wasi-testsuite. Authoritative matrix: [docs/support.md](../support.md).
 
 ## Caveats
 
 - **Call depth is bounded by a counter.** Perl recursion grows on the heap and only stops at the OOM killer, so generated functions maintain an explicit depth counter (`$Rt::DEPTH`, limit `$Rt::LIMIT` = 100000) and trap with `call stack exhausted` past it ([ADR-55](../adr/55-perl-backend-lowering.md)). Raise `$Package::Rt::LIMIT` for legitimately deeper recursion (each frame costs heap).
 - Float arithmetic goes through helpers (`Rt::fadd` and friends): perl's own operators take an integer fast path that exceeds double precision and drops `-0.0`, and perl dies on `x / 0.0` and `sqrt(-1)` ([ADR-55](../adr/55-perl-backend-lowering.md)).
 - Numeric conventions are the shared masked-unsigned model ([ADR-2](../adr/2-numeric-semantics.md)); `use integer` appears only inside tightly-scoped runtime helpers.
+- **File timestamps are capped below nanosecond precision.** Core perl's only sub-second time APIs (`Time::HiRes` utime/stat) pass NV seconds (~400ns resolution at the current epoch), and there is no `lutimes`/`utimensat`, so a symlink cannot carry its own times (`path_filestat_set_times` without SYMLINK_FOLLOW sets the target's). Both are attributed in the wasi-testsuite ledger (`crates/dewasm-backend-perl/tests/wasi_testsuite.rs`).

--- a/docs/standalone-interface.md
+++ b/docs/standalone-interface.md
@@ -22,6 +22,7 @@ The generated `main` consumes a **leading run of `--dir` flags** and hands every
 | --- | --- | --- |
 | Ruby | — | `ruby prog.rb [--dir H::G]... [args...]` |
 | Python | — | `python3 prog.py [--dir H::G]... [args...]` |
+| Perl | — | `perl prog.pl [--dir H::G]... [args...]` |
 | Bash | — | `bash prog.sh [--dir H::G]... [args...]` |
 | Go | `go build -o prog prog.go` | `./prog [--dir H::G]... [args...]` |
 | Java | `javac Main.java` | `java Main [--dir H::G]... [args...]` |

--- a/docs/support.md
+++ b/docs/support.md
@@ -23,48 +23,48 @@ Derived from the runtime units; unimplemented syscalls resolve to an ENOSYS stub
 
 | Function | ruby | bash | python | perl | go | java |
 | --- | --- | --- | --- | --- | --- | --- |
-| args_get | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| args_sizes_get | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| environ_get | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| environ_sizes_get | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| clock_res_get | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| clock_time_get | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| fd_advise | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| fd_allocate | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| fd_close | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| fd_datasync | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| fd_fdstat_get | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| fd_fdstat_set_flags | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| fd_fdstat_set_rights | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| fd_filestat_get | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| fd_filestat_set_size | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| fd_filestat_set_times | ✅ | ❌ (ENOSYS) | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| fd_pread | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| fd_prestat_get | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| fd_prestat_dir_name | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| fd_pwrite | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| fd_read | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| fd_readdir | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| fd_renumber | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| fd_seek | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| fd_sync | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| fd_tell | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| fd_write | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| path_create_directory | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| path_filestat_get | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| path_filestat_set_times | ✅ | ❌ (ENOSYS) | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| path_link | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| path_open | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| path_readlink | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| path_remove_directory | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| path_rename | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| path_symlink | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| path_unlink_file | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| poll_oneoff | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| proc_exit | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
+| args_get | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| args_sizes_get | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| environ_get | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| environ_sizes_get | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| clock_res_get | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| clock_time_get | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| fd_advise | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| fd_allocate | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| fd_close | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| fd_datasync | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| fd_fdstat_get | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| fd_fdstat_set_flags | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| fd_fdstat_set_rights | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| fd_filestat_get | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| fd_filestat_set_size | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| fd_filestat_set_times | ✅ | ❌ (ENOSYS) | ✅ | ✅ | ✅ | ✅ |
+| fd_pread | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| fd_prestat_get | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| fd_prestat_dir_name | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| fd_pwrite | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| fd_read | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| fd_readdir | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| fd_renumber | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| fd_seek | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| fd_sync | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| fd_tell | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| fd_write | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| path_create_directory | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| path_filestat_get | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| path_filestat_set_times | ✅ | ❌ (ENOSYS) | ✅ | ✅ | ✅ | ✅ |
+| path_link | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| path_open | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| path_readlink | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| path_remove_directory | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| path_rename | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| path_symlink | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| path_unlink_file | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| poll_oneoff | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| proc_exit | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | proc_raise | — | — | — | — | — | — |
-| random_get | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
-| sched_yield | ✅ | ✅ | ✅ | ❌ (ENOSYS) | ✅ | ✅ |
+| random_get | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| sched_yield | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | sock_accept | — | — | — | — | — | — |
 | sock_recv | — | — | — | — | — | — |
 | sock_send | — | — | — | — | — | — |

--- a/runtime/perl/units/memory/read_string.pl
+++ b/runtime/perl/units/memory/read_string.pl
@@ -1,0 +1,5 @@
+sub read_string {
+    my ($self, $ptr, $len) = @_;
+    $self->check($ptr, $len);
+    return substr($self->{data}, $ptr, $len);
+}

--- a/runtime/perl/units/wasi/_package.pl
+++ b/runtime/perl/units/wasi/_package.pl
@@ -1,0 +1,134 @@
+# WASI preview 1 runtime state (ADR-14 model, mirroring the Ruby/Python
+# runtimes): a fd table plus a parallel per-fd capability map, seeded from
+# the constructor's preopens. Per-fd rights are modelled after wasmtime's
+# wasi-common (ADR-40): a directory and a file each carry a different
+# default set, path_open narrows the requested rights against the parent's
+# inheriting set (then per-filetype), and fd_fdstat_set_rights can only
+# drop bits. Kept in the always-bundled prelude because new() seeds the
+# fd -> [base, inheriting, fdflags] meta map for every preopen and for
+# stdio, so the constants must exist whenever any WASI import is used.
+use Cwd ();
+
+use constant {
+    ERRNO_SUCCESS => 0,
+    ERRNO_BADF => 8,
+    ERRNO_INVAL => 28,
+    ERRNO_IO => 29,
+    ERRNO_NOSYS => 52,
+    ERRNO_SPIPE => 70,
+    ERRNO_NOTCAPABLE => 76,
+};
+
+use constant {
+    RIGHTS_FD_DATASYNC => 1 << 0,
+    RIGHTS_FD_READ => 1 << 1,
+    RIGHTS_FD_SEEK => 1 << 2,
+    RIGHTS_FD_FDSTAT_SET_FLAGS => 1 << 3,
+    RIGHTS_FD_SYNC => 1 << 4,
+    RIGHTS_FD_TELL => 1 << 5,
+    RIGHTS_FD_WRITE => 1 << 6,
+    RIGHTS_FD_ADVISE => 1 << 7,
+    RIGHTS_FD_ALLOCATE => 1 << 8,
+    RIGHTS_PATH_CREATE_DIRECTORY => 1 << 9,
+    RIGHTS_PATH_CREATE_FILE => 1 << 10,
+    RIGHTS_PATH_LINK_SOURCE => 1 << 11,
+    RIGHTS_PATH_LINK_TARGET => 1 << 12,
+    RIGHTS_PATH_OPEN => 1 << 13,
+    RIGHTS_FD_READDIR => 1 << 14,
+    RIGHTS_PATH_READLINK => 1 << 15,
+    RIGHTS_PATH_RENAME_SOURCE => 1 << 16,
+    RIGHTS_PATH_RENAME_TARGET => 1 << 17,
+    RIGHTS_PATH_FILESTAT_GET => 1 << 18,
+    RIGHTS_PATH_FILESTAT_SET_SIZE => 1 << 19,
+    RIGHTS_PATH_FILESTAT_SET_TIMES => 1 << 20,
+    RIGHTS_FD_FILESTAT_GET => 1 << 21,
+    RIGHTS_FD_FILESTAT_SET_SIZE => 1 << 22,
+    RIGHTS_FD_FILESTAT_SET_TIMES => 1 << 23,
+    RIGHTS_PATH_SYMLINK => 1 << 24,
+    RIGHTS_PATH_REMOVE_DIRECTORY => 1 << 25,
+    RIGHTS_PATH_UNLINK_FILE => 1 << 26,
+    RIGHTS_POLL_FD_READWRITE => 1 << 27,
+};
+
+# The rights a directory descriptor carries (base) and the rights it may
+# pass to things opened beneath it (inheriting = directory rights plus
+# every file right). Mirrors wasmtime's DIR_RIGHTS / FILE_RIGHTS.
+use constant DIR_RIGHTS_BASE =>
+    RIGHTS_FD_FDSTAT_SET_FLAGS | RIGHTS_FD_SYNC | RIGHTS_FD_ADVISE
+    | RIGHTS_PATH_CREATE_DIRECTORY | RIGHTS_PATH_CREATE_FILE
+    | RIGHTS_PATH_LINK_SOURCE | RIGHTS_PATH_LINK_TARGET | RIGHTS_PATH_OPEN
+    | RIGHTS_FD_READDIR | RIGHTS_PATH_READLINK | RIGHTS_PATH_RENAME_SOURCE
+    | RIGHTS_PATH_RENAME_TARGET | RIGHTS_PATH_FILESTAT_GET
+    | RIGHTS_PATH_FILESTAT_SET_SIZE | RIGHTS_PATH_FILESTAT_SET_TIMES
+    | RIGHTS_FD_FILESTAT_GET | RIGHTS_FD_FILESTAT_SET_TIMES
+    | RIGHTS_PATH_SYMLINK | RIGHTS_PATH_REMOVE_DIRECTORY
+    | RIGHTS_PATH_UNLINK_FILE | RIGHTS_POLL_FD_READWRITE;
+use constant FILE_RIGHTS_BASE =>
+    RIGHTS_FD_DATASYNC | RIGHTS_FD_READ | RIGHTS_FD_SEEK
+    | RIGHTS_FD_FDSTAT_SET_FLAGS | RIGHTS_FD_SYNC | RIGHTS_FD_TELL
+    | RIGHTS_FD_WRITE | RIGHTS_FD_ADVISE | RIGHTS_FD_ALLOCATE
+    | RIGHTS_FD_FILESTAT_GET | RIGHTS_FD_FILESTAT_SET_SIZE
+    | RIGHTS_FD_FILESTAT_SET_TIMES | RIGHTS_POLL_FD_READWRITE;
+use constant DIR_RIGHTS_INHERITING => DIR_RIGHTS_BASE | FILE_RIGHTS_BASE;
+
+# An fd-table entry is a plain hashref of one of three shapes:
+# * stdio:  { fh => glob ref, std => 0|1|2 } (SPIPE on seek/tell/pread/
+#   pwrite, never closed; keyed by the `std` field, in lockstep with the
+#   fd table, not by whatever the globals point at when a syscall runs);
+# * file:   { fh => handle, path => host path } — sysopen'd, unbuffered
+#   (sysread/syswrite/sysseek only), so pread/pwrite emulation and
+#   read/write/seek stay coherent on one fd (sqlite mixes both);
+# * dir:    { dir => 1, path => realpath'd host path, preopen => guest
+#   name (undef when the guest opened it itself via path_open),
+#   entries => lazily built fd_readdir cache }.
+sub new {
+    my ($class, %opts) = @_;
+    my $env = $opts{env} // {};
+    my $self = bless({
+        args => [map { "$_" } @{$opts{args} // []}],
+        env => [map { "$_=$env->{$_}" } sort keys %$env],
+        memory => undef,
+    }, $class);
+    binmode(STDIN);
+    binmode(STDOUT);
+    binmode(STDERR);
+    $self->{fds} = {
+        0 => { fh => \*STDIN, std => 0 },
+        1 => { fh => \*STDOUT, std => 1 },
+        2 => { fh => \*STDERR, std => 2 },
+    };
+    # stdio gets the full file-right set (a stream can read/write/etc.);
+    # preopens get the directory base and the directory-plus-file
+    # inheriting set (ADR-40).
+    $self->{meta} = {
+        0 => [FILE_RIGHTS_BASE, 0, 0],
+        1 => [FILE_RIGHTS_BASE, 0, 0],
+        2 => [FILE_RIGHTS_BASE, 0, 0],
+    };
+    my $next_fd = 3;
+    my $preopens = $opts{preopens} // {};
+    for my $guest (sort keys %$preopens) {
+        my $real = Cwd::realpath($preopens->{$guest});
+        die "preopen '$guest' => '$preopens->{$guest}': not a directory\n"
+            unless defined $real && -d $real;
+        $self->{fds}{$next_fd} = { dir => 1, path => $real, preopen => "$guest", entries => undef };
+        $self->{meta}{$next_fd} = [DIR_RIGHTS_BASE, DIR_RIGHTS_INHERITING, 0];
+        $next_fd++;
+    }
+    $self->{next_fd} = $next_fd;
+    return $self;
+}
+
+# Import-provider protocol (ADR-7): a custom WASI runtime can replace this
+# package wholesale by implementing wasm_import($name) and attach($instance).
+sub wasm_import {
+    my ($self, $name) = @_;
+    my $method = "wasi_$name";
+    return undef unless $self->can($method);
+    return sub { return $self->$method(@_); };
+}
+
+sub attach {
+    my ($self, $instance) = @_;
+    $self->{memory} = $instance->{memory};
+}

--- a/runtime/perl/units/wasi/args_get.pl
+++ b/runtime/perl/units/wasi/args_get.pl
@@ -1,0 +1,5 @@
+# requires: wasi/write_string_list
+sub wasi_args_get {
+    my ($self, $argv_ptr, $buf_ptr) = @_;
+    return $self->write_string_list($self->{args}, $argv_ptr, $buf_ptr);
+}

--- a/runtime/perl/units/wasi/args_sizes_get.pl
+++ b/runtime/perl/units/wasi/args_sizes_get.pl
@@ -1,0 +1,9 @@
+# requires: memory/i32_store
+sub wasi_args_sizes_get {
+    my ($self, $argc_ptr, $buf_size_ptr) = @_;
+    my $bytes = 0;
+    $bytes += length($_) + 1 for @{$self->{args}};
+    $self->{memory}->i32_store($argc_ptr, scalar @{$self->{args}});
+    $self->{memory}->i32_store($buf_size_ptr, $bytes);
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/clock_res_get.pl
+++ b/runtime/perl/units/wasi/clock_res_get.pl
@@ -1,0 +1,6 @@
+# requires: memory/i64_store
+sub wasi_clock_res_get {
+    my ($self, $id, $out_ptr) = @_;
+    $self->{memory}->i64_store($out_ptr, 1);
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/clock_time_get.pl
+++ b/runtime/perl/units/wasi/clock_time_get.pl
@@ -1,0 +1,16 @@
+# requires: memory/i64_store
+use Time::HiRes ();
+
+sub wasi_clock_time_get {
+    my ($self, $id, $precision, $out_ptr) = @_;
+    my $ns;
+    if ($id == 0) {  # realtime
+        $ns = int(Time::HiRes::time() * 1e9);
+    } elsif ($id >= 1 && $id <= 3) {  # monotonic / process / thread cputime
+        $ns = int(Time::HiRes::clock_gettime(Time::HiRes::CLOCK_MONOTONIC()) * 1e9);
+    } else {
+        return ERRNO_INVAL;
+    }
+    $self->{memory}->i64_store($out_ptr, $ns);
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/environ_get.pl
+++ b/runtime/perl/units/wasi/environ_get.pl
@@ -1,0 +1,5 @@
+# requires: wasi/write_string_list
+sub wasi_environ_get {
+    my ($self, $environ_ptr, $buf_ptr) = @_;
+    return $self->write_string_list($self->{env}, $environ_ptr, $buf_ptr);
+}

--- a/runtime/perl/units/wasi/environ_sizes_get.pl
+++ b/runtime/perl/units/wasi/environ_sizes_get.pl
@@ -1,0 +1,9 @@
+# requires: memory/i32_store
+sub wasi_environ_sizes_get {
+    my ($self, $count_ptr, $buf_size_ptr) = @_;
+    my $bytes = 0;
+    $bytes += length($_) + 1 for @{$self->{env}};
+    $self->{memory}->i32_store($count_ptr, scalar @{$self->{env}});
+    $self->{memory}->i32_store($buf_size_ptr, $bytes);
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/errno_fs.pl
+++ b/runtime/perl/units/wasi/errno_fs.pl
@@ -1,0 +1,42 @@
+# Filesystem-only errno codes (ADR-14): kept out of the always-bundled
+# wasi/_package prelude so a stdio-only WASI module (no path_* / fs-only
+# fd_* imports) doesn't carry them. ERRNO_NOTCAPABLE (76) lives in the
+# prelude: rights enforcement in fd_read/fd_write/etc. needs it even when
+# errno_fs is not otherwise bundled.
+use Errno ();
+
+use constant {
+    ERRNO_ACCES => 2,
+    ERRNO_EXIST => 20,
+    ERRNO_ISDIR => 31,
+    ERRNO_LOOP => 32,
+    ERRNO_NAMETOOLONG => 37,
+    ERRNO_NOENT => 44,
+    ERRNO_NOTDIR => 54,
+    ERRNO_NOTEMPTY => 55,
+    ERRNO_PERM => 63,
+};
+
+# One host-errno-to-WASI-errno table shared by every filesystem syscall,
+# so the same host error never maps to different codes depending on which
+# syscall raised it. Callers pass the numified $! immediately after the
+# failed call ($! is easily clobbered).
+our %FS_ERRNO = (
+    Errno::EACCES() => ERRNO_ACCES,
+    Errno::EBADF() => ERRNO_BADF,
+    Errno::EEXIST() => ERRNO_EXIST,
+    Errno::EINVAL() => ERRNO_INVAL,
+    Errno::EISDIR() => ERRNO_ISDIR,
+    Errno::ELOOP() => ERRNO_LOOP,
+    Errno::ENAMETOOLONG() => ERRNO_NAMETOOLONG,
+    Errno::ENOENT() => ERRNO_NOENT,
+    Errno::ENOTDIR() => ERRNO_NOTDIR,
+    Errno::ENOTEMPTY() => ERRNO_NOTEMPTY,
+    Errno::EPERM() => ERRNO_PERM,
+    Errno::ESPIPE() => ERRNO_SPIPE,
+);
+
+sub fs_errno {
+    my ($self, $e) = @_;
+    return $FS_ERRNO{$e} // ERRNO_IO;
+}

--- a/runtime/perl/units/wasi/fd_advise.pl
+++ b/runtime/perl/units/wasi/fd_advise.pl
@@ -1,0 +1,9 @@
+# requires:
+sub wasi_fd_advise {
+    my ($self, $fd, $offset, $len, $advice) = @_;
+    my $e = $self->{fds}{$fd};
+    return ERRNO_BADF if !defined($e) || $e->{dir};
+    # posix_fadvise is purely advisory; validating the fd and succeeding is
+    # a faithful no-op (ADR-40).
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/fd_allocate.pl
+++ b/runtime/perl/units/wasi/fd_allocate.pl
@@ -1,0 +1,14 @@
+# requires: wasi/errno_fs
+sub wasi_fd_allocate {
+    my ($self, $fd, $offset, $len) = @_;
+    my $e = $self->{fds}{$fd};
+    return ERRNO_BADF if !defined($e) || $e->{dir};
+    # fallocate never shrinks: grow the file to offset+len when that
+    # exceeds the current size, otherwise leave it untouched (ADR-40).
+    my $size = (stat($e->{fh}))[7];
+    return $self->fs_errno(0 + $!) unless defined $size;
+    if ($offset + $len > $size) {
+        truncate($e->{fh}, $offset + $len) or return $self->fs_errno(0 + $!);
+    }
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/fd_close.pl
+++ b/runtime/perl/units/wasi/fd_close.pl
@@ -1,0 +1,9 @@
+# requires:
+sub wasi_fd_close {
+    my ($self, $fd) = @_;
+    my $e = delete $self->{fds}{$fd};
+    return ERRNO_BADF unless defined $e;
+    # A dir has no real OS handle to close; stdio is never closed.
+    close($e->{fh}) if !$e->{dir} && !defined($e->{std});
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/fd_datasync.pl
+++ b/runtime/perl/units/wasi/fd_datasync.pl
@@ -1,0 +1,12 @@
+# requires:
+# Core perl exposes no fdatasync; IO::Handle::sync (fsync) is the faithful
+# superset (macOS python does the same).
+use IO::Handle ();
+
+sub wasi_fd_datasync {
+    my ($self, $fd) = @_;
+    my $e = $self->{fds}{$fd};
+    return ERRNO_BADF if !defined($e) || $e->{dir};
+    return ERRNO_IO unless defined $e->{fh}->sync;
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/fd_fdstat_get.pl
+++ b/runtime/perl/units/wasi/fd_fdstat_get.pl
@@ -1,0 +1,16 @@
+# requires: memory/fill, memory/i32_store8, memory/i32_store16, memory/i64_store
+sub wasi_fd_fdstat_get {
+    my ($self, $fd, $out_ptr) = @_;
+    my $e = $self->{fds}{$fd};
+    return ERRNO_BADF unless defined $e;
+    my $filetype = $e->{dir} ? 3 : (-t $e->{fh} ? 2 : 4);  # directory / char device / regular file
+    my ($base, $inheriting, $fdflags) = @{$self->{meta}{$fd}};
+    # fdstat: fs_filetype (u8) + pad + fs_flags (u16) + pad + fs_rights_base
+    # (u64) + fs_rights_inheriting (u64) = 24 bytes.
+    $self->{memory}->fill($out_ptr, 0, 24);
+    $self->{memory}->i32_store8($out_ptr, $filetype);
+    $self->{memory}->i32_store16($out_ptr + 2, $fdflags);
+    $self->{memory}->i64_store($out_ptr + 8, $base);
+    $self->{memory}->i64_store($out_ptr + 16, $inheriting);
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/fd_fdstat_set_flags.pl
+++ b/runtime/perl/units/wasi/fd_fdstat_set_flags.pl
@@ -1,0 +1,11 @@
+# requires:
+sub wasi_fd_fdstat_set_flags {
+    my ($self, $fd, $flags) = @_;
+    my $e = $self->{fds}{$fd};
+    return ERRNO_BADF if !defined($e) || $e->{dir};
+    # Store the new fdflags; fd_write consults fdflags::APPEND before each
+    # write so clearing it here (set_flags 0) actually turns append off
+    # (ADR-40).
+    $self->{meta}{$fd}[2] = $flags & 0xFFFF;
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/fd_fdstat_set_rights.pl
+++ b/runtime/perl/units/wasi/fd_fdstat_set_rights.pl
@@ -1,0 +1,14 @@
+# requires:
+sub wasi_fd_fdstat_set_rights {
+    my ($self, $fd, $fs_rights_base, $fs_rights_inheriting) = @_;
+    my $meta = $self->{meta}{$fd};
+    return ERRNO_BADF if !defined($meta) || !exists $self->{fds}{$fd};
+    # Rights can only be narrowed, never re-granted: a request for any bit
+    # the fd does not already hold is NOTCAPABLE (ADR-40).
+    if (($fs_rights_base & ~$meta->[0]) || ($fs_rights_inheriting & ~$meta->[1])) {
+        return ERRNO_NOTCAPABLE;
+    }
+    $meta->[0] = $fs_rights_base;
+    $meta->[1] = $fs_rights_inheriting;
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/fd_filestat_get.pl
+++ b/runtime/perl/units/wasi/fd_filestat_get.pl
@@ -1,0 +1,12 @@
+# requires: memory/init, wasi/pack_filestat
+use Time::HiRes ();
+
+sub wasi_fd_filestat_get {
+    my ($self, $fd, $buf_ptr) = @_;
+    my $e = $self->{fds}{$fd};
+    return ERRNO_BADF unless defined $e;
+    my @st = $e->{dir} ? Time::HiRes::stat($e->{path}) : Time::HiRes::stat($e->{fh});
+    return ERRNO_IO unless @st;
+    $self->{memory}->init($buf_ptr, $self->pack_filestat(\@st), 0, 64);
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/fd_filestat_set_size.pl
+++ b/runtime/perl/units/wasi/fd_filestat_set_size.pl
@@ -1,0 +1,9 @@
+# requires:
+sub wasi_fd_filestat_set_size {
+    my ($self, $fd, $size) = @_;
+    my $e = $self->{fds}{$fd};
+    return ERRNO_BADF if !defined($e) || $e->{dir};
+    return ERRNO_NOTCAPABLE unless $self->{meta}{$fd}[0] & RIGHTS_FD_FILESTAT_SET_SIZE;
+    return ERRNO_IO unless truncate($e->{fh}, $size);
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/fd_filestat_set_times.pl
+++ b/runtime/perl/units/wasi/fd_filestat_set_times.pl
@@ -1,0 +1,14 @@
+# requires: wasi/fst_times
+use Time::HiRes ();
+
+sub wasi_fd_filestat_set_times {
+    my ($self, $fd, $atim, $mtim, $fst_flags) = @_;
+    my $e = $self->{fds}{$fd};
+    return ERRNO_BADF if !defined($e) || $e->{dir};
+    my @st = Time::HiRes::stat($e->{fh});
+    return ERRNO_IO unless @st;
+    my ($a, $m, $err) = $self->fst_times($st[8], $st[9], $atim, $mtim, $fst_flags);
+    return $err if defined $err;
+    Time::HiRes::utime($a, $m, $e->{fh}) or return ERRNO_IO;
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/fd_pread.pl
+++ b/runtime/perl/units/wasi/fd_pread.pl
@@ -1,0 +1,34 @@
+# requires: memory/i32_load, memory/i32_store, memory/init
+sub wasi_fd_pread {
+    my ($self, $fd, $iovs_ptr, $iovs_len, $offset, $nread_ptr) = @_;
+    my $e = $self->{fds}{$fd};
+    return ERRNO_BADF if !defined($e) || $e->{dir};
+    return ERRNO_SPIPE if defined $e->{std};
+    return ERRNO_NOTCAPABLE unless $self->{meta}{$fd}[0] & RIGHTS_FD_READ;
+    # Core perl has no pread(2): emulate with a save/seek/read/restore on
+    # the unbuffered (sysread/sysseek-only) handle, which stays coherent.
+    my $cur = sysseek($e->{fh}, 0, 1);
+    return ERRNO_IO unless defined $cur;
+    my $nread = 0;
+    for my $i (0 .. $iovs_len - 1) {
+        my $ptr = $self->{memory}->i32_load($iovs_ptr + $i * 8);
+        my $len = $self->{memory}->i32_load($iovs_ptr + $i * 8 + 4);
+        next if $len == 0;
+        my $chunk = '';
+        my $n;
+        if (defined sysseek($e->{fh}, $offset + $nread, 0)) {
+            $n = sysread($e->{fh}, $chunk, $len);
+        }
+        if (!defined $n) {
+            sysseek($e->{fh}, $cur, 0);
+            return ERRNO_IO;
+        }
+        last if $n == 0;
+        $self->{memory}->init($ptr, $chunk, 0, $n);
+        $nread += $n;
+        last if $n < $len;
+    }
+    sysseek($e->{fh}, $cur, 0);
+    $self->{memory}->i32_store($nread_ptr, $nread);
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/fd_prestat_dir_name.pl
+++ b/runtime/perl/units/wasi/fd_prestat_dir_name.pl
@@ -1,0 +1,10 @@
+# requires: memory/init, wasi/errno_fs
+sub wasi_fd_prestat_dir_name {
+    my ($self, $fd, $path_ptr, $path_len) = @_;
+    my $e = $self->{fds}{$fd};
+    return ERRNO_BADF unless defined($e) && $e->{dir} && defined($e->{preopen});
+    my $name = $e->{preopen};
+    return ERRNO_NAMETOOLONG if length($name) > $path_len;
+    $self->{memory}->init($path_ptr, $name, 0, length($name));
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/fd_prestat_get.pl
+++ b/runtime/perl/units/wasi/fd_prestat_get.pl
@@ -1,0 +1,9 @@
+# requires: memory/init
+sub wasi_fd_prestat_get {
+    my ($self, $fd, $out_ptr) = @_;
+    my $e = $self->{fds}{$fd};
+    return ERRNO_BADF unless defined($e) && $e->{dir} && defined($e->{preopen});
+    # prestat: tag (u8, 0 = dir) + 3 pad + pr_name_len (u32).
+    $self->{memory}->init($out_ptr, pack('CxxxV', 0, length($e->{preopen})), 0, 8);
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/fd_pwrite.pl
+++ b/runtime/perl/units/wasi/fd_pwrite.pl
@@ -1,0 +1,34 @@
+# requires: memory/i32_load, memory/i32_store, memory/read_string
+sub wasi_fd_pwrite {
+    my ($self, $fd, $iovs_ptr, $iovs_len, $offset, $nwritten_ptr) = @_;
+    my $e = $self->{fds}{$fd};
+    return ERRNO_BADF if !defined($e) || $e->{dir};
+    return ERRNO_SPIPE if defined $e->{std};
+    return ERRNO_NOTCAPABLE unless $self->{meta}{$fd}[0] & RIGHTS_FD_WRITE;
+    # Core perl has no pwrite(2): emulate with a save/seek/write/restore on
+    # the unbuffered handle (see fd_pread).
+    my $cur = sysseek($e->{fh}, 0, 1);
+    return ERRNO_IO unless defined $cur;
+    my $written = 0;
+    for my $i (0 .. $iovs_len - 1) {
+        my $ptr = $self->{memory}->i32_load($iovs_ptr + $i * 8);
+        my $len = $self->{memory}->i32_load($iovs_ptr + $i * 8 + 4);
+        next if $len == 0;
+        my $chunk = $self->{memory}->read_string($ptr, $len);
+        my $n;
+        if (defined sysseek($e->{fh}, $offset + $written, 0)) {
+            $n = syswrite($e->{fh}, $chunk);
+        }
+        if (!defined $n) {
+            sysseek($e->{fh}, $cur, 0);
+            return ERRNO_IO;
+        }
+        $written += $n;
+        # A single pwrite(2) may write short; stop so the reported nwritten
+        # stays contiguous.
+        last if $n < $len;
+    }
+    sysseek($e->{fh}, $cur, 0);
+    $self->{memory}->i32_store($nwritten_ptr, $written);
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/fd_read.pl
+++ b/runtime/perl/units/wasi/fd_read.pl
@@ -1,0 +1,26 @@
+# requires: memory/i32_load, memory/i32_store, memory/init
+sub wasi_fd_read {
+    my ($self, $fd, $iovs_ptr, $iovs_len, $nread_ptr) = @_;
+    my $e = $self->{fds}{$fd};
+    return ERRNO_BADF if !defined($e) || $e->{dir};
+    return ERRNO_NOTCAPABLE unless $self->{meta}{$fd}[0] & RIGHTS_FD_READ;
+    my $nread = 0;
+    for my $i (0 .. $iovs_len - 1) {
+        my $ptr = $self->{memory}->i32_load($iovs_ptr + $i * 8);
+        my $len = $self->{memory}->i32_load($iovs_ptr + $i * 8 + 4);
+        next if $len == 0;
+        # sysread is a raw read(2): it returns as soon as any bytes are
+        # available — the WASI short-read semantics wasmtime uses — so an
+        # interactive tty stdin (the QuickJS REPL under a pty) never
+        # deadlocks waiting for a full buffer.
+        my $chunk = '';
+        my $n = sysread($e->{fh}, $chunk, $len);
+        return ERRNO_IO unless defined $n;
+        last if $n == 0;
+        $self->{memory}->init($ptr, $chunk, 0, $n);
+        $nread += $n;
+        last if $n < $len;
+    }
+    $self->{memory}->i32_store($nread_ptr, $nread);
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/fd_readdir.pl
+++ b/runtime/perl/units/wasi/fd_readdir.pl
@@ -1,0 +1,44 @@
+# requires: memory/init, memory/i32_store, wasi/wasi_filetype
+sub wasi_fd_readdir {
+    my ($self, $fd, $buf_ptr, $buf_len, $cookie, $bufused_ptr) = @_;
+    my $e = $self->{fds}{$fd};
+    return ERRNO_BADF unless defined($e) && $e->{dir};
+    return ERRNO_NOTCAPABLE unless $self->{meta}{$fd}[0] & RIGHTS_FD_READDIR;
+    # cookie 0 starts a fresh enumeration, so re-scan the directory then; a
+    # non-zero cookie resumes the snapshot cached from that start (the
+    # opaque-resume-point contract, ADR-14).
+    if (!defined($e->{entries}) || $cookie == 0) {
+        $e->{entries} = $self->readdir_entries($e->{path});
+        return ERRNO_IO unless defined $e->{entries};
+    }
+    my $entries = $e->{entries};
+    my $out = '';
+    my $i = $cookie;
+    while ($i < @$entries && length($out) < $buf_len) {
+        my ($name, $filetype, $ino) = @{$entries->[$i]};
+        # dirent: d_next (u64, resume cookie) + d_ino (u64) + d_namlen
+        # (u32) + d_type (u8) + 3 pad, followed by the (unpadded) name.
+        $out .= pack('Q<Q<VCxxx', $i + 1, $ino, length($name), $filetype) . $name;
+        $i++;
+    }
+    # A dirent may be legally truncated at the tail once buf_len runs out.
+    $out = substr($out, 0, $buf_len) if length($out) > $buf_len;
+    $self->{memory}->init($buf_ptr, $out, 0, length($out));
+    $self->{memory}->i32_store($bufused_ptr, length($out));
+    return ERRNO_SUCCESS;
+}
+
+sub readdir_entries {
+    my ($self, $path) = @_;
+    opendir(my $dh, $path) or return undef;
+    my @names = sort grep { $_ ne '.' && $_ ne '..' } readdir($dh);
+    closedir($dh);
+    my @self_st = lstat($path);
+    my @up_st = lstat("$path/..");
+    my @entries = (['.', 3, $self_st[1] // 0], ['..', 3, $up_st[1] // 0]);
+    for my $name (@names) {
+        my @st = lstat("$path/$name") or next;
+        push @entries, [$name, $self->wasi_filetype($st[2]), $st[1]];
+    }
+    return \@entries;
+}

--- a/runtime/perl/units/wasi/fd_renumber.pl
+++ b/runtime/perl/units/wasi/fd_renumber.pl
@@ -1,0 +1,13 @@
+# requires:
+sub wasi_fd_renumber {
+    my ($self, $fd, $to) = @_;
+    # Both descriptors must currently be open; the destination's own
+    # resource is closed, then the source is moved onto it and the source
+    # number retired (works onto stdio and preopens too, ADR-40).
+    return ERRNO_BADF unless exists $self->{fds}{$fd} && exists $self->{fds}{$to};
+    my $dst = $self->{fds}{$to};
+    close($dst->{fh}) if !$dst->{dir} && !defined($dst->{std});
+    $self->{fds}{$to} = delete $self->{fds}{$fd};
+    $self->{meta}{$to} = delete $self->{meta}{$fd};
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/fd_seek.pl
+++ b/runtime/perl/units/wasi/fd_seek.pl
@@ -1,0 +1,19 @@
+# requires: memory/i64_store, rt/s64
+use Errno ();
+
+sub wasi_fd_seek {
+    my ($self, $fd, $offset, $whence, $out_ptr) = @_;
+    my $e = $self->{fds}{$fd};
+    return ERRNO_BADF if !defined($e) || $e->{dir};
+    return ERRNO_SPIPE if defined $e->{std};
+    return ERRNO_NOTCAPABLE unless $self->{meta}{$fd}[0] & RIGHTS_FD_SEEK;
+    return ERRNO_INVAL if $whence > 2;  # WASI whence 0/1/2 = sysseek SET/CUR/END
+    my $pos = sysseek($e->{fh}, Rt::s64($offset), $whence);
+    if (!defined $pos) {
+        # A negative resulting offset is EINVAL, which WASI reports as
+        # INVAL (not the generic IO used for other seek failures).
+        return 0 + $! == Errno::EINVAL() ? ERRNO_INVAL : ERRNO_IO;
+    }
+    $self->{memory}->i64_store($out_ptr, $pos);
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/fd_sync.pl
+++ b/runtime/perl/units/wasi/fd_sync.pl
@@ -1,0 +1,10 @@
+# requires:
+use IO::Handle ();
+
+sub wasi_fd_sync {
+    my ($self, $fd) = @_;
+    my $e = $self->{fds}{$fd};
+    return ERRNO_BADF if !defined($e) || $e->{dir};
+    return ERRNO_IO unless defined $e->{fh}->sync;
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/fd_tell.pl
+++ b/runtime/perl/units/wasi/fd_tell.pl
@@ -1,0 +1,11 @@
+# requires: memory/i64_store
+sub wasi_fd_tell {
+    my ($self, $fd, $out_ptr) = @_;
+    my $e = $self->{fds}{$fd};
+    return ERRNO_BADF if !defined($e) || $e->{dir};
+    return ERRNO_SPIPE if defined $e->{std};
+    my $pos = sysseek($e->{fh}, 0, 1);
+    return ERRNO_IO unless defined $pos;
+    $self->{memory}->i64_store($out_ptr, $pos);
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/fd_write.pl
+++ b/runtime/perl/units/wasi/fd_write.pl
@@ -1,0 +1,27 @@
+# requires: memory/i32_load, memory/i32_store, memory/read_string
+sub wasi_fd_write {
+    my ($self, $fd, $iovs_ptr, $iovs_len, $nwritten_ptr) = @_;
+    my $e = $self->{fds}{$fd};
+    return ERRNO_BADF if !defined($e) || $e->{dir};
+    return ERRNO_NOTCAPABLE unless $self->{meta}{$fd}[0] & RIGHTS_FD_WRITE;
+    # fdflags::APPEND is honoured here (not via O_APPEND on the OS handle)
+    # so fd_fdstat_set_flags(0) can turn it back off (ADR-40).
+    if (($self->{meta}{$fd}[2] & 0x1) && !defined($e->{std})) {
+        return ERRNO_IO unless defined sysseek($e->{fh}, 0, 2);
+    }
+    my $written = 0;
+    for my $i (0 .. $iovs_len - 1) {
+        my $ptr = $self->{memory}->i32_load($iovs_ptr + $i * 8);
+        my $len = $self->{memory}->i32_load($iovs_ptr + $i * 8 + 4);
+        next if $len == 0;
+        my $chunk = $self->{memory}->read_string($ptr, $len);
+        my $n = syswrite($e->{fh}, $chunk);
+        return ERRNO_IO unless defined $n;
+        $written += $n;
+        # A single write(2) may write short; stop so the reported nwritten
+        # stays contiguous.
+        last if $n < $len;
+    }
+    $self->{memory}->i32_store($nwritten_ptr, $written);
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/fst_times.pl
+++ b/runtime/perl/units/wasi/fst_times.pl
@@ -1,0 +1,17 @@
+# Validate the fstflags and compute the (atime, mtime) pair for
+# Time::HiRes::utime in NV seconds, filling any field not being set from
+# the current stat times (ADR-40). ATIM with ATIM_NOW (or MTIM with
+# MTIM_NOW) is a contradiction and yields INVAL; returns (atime, mtime,
+# err).
+use Time::HiRes ();
+
+sub fst_times {
+    my ($self, $cur_atime, $cur_mtime, $atim, $mtim, $fst_flags) = @_;
+    if ((($fst_flags & 0x1) && ($fst_flags & 0x2)) || (($fst_flags & 0x4) && ($fst_flags & 0x8))) {
+        return (undef, undef, ERRNO_INVAL);
+    }
+    my $now = Time::HiRes::time();
+    my $a = $fst_flags & 0x1 ? $atim / 1e9 : ($fst_flags & 0x2 ? $now : $cur_atime);
+    my $m = $fst_flags & 0x4 ? $mtim / 1e9 : ($fst_flags & 0x8 ? $now : $cur_mtime);
+    return ($a, $m, undef);
+}

--- a/runtime/perl/units/wasi/pack_filestat.pl
+++ b/runtime/perl/units/wasi/pack_filestat.pl
@@ -1,0 +1,11 @@
+# requires: wasi/wasi_filetype
+# Packs a Time::HiRes::stat result (arrayref) into a WASI filestat (64
+# bytes): dev, ino, filetype (+7 pad), nlink, size, atim/mtim/ctim (all
+# u64, times in nanoseconds — quantized to what NV seconds can carry,
+# roughly 400ns granularity at the current epoch).
+sub pack_filestat {
+    my ($self, $st) = @_;
+    return pack('Q<Q<Cx7Q<Q<Q<Q<Q<',
+        $st->[0], $st->[1], $self->wasi_filetype($st->[2]), $st->[3], $st->[7],
+        map { int($_ * 1e9 + 0.5) } @{$st}[8, 9, 10]);
+}

--- a/runtime/perl/units/wasi/path_create_directory.pl
+++ b/runtime/perl/units/wasi/path_create_directory.pl
@@ -1,0 +1,14 @@
+# requires: memory/read_string, wasi/resolve_path, wasi/errno_fs
+sub wasi_path_create_directory {
+    my ($self, $dirfd, $path_ptr, $path_len) = @_;
+    my $rel = $self->{memory}->read_string($path_ptr, $path_len);
+    # Strip a trailing slash: mkdir names a directory anyway, and EEXIST is
+    # wasmtime's answer for mkdir("file/") where the hosts split (ADR-49).
+    (my $core = $rel) =~ s{/+\z}{};
+    $rel = $core if $core ne '';
+    # mkdir(2) never follows a trailing symlink (an existing one is EEXIST).
+    my ($host, $err) = $self->resolve_path($dirfd, $rel, 0);
+    return $err if defined $err;
+    mkdir($host) or return $self->fs_errno(0 + $!);
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/path_filestat_get.pl
+++ b/runtime/perl/units/wasi/path_filestat_get.pl
@@ -1,0 +1,14 @@
+# requires: memory/read_string, memory/init, wasi/resolve_path, wasi/pack_filestat, wasi/errno_fs
+use Time::HiRes ();
+
+sub wasi_path_filestat_get {
+    my ($self, $dirfd, $flags, $path_ptr, $path_len, $buf_ptr) = @_;
+    my $rel = $self->{memory}->read_string($path_ptr, $path_len);
+    my $follow = ($flags & 0x1) != 0;  # lookupflags::SYMLINK_FOLLOW
+    my ($host, $err) = $self->resolve_path($dirfd, $rel, $follow);
+    return $err if defined $err;
+    my @st = $follow ? Time::HiRes::stat($host) : Time::HiRes::lstat($host);
+    return $self->fs_errno(0 + $!) unless @st;
+    $self->{memory}->init($buf_ptr, $self->pack_filestat(\@st), 0, 64);
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/path_filestat_set_times.pl
+++ b/runtime/perl/units/wasi/path_filestat_set_times.pl
@@ -1,0 +1,20 @@
+# requires: memory/read_string, wasi/resolve_path, wasi/fst_times, wasi/errno_fs
+use Time::HiRes ();
+
+sub wasi_path_filestat_set_times {
+    my ($self, $fd, $flags, $path_ptr, $path_len, $atim, $mtim, $fst_flags) = @_;
+    my $rel = $self->{memory}->read_string($path_ptr, $path_len);
+    my $follow = ($flags & 0x1) != 0;  # lookupflags::SYMLINK_FOLLOW
+    my ($host, $err) = $self->resolve_path($fd, $rel, $follow);
+    return $err if defined $err;
+    my @st = $follow ? Time::HiRes::stat($host) : Time::HiRes::lstat($host);
+    return $self->fs_errno(0 + $!) unless @st;
+    my ($a, $m, $terr) = $self->fst_times($st[8], $st[9], $atim, $mtim, $fst_flags);
+    return $terr if defined $terr;
+    # Core perl exposes no lutimes/utimensat(AT_SYMLINK_NOFOLLOW), so a
+    # final-component symlink cannot carry its own times: the utime below
+    # follows it (the one NOFOLLOW gap in this backend's WASI surface; the
+    # wasi-testsuite ledger carries the attribution).
+    Time::HiRes::utime($a, $m, $host) or return $self->fs_errno(0 + $!);
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/path_link.pl
+++ b/runtime/perl/units/wasi/path_link.pl
@@ -1,0 +1,27 @@
+# requires: memory/read_string, wasi/resolve_path, wasi/errno_fs
+sub wasi_path_link {
+    my ($self, $old_fd, $old_flags, $old_path_ptr, $old_path_len, $new_fd, $new_path_ptr, $new_path_len) = @_;
+    # path_link operates on the source link itself; SYMLINK_FOLLOW is
+    # rejected rather than silently dereferenced (ADR-40).
+    return ERRNO_INVAL if $old_flags & 0x1;
+    my $old_rel = $self->{memory}->read_string($old_path_ptr, $old_path_len);
+    my ($old_host, $old_err) = $self->resolve_path($old_fd, $old_rel, 0);
+    return $old_err if defined $old_err;
+    my $new_rel = $self->{memory}->read_string($new_path_ptr, $new_path_len);
+    my ($new_host, $new_err) = $self->resolve_path($new_fd, $new_rel, 0);
+    return $new_err if defined $new_err;
+    # WASI must hardlink the source link itself, but macOS link(2) follows
+    # a source symlink (Linux's does not) and core perl has no linkat to
+    # ask for NOFOLLOW (Ruby binds it via Fiddle). Clone the symlink
+    # instead: same target, though a distinct inode/link count — the
+    # closest core-perl emulation. An existing destination still reports
+    # EEXIST, as link(2) would.
+    if ($^O eq 'darwin' && -l $old_host) {
+        my $target = readlink($old_host);
+        return $self->fs_errno(0 + $!) unless defined $target;
+        symlink($target, $new_host) or return $self->fs_errno(0 + $!);
+        return ERRNO_SUCCESS;
+    }
+    link($old_host, $new_host) or return $self->fs_errno(0 + $!);
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/path_open.pl
+++ b/runtime/perl/units/wasi/path_open.pl
@@ -1,0 +1,68 @@
+# requires: memory/read_string, memory/i32_store, wasi/resolve_path, wasi/errno_fs
+use Cwd ();
+use Fcntl ();
+
+sub wasi_path_open {
+    my ($self, $dirfd, $dirflags, $path_ptr, $path_len, $oflags, $fs_rights_base, $fs_rights_inheriting, $fdflags, $opened_fd_ptr) = @_;
+    my $rel = $self->{memory}->read_string($path_ptr, $path_len);
+    my $follow = ($dirflags & 0x1) != 0;  # lookupflags::SYMLINK_FOLLOW
+    my ($host, $err) = $self->resolve_path($dirfd, $rel, $follow);
+    return $err if defined $err;
+    # The dirfd must itself carry PATH_OPEN (ADR-40); a rights-narrowed dir
+    # fd that dropped it can no longer open beneath itself.
+    return ERRNO_NOTCAPABLE unless $self->{meta}{$dirfd}[0] & RIGHTS_PATH_OPEN;
+    # OFLAGS_TRUNC needs the PATH_FILESTAT_SET_SIZE right on the dirfd
+    # (ADR-40).
+    if (($oflags & 0x8) && !($self->{meta}{$dirfd}[0] & RIGHTS_PATH_FILESTAT_SET_SIZE)) {
+        return ERRNO_NOTCAPABLE;
+    }
+    my $read = ($fs_rights_base & RIGHTS_FD_READ) != 0;
+    my $write = ($fs_rights_base & RIGHTS_FD_WRITE) != 0;
+    my $flags = $read && $write ? Fcntl::O_RDWR() : ($write ? Fcntl::O_WRONLY() : Fcntl::O_RDONLY());
+    # Without SYMLINK_FOLLOW a final symlink must not be traversed:
+    # O_NOFOLLOW turns that into ELOOP, matching wasmtime's O_NOFOLLOW
+    # default.
+    $flags |= Fcntl::O_NOFOLLOW() unless $follow;
+    $flags |= Fcntl::O_DIRECTORY() if $oflags & 0x2;  # oflags::DIRECTORY
+    $flags |= Fcntl::O_CREAT() if $oflags & 0x1;  # oflags::CREAT
+    $flags |= Fcntl::O_EXCL() if $oflags & 0x4;  # oflags::EXCL
+    $flags |= Fcntl::O_TRUNC() if $oflags & 0x8;  # oflags::TRUNC
+    # O_CREAT must not create through a trailing slash (issue #42); per
+    # wasmtime (ADR-49): EINVAL on macOS, EISDIR on Linux, plain open
+    # ENOENT.
+    if (substr($host, -1) eq '/' && !lstat(substr($host, 0, -1))) {
+        return ERRNO_NOENT unless $oflags & 0x1;  # no oflags::CREAT
+        return $^O eq 'darwin' ? ERRNO_INVAL : ERRNO_ISDIR;
+    }
+    sysopen(my $fh, $host, $flags, 0644) or return $self->fs_errno(0 + $!);
+    my @st = stat($fh);
+    if (!@st) {
+        my $e = 0 + $!;
+        close($fh);
+        return $self->fs_errno($e);
+    }
+    my ($base, $inheriting);
+    if (($st[2] & 0170000) == 0040000) {  # a directory
+        # Opening a directory: keep a dir entry (sysread on it is not
+        # meaningful), narrow to the directory rights, and drop the
+        # throwaway OS handle.
+        close($fh);
+        my $real = Cwd::realpath($host);
+        return $self->fs_errno(0 + $!) unless defined $real;
+        $self->{fds}{$self->{next_fd}} = { dir => 1, path => $real, preopen => undef, entries => undef };
+        $base = $fs_rights_base & $self->{meta}{$dirfd}[1] & DIR_RIGHTS_BASE;
+        $inheriting = $fs_rights_inheriting & $self->{meta}{$dirfd}[1] & DIR_RIGHTS_INHERITING;
+    } else {
+        # Unbuffered by construction: every access goes through sysread/
+        # syswrite/sysseek, so pread/pwrite emulation stays coherent with
+        # read/write/seek — sqlite mixes both on one fd.
+        binmode($fh);
+        $self->{fds}{$self->{next_fd}} = { fh => $fh, path => $host };
+        $base = $fs_rights_base & $self->{meta}{$dirfd}[1] & FILE_RIGHTS_BASE;
+        $inheriting = $fs_rights_inheriting & $self->{meta}{$dirfd}[1] & FILE_RIGHTS_BASE;
+    }
+    $self->{meta}{$self->{next_fd}} = [$base, $inheriting, $fdflags & 0xFFFF];
+    $self->{memory}->i32_store($opened_fd_ptr, $self->{next_fd});
+    $self->{next_fd}++;
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/path_readlink.pl
+++ b/runtime/perl/units/wasi/path_readlink.pl
@@ -1,0 +1,15 @@
+# requires: memory/read_string, memory/init, memory/i32_store, wasi/resolve_path, wasi/errno_fs
+sub wasi_path_readlink {
+    my ($self, $fd, $path_ptr, $path_len, $buf_ptr, $buf_len, $bufused_ptr) = @_;
+    my $rel = $self->{memory}->read_string($path_ptr, $path_len);
+    my ($host, $err) = $self->resolve_path($fd, $rel, 0);
+    return $err if defined $err;
+    my $target = readlink($host);
+    return $self->fs_errno(0 + $!) unless defined $target;
+    # The content is truncated to buf_len (no NUL terminator); bufused
+    # reports how many bytes were written.
+    my $n = length($target) < $buf_len ? length($target) : $buf_len;
+    $self->{memory}->init($buf_ptr, $target, 0, $n);
+    $self->{memory}->i32_store($bufused_ptr, $n);
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/path_remove_directory.pl
+++ b/runtime/perl/units/wasi/path_remove_directory.pl
@@ -1,0 +1,13 @@
+# requires: memory/read_string, wasi/resolve_path, wasi/errno_fs
+sub wasi_path_remove_directory {
+    my ($self, $dirfd, $path_ptr, $path_len) = @_;
+    my $rel = $self->{memory}->read_string($path_ptr, $path_len);
+    # rmdir(2) never follows a trailing symlink.
+    my ($host, $err) = $self->resolve_path($dirfd, $rel, 0);
+    return $err if defined $err;
+    # rmdir through a trailing slash on an existing directory is EINVAL per
+    # wasmtime (ADR-49); other shapes come from the host call.
+    return ERRNO_INVAL if substr($host, -1) eq '/' && -d substr($host, 0, -1);
+    rmdir($host) or return $self->fs_errno(0 + $!);
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/path_rename.pl
+++ b/runtime/perl/units/wasi/path_rename.pl
@@ -1,0 +1,22 @@
+# requires: memory/read_string, wasi/resolve_path, wasi/errno_fs
+sub wasi_path_rename {
+    my ($self, $old_dirfd, $old_path_ptr, $old_path_len, $new_dirfd, $new_path_ptr, $new_path_len) = @_;
+    my $old_rel = $self->{memory}->read_string($old_path_ptr, $old_path_len);
+    # rename(2) never follows trailing symlinks: it moves the link itself
+    # and replaces the destination link.
+    my ($old_host, $old_err) = $self->resolve_path($old_dirfd, $old_rel, 0);
+    return $old_err if defined $old_err;
+    my $new_rel = $self->{memory}->read_string($new_path_ptr, $new_path_len);
+    my ($new_host, $new_err) = $self->resolve_path($new_dirfd, $new_rel, 0);
+    return $new_err if defined $new_err;
+    # The preserved slash lets the host rename(2) enforce the existing and
+    # missing shapes; a *nonexistent* slash-suffixed destination is
+    # stripped so the rename proceeds, as wasmtime does (issue #42,
+    # ADR-49). Probe the bare path — stat on "x/" fails ENOTDIR and reads
+    # as missing.
+    if (substr($new_host, -1) eq '/' && !lstat(substr($new_host, 0, -1))) {
+        $new_host = substr($new_host, 0, -1);
+    }
+    rename($old_host, $new_host) or return $self->fs_errno(0 + $!);
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/path_symlink.pl
+++ b/runtime/perl/units/wasi/path_symlink.pl
@@ -1,0 +1,25 @@
+# requires: memory/read_string, wasi/resolve_path, wasi/errno_fs
+sub wasi_path_symlink {
+    my ($self, $old_path_ptr, $old_path_len, $fd, $new_path_ptr, $new_path_len) = @_;
+    my $target = $self->{memory}->read_string($old_path_ptr, $old_path_len);
+    # The symlink target is stored verbatim (never pre-resolved);
+    # containment is enforced when the link is later followed (ADR-40). An
+    # absolute target can never be confined to the preopen, so it is
+    # rejected up front.
+    return ERRNO_NOTCAPABLE if rindex($target, '/', 0) == 0;
+    my $new_rel = $self->{memory}->read_string($new_path_ptr, $new_path_len);
+    my ($link_host, $err) = $self->resolve_path($fd, $new_rel, 0);
+    return $err if defined $err;
+    # Slash-suffixed link name, per wasmtime (ADR-49): EEXIST on a
+    # directory, ENOTDIR on a non-directory (raw Linux would say EEXIST),
+    # ENOENT when missing. Probe the slash-stripped path.
+    if (substr($link_host, -1) eq '/') {
+        my $bare = substr($link_host, 0, -1);
+        if (lstat($bare)) {
+            return -d $bare ? ERRNO_EXIST : ERRNO_NOTDIR;
+        }
+        return ERRNO_NOENT;
+    }
+    symlink($target, $link_host) or return $self->fs_errno(0 + $!);
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/path_unlink_file.pl
+++ b/runtime/perl/units/wasi/path_unlink_file.pl
@@ -1,0 +1,19 @@
+# requires: memory/read_string, wasi/resolve_path, wasi/errno_fs
+sub wasi_path_unlink_file {
+    my ($self, $dirfd, $path_ptr, $path_len) = @_;
+    my $rel = $self->{memory}->read_string($path_ptr, $path_len);
+    # unlink(2) never follows a trailing symlink: it removes the link.
+    my ($host, $err) = $self->resolve_path($dirfd, $rel, 0);
+    return $err if defined $err;
+    # Perl's unlink refuses directories client-side (EISDIR) before the
+    # syscall reports its own flavor; wasmtime surfaces the host unlink(2)
+    # errno — EPERM on macOS, EISDIR elsewhere (ADR-49) — so probe a
+    # directory target and answer it directly.
+    my $bare = substr($host, -1) eq '/' ? substr($host, 0, -1) : $host;
+    my @st = lstat($bare);
+    if (@st && ($st[2] & 0170000) == 0040000) {
+        return $^O eq 'darwin' ? ERRNO_PERM : ERRNO_ISDIR;
+    }
+    unlink($host) or return $self->fs_errno(0 + $!);
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/poll_oneoff.pl
+++ b/runtime/perl/units/wasi/poll_oneoff.pl
@@ -1,0 +1,94 @@
+# requires: memory/fill, memory/i32_load, memory/i32_load8_u, memory/i32_load16_u, memory/i64_load, memory/i32_store, memory/i32_store8, memory/i32_store16, memory/i64_store
+# poll_oneoff waits until at least one subscription is ready, then writes
+# one event per ready subscription (WASI p1 layout: 48-byte subscriptions
+# in, 32-byte events out). Only fd_read on stdin actually blocks (via
+# 4-arg select); regular files, stdout/stderr, and every fd_write are
+# treated as immediately ready, and unknown fds report EBADF. Clock
+# subscriptions set the wait deadline; if it elapses with no fd ready, the
+# due clock subs fire. Motivated by event-loop guests such as the QuickJS
+# REPL, which blocks here on stdin between prompts (ADR-14).
+use Time::HiRes ();
+
+sub wasi_poll_oneoff {
+    my ($self, $in_ptr, $out_ptr, $nsubs, $nevents_ptr) = @_;
+    return ERRNO_INVAL if $nsubs == 0;
+    my @ready;    # [userdata, error, type, nbytes, flags] resolvable without waiting
+    my @waiters;  # [userdata, type, fh] fd_read on stdin — needs a host wait
+    my @clocks;   # [userdata, rel_ns]
+    for my $i (0 .. $nsubs - 1) {
+        my $base = $in_ptr + $i * 48;
+        my $userdata = $self->{memory}->i64_load($base);
+        my $tag = $self->{memory}->i32_load8_u($base + 8);
+        if ($tag == 0) {  # clock
+            my $clock_id = $self->{memory}->i32_load($base + 16);
+            my $timeout = $self->{memory}->i64_load($base + 24);
+            my $flags = $self->{memory}->i32_load16_u($base + 40);
+            my $now = $clock_id == 0
+                ? int(Time::HiRes::time() * 1e9)
+                : int(Time::HiRes::clock_gettime(Time::HiRes::CLOCK_MONOTONIC()) * 1e9);
+            my $rel = ($flags & 1) ? ($timeout > $now ? $timeout - $now : 0) : $timeout;
+            push @clocks, [$userdata, $rel];
+        } elsif ($tag == 1 || $tag == 2) {  # fd_read / fd_write
+            my $fd = $self->{memory}->i32_load($base + 16);
+            my $e = $self->{fds}{$fd};
+            if (!defined($e) || $e->{dir}) {
+                push @ready, [$userdata, ERRNO_BADF, $tag, 0, 0];
+            } elsif ($tag == 1 && defined($e->{std}) && $e->{std} == 0) {
+                push @waiters, [$userdata, $tag, $e->{fh}];
+            } else {
+                my $nbytes = 1;
+                if ($tag == 1 && !defined($e->{std})) {
+                    my $size = (stat($e->{fh}))[7];
+                    my $pos = sysseek($e->{fh}, 0, 1);
+                    $nbytes = defined($size) && defined($pos) && $size > $pos ? $size - $pos : 0;
+                }
+                push @ready, [$userdata, 0, $tag, $nbytes, 0];
+            }
+        } else {
+            return ERRNO_INVAL;
+        }
+    }
+
+    my @events = @ready;
+    if (!@events) {
+        if (@waiters) {
+            my $timeout_s;
+            if (@clocks) {
+                my $min = $clocks[0][1];
+                $min = $_->[1] < $min ? $_->[1] : $min for @clocks;
+                $timeout_s = $min / 1e9;
+            }
+            my $rin = '';
+            vec($rin, fileno($_->[2]), 1) = 1 for @waiters;
+            my $rout = $rin;
+            select($rout, undef, undef, $timeout_s);
+            for my $w (@waiters) {
+                push @events, [$w->[0], 0, $w->[1], 1, 0] if vec($rout, fileno($w->[2]), 1);
+            }
+        } elsif (@clocks) {
+            my $min = $clocks[0][1];
+            $min = $_->[1] < $min ? $_->[1] : $min for @clocks;
+            Time::HiRes::sleep($min / 1e9) if $min > 0;
+        }
+        if (!@events && @clocks) {
+            my $due = $clocks[0][1];
+            $due = $_->[1] < $due ? $_->[1] : $due for @clocks;
+            for my $c (@clocks) {
+                push @events, [$c->[0], 0, 0, 0, 0] if $c->[1] <= $due;
+            }
+        }
+    }
+
+    for my $i (0 .. $#events) {
+        my ($userdata, $error, $type, $nbytes, $flags) = @{$events[$i]};
+        my $ev = $out_ptr + $i * 32;
+        $self->{memory}->fill($ev, 0, 32);
+        $self->{memory}->i64_store($ev, $userdata);
+        $self->{memory}->i32_store16($ev + 8, $error);
+        $self->{memory}->i32_store8($ev + 10, $type);
+        $self->{memory}->i64_store($ev + 16, $nbytes);
+        $self->{memory}->i32_store16($ev + 24, $flags);
+    }
+    $self->{memory}->i32_store($nevents_ptr, scalar @events);
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/proc_exit.pl
+++ b/runtime/perl/units/wasi/proc_exit.pl
@@ -1,0 +1,5 @@
+# requires: rt/exit
+sub wasi_proc_exit {
+    my ($self, $code) = @_;
+    die bless({ code => $code }, 'Rt::Exit');
+}

--- a/runtime/perl/units/wasi/random_get.pl
+++ b/runtime/perl/units/wasi/random_get.pl
@@ -1,0 +1,16 @@
+# requires: memory/init
+# /dev/urandom is the core-perl entropy source; the rand() tail is a
+# non-cryptographic fallback for hosts without it.
+sub wasi_random_get {
+    my ($self, $buf_ptr, $len) = @_;
+    my $bytes = '';
+    if (open(my $fh, '<:raw', '/dev/urandom')) {
+        while (length($bytes) < $len) {
+            last unless sysread($fh, $bytes, $len - length($bytes), length($bytes));
+        }
+        close($fh);
+    }
+    $bytes .= chr(int(rand(256))) while length($bytes) < $len;
+    $self->{memory}->init($buf_ptr, $bytes, 0, $len);
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/resolve_path.pl
+++ b/runtime/perl/units/wasi/resolve_path.pl
@@ -1,0 +1,101 @@
+# requires: wasi/errno_fs
+use Cwd ();
+use Errno ();
+use File::Basename ();
+
+sub within {
+    my ($self, $base, $path) = @_;
+    my $prefix = substr($base, -1) eq '/' ? $base : "$base/";
+    return $path eq $base || rindex($path, $prefix, 0) == 0;
+}
+
+# Lexical escape guard: expand "." and ".." purely textually and report
+# whether the path climbs out of the base. Cwd::realpath below is the
+# symlink-aware check, but it returns undef when the escaped-to parent
+# does not exist on disk, so a path like "a/../../etc" needs catching here
+# to report NOTCAPABLE rather than NOENT (mirrors the Ruby runtime's
+# File.expand_path guard).
+sub lexical_escape {
+    my ($self, $rel) = @_;
+    my @stack;
+    for my $c (split m{/+}, $rel) {
+        next if $c eq '' || $c eq '.';
+        if ($c eq '..') {
+            return 1 unless @stack;
+            pop @stack;
+        } else {
+            push @stack, $c;
+        }
+    }
+    return 0;
+}
+
+# Resolves a guest-relative path against a directory fd to an absolute
+# host path, confined to that directory fd's own (already-realpath'd)
+# root. Every call re-validates against its own dirfd's root, so nested
+# path_opens can't be used to launder an escape one level cheaper.
+#
+# A non-directory base fd is NOTDIR (a file used as a dirfd); an absent
+# one is BADF. A leading "/" is NOTCAPABLE before any join (an absolute
+# guest path escapes the preopen). A trailing slash is preserved on the
+# returned host path so the underlying host call enforces the POSIX "must
+# be a directory" rule (ADR-40).
+#
+# $follow_last false resolves the parent but leaves the final component
+# untouched (the AT_SYMLINK_NOFOLLOW shape), for syscalls that operate on
+# a symlink itself (lstat, unlink, rename, rmdir, mkdir, symlink, link).
+# A trailing "." or ".." is never a symlink, so those fall back to full
+# resolution.
+#
+# Known limitation (ADR-14): this is a check-then-open, not an atomic
+# openat(2)-beneath resolution — a TOCTOU race or a symlink planted inside
+# the sandbox between the check and the actual filesystem call could in
+# principle escape. Accepted for a single-process research/demo runtime,
+# not a multi-tenant sandbox host.
+sub resolve_path {
+    my ($self, $dirfd, $rel, $follow_last) = @_;
+    $follow_last = 1 unless defined $follow_last;
+    my $entry = $self->{fds}{$dirfd};
+    return (undef, ERRNO_BADF) unless defined $entry;
+    return (undef, ERRNO_NOTDIR) unless $entry->{dir};
+    return (undef, ERRNO_INVAL) if index($rel, "\0") >= 0;
+    return (undef, ERRNO_NOTCAPABLE) if rindex($rel, '/', 0) == 0;
+    my $base = $entry->{path};
+    # Containment is checked before existence: a path whose "..s" escape
+    # the sandbox is NOTCAPABLE even when the escaped-to parent does not
+    # exist.
+    return (undef, ERRNO_NOTCAPABLE) if $self->lexical_escape($rel);
+    my $trailing = length($rel) > 1 && substr($rel, -1) eq '/';
+    my $suffix = $trailing ? '/' : '';
+    (my $core = $rel) =~ s{/+\z}{};
+    my $joined = $core eq '' ? $base : "$base/$core";
+    my $last = File::Basename::basename($joined);
+    if (!$follow_last && $last ne '.' && $last ne '..') {
+        my $real_parent = Cwd::realpath(File::Basename::dirname($joined));
+        if (!defined $real_parent) {
+            my $e = 0 + $!;
+            return (undef, ERRNO_LOOP) if $e == Errno::ELOOP();
+            return (undef, ERRNO_NOENT) if $e == Errno::ENOENT();
+            return (undef, ERRNO_IO);
+        }
+        return (undef, ERRNO_NOTCAPABLE) unless $self->within($base, $real_parent);
+        return ("$real_parent/$last$suffix", undef);
+    }
+    my $real = Cwd::realpath($joined);
+    if (defined $real) {
+        return (undef, ERRNO_NOTCAPABLE) unless $self->within($base, $real);
+        return ($real . $suffix, undef);
+    }
+    my $e = 0 + $!;
+    return (undef, ERRNO_LOOP) if $e == Errno::ELOOP();
+    return (undef, ERRNO_IO) if $e != Errno::ENOENT();
+    # The final component is missing (or a dangling symlink): resolve the
+    # parent and re-attach it, so a create (path_open O_CREAT) still gets
+    # a sandboxed target path.
+    my $real_parent = Cwd::realpath(File::Basename::dirname($joined));
+    if (!defined $real_parent) {
+        return (undef, 0 + $! == Errno::ENOENT() ? ERRNO_NOENT : ERRNO_IO);
+    }
+    return (undef, ERRNO_NOTCAPABLE) unless $self->within($base, $real_parent);
+    return ("$real_parent/" . File::Basename::basename($joined) . $suffix, undef);
+}

--- a/runtime/perl/units/wasi/sched_yield.pl
+++ b/runtime/perl/units/wasi/sched_yield.pl
@@ -1,0 +1,3 @@
+sub wasi_sched_yield {
+    return ERRNO_SUCCESS;
+}

--- a/runtime/perl/units/wasi/wasi_filetype.pl
+++ b/runtime/perl/units/wasi/wasi_filetype.pl
@@ -1,0 +1,13 @@
+# Map a stat mode word to a WASI filetype tag (S_IFMT bits, avoiding a
+# POSIX-constant dependency).
+sub wasi_filetype {
+    my ($self, $mode) = @_;
+    my $fmt = $mode & 0170000;
+    return 3 if $fmt == 0040000;  # directory
+    return 2 if $fmt == 0020000;  # character device
+    return 1 if $fmt == 0060000;  # block device
+    return 7 if $fmt == 0120000;  # symbolic link
+    return 6 if $fmt == 0140000;  # socket (stream)
+    return 4 if $fmt == 0100000;  # regular file
+    return 0;  # unknown
+}

--- a/runtime/perl/units/wasi/write_string_list.pl
+++ b/runtime/perl/units/wasi/write_string_list.pl
@@ -1,0 +1,12 @@
+# requires: memory/i32_store, memory/i32_store8, memory/init
+sub write_string_list {
+    my ($self, $strings, $list_ptr, $buf_ptr) = @_;
+    for my $i (0 .. $#$strings) {
+        my $s = $strings->[$i];
+        $self->{memory}->i32_store($list_ptr + $i * 4, $buf_ptr);
+        $self->{memory}->init($buf_ptr, $s, 0, length($s));
+        $self->{memory}->i32_store8($buf_ptr + length($s), 0);
+        $buf_ptr += length($s) + 1;
+    }
+    return ERRNO_SUCCESS;
+}


### PR DESCRIPTION
Closes #69. Stacked on #73 (base: `perl-backend`; retarget to `main` once #73 merges).

Brings the Perl backend to the standard goal — wasm 1.0 + full WASI p1 — and wires the app e2e surface to parity with Python's.

- **48 `runtime/perl/units/wasi/` units** mirroring Ruby's fd-table model (preopens, per-fd rights + inheriting rights, fdflags meta; `resolve_path` with lexical + realpath containment). All I/O is byte-wise `sysread`/`syswrite`/`sysseek` on `binmode`d raw handles so the pread/pwrite emulation (core Perl has no pread) stays coherent with seeks on one fd.
- Instance surface: `Package->new($imports, args =>, env =>, preopens =>)`, ADR-7 provider `attach` loop, ADR-31 standalone `--dir` preamble, proc_exit → real exit status.
- **wasi-testsuite: 72/72 trials green** (5 ledgered with tags: `sock_shutdown` ×2 out of scope like Ruby/Python; two time-precision rows — Perl's NV-seconds `utime` can't round-trip the suite's ns-granularity set-then-get; one NOFOLLOW set-times row — core Perl lacks `lutimes`/`utimensat`). Notably no macOS environ ledger rows: Perl injects zero environ entries, unlike CF-linked Ruby/CPython.
- **e2e: 29 cases green** — fast tier 17 (incl. all 8 WASI fs fixtures with the trailing-slash and rights pins), slow tier 12 (qjs eval ~1 s, rg 2.2 s, `cpython_hello` 17.4 s — CPython-on-Perl works), plus `cruby_hello` at 56.8 s crossing the ~1-min CI line → the crate gains `ultra_slow_test` and the case is tiered ultra. DOOM/pty-REPL left as follow-ups.
- The perl `--data-file` runnable case deferred from #68 now lands in `crates/dewasm-cli/tests/data_file.rs`.
- Wasmtime-copying host-gap emulations documented in the units (ADR-49): darwin `link(2)` follows source symlinks and core Perl has no `linkat`, so `path_link` clones the symlink on darwin; `path_unlink_file` answers the host errno flavor directly since Perl's `unlink` refuses directories client-side.
- docs/support.md regenerated: Perl flips to ✅ for every p1 function except `sock_*` (same shape as Ruby/Python).

Verification: spec sweep stays **257/257** with the unchanged ledger; convert 13/13; `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, workspace fast gate, `--features slow_test` (85.5 s wall), support_docs — all green; the ultra `cruby_hello` run once under its feature: passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)