### PR TITLE
Wire the qjs REPL pty, zeroperl, and exiftool e2e cases for Perl

### DIFF
--- a/crates/dewasm-backend-perl/tests/e2e.rs
+++ b/crates/dewasm-backend-perl/tests/e2e.rs
@@ -6,12 +6,13 @@ use dewasm_backend::{Backend, Mode, RuntimeLinkage};
 use dewasm_backend_perl::{find_perl, PerlBackend};
 use dewasm_test_helper::{
     convert, cowsay_args_e2e, cowsay_stdin_e2e, cpython_hello_e2e, cruby_hello_e2e,
-    custom_wasi_provider_e2e, deep_recursion_e2e, embedded_coexist_e2e, examples_dir, gzip_e2e,
-    library_add_e2e, libsqlite3_c_api_e2e, partial_override_e2e, pcap_compile_e2e, qjs_eval_e2e,
-    qjs_file_io_e2e, qjs_repl_e2e, rg_search_e2e, shared_table_e2e, sqlite3_callback_binding_e2e,
-    sqlite3_file_c_api_e2e, sqlite3_shell_dbfile_e2e, sqlite3_shell_e2e, standalone_dir_e2e,
-    stdio_capture_e2e, treesitter_parse_e2e, wasi_import_override_e2e, wasi_root_containment_e2e,
-    wasi_suite, BackendUnderTest,
+    custom_wasi_provider_e2e, deep_recursion_e2e, embedded_coexist_e2e, examples_dir,
+    exiftool_extract_e2e, gzip_e2e, library_add_e2e, libsqlite3_c_api_e2e, partial_override_e2e,
+    pcap_compile_e2e, qjs_eval_e2e, qjs_file_io_e2e, qjs_repl_e2e, qjs_repl_pty_e2e, rg_search_e2e,
+    shared_table_e2e, sqlite3_callback_binding_e2e, sqlite3_file_c_api_e2e,
+    sqlite3_shell_dbfile_e2e, sqlite3_shell_e2e, standalone_dir_e2e, stdio_capture_e2e,
+    treesitter_parse_e2e, wasi_import_override_e2e, wasi_root_containment_e2e, wasi_suite,
+    zeroperl_eval_e2e, BackendUnderTest,
 };
 
 pub struct Perl;
@@ -404,6 +405,73 @@ $inst->invoke('free', $r);
 print "TS-OK\n";
 "#;
 
+/// zeroperl Perl-5.42 eval (issue #67): instantiate the reactor with a
+/// zero-returning `env.call_host_function` import stub (only invoked when the
+/// guest registers host callbacks — this program registers none) and a
+/// `/dev/null` preopen (`zeroperl_init` returns 1 without it), then
+/// `_initialize` → `zeroperl_init` → `malloc` + copy a Perl program into guest
+/// memory → `zeroperl_eval` → `zeroperl_flush`. Perl-on-Perl: the guest snippet
+/// (a non-interpolating `<<'GUEST_PROGRAM'` heredoc, delimiter chosen not to
+/// collide with either Perl layer) is byte-identical to the other backends'.
+const PERL_ZEROPERL_EVAL: &str = r#"
+my $inst = Zeroperl->new(
+    { 'env' => { 'call_host_function' => sub { 0 } } },
+    preopens => { '/dev/null' => '/dev/null' },
+);
+$inst->invoke('_initialize');
+my $rc = $inst->invoke('zeroperl_init');
+die "zeroperl_init rc=$rc" unless $rc == 0;
+my $mem = $inst->{memory};
+
+my $prog = <<'GUEST_PROGRAM';
+my $s = "hello world 42";
+if ($s =~ /(\w+)\s+(\w+)\s+(\d+)/) {
+  printf("m=%s|%s|%d sum=%d\n", $1, $2, $3, $3 + 8);
+}
+GUEST_PROGRAM
+my $bytes = $prog . "\0";
+my $ptr = $inst->invoke('malloc', length($bytes));
+$mem->init($ptr, $bytes, 0, length($bytes));
+$inst->invoke('zeroperl_eval', $ptr, 0, 0, 0);
+$inst->invoke('zeroperl_flush');
+"#;
+
+/// ExifTool on zeroperl (issue #70): the flattened `exiftool` CLI driver
+/// (`{cache}/exiftool-lib`, preopened at `/work`) run on the same
+/// `cache/zeroperl.wasm` reactor, whose SFS blob embeds the `Image::ExifTool`
+/// module tree. Instantiated like [`PERL_ZEROPERL_EVAL`] plus the staged image
+/// at `/img`. The guest driver snippet (identical bytes to the other backends')
+/// overrides `CORE::GLOBAL::exit` to a `die` so ExifTool's terminal `exit`
+/// unwinds back into `eval_pv` instead of tripping `proc_exit`, sets
+/// `@ARGV`/`$0`, and `do`es the script; `zeroperl_flush` then pushes ExifTool's
+/// buffered stdout out through fd 1.
+const PERL_EXIFTOOL: &str = r#"
+my $inst = Zeroperl->new(
+    { 'env' => { 'call_host_function' => sub { 0 } } },
+    preopens => {
+        '/dev/null' => '/dev/null',
+        '/work' => '{cache}/exiftool-lib',
+        '/img' => '{scratch}',
+    },
+);
+$inst->invoke('_initialize');
+my $rc = $inst->invoke('zeroperl_init');
+die "zeroperl_init rc=$rc" unless $rc == 0;
+my $mem = $inst->{memory};
+
+my $driver = <<'GUEST_PROGRAM';
+BEGIN { *CORE::GLOBAL::exit = sub (;$) { die "zeroperl_exit\n" }; }
+@ARGV = ('-S', '-Make', '-Model', '-DateTimeOriginal', '/img/exif_fixture.jpg');
+$0 = '/work/exiftool';
+do '/work/exiftool';
+GUEST_PROGRAM
+my $bytes = $driver . "\0";
+my $ptr = $inst->invoke('malloc', length($bytes));
+$mem->init($ptr, $bytes, 0, length($bytes));
+$inst->invoke('zeroperl_eval', $ptr, 0, 0, 0);
+$inst->invoke('zeroperl_flush');
+"#;
+
 // --------------------------------------------------------------------- Multi-module drive glue.
 
 /// Driver for the shared-table case: instantiate the exporter and the importer linked against it, then print `call0` (call_indirect through the shared table -> 42).
@@ -453,13 +521,16 @@ rg_search_e2e!(Perl, PERL_RG_SEARCH_GLUE);
 cpython_hello_e2e!(Perl, PERL_CPYTHON_GLUE);
 // Ultra tier (ADR-48): measured ~57s locally (CRuby-on-Perl), which crosses the ~1-minute CI-runner line the other backends' cruby cases stay under.
 cruby_hello_e2e!(Perl, PERL_CRUBY_GLUE, ultra);
-// qjs_repl_pty_e2e!: not invoked — the interactive-REPL pty case is deferred with DOOM to a follow-up (issue #69 scope note); the file-driven qjs_repl case above covers the REPL loop itself.
+qjs_repl_pty_e2e!(Perl);
 
 libsqlite3_c_api_e2e!(Perl, PERL_LIBSQLITE3_MEM);
 sqlite3_file_c_api_e2e!(Perl, PERL_LIBSQLITE3_FILE);
 sqlite3_callback_binding_e2e!(Perl, PERL_SQLITE3_CALLBACK);
 pcap_compile_e2e!(Perl, PERL_PCAP_COMPILE);
 treesitter_parse_e2e!(Perl, PERL_TREESITTER_PARSE);
+zeroperl_eval_e2e!(Perl, PERL_ZEROPERL_EVAL);
+// Ultra tier (ADR-48): measured ~75s locally (ExifTool-on-zeroperl-on-Perl), well past the ~1-minute CI-runner line; the zeroperl_eval case above (~7s: same convert + host-perl compile, tiny guest program) pins the embedding path at the slow tier.
+exiftool_extract_e2e!(Perl, PERL_EXIFTOOL, ultra);
 
 // doom_frame_e2e!: not invoked — DOOM is deferred to a follow-up (issue #69 scope note).
 

--- a/runtime/perl/units/wasi/_package.pl
+++ b/runtime/perl/units/wasi/_package.pl
@@ -108,9 +108,13 @@ sub new {
     my $next_fd = 3;
     my $preopens = $opts{preopens} // {};
     for my $guest (sort keys %$preopens) {
+        # The host path must resolve, but need not be a directory: like the
+        # Ruby runtime, a single-file preopen (e.g. '/dev/null' for the
+        # zeroperl reactor's init probe) is accepted — the guest resolves
+        # it as the preopen root itself.
         my $real = Cwd::realpath($preopens->{$guest});
-        die "preopen '$guest' => '$preopens->{$guest}': not a directory\n"
-            unless defined $real && -d $real;
+        die "preopen '$guest' => '$preopens->{$guest}': does not exist\n"
+            unless defined $real;
         $self->{fds}{$next_fd} = { dir => 1, path => $real, preopen => "$guest", entries => undef };
         $self->{meta}{$next_fd} = [DIR_RIGHTS_BASE, DIR_RIGHTS_INHERITING, 0];
         $next_fd++;


### PR DESCRIPTION
Closes #77. Brings the Perl backend's e2e surface to parity with Ruby's remaining cases.

- `qjs_repl_pty_e2e!(Perl)` — slow tier, 2.9 s; `pty_command`'s interpreted-backend default works unmodified and the transcript matches the wasmtime golden byte for byte.
- `zeroperl_eval_e2e!(Perl, …)` — slow tier, 7.2 s. Perl-on-Perl: the guest-side driver snippet is byte-identical to the Ruby glue's (the shared case const pins the stdout). Host perl handles the 178 MB generated source without drama (~7 s convert, ~2 s compile).
- `exiftool_extract_e2e!(Perl, …, ultra)` — **ultra tier**: 75.4 s dedicated (108.7 s on a loaded machine), past the ~1-min ADR-48 line; verified once under `--features ultra_slow_test`.
- One runtime change was genuinely required: the Perl WASI constructor's preopen check demanded `-d` and died on the `/dev/null` single-file preopen the zeroperl reactor needs. Relaxed to realpath-must-resolve, matching the Ruby runtime these cases were written against (nothing pinned the old message; wasi-testsuite stays 72/72).

Gates: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, workspace fast gate, and the perl slow suite — e2e 31 green + 2 ultra-ignored, spec 257/257, convert 14/14, wasi-testsuite 72/72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)