### PR TITLE
Read tty stdin line-wise in the bash backend to stop ICANON re-echo

### DIFF
--- a/crates/dewasm-backend-bash/src/lib.rs
+++ b/crates/dewasm-backend-bash/src/lib.rs
@@ -394,7 +394,7 @@ impl<'a> Gen<'a> {
             w.line(format!("{p}t{idx}sz={}", table.min));
         }
         if wasi_bundled(m, self.default_wasi) {
-            // Callers set the WASI_ARGS/WASI_ENV/WASI_DIRS arrays before init (the bash analogue of Ruby's args:/env:/preopens: keywords); stdio fds are preopened and fd_read/fd_write track per-fd offsets. wnext is the next fd; wpush is poll_oneoff's one-byte stdin pushback slot; init_preopens registers the --dir mounts and the filesystem fd-table arrays, failing init loudly on an unresolvable host (ADR-34).
+            // Callers set the WASI_ARGS/WASI_ENV/WASI_DIRS arrays before init (the bash analogue of Ruby's args:/env:/preopens: keywords); stdio fds are preopened and fd_read/fd_write track per-fd offsets. wnext is the next fd; wpush is the stdin pushback buffer (a space-separated byte-ordinal list) shared by fd_read and poll_oneoff; init_preopens registers the --dir mounts and the filesystem fd-table arrays, failing init loudly on an unresolvable host (ADR-34).
             w.line(format!("{p}wargs=(\"${{WASI_ARGS[@]}}\")"));
             w.line(format!("{p}wenv=(\"${{WASI_ENV[@]}}\")"));
             w.line(format!("{p}wfds=([0]=1 [1]=1 [2]=1)"));

--- a/runtime/bash/units/wasi/fd_read.sh
+++ b/runtime/bash/units/wasi/fd_read.sh
@@ -1,9 +1,15 @@
 # requires: mem/check, mem/i32_load, mem/i32_store
 # Byte-wise binary-safe reads. A file fd (kind 2) copies from its whole-file
-# byte buffer at the current offset (ADR-34); stdin (kind 1, fd 0) reads live via
-# `read -d '' -n 1`, where '' with success is a NUL byte and failure is EOF, and
-# consumes any pushed-back byte first (<p>wpush, set by poll_oneoff). A directory
-# fd is EISDIR. LC_ALL=C keeps reads and ordinal conversion byte-granular.
+# byte buffer at the current offset (ADR-34); stdin (kind 1, fd 0) consumes the
+# pushback buffer first (<p>wpush, a space-separated byte-ordinal list shared
+# with poll_oneoff), then reads live. A non-tty stdin reads via `read -d '' -n
+# 1`, where '' with success is a NUL byte and failure is EOF. A tty stdin
+# instead reads a whole canonical line into the pushback buffer with a plain
+# `read`: bash's `-n`/`-N`/`-t` reads toggle ICANON per call and each restore
+# makes the pty line discipline re-echo the still-pending line, so the tty path
+# must not use them. Bash strings cannot hold NUL, but canonical tty line input
+# never contains one. A directory fd is EISDIR. LC_ALL=C keeps reads and
+# ordinal conversion byte-granular.
 wasi_fd_read() {
   local __p=$1 __fd=$2 __iovs=$3 __iovs_len=$4 __nread_ptr=$5
   local -n __m=${__p}mem
@@ -51,7 +57,8 @@ wasi_fd_read() {
     return 0
   fi
   local -n __push=${__p}wpush
-  local __ch __b __stop=0
+  local __ch __b __stop=0 __line __rc __k __tty=0
+  [[ -t 0 ]] && __tty=1
   for (( __i = 0; __i < __iovs_len && __stop == 0; __i++ )); do
     mem_i32_load "$__p" $(( __iovs + __i * 8 )) || return $?
     __ptr=$R0
@@ -61,8 +68,35 @@ wasi_fd_read() {
     mem_check "$__p" "$__ptr" "$__len" || return $?
     for (( __j = 0; __j < __len; __j++ )); do
       if [[ -n $__push ]]; then
-        __b=$__push
-        __push=''
+        __b=${__push%% *}
+        if [[ $__push == *' '* ]]; then __push=${__push#* }; else __push=''; fi
+      elif (( __tty )); then
+        # Short-read gating as below: only the first byte of the call blocks.
+        # Once the buffered line is drained, return what was delivered rather
+        # than blocking on the next line.
+        if (( __total > 0 )); then
+          __stop=1
+          break
+        fi
+        IFS= read -r __line
+        __rc=$?
+        if (( __rc != 0 )) && [[ -z $__line ]]; then
+          __stop=1 # EOF
+          break
+        fi
+        for (( __k = 0; __k < ${#__line}; __k++ )); do
+          printf -v __b '%d' "'${__line:__k:1}"
+          __push+=${__push:+ }
+          __push+=$__b
+        done
+        if (( __rc == 0 )); then
+          # `read` strips the delimiter; restore it (rc != 0 with content is
+          # EOF without a trailing newline).
+          __push+=${__push:+ }
+          __push+=10
+        fi
+        __b=${__push%% *}
+        if [[ $__push == *' '* ]]; then __push=${__push#* }; else __push=''; fi
       else
         # Short-read gating: only the first byte of the call blocks; each
         # further byte is taken only while input is already available. `read

--- a/runtime/bash/units/wasi/poll_oneoff.sh
+++ b/runtime/bash/units/wasi/poll_oneoff.sh
@@ -7,8 +7,12 @@
 # subscription sets the wait deadline; if it elapses with no fd ready the
 # soonest clock(s) fire, exactly as Ruby (ready fd events win outright, so a
 # clock is never consulted once any fd is ready). stdin blocks via `read -t
-# <deadline>` and a byte that arrives is held in the one-byte pushback slot
-# (<p>wpush) for the next fd_read; a clock-only wait sleeps with a bash-only
+# <deadline>` and the bytes that arrive are held in the pushback buffer
+# (<p>wpush, a space-separated byte-ordinal list shared with fd_read); a
+# non-tty stdin waits for one byte with `read -d '' -n 1`, while a tty stdin
+# waits for a whole canonical line with a plain `read` (`-n 1` toggles ICANON
+# per byte and each restore makes the pty line discipline re-echo the pending
+# line — see fd_read); a clock-only wait sleeps with a bash-only
 # coproc timer (a process substitution opened `<>` is rejected on some hosts, so
 # a coproc that blocks on its own pipe is the portable sleep). `now` comes from
 # EPOCHREALTIME, with monotonic falling back to realtime (the ADR-12 clock
@@ -60,7 +64,8 @@ wasi_poll_oneoff() {
         __ev+=("$__ud 8 $__tag 0 0") # EBADF: unknown or directory fd
       elif (( __tag == 1 && __fd == 0 )); then
         if [[ -n $__push ]]; then
-          __ev+=("$__ud 0 1 1 0") # a pushed-back byte is already readable
+          local -a __pw=($__push)
+          __ev+=("$__ud 0 1 ${#__pw[@]} 0") # pushed-back bytes are readable
         else
           __wait+=("$__ud")
         fi
@@ -91,15 +96,40 @@ wasi_poll_oneoff() {
       printf -v __to '%d.%06d' $(( __min / 1000000000 )) $(( __min % 1000000000 / 1000 ))
     fi
     if (( ${#__wait[@]} > 0 )); then
-      local __ch __ord __rc
-      if (( __have_clock )); then
+      local __ch __ord __rc __line __kk
+      if [[ -t 0 ]]; then
+        if (( __have_clock )); then
+          IFS= read -r -t "$__to" __line
+          __rc=$?
+        else
+          IFS= read -r __line
+          __rc=$?
+        fi
+      elif (( __have_clock )); then
         IFS= read -r -d '' -n 1 -t "$__to" __ch
         __rc=$?
+        __line=''
       else
         IFS= read -r -d '' -n 1 __ch
         __rc=$?
+        __line=''
       fi
-      if (( __rc == 0 )); then
+      if [[ -n $__line ]] || { [[ -t 0 ]] && (( __rc == 0 )); }; then
+        # tty: buffer the whole line; the stripped newline is restored unless
+        # this was EOF (or timeout) without a delimiter.
+        for (( __kk = 0; __kk < ${#__line}; __kk++ )); do
+          printf -v __ord '%d' "'${__line:__kk:1}"
+          __push+=${__push:+ }
+          __push+=$__ord
+        done
+        if (( __rc == 0 )); then
+          __push+=${__push:+ }
+          __push+=10
+        fi
+        local -a __pw2=($__push)
+        for __ud in "${__wait[@]}"; do __ev+=("$__ud 0 1 ${#__pw2[@]} 0"); done
+      elif (( __rc == 0 )); then
+        # non-tty: one byte arrived
         if [[ -z $__ch ]]; then __ord=0; else printf -v __ord '%d' "'$__ch"; fi
         __push=$__ord
         for __ud in "${__wait[@]}"; do __ev+=("$__ud 0 1 1 0"); done


### PR DESCRIPTION
## Problem

`cargo test --features slow_test,ultra_slow_test -p dewasm-backend-bash --test e2e qjs_repl_pty` failed: the pty transcript contained a progressively shortened re-echo of every typed line (`1+2` followed by `+2`, `2`, …), diverging from the wasmtime snapshot at byte 47.

## Root cause

Bash's `read` builtin toggles ICANON off and restores it for every call that uses `-n`/`-N`/`-t`. The stdin branch of `wasi_fd_read` read tty input one byte at a time with `read -n 1`, so ICANON was restored once per byte while the tty line buffer still held the rest of the typed line — and each restore made the line discipline re-echo the remaining buffer. wasmtime and the Ruby/Perl backends read via plain `read()` syscalls and never touch termios, so their transcripts were clean. `poll_oneoff`'s stdin-wait path had the same per-byte read.

## Fix

When stdin is a tty, read a whole canonical line with a plain `IFS= read -r` (zero termios toggles), restore the stripped newline, and serve iovecs from a multi-byte holding buffer that generalizes the old one-byte `wpush` pushback slot. `poll_oneoff` shares the same buffer for stdin readiness. Non-tty stdin (pipes/files) keeps the byte-wise binary-safe path from ADR-12 unchanged. Canonical tty input cannot contain NUL, so holding it in a bash string is safe.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`: clean
- `cargo test` (fast gate): green, including bash spec 257/257 and wasi_testsuite 72/72 (exercises the unchanged non-tty stdin path)
- `qjs_repl_pty` itself: passes (177s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)