### PR TITLE
Cut the Java suites' javac cost

### DIFF
--- a/crates/dewasm-backend-bash/src/lib.rs
+++ b/crates/dewasm-backend-bash/src/lib.rs
@@ -72,6 +72,12 @@ pub fn shared_runtime(seeds: &BTreeSet<String>) -> Result<String> {
 
 /// Locate a bash >= 5 interpreter able to run generated scripts: tries `$DEWASM_BASH`, then `bash` on PATH, then the common Homebrew/local install paths (macOS system bash is 3.2 and does not qualify).
 pub fn find_bash5() -> Option<std::path::PathBuf> {
+    static BASH: OnceLock<Option<std::path::PathBuf>> = OnceLock::new();
+    BASH.get_or_init(find_bash5_uncached).clone()
+}
+
+/// The probe behind [`find_bash5`], memoized there: it spawns a process per candidate per call, and the interpreter cannot change under a running process.
+fn find_bash5_uncached() -> Option<std::path::PathBuf> {
     use std::path::PathBuf;
     let mut candidates: Vec<PathBuf> = Vec::new();
     if let Ok(env) = std::env::var("DEWASM_BASH") {

--- a/crates/dewasm-backend-go/src/lib.rs
+++ b/crates/dewasm-backend-go/src/lib.rs
@@ -71,6 +71,12 @@ pub fn bundler() -> &'static RuntimeBundler {
 
 /// Locate a `go` toolchain able to compile generated programs. Honors `$DEWASM_GO`, then `go` on `PATH` (ADR-15: a missing toolchain is a loud failure at the call site, not here — this only reports what qualifies).
 pub fn find_go() -> Option<std::path::PathBuf> {
+    static GO: OnceLock<Option<std::path::PathBuf>> = OnceLock::new();
+    GO.get_or_init(find_go_uncached).clone()
+}
+
+/// The probe behind [`find_go`], memoized there: it spawns a process per call, and the toolchain cannot change under a running process.
+fn find_go_uncached() -> Option<std::path::PathBuf> {
     use std::path::PathBuf;
     let mut candidates: Vec<PathBuf> = Vec::new();
     if let Ok(env) = std::env::var("DEWASM_GO") {

--- a/crates/dewasm-backend-java/src/lib.rs
+++ b/crates/dewasm-backend-java/src/lib.rs
@@ -92,14 +92,20 @@ pub fn bundler() -> &'static RuntimeBundler {
 
 /// Locate a `java` launcher (ADR-15: a missing toolchain is a loud failure at the call site, not here). Honors `$DEWASM_JAVA`, then `java` on `PATH`.
 pub fn find_java() -> Option<std::path::PathBuf> {
-    find_tool("DEWASM_JAVA", "java")
+    static JAVA: OnceLock<Option<std::path::PathBuf>> = OnceLock::new();
+    JAVA.get_or_init(|| find_tool("DEWASM_JAVA", "java"))
+        .clone()
 }
 
 /// Locate a `javac` compiler. Honors `$DEWASM_JAVAC`, then `javac` on `PATH`.
 pub fn find_javac() -> Option<std::path::PathBuf> {
-    find_tool("DEWASM_JAVAC", "javac")
+    static JAVAC: OnceLock<Option<std::path::PathBuf>> = OnceLock::new();
+    JAVAC
+        .get_or_init(|| find_tool("DEWASM_JAVAC", "javac"))
+        .clone()
 }
 
+/// The probe behind [`find_java`]/[`find_javac`]. Each spawns a JVM (~0.35 s for `javac -version`), so both callers memoize the answer for the process: a test binary asks once per trial, and the toolchain cannot change under a running process.
 fn find_tool(env: &str, default: &str) -> Option<std::path::PathBuf> {
     use std::path::PathBuf;
     let mut candidates: Vec<PathBuf> = Vec::new();

--- a/crates/dewasm-backend-java/src/lib.rs
+++ b/crates/dewasm-backend-java/src/lib.rs
@@ -105,6 +105,23 @@ pub fn find_javac() -> Option<std::path::PathBuf> {
         .clone()
 }
 
+/// The one way dewasm's suites invoke `javac`: the located compiler, tuned for a one-shot compile. A missing `javac` is the loud failure ADR-15 asks for, with the setup instruction in the message.
+///
+/// C2 cannot repay its own compilation cost inside a single ~1 s `javac` run, and N of these JVMs running concurrently — each with two C2 compiler threads and a G1 thread pool sized for the whole machine — is what destroys parallel scaling on a small CI runner. So: cap the JIT at C1, take the serial collector, and stop each JVM from sizing its pools for every core. The heap is deliberately left at the default; the slow tier's qjs/DOOM sources need the headroom.
+///
+/// The `.class` output is byte-identical with and without these flags (verified on the 4.2 MB cowsay and 15 MB qjs standalone sources) — they change only how the JVM runs the compiler.
+pub fn javac_command() -> std::process::Command {
+    let javac =
+        find_javac().expect("javac not found on PATH (or $DEWASM_JAVAC) — see docs/testing.md");
+    let mut cmd = std::process::Command::new(javac);
+    cmd.args([
+        "-J-XX:TieredStopAtLevel=1",
+        "-J-XX:+UseSerialGC",
+        "-J-XX:ActiveProcessorCount=1",
+    ]);
+    cmd
+}
+
 /// The probe behind [`find_java`]/[`find_javac`]. Each spawns a JVM (~0.35 s for `javac -version`), so both callers memoize the answer for the process: a test binary asks once per trial, and the toolchain cannot change under a running process.
 fn find_tool(env: &str, default: &str) -> Option<std::path::PathBuf> {
     use std::path::PathBuf;
@@ -2246,14 +2263,12 @@ mod units {
     /// The whole runtime — every unit, not just the subset cowsay uses — must be valid Java. Compile the full bundle with `javac` (ADR-15).
     #[test]
     fn all_units_compile_as_java() {
-        let javac =
-            find_javac().expect("javac not found on PATH (or $DEWASM_JAVAC) — see docs/testing.md");
         let source = full_bundle_java().expect("full bundle assembles");
         let dir = std::env::temp_dir().join(format!("dewasm-java-units-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         let src = dir.join("Main.java");
         std::fs::write(&src, &source).unwrap();
-        let out = std::process::Command::new(&javac)
+        let out = javac_command()
             .arg("-d")
             .arg(&dir)
             .arg(&src)

--- a/crates/dewasm-backend-java/tests/common/mod.rs
+++ b/crates/dewasm-backend-java/tests/common/mod.rs
@@ -1,0 +1,47 @@
+//! The one compile-and-cache recipe shared by the Java suites (spec, e2e, wasi-testsuite, memory_grow). Java is the only compiled-to-a-class-dir backend, so every one of those suites needs the same step; keeping four copies of it also kept four cache namespaces, which made identical sources compile once per suite.
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::path::PathBuf;
+use std::process::Output;
+
+use dewasm_backend_java::javac_command;
+
+static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Compile `source` (a single `Main.java`) into a content-addressed class-dir cache and return its path. `Err(Output)` carries the `javac` failure, so a caller that reports compile errors through a run's `status.success()` can hand it straight back while one that treats a compile failure as a bug panics on it. A missing `javac` is the loud failure ADR-15 asks for (from `javac_command`).
+///
+/// The cache is keyed on the source alone and shared by every suite in the crate: the spec harness's `Main.java` for a `.wast` file, the e2e glue programs, and the wasi-testsuite drivers all land in the same namespace, so a source two suites happen to agree on is compiled once.
+pub fn build_java(source: &str) -> Result<PathBuf, Output> {
+    let mut hasher = DefaultHasher::new();
+    source.hash(&mut hasher);
+    let hash = hasher.finish();
+
+    let cache = std::env::temp_dir().join("dewasm-java-cache");
+    std::fs::create_dir_all(&cache).unwrap();
+    let classdir = cache.join(format!("cls-{hash:016x}"));
+
+    if !classdir.join("Main.class").exists() {
+        // Compile into a per-attempt unique dir, then rename onto the cache key: two threads with the same hash may build concurrently, and only the final rename is shared — so no reader ever sees a half-written class dir.
+        let tmp = cache.join(format!(
+            "cls-{hash:016x}.{}.{}",
+            std::process::id(),
+            COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let src = tmp.join("Main.java");
+        std::fs::write(&src, source).unwrap();
+        let build = javac_command()
+            .arg("-d")
+            .arg(&tmp)
+            .arg(&src)
+            .output()
+            .expect("spawn javac");
+        if !build.status.success() {
+            return Err(build);
+        }
+        let _ = std::fs::rename(&tmp, &classdir);
+    }
+
+    Ok(classdir)
+}

--- a/crates/dewasm-backend-java/tests/common/mod.rs
+++ b/crates/dewasm-backend-java/tests/common/mod.rs
@@ -40,7 +40,10 @@ pub fn build_java(source: &str) -> Result<PathBuf, Output> {
         if !build.status.success() {
             return Err(build);
         }
-        let _ = std::fs::rename(&tmp, &classdir);
+        // A concurrent builder of the same source may have claimed the key first, in which case the rename fails and this attempt's dir is redundant — drop it rather than leave it in /tmp.
+        if std::fs::rename(&tmp, &classdir).is_err() {
+            let _ = std::fs::remove_dir_all(&tmp);
+        }
     }
 
     Ok(classdir)

--- a/crates/dewasm-backend-java/tests/e2e.rs
+++ b/crates/dewasm-backend-java/tests/e2e.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use std::process::{Command, Output};
 
 use dewasm_backend::Backend;
-use dewasm_backend_java::{find_java, find_javac, JavaBackend};
+use dewasm_backend_java::{find_java, javac_command, JavaBackend};
 use dewasm_test_helper::{
     cowsay_args_e2e, cowsay_stdin_e2e, doom_frame_e2e, examples_dir, gzip_e2e, library_add_e2e,
     libsqlite3_c_api_e2e, qjs_eval_e2e, qjs_file_io_e2e, qjs_repl_pty_e2e, rg_search_e2e,
@@ -23,9 +23,6 @@ static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new
 
 /// Compile `source` (a single `Main.java`) to a content-addressed class-dir cache (so identical sources compile once) and return its path. `Err(Output)` carries the `javac` failure so a piped run can report it via `status.success()` while a pty run panics on it. A missing `javac` is a loud failure (ADR-15).
 fn build_java(source: &str) -> Result<PathBuf, Output> {
-    let javac =
-        find_javac().expect("javac not found on PATH (or $DEWASM_JAVAC) — see docs/testing.md");
-
     let mut hasher = DefaultHasher::new();
     source.hash(&mut hasher);
     let hash = hasher.finish();
@@ -44,7 +41,7 @@ fn build_java(source: &str) -> Result<PathBuf, Output> {
         std::fs::create_dir_all(&tmp).unwrap();
         let src = tmp.join("Main.java");
         std::fs::write(&src, source).unwrap();
-        let build = Command::new(&javac)
+        let build = javac_command()
             .arg("-d")
             .arg(&tmp)
             .arg(&src)

--- a/crates/dewasm-backend-java/tests/e2e.rs
+++ b/crates/dewasm-backend-java/tests/e2e.rs
@@ -2,13 +2,10 @@
 //!
 //! Java is a compiled backend, so it overrides `BackendUnderTest::run` (ADR-27's hook) to compile-and-execute: `javac` the generated `Main.java` into a content-addressed class-dir cache (so identical sources compile once), then run `java -cp <dir> Main` (ADR-30). Java covers full WASI preview 1 incl. the filesystem.
 
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
-use std::path::PathBuf;
 use std::process::{Command, Output};
 
 use dewasm_backend::Backend;
-use dewasm_backend_java::{find_java, javac_command, JavaBackend};
+use dewasm_backend_java::{find_java, JavaBackend};
 use dewasm_test_helper::{
     cowsay_args_e2e, cowsay_stdin_e2e, doom_frame_e2e, examples_dir, gzip_e2e, library_add_e2e,
     libsqlite3_c_api_e2e, qjs_eval_e2e, qjs_file_io_e2e, qjs_repl_pty_e2e, rg_search_e2e,
@@ -17,44 +14,11 @@ use dewasm_test_helper::{
     wasi_import_override_e2e, wasi_root_containment_e2e, wasi_suite, BackendUnderTest, PtyCommand,
 };
 
+mod common;
+
+use common::build_java;
+
 pub struct Java;
-
-static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-
-/// Compile `source` (a single `Main.java`) to a content-addressed class-dir cache (so identical sources compile once) and return its path. `Err(Output)` carries the `javac` failure so a piped run can report it via `status.success()` while a pty run panics on it. A missing `javac` is a loud failure (ADR-15).
-fn build_java(source: &str) -> Result<PathBuf, Output> {
-    let mut hasher = DefaultHasher::new();
-    source.hash(&mut hasher);
-    let hash = hasher.finish();
-
-    let cache = std::env::temp_dir().join("dewasm-java-cache");
-    std::fs::create_dir_all(&cache).unwrap();
-    let classdir = cache.join(format!("prog-{hash:016x}"));
-
-    if !classdir.join("Main.class").exists() {
-        // Compile into a unique temp dir, then rename onto the cache key so concurrent test threads never hand out a half-written class dir.
-        let tmp = cache.join(format!(
-            "prog-{hash:016x}.{}.{}",
-            std::process::id(),
-            COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-        ));
-        std::fs::create_dir_all(&tmp).unwrap();
-        let src = tmp.join("Main.java");
-        std::fs::write(&src, source).unwrap();
-        let build = javac_command()
-            .arg("-d")
-            .arg(&tmp)
-            .arg(&src)
-            .output()
-            .expect("spawn javac");
-        if !build.status.success() {
-            return Err(build);
-        }
-        let _ = std::fs::rename(&tmp, &classdir);
-    }
-
-    Ok(classdir)
-}
 
 impl BackendUnderTest for Java {
     fn name(&self) -> &'static str {

--- a/crates/dewasm-backend-java/tests/memory_grow.rs
+++ b/crates/dewasm-backend-java/tests/memory_grow.rs
@@ -1,15 +1,17 @@
 //! Regression tests for issue #27's memory-size overflow: Java's linear memory is a single `byte[]`, capped at `Integer.MAX_VALUE` bytes, so a spec-legal size of 32768+ pages (2 GiB+) cannot be represented. `memory.grow` must answer -1 (never `NegativeArraySizeException` from the overflowing int multiply), and instantiating a module whose *initial* size already exceeds the cap must fail with a clear trap, not the raw exception.
 //!
-//! These cases are Java-only (the cap is a JVM artifact — the other backends can grow to 32768 pages for real, which a shared case must not force), so they live here with their own minimal `javac`-and-run plumbing, mirroring the e2e suite's compile-and-execute recipe (ADR-30). A missing `javac`/`java` fails loud (ADR-15).
+//! These cases are Java-only (the cap is a JVM artifact — the other backends can grow to 32768 pages for real, which a shared case must not force), so they live here, running on the crate's shared compile-and-cache recipe (ADR-30). A missing `javac`/`java` fails loud (ADR-15).
 
 use std::process::{Command, Output};
 
 use dewasm_backend::Mode;
-use dewasm_backend_java::{find_java, javac_command, JavaBackend};
+use dewasm_backend_java::{find_java, JavaBackend};
 use dewasm_test_helper::convert_bytes;
 
-/// Convert `wat` in library mode, append `glue` (a `public class Main`), compile the single compilation unit into a fresh scratch dir keyed by `name`, and run `java -cp <dir> Main`.
-fn convert_and_run(wat: &str, glue: &str, name: &str) -> Output {
+mod common;
+
+/// Convert `wat` in library mode, append `glue` (a `public class Main`), compile the single compilation unit, and run `java -cp <classdir> Main`. Generated code that does not compile is a bug here, not an observable, so a `javac` failure panics.
+fn convert_and_run(wat: &str, glue: &str) -> Output {
     let java = find_java().expect("java not found on PATH (or $DEWASM_JAVA) — see docs/testing.md");
 
     let bytes = wat::parse_str(wat).expect("parse wat");
@@ -18,25 +20,12 @@ fn convert_and_run(wat: &str, glue: &str, name: &str) -> Output {
         convert_bytes(&JavaBackend, &bytes, Mode::Library, "prog")
     );
 
-    let dir = std::env::temp_dir().join(format!("dewasm-java-{name}-{}", std::process::id()));
-    let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(&dir).unwrap();
-    let src = dir.join("Main.java");
-    std::fs::write(&src, source).unwrap();
-    let build = javac_command()
-        .arg("-d")
-        .arg(&dir)
-        .arg(&src)
-        .output()
-        .expect("spawn javac");
-    assert!(
-        build.status.success(),
-        "javac failed:\n{}",
-        String::from_utf8_lossy(&build.stderr)
-    );
+    let classdir = common::build_java(&source).unwrap_or_else(|build| {
+        panic!("javac failed:\n{}", String::from_utf8_lossy(&build.stderr))
+    });
     Command::new(&java)
         .arg("-cp")
-        .arg(&dir)
+        .arg(&classdir)
         .arg("Main")
         .output()
         .expect("spawn java")
@@ -58,7 +47,7 @@ fn grow_beyond_byte_array_cap_returns_minus_one() {
     }
 }
 "#;
-    let out = convert_and_run(wat, glue, "grow-cap");
+    let out = convert_and_run(wat, glue);
     assert!(
         out.status.success(),
         "run failed: {}\n{}",
@@ -83,7 +72,7 @@ fn initial_memory_beyond_byte_array_cap_traps_clearly() {
     }
 }
 "#;
-    let out = convert_and_run(wat, glue, "grow-initial-cap");
+    let out = convert_and_run(wat, glue);
     assert!(
         out.status.success(),
         "run failed: {}\n{}",

--- a/crates/dewasm-backend-java/tests/memory_grow.rs
+++ b/crates/dewasm-backend-java/tests/memory_grow.rs
@@ -5,13 +5,11 @@
 use std::process::{Command, Output};
 
 use dewasm_backend::Mode;
-use dewasm_backend_java::{find_java, find_javac, JavaBackend};
+use dewasm_backend_java::{find_java, javac_command, JavaBackend};
 use dewasm_test_helper::convert_bytes;
 
 /// Convert `wat` in library mode, append `glue` (a `public class Main`), compile the single compilation unit into a fresh scratch dir keyed by `name`, and run `java -cp <dir> Main`.
 fn convert_and_run(wat: &str, glue: &str, name: &str) -> Output {
-    let javac =
-        find_javac().expect("javac not found on PATH (or $DEWASM_JAVAC) — see docs/testing.md");
     let java = find_java().expect("java not found on PATH (or $DEWASM_JAVA) — see docs/testing.md");
 
     let bytes = wat::parse_str(wat).expect("parse wat");
@@ -25,7 +23,7 @@ fn convert_and_run(wat: &str, glue: &str, name: &str) -> Output {
     std::fs::create_dir_all(&dir).unwrap();
     let src = dir.join("Main.java");
     std::fs::write(&src, source).unwrap();
-    let build = Command::new(&javac)
+    let build = javac_command()
         .arg("-d")
         .arg(&dir)
         .arg(&src)

--- a/crates/dewasm-backend-java/tests/spec.rs
+++ b/crates/dewasm-backend-java/tests/spec.rs
@@ -11,7 +11,7 @@ use std::hash::{Hash, Hasher};
 use std::process::{Command, Output};
 
 use dewasm_backend::Backend;
-use dewasm_backend_java::{find_java, find_javac, JavaBackend};
+use dewasm_backend_java::{find_java, javac_command, JavaBackend};
 use dewasm_core::ir;
 use dewasm_test_helper::{run_command_bytes, spec_suite, BackendUnderTest, Converted, SpecBackend};
 use wast::core::{AbstractHeapType, HeapType, NanPattern, WastArgCore, WastRetCore};
@@ -127,8 +127,6 @@ impl BackendUnderTest for JavaSpec {
 
     /// Compile `source` (one `Main.java`) to a content-addressed class-dir cache (identical programs compile once) and run it. A missing `javac`/`java` fails loud (ADR-15); a `javac` failure is surfaced as its `Output` so the harness reports the compile error.
     fn run_bytes(&self, source: &str, args: &[&str], stdin: &[u8]) -> Output {
-        let javac =
-            find_javac().expect("javac not found on PATH (or $DEWASM_JAVAC) — see docs/testing.md");
         let java =
             find_java().expect("java not found on PATH (or $DEWASM_JAVA) — see docs/testing.md");
 
@@ -149,7 +147,7 @@ impl BackendUnderTest for JavaSpec {
             std::fs::create_dir_all(&tmp).unwrap();
             let src = tmp.join("Main.java");
             std::fs::write(&src, source).unwrap();
-            let build = Command::new(&javac)
+            let build = javac_command()
                 .arg("-d")
                 .arg(&tmp)
                 .arg(&src)

--- a/crates/dewasm-backend-java/tests/spec.rs
+++ b/crates/dewasm-backend-java/tests/spec.rs
@@ -4,14 +4,12 @@
 //! - A JVM `StackOverflowError` is *catchable* (unlike Go's fatal goroutine overflow), so exhaustion maps directly: `check_exhaust` catches it, exactly as Ruby catches `SystemStackError`. No spec-build recursion guard is instrumented into the generated functions — each assertion is independent, so unwinding a mid-call overflow cannot corrupt a later, independent check.
 //! - Type/class declarations cannot live inside a method, so per-module classes are accumulated in the harness's file-scoped `decls` buffer (hoisted ahead of `main`'s body by `assemble`) while only instantiation/assertion statements go in `main`.
 
-use std::collections::hash_map::DefaultHasher;
 use std::collections::BTreeSet;
 use std::fmt::Write as _;
-use std::hash::{Hash, Hasher};
 use std::process::{Command, Output};
 
 use dewasm_backend::Backend;
-use dewasm_backend_java::{find_java, javac_command, JavaBackend};
+use dewasm_backend_java::{find_java, JavaBackend};
 use dewasm_core::ir;
 use dewasm_test_helper::{run_command_bytes, spec_suite, BackendUnderTest, Converted, SpecBackend};
 use wast::core::{AbstractHeapType, HeapType, NanPattern, WastArgCore, WastRetCore};
@@ -112,9 +110,9 @@ const CURATED_FILES: &[&str] = &[
     "utf8-invalid-encoding",
 ];
 
-pub struct JavaSpec;
+mod common;
 
-static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+pub struct JavaSpec;
 
 impl BackendUnderTest for JavaSpec {
     fn name(&self) -> &'static str {
@@ -129,35 +127,11 @@ impl BackendUnderTest for JavaSpec {
     fn run_bytes(&self, source: &str, args: &[&str], stdin: &[u8]) -> Output {
         let java =
             find_java().expect("java not found on PATH (or $DEWASM_JAVA) — see docs/testing.md");
-
-        let mut hasher = DefaultHasher::new();
-        source.hash(&mut hasher);
-        let hash = hasher.finish();
-
-        let cache = std::env::temp_dir().join("dewasm-java-spec-cache");
-        std::fs::create_dir_all(&cache).unwrap();
-        let classdir = cache.join(format!("spec-{hash:016x}"));
-
-        if !classdir.join("Main.class").exists() {
-            let tmp = cache.join(format!(
-                "spec-{hash:016x}.{}.{}",
-                std::process::id(),
-                COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-            ));
-            std::fs::create_dir_all(&tmp).unwrap();
-            let src = tmp.join("Main.java");
-            std::fs::write(&src, source).unwrap();
-            let build = javac_command()
-                .arg("-d")
-                .arg(&tmp)
-                .arg(&src)
-                .output()
-                .expect("spawn javac");
-            if !build.status.success() {
-                return build;
-            }
-            let _ = std::fs::rename(&tmp, &classdir);
-        }
+        let classdir = match common::build_java(source) {
+            // A compile failure is surfaced as the `javac` `Output` so the harness reports the compile error.
+            Err(build) => return build,
+            Ok(classdir) => classdir,
+        };
 
         run_command_bytes(
             // A generous per-thread stack keeps genuinely deep but terminating recursions (fac, deep br chains) under the limit while a runaway still overflows into a catchable StackOverflowError (ADR-30).

--- a/crates/dewasm-backend-java/tests/wasi_testsuite.rs
+++ b/crates/dewasm-backend-java/tests/wasi_testsuite.rs
@@ -1,15 +1,14 @@
 //! Java side of the official WASI p1 conformance harness (ADR-36): drives the prebuilt `WebAssembly/wasi-testsuite` modules through the Java backend's standalone interface. Java is compiled, so it overrides `pty_command` to `javac` the generated `Main.java` to a content-addressed class-dir cache — the launch recipe the shared `run_standalone_wasi` runs with the manifest's env/args/dirs applied. The generic harness lives in `dewasm-test-helper`.
 
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
-use std::path::PathBuf;
-use std::process::Output;
-
 use dewasm_backend::Backend;
-use dewasm_backend_java::{find_java, javac_command, JavaBackend};
+use dewasm_backend_java::{find_java, JavaBackend};
 use dewasm_test_helper::{
     wasi_testsuite_suite, BackendUnderTest, PtyCommand, WasiTestsuiteBackend,
 };
+
+mod common;
+
+use common::build_java;
 
 /// Known trial failures with their attribution (ADR-8, policy in ADR-36): `(trial, tag)` — declared ENOSYS/out-of-scope syscalls, semantics-precision gaps on supported syscalls (tracked bugs in the shared WASI runtime), and environ entries the JVM host injects itself, which count-exact `environ_*` assertions cannot absorb (ADR-40).
 const WASI_TESTSUITE_EXPECTED_FAILURES: &[(&str, &str)] = &[
@@ -39,8 +38,6 @@ const WASI_TESTSUITE_EXPECTED_FAILURES_LINUX: &[(&str, &str)] = &[(
     "rust/symlink_filestat",
     "path_filestat_set_times: Linux JDK sets NOFOLLOW symlink times via microsecond lutimes, truncating ns",
 )];
-
-static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 struct JavaWasi;
 
@@ -73,40 +70,6 @@ impl BackendUnderTest for JavaWasi {
             cwd: None,
         }
     }
-}
-
-/// Compile `source` to a content-addressed class-dir cache (identical programs compile once).
-fn build_java(source: &str) -> Result<PathBuf, Output> {
-    let mut hasher = DefaultHasher::new();
-    source.hash(&mut hasher);
-    let hash = hasher.finish();
-
-    let cache = std::env::temp_dir().join("dewasm-java-cache");
-    std::fs::create_dir_all(&cache).unwrap();
-    let classdir = cache.join(format!("wasitest-{hash:016x}"));
-
-    if !classdir.join("Main.class").exists() {
-        let tmp = cache.join(format!(
-            "wasitest-{hash:016x}.{}.{}",
-            std::process::id(),
-            COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-        ));
-        std::fs::create_dir_all(&tmp).unwrap();
-        let src = tmp.join("Main.java");
-        std::fs::write(&src, source).unwrap();
-        let build = javac_command()
-            .arg("-d")
-            .arg(&tmp)
-            .arg(&src)
-            .output()
-            .expect("spawn javac");
-        if !build.status.success() {
-            return Err(build);
-        }
-        let _ = std::fs::rename(&tmp, &classdir);
-    }
-
-    Ok(classdir)
 }
 
 impl WasiTestsuiteBackend for JavaWasi {

--- a/crates/dewasm-backend-java/tests/wasi_testsuite.rs
+++ b/crates/dewasm-backend-java/tests/wasi_testsuite.rs
@@ -3,10 +3,10 @@
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
-use std::process::{Command, Output};
+use std::process::Output;
 
 use dewasm_backend::Backend;
-use dewasm_backend_java::{find_java, find_javac, JavaBackend};
+use dewasm_backend_java::{find_java, javac_command, JavaBackend};
 use dewasm_test_helper::{
     wasi_testsuite_suite, BackendUnderTest, PtyCommand, WasiTestsuiteBackend,
 };
@@ -77,9 +77,6 @@ impl BackendUnderTest for JavaWasi {
 
 /// Compile `source` to a content-addressed class-dir cache (identical programs compile once).
 fn build_java(source: &str) -> Result<PathBuf, Output> {
-    let javac =
-        find_javac().expect("javac not found on PATH (or $DEWASM_JAVAC) — see docs/testing.md");
-
     let mut hasher = DefaultHasher::new();
     source.hash(&mut hasher);
     let hash = hasher.finish();
@@ -97,7 +94,7 @@ fn build_java(source: &str) -> Result<PathBuf, Output> {
         std::fs::create_dir_all(&tmp).unwrap();
         let src = tmp.join("Main.java");
         std::fs::write(&src, source).unwrap();
-        let build = Command::new(&javac)
+        let build = javac_command()
             .arg("-d")
             .arg(&tmp)
             .arg(&src)

--- a/crates/dewasm-backend-perl/src/lib.rs
+++ b/crates/dewasm-backend-perl/src/lib.rs
@@ -77,6 +77,12 @@ pub fn shared_runtime(seeds: &BTreeSet<String>) -> Result<String> {
 
 /// Locate a perl interpreter (>= 5.26, 64-bit IVs and doubles) able to run generated scripts. Honors `$DEWASM_PERL`, then `perl` (ADR-15: a missing or unsuitable interpreter is a loud failure at the call site, not here — this only reports what qualifies).
 pub fn find_perl() -> Option<std::path::PathBuf> {
+    static PERL: OnceLock<Option<std::path::PathBuf>> = OnceLock::new();
+    PERL.get_or_init(find_perl_uncached).clone()
+}
+
+/// The probe behind [`find_perl`], memoized there: it spawns a process per candidate per call, and the interpreter cannot change under a running process.
+fn find_perl_uncached() -> Option<std::path::PathBuf> {
     use std::path::PathBuf;
     let mut candidates: Vec<PathBuf> = Vec::new();
     if let Ok(env) = std::env::var("DEWASM_PERL") {

--- a/crates/dewasm-backend-python/src/lib.rs
+++ b/crates/dewasm-backend-python/src/lib.rs
@@ -76,6 +76,12 @@ pub fn shared_runtime(seeds: &BTreeSet<String>) -> Result<String> {
 
 /// Locate a python3 interpreter (>= 3.9) able to run generated scripts. Honors `$DEWASM_PYTHON`, then `python3`, then `python` (ADR-15: a missing or too-old interpreter is a loud failure at the call site, not here — this only reports what qualifies).
 pub fn find_python() -> Option<std::path::PathBuf> {
+    static PYTHON: OnceLock<Option<std::path::PathBuf>> = OnceLock::new();
+    PYTHON.get_or_init(find_python_uncached).clone()
+}
+
+/// The probe behind [`find_python`], memoized there: it spawns a process per call, and the interpreter cannot change under a running process.
+fn find_python_uncached() -> Option<std::path::PathBuf> {
     use std::path::PathBuf;
     let mut candidates: Vec<PathBuf> = Vec::new();
     if let Ok(env) = std::env::var("DEWASM_PYTHON") {

--- a/crates/dewasm-backend-ruby/src/lib.rs
+++ b/crates/dewasm-backend-ruby/src/lib.rs
@@ -76,6 +76,12 @@ pub fn shared_runtime(seeds: &BTreeSet<String>) -> Result<String> {
 
 /// Locate a ruby interpreter able to run generated scripts. Unlike `dewasm_backend_bash::find_bash5`'s version floor: no alternate-path search is needed (ruby is expected on `PATH`), but the generated runtime's memory model is `IO::Buffer`-backed (see docs/adr/33-ruby-io-buffer-memory.md), which requires Ruby >= 3.4. Per ADR-15, fail loud with a setup instruction rather than silently skipping.
 pub fn find_ruby() -> Option<std::path::PathBuf> {
+    static RUBY: OnceLock<Option<std::path::PathBuf>> = OnceLock::new();
+    RUBY.get_or_init(find_ruby_uncached).clone()
+}
+
+/// The probe behind [`find_ruby`], memoized there: it spawns a process per call, and the interpreter cannot change under a running process.
+fn find_ruby_uncached() -> Option<std::path::PathBuf> {
     let out = std::process::Command::new("ruby")
         .args(["-e", "print RUBY_VERSION"])
         .output()

--- a/crates/dewasm-cli/tests/data_file.rs
+++ b/crates/dewasm-cli/tests/data_file.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
 use dewasm_backend_go::find_go;
-use dewasm_backend_java::{find_java, find_javac};
+use dewasm_backend_java::{find_java, javac_command};
 use dewasm_backend_perl::find_perl;
 use dewasm_backend_python::find_python;
 use dewasm_backend_ruby::find_ruby;
@@ -137,10 +137,8 @@ fn run_perl(prog: &Path, args: &[&str]) -> (Vec<u8>, i32) {
 
 /// Compile `Main.java` into `classdir` (mirrors the java spec harness recipe).
 fn compile_java(src: &Path, classdir: &Path) {
-    let javac =
-        find_javac().expect("javac not found on PATH (or $DEWASM_JAVAC) — see docs/testing.md");
     std::fs::create_dir_all(classdir).unwrap();
-    let build = Command::new(&javac)
+    let build = javac_command()
         .arg("-d")
         .arg(classdir)
         .arg(src)


### PR DESCRIPTION
Java is the second-slowest backend in CI's slow tier and by far the
noisiest (355–530 s across four recent `main` runs). Almost none of that
is dewasm: on the fast gate, conversion is 1.07 s while `javac` is ~75 %
of wall time and ~95 % of subprocess CPU. `java` itself is negligible
(40 s of 889 s aggregate), so its flags are deliberately left alone —
tuning them was measured at ~7 % and is not worth the churn.

Three commits, each measured on its own.

## Memoize the per-backend toolchain probe

`find_javac`/`find_java` spawned `javac -version` / `java -version` on
*every* call, and both are called at the top of every trial. A cold
`cargo test -p dewasm-backend-java` measured **168 `javac -version` execs
(59.9 s aggregate CPU) and 167 `java -version` execs (15.0 s)** — roughly
half the suite's warm subprocess time — to re-answer a question whose
answer cannot change under a running process.

`OnceLock` per tool. The `$DEWASM_*` override and the ADR-15 fail-loud
contract are untouched: the probe still runs (once), still returns `None`
when nothing qualifies, and the call sites still panic with their setup
instruction. Nothing in the tree ever writes these env vars, so the memo
cannot go stale.

This turned out not to be Java-specific: `find_go`, `find_ruby`,
`find_python`, `find_bash5` and `find_perl` all have the same
probe-per-call shape, so they get the same treatment. Their probes are
cheaper (10–80 ms against javac's ~350 ms) but just as redundant.

## Run javac through one command builder tuned for one-shot compiles

Six near-identical call sites each spelled out their own invocation, so
there was nowhere to put a flag. All now route through `javac_command()`,
which adds `-J-XX:TieredStopAtLevel=1 -J-XX:+UseSerialGC
-J-XX:ActiveProcessorCount=1`.

C2 cannot repay its own compilation cost inside a single ~1 s javac run,
and the suite starts one JVM per trial — N of them concurrently, each
with two C2 compiler threads and a G1 pool sized for the whole machine,
is what collapses parallel scaling on a 4-vCPU runner. The heap is left
at the default on purpose: the slow tier's qjs and DOOM sources need the
headroom.

`.class` output is byte-identical with and without the flags, verified
on the 4.2 MB cowsay and 15 MB qjs standalone sources (40 and 108
classes).

**Caveat for whoever re-measures this:** on an idle many-core box a
single large compile gets *slower* in wall time (qjs alone: 5.0 s →
8.6 s wall, but 10.8 s → 8.6 s CPU), because C2 is free when cores sit
idle. CPU time is the metric that predicts the saturated runner; the
whole-suite numbers below show wall improving too, once trials contend.

## Share one compile cache across the Java suites

The spec, e2e and wasi-testsuite suites each carried their own copy of
the same content-addressed compile-and-rename recipe, and the copies
disagreed — two prefixes inside `/tmp/dewasm-java-cache` plus a third
cache directory of its own for spec. `memory_grow` had no cache at all:
it compiled into a fresh per-pid scratch dir every run and never removed
it, leaving a trail in `/tmp` (~128 stale dirs found locally).

Honest accounting: the dedup itself buys nothing at the fast tier, where
166 trials produce 166 distinct sources. The win is one recipe instead of
four, plus caching and the leak fix for `memory_grow`.

A follow-up commit closes the same leak in the shared recipe's own race
path — two threads compiling the same source race to rename onto the
cache key, and the loser's rename fails with `ENOTEMPTY`. That was
carried over faithfully from the original, so it is not a regression from
this PR, but it is the same trail this consolidation set out to stop.

`dewasm-test-helper` would have been the natural home for the shared
recipe, but its module doc states it "depends only on `dewasm-core` and
`dewasm-backend` — never on a concrete backend crate". So
`javac_command()` sits next to `find_javac`, and the cache recipe in
`crates/dewasm-backend-java/tests/common/mod.rs`.

## Measurements

Cold compile cache each time. **User CPU is the stable metric** — it
varied by <0.1 % across baseline repeats, while wall varied by 8 %.

Fast gate, `cargo test -p dewasm-backend-java`:

| | wall | user CPU |
| --- | --- | --- |
| baseline | 121.1 s | 553.9 s |
| + memoized probe | 123.1 s | 494.2 s |
| + javac flags | 67.9 s | **247.0 s** |
| + shared cache | 61.1 s | 245.7 s |

The actual CI job (`--features dewasm-backend-java/slow_test`):

| | wall | user CPU |
| --- | --- | --- |
| main | 198.6 s | 796.9 s |
| this branch | **118.4 s** | **442.3 s** |

−40 % wall, −44.5 % CPU. `--test spec -- --include-ignored` is 257/257.

## Not done

A warm-compiler daemon (a `javax.tools.JavaCompiler` server fed over
stdin) measured 92.9 s → 25.7 s on the raw compile set, but that 3.6x was
against a baseline that no longer exists — the same suite now costs 44 %
less CPU, so the remaining headroom is much smaller, against high effort
and a persistent-process failure mode in the harness. Worth re-measuring
on the real 4-vCPU runner once this lands; if the job still sits above
~300 s there, revisit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)