### PR TITLE
Show FPS/controls in the DOOM and NES examples, fix status-line colors

### DIFF
--- a/examples/doom/bash/main.sh
+++ b/examples/doom/bash/main.sh
@@ -37,6 +37,11 @@ cd "$(dirname "${BASH_SOURCE[0]}")" || exit 1
 
 readonly ESC=$'\e'
 
+# Fixed status-line colors (white on black), independent of the game's own
+# palette -- without an explicit color the status line inherits whatever
+# fg/bg the last-drawn pixel cell left active, flickering with the game.
+readonly STATUS_SGR="${ESC}[48;2;0;0;0m${ESC}[38;2;255;255;255m"
+
 MODE=interactive
 [[ ${1-} == --smoke ]] && MODE=smoke
 # Info messages would corrupt the alternate-screen frame if printed there,
@@ -441,7 +446,9 @@ run_interactive() {
   ORIG_STTY=$(stty -g)
   restore_terminal() {
     stty "$ORIG_STTY" 2>/dev/null || true
-    printf '%s' "${ESC}[?25h${ESC}[?1049l"
+    # SGR reset first: the fixed status-line colors otherwise persist past
+    # leaving the alternate screen and tint the shell prompt underneath.
+    printf '%s' "${ESC}[0m${ESC}[?25h${ESC}[?1049l"
   }
   # Ctrl-C is handled explicitly as a byte in drain_input (once raw mode
   # is active) because raw mode disables the terminal's own SIGINT
@@ -512,7 +519,7 @@ run_interactive() {
     render_frame
     local status_text
     status_text="dewasm DOOM (bash) | tick $tick | $(fmt_secs "$dt_ms")s/tick | q quit  f fire  space use  arrows move  ,/. strafe  tab automap  enter confirm"
-    printf '%s' "$RENDER_OUT${ESC}[$(( GRID_ROWS + 1 ));1H${ESC}[K${status_text}"
+    printf '%s' "$RENDER_OUT${ESC}[$(( GRID_ROWS + 1 ));1H${ESC}[0m${STATUS_SGR}${ESC}[K${status_text}"
   done
 }
 

--- a/examples/doom/go/main.go
+++ b/examples/doom/go/main.go
@@ -13,13 +13,16 @@ import (
 	"flag"
 	"fmt"
 	"image"
+	"image/color"
 	"image/png"
 	"os"
 	"path/filepath"
 	"time"
 
 	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
 	"github.com/hajimehoshi/ebiten/v2/inpututil"
+	"github.com/hajimehoshi/ebiten/v2/vector"
 )
 
 // doomInst is package-level because the host import closures below need to
@@ -205,6 +208,15 @@ func mapKey(k ebiten.Key) (uint32, bool) {
 	return 0, false
 }
 
+// controlsText mirrors the key mapping in mapKey; shown as an on-screen
+// overlay since there's no other discoverability path for a window app.
+const controlsText = "arrows move  ctrl fire  space use  shift run  tab automap  ,/. strafe  1-7 weapon  esc menu"
+
+// titleUpdateEvery throttles ebiten.SetWindowTitle calls: the title only
+// needs to be legible, not frame-accurate, and OS window-title updates are
+// not free every tick.
+const titleUpdateEvery = 35 // roughly once a second at DOOM's 35 TPS
+
 // Game implements ebiten.Game. tickGame/reportKeyDown/reportKeyUp are the
 // module's exported funcs, type-asserted once in main rather than on every
 // call.
@@ -212,6 +224,8 @@ type Game struct {
 	tickGame      func()
 	reportKeyDown func(uint32)
 	reportKeyUp   func(uint32)
+
+	ticks int
 }
 
 func (g *Game) Update() error {
@@ -226,6 +240,11 @@ func (g *Game) Update() error {
 		}
 	}
 	g.tickGame() // drives ui.drawFrame internally, refreshing frameBuf
+
+	g.ticks++
+	if g.ticks%titleUpdateEvery == 0 {
+		ebiten.SetWindowTitle(fmt.Sprintf("DOOM (dewasm) - %.1f FPS", ebiten.ActualFPS()))
+	}
 	return nil
 }
 
@@ -233,6 +252,18 @@ func (g *Game) Draw(screen *ebiten.Image) {
 	if frameBuf != nil {
 		screen.WritePixels(frameBuf)
 	}
+	drawHUD(screen, ebiten.ActualFPS())
+}
+
+// drawHUD overlays the FPS and control scheme on a dark bar along the
+// bottom edge of the frame, so both stay legible against DOOM's own
+// (highly variable) palette.
+func drawHUD(screen *ebiten.Image, fps float64) {
+	bounds := screen.Bounds()
+	const barHeight = 16
+	barY := float32(bounds.Dy() - barHeight)
+	vector.FillRect(screen, 0, barY, float32(bounds.Dx()), barHeight, color.NRGBA{0, 0, 0, 180}, false)
+	ebitenutil.DebugPrintAt(screen, fmt.Sprintf("%.0f FPS  |  %s", fps, controlsText), 4, bounds.Dy()-barHeight+2)
 }
 
 // Layout reports the module's native resolution as ebiten's logical screen

--- a/examples/doom/java/Main.java
+++ b/examples/doom/java/Main.java
@@ -100,6 +100,13 @@ public class Main {
         System.out.println("smoke: OK");
     }
 
+    // Shown as an on-screen overlay (mirrors mapKey) since there's no other
+    // discoverability path for a window app.
+    private static final String CONTROLS_TEXT =
+        "arrows move  ctrl fire  space use  shift run  tab automap  ,/. strafe  1-7 weapon  esc menu";
+
+    private static final String WINDOW_TITLE = "DOOM (dewasm)";
+
     // Interactive window: a JFrame whose panel blits the engine's current
     // BufferedImage scaled to the panel size, plus a KeyListener that queues
     // key events for the game thread to drain. DOOM ticks on its own thread
@@ -107,8 +114,9 @@ public class Main {
     // must all be called from one thread) while Swing delivers input on the
     // EDT; the ConcurrentLinkedQueue is the handoff between the two.
     private static void runGui() throws IOException {
-        JFrame window = new JFrame("DOOM (dewasm)");
+        JFrame window = new JFrame(WINDOW_TITLE);
         DoomPanel panel = new DoomPanel();
+        panel.controlsText = CONTROLS_TEXT;
         window.setContentPane(panel);
         window.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 
@@ -149,8 +157,23 @@ public class Main {
 
         Thread gameThread = new Thread(() -> {
             engine.init();
+            // FPS is measured over ~1s windows (tick counting), not one tick
+            // at a time: DOOM's own 35Hz pacing plus JIT warmup jitter would
+            // otherwise make a per-tick instantaneous rate too noisy to read.
+            long fpsWindowStart = System.nanoTime();
+            int fpsWindowTicks = 0;
             while (!Thread.currentThread().isInterrupted()) {
                 engine.tick();
+                fpsWindowTicks++;
+                long now = System.nanoTime();
+                double elapsedSec = (now - fpsWindowStart) / 1e9;
+                if (elapsedSec >= 1.0) {
+                    double fps = fpsWindowTicks / elapsedSec;
+                    panel.fps = fps;
+                    SwingUtilities.invokeLater(() -> window.setTitle(String.format("%s - %.1f FPS", WINDOW_TITLE, fps)));
+                    fpsWindowStart = now;
+                    fpsWindowTicks = 0;
+                }
                 try {
                     Thread.sleep(1);
                 } catch (InterruptedException e) {
@@ -219,6 +242,8 @@ public class Main {
     // aspect ratio and letterboxing with black bars on the short axis.
     private static final class DoomPanel extends JPanel {
         volatile DoomEngine engine;
+        volatile double fps;
+        volatile String controlsText = "";
 
         DoomPanel() {
             setBackground(Color.BLACK);
@@ -243,6 +268,21 @@ public class Main {
             Graphics2D g2 = (Graphics2D) g;
             g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
             g2.drawImage(frame, dx, dy, dw, dh, null);
+            drawHud(g2, dx, dy + dh);
+        }
+
+        // Overlays the FPS and control scheme on a fixed-color dark bar
+        // along the bottom edge of the rendered frame, so both stay legible
+        // against the game's own (highly variable) palette rather than the
+        // panel's plain black background bleeding through.
+        private void drawHud(Graphics2D g2, int frameLeft, int frameBottom) {
+            String text = String.format("%.0f FPS  |  %s", fps, controlsText);
+            int barHeight = 18;
+            int barTop = frameBottom - barHeight;
+            g2.setColor(new Color(0, 0, 0, 180));
+            g2.fillRect(frameLeft, barTop, getWidth() - 2 * frameLeft, barHeight);
+            g2.setColor(Color.WHITE);
+            g2.drawString(text, frameLeft + 4, frameBottom - 5);
         }
     }
 

--- a/examples/doom/perl/main.pl
+++ b/examples/doom/perl/main.pl
@@ -30,6 +30,11 @@ use constant KEY_HOLD_SECONDS => 0.4;
 
 my $HALF_BLOCK = "\xE2\x96\x80";    # U+2580 upper half block, as raw UTF-8
 
+# Fixed status-line colors (white on black), independent of the game's own
+# palette -- without an explicit color the status line inherits whatever
+# fg/bg the last-drawn pixel cell left active, flickering with the game.
+my $STATUS_SGR = "\e[48;2;0;0;0m\e[38;2;255;255;255m";
+
 sub monotonic { return clock_gettime(CLOCK_MONOTONIC); }
 
 sub save_game_path { return SAVE_DIR . "/doomsav$_[0].dsg"; }
@@ -218,11 +223,19 @@ sub render {
         }
     }
     if (!defined($self->{last_status}) || $status_text ne $self->{last_status}) {
-        $buf .= sprintf("\e[%d;1H\e[K%s", $self->{cell_rows} + 1, $status_text);
+        # Reset SGR first: otherwise the status line inherits whichever
+        # fg/bg the last-drawn pixel cell left active, making its background
+        # flicker with the game's own colors instead of staying the
+        # terminal default.
+        $buf .= sprintf("\e[%d;1H\e[0m%s\e[K%s", $self->{cell_rows} + 1, $STATUS_SGR, $status_text);
         $self->{last_status} = $status_text;
         # Force the next painted cell to reposition: the cursor is now on
         # the status line.
         $self->{cursor_row} = -1;
+        # The reset above invalidated the SGR cache; force the next cell to
+        # re-emit its color.
+        $self->{last_fg} = undef;
+        $self->{last_bg} = undef;
     }
     return $buf;
 }
@@ -434,7 +447,9 @@ sub run_smoke {
 }
 
 use constant ENTER_ALT_SCREEN => "\e[?1049h\e[?25l\e[2J\e[H";
-use constant EXIT_ALT_SCREEN  => "\e[?25h\e[?1049l";
+# SGR reset first: the fixed status-line colors otherwise persist past
+# leaving the alternate screen and tint the shell prompt underneath.
+use constant EXIT_ALT_SCREEN  => "\e[0m\e[?25h\e[?1049l";
 
 sub run_interactive {
     unless (-t STDIN && -t STDOUT) {

--- a/examples/doom/python/main.py
+++ b/examples/doom/python/main.py
@@ -171,6 +171,11 @@ IMPORTS = {
 
 UPPER_HALF_BLOCK = "▀"
 
+# Fixed status-line colors (white on black), independent of the game's own
+# palette -- without an explicit color the status line inherits whatever
+# fg/bg the last-drawn pixel cell left active, flickering with the game.
+STATUS_SGR = "\x1b[48;2;0;0;0m\x1b[38;2;255;255;255m"
+
 
 def _pixel(mv, off, buf_w, lx, ly):
     # Memory byte order is B, G, R, A (see loading/drawFrame host contract).
@@ -261,7 +266,7 @@ class Renderer:
         out = "\x1b[2J" if resized else ""
         out += diff_escapes(cells, prev, rows, width)
         # Status line always redrawn: it's one line, and its own text changes tick to tick.
-        out += f"\x1b[{rows + 1};1H\x1b[0m\x1b[K{status_line}"
+        out += f"\x1b[{rows + 1};1H\x1b[0m{STATUS_SGR}\x1b[K{status_line}"
         os.write(1, out.encode())
 
         self.prev, self.width, self.rows = cells, width, rows
@@ -328,7 +333,10 @@ def run_interactive():
 
     def restore():
         termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
-        os.write(1, b"\x1b[?25h\x1b[?1049l")
+        # SGR reset first: the fixed status-line colors otherwise persist
+        # past leaving the alternate screen and tint the shell prompt
+        # underneath.
+        os.write(1, b"\x1b[0m\x1b[?25h\x1b[?1049l")
 
     def on_sigterm(signum, frame):
         raise SystemExit(0)

--- a/examples/doom/ruby/main.rb
+++ b/examples/doom/ruby/main.rb
@@ -125,6 +125,11 @@ end
 # emits an SGR code when a cell's color actually differs from the one
 # before it — DOOM's software renderer is paletted, so most cells repeat
 # exactly from one frame to the next.
+# Fixed status-line colors (white on black), independent of the game's own
+# palette -- without an explicit color the status line inherits whatever
+# fg/bg the last-drawn pixel cell left active, flickering with the game.
+STATUS_SGR = "\e[48;2;0;0;0m\e[38;2;255;255;255m"
+
 class Renderer
   attr_reader :cell_cols, :cell_rows
 
@@ -194,9 +199,15 @@ class Renderer
       end
     end
     if status_text != @last_status
-      buf << "\e[#{@cell_rows + 1};1H\e[K#{status_text}"
+      # Reset SGR first: otherwise the status line inherits whichever
+      # fg/bg the last-drawn pixel cell left active, making its background
+      # flicker with the game's own colors instead of staying the terminal
+      # default.
+      buf << "\e[#{@cell_rows + 1};1H\e[0m#{STATUS_SGR}\e[K#{status_text}"
       @last_status = status_text
       @cursor_row = -1 # force the next painted cell to reposition: the cursor is now on the status line
+      @last_fg = nil # the reset above invalidated the SGR cache; force the next cell to re-emit its color
+      @last_bg = nil
     end
     buf
   end
@@ -414,7 +425,9 @@ def run_smoke
 end
 
 ENTER_ALT_SCREEN = "\e[?1049h\e[?25l\e[2J\e[H"
-EXIT_ALT_SCREEN = "\e[?25h\e[?1049l"
+# SGR reset first: the fixed status-line colors otherwise persist past
+# leaving the alternate screen and tint the shell prompt underneath.
+EXIT_ALT_SCREEN = "\e[0m\e[?25h\e[?1049l"
 
 def run_interactive
   unless $stdin.tty? && $stdout.tty? && IO.console

--- a/examples/nes/bash/main.sh
+++ b/examples/nes/bash/main.sh
@@ -36,6 +36,11 @@ cd "$(dirname "${BASH_SOURCE[0]}")" || exit 1
 readonly ESC=$'\e'
 readonly DEFAULT_ROM=../../apps/cache/alter_ego.nes
 
+# Fixed status-line colors (white on black), independent of the game's own
+# palette -- without an explicit color the status line inherits whatever
+# fg/bg the last-drawn pixel cell left active, flickering with the game.
+readonly STATUS_SGR="${ESC}[48;2;0;0;0m${ESC}[38;2;255;255;255m"
+
 # NES controller button bits, matching src/nes_demo.c's setInput().
 readonly BTN_A=1 BTN_B=2 BTN_SELECT=4 BTN_START=8
 readonly BTN_UP=16 BTN_DOWN=32 BTN_LEFT=64 BTN_RIGHT=128
@@ -376,7 +381,9 @@ run_interactive() {
   ORIG_STTY=$(stty -g)
   restore_terminal() {
     stty "$ORIG_STTY" 2>/dev/null || true
-    printf '%s' "${ESC}[?25h${ESC}[?1049l"
+    # SGR reset first: the fixed status-line colors otherwise persist past
+    # leaving the alternate screen and tint the shell prompt underneath.
+    printf '%s' "${ESC}[0m${ESC}[?25h${ESC}[?1049l"
   }
   # Ctrl-C is handled as a byte in drain_input (raw mode disables the
   # terminal's own SIGINT); the INT/TERM traps are a backstop for `kill` or a
@@ -417,7 +424,7 @@ run_interactive() {
     render_frame
     local status_text
     status_text="dewasm NES (bash) | frame $frame | $(fmt_secs "$dt_ms")s/frame | q quit  arrows d-pad  x A  z B  enter Start  space Select"
-    printf '%s' "$RENDER_OUT${ESC}[$(( GRID_ROWS + 1 ));1H${ESC}[K${status_text}"
+    printf '%s' "$RENDER_OUT${ESC}[$(( GRID_ROWS + 1 ));1H${ESC}[0m${STATUS_SGR}${ESC}[K${status_text}"
   done
 }
 

--- a/examples/nes/go/main.go
+++ b/examples/nes/go/main.go
@@ -14,12 +14,15 @@ import (
 	"flag"
 	"fmt"
 	"image"
+	"image/color"
 	"image/png"
 	"os"
 	"path/filepath"
 	"time"
 
 	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
+	"github.com/hajimehoshi/ebiten/v2/vector"
 )
 
 // nesInst is package-level so runSmoke and the Game methods below can reach
@@ -115,12 +118,23 @@ func drawFrame(setInput func(uint32), tickGame func(), frameOffset func() uint32
 	}
 }
 
+// controlsText mirrors the key mapping in buttonMask; shown as an on-screen
+// overlay since there's no other discoverability path for a window app.
+const controlsText = "arrows d-pad  x A  z B  enter start  space select  esc quit"
+
+// titleUpdateEvery throttles ebiten.SetWindowTitle calls: the title only
+// needs to be legible, not frame-accurate, and OS window-title updates are
+// not free every tick.
+const titleUpdateEvery = 60 // roughly once a second at the NES's ~60Hz frame rate
+
 // Game implements ebiten.Game. The three exported funcs are type-asserted
 // once in main rather than on every call.
 type Game struct {
 	setInput    func(uint32)
 	tickGame    func()
 	frameOffset func() uint32
+
+	ticks int
 }
 
 func (g *Game) Update() error {
@@ -128,6 +142,11 @@ func (g *Game) Update() error {
 		return ebiten.Termination
 	}
 	drawFrame(g.setInput, g.tickGame, g.frameOffset)
+
+	g.ticks++
+	if g.ticks%titleUpdateEvery == 0 {
+		ebiten.SetWindowTitle(fmt.Sprintf("NES (dewasm) - %.1f FPS", ebiten.ActualFPS()))
+	}
 	return nil
 }
 
@@ -135,6 +154,18 @@ func (g *Game) Draw(screen *ebiten.Image) {
 	if frameBuf != nil {
 		screen.WritePixels(frameBuf)
 	}
+	drawHUD(screen, ebiten.ActualFPS())
+}
+
+// drawHUD overlays the FPS and control scheme on a dark bar along the
+// bottom edge of the frame, so both stay legible against the game's own
+// (highly variable) palette.
+func drawHUD(screen *ebiten.Image, fps float64) {
+	bounds := screen.Bounds()
+	const barHeight = 16
+	barY := float32(bounds.Dy() - barHeight)
+	vector.FillRect(screen, 0, barY, float32(bounds.Dx()), barHeight, color.NRGBA{0, 0, 0, 180}, false)
+	ebitenutil.DebugPrintAt(screen, fmt.Sprintf("%.0f FPS  |  %s", fps, controlsText), 4, bounds.Dy()-barHeight+2)
 }
 
 // Layout reports the module's native resolution as ebiten's logical screen

--- a/examples/nes/java/Main.java
+++ b/examples/nes/java/Main.java
@@ -56,6 +56,12 @@ public class Main {
 
     private static final int FPS = 60;
 
+    // Shown as an on-screen overlay (mirrors mapKey) since there's no other
+    // discoverability path for a window app.
+    private static final String CONTROLS_TEXT = "arrows d-pad  x A  z B  enter start  space select  esc quit";
+
+    private static final String WINDOW_TITLE = "NES (dewasm) - Alter Ego";
+
     public static void main(String[] args) throws Exception {
         boolean smoke = false;
         String romPath = DEFAULT_ROM;
@@ -128,13 +134,14 @@ public class Main {
     // held-key set is read from the game thread each tick, guarded by a
     // simple lock since it's small and touched every ~16ms either way.
     private static void runGui(byte[] rom) throws IOException {
-        JFrame window = new JFrame("NES (dewasm) - Alter Ego");
+        JFrame window = new JFrame(WINDOW_TITLE);
         NesPanel panel = new NesPanel();
         window.setContentPane(panel);
         window.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 
         NesEngine engine = new NesEngine(rom);
         panel.engine = engine;
+        panel.controlsText = CONTROLS_TEXT;
         panel.setPreferredSize(new Dimension(engine.width * 2, engine.height * 2));
 
         Object heldLock = new Object();
@@ -176,6 +183,11 @@ public class Main {
         Thread gameThread = new Thread(() -> {
             long frameNanos = 1_000_000_000L / FPS;
             long next = System.nanoTime();
+            // Measured over ~1s windows (frame counting), not one frame at a
+            // time: a per-frame instantaneous rate would be far too noisy to
+            // read even though tickGame paces at a fixed 60Hz target.
+            long fpsWindowStart = next;
+            int fpsWindowFrames = 0;
             while (running.get() != 0) {
                 int buttons;
                 synchronized (heldLock) {
@@ -186,6 +198,18 @@ public class Main {
                 }
                 engine.tick(buttons);
                 panel.repaint();
+
+                fpsWindowFrames++;
+                long now = System.nanoTime();
+                double elapsedSec = (now - fpsWindowStart) / 1e9;
+                if (elapsedSec >= 1.0) {
+                    double measuredFps = fpsWindowFrames / elapsedSec;
+                    panel.fps = measuredFps;
+                    SwingUtilities.invokeLater(
+                        () -> window.setTitle(String.format("%s - %.1f FPS", WINDOW_TITLE, measuredFps)));
+                    fpsWindowStart = now;
+                    fpsWindowFrames = 0;
+                }
 
                 next += frameNanos;
                 long sleepNanos = next - System.nanoTime();
@@ -249,6 +273,8 @@ public class Main {
     // aspect ratio and letterboxing with black bars on the short axis.
     private static final class NesPanel extends JPanel {
         volatile NesEngine engine;
+        volatile double fps;
+        volatile String controlsText = "";
 
         NesPanel() {
             setBackground(Color.BLACK);
@@ -273,6 +299,21 @@ public class Main {
             Graphics2D g2 = (Graphics2D) g;
             g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
             g2.drawImage(frame, dx, dy, dw, dh, null);
+            drawHud(g2, dx, dy + dh);
+        }
+
+        // Overlays the FPS and control scheme on a fixed-color dark bar
+        // along the bottom edge of the rendered frame, so both stay legible
+        // against the game's own (highly variable) palette rather than the
+        // panel's plain black background bleeding through.
+        private void drawHud(Graphics2D g2, int frameLeft, int frameBottom) {
+            String text = String.format("%.0f FPS  |  %s", fps, controlsText);
+            int barHeight = 18;
+            int barTop = frameBottom - barHeight;
+            g2.setColor(new Color(0, 0, 0, 180));
+            g2.fillRect(frameLeft, barTop, getWidth() - 2 * frameLeft, barHeight);
+            g2.setColor(Color.WHITE);
+            g2.drawString(text, frameLeft + 4, frameBottom - 5);
         }
     }
 

--- a/examples/nes/perl/main.pl
+++ b/examples/nes/perl/main.pl
@@ -54,6 +54,11 @@ use constant {
 
 my $HALF_BLOCK = "\xE2\x96\x80";    # U+2580 upper half block, as raw UTF-8
 
+# Fixed status-line colors (white on black), independent of the game's own
+# palette -- without an explicit color the status line inherits whatever
+# fg/bg the last-drawn pixel cell left active, flickering with the game.
+my $STATUS_SGR = "\e[48;2;0;0;0m\e[38;2;255;255;255m";
+
 sub monotonic { return clock_gettime(CLOCK_MONOTONIC); }
 
 sub load_rom {
@@ -169,11 +174,19 @@ sub render {
         }
     }
     if (!defined($self->{last_status}) || $status_text ne $self->{last_status}) {
-        $buf .= sprintf("\e[%d;1H\e[K%s", $self->{cell_rows} + 1, $status_text);
+        # Reset SGR first: otherwise the status line inherits whichever
+        # fg/bg the last-drawn pixel cell left active, making its background
+        # flicker with the game's own colors instead of staying the
+        # terminal default.
+        $buf .= sprintf("\e[%d;1H\e[0m%s\e[K%s", $self->{cell_rows} + 1, $STATUS_SGR, $status_text);
         $self->{last_status} = $status_text;
         # Force the next painted cell to reposition: the cursor is now on
         # the status line.
         $self->{cursor_row} = -1;
+        # The reset above invalidated the SGR cache; force the next cell to
+        # re-emit its color.
+        $self->{last_fg} = undef;
+        $self->{last_bg} = undef;
     }
     return $buf;
 }
@@ -382,7 +395,9 @@ sub run_smoke {
 }
 
 use constant ENTER_ALT_SCREEN => "\e[?1049h\e[?25l\e[2J\e[H";
-use constant EXIT_ALT_SCREEN  => "\e[?25h\e[?1049l";
+# SGR reset first: the fixed status-line colors otherwise persist past
+# leaving the alternate screen and tint the shell prompt underneath.
+use constant EXIT_ALT_SCREEN  => "\e[0m\e[?25h\e[?1049l";
 
 sub run_interactive {
     my $rom_path = shift(@_) || DEFAULT_ROM;

--- a/examples/nes/python/main.py
+++ b/examples/nes/python/main.py
@@ -84,6 +84,11 @@ def load_rom(path):
 
 UPPER_HALF_BLOCK = "▀"
 
+# Fixed status-line colors (white on black), independent of the game's own
+# palette -- without an explicit color the status line inherits whatever
+# fg/bg the last-drawn pixel cell left active, flickering with the game.
+STATUS_SGR = "\x1b[48;2;0;0;0m\x1b[38;2;255;255;255m"
+
 
 def _pixel(mv, off, buf_w, x, y):
     # Memory byte order is B, G, R, A (see nes_demo.c's tickGame).
@@ -173,7 +178,7 @@ class Renderer:
         out = "\x1b[2J" if resized else ""
         out += diff_escapes(cells, prev, rows, width)
         # Status line always redrawn: it's one line, and its own text changes tick to tick.
-        out += f"\x1b[{rows + 1};1H\x1b[0m\x1b[K{status_line}"
+        out += f"\x1b[{rows + 1};1H\x1b[0m{STATUS_SGR}\x1b[K{status_line}"
         os.write(1, out.encode())
 
         self.prev, self.width, self.rows = cells, width, rows
@@ -237,7 +242,10 @@ def run_interactive(rom_path):
 
     def restore():
         termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
-        os.write(1, b"\x1b[?25h\x1b[?1049l")
+        # SGR reset first: the fixed status-line colors otherwise persist
+        # past leaving the alternate screen and tint the shell prompt
+        # underneath.
+        os.write(1, b"\x1b[0m\x1b[?25h\x1b[?1049l")
 
     renderer = Renderer()
     held = {}  # controller bit -> release deadline (time.monotonic() seconds)

--- a/examples/nes/ruby/main.rb
+++ b/examples/nes/ruby/main.rb
@@ -62,6 +62,11 @@ end
 # it diffs against the previous frame's cell contents and the terminal's own
 # cursor position, and only emits an SGR code when a cell's color actually
 # changed.
+# Fixed status-line colors (white on black), independent of the game's own
+# palette -- without an explicit color the status line inherits whatever
+# fg/bg the last-drawn pixel cell left active, flickering with the game.
+STATUS_SGR = "\e[48;2;0;0;0m\e[38;2;255;255;255m"
+
 class Renderer
   attr_reader :cell_cols, :cell_rows
 
@@ -129,9 +134,15 @@ class Renderer
       end
     end
     if status_text != @last_status
-      buf << "\e[#{@cell_rows + 1};1H\e[K#{status_text}"
+      # Reset SGR first: otherwise the status line inherits whichever
+      # fg/bg the last-drawn pixel cell left active, making its background
+      # flicker with the game's own colors instead of staying the terminal
+      # default.
+      buf << "\e[#{@cell_rows + 1};1H\e[0m#{STATUS_SGR}\e[K#{status_text}"
       @last_status = status_text
       @cursor_row = -1 # force the next painted cell to reposition: the cursor is now on the status line
+      @last_fg = nil # the reset above invalidated the SGR cache; force the next cell to re-emit its color
+      @last_bg = nil
     end
     buf
   end
@@ -341,7 +352,9 @@ def run_smoke(rom_path)
 end
 
 ENTER_ALT_SCREEN = "\e[?1049h\e[?25l\e[2J\e[H"
-EXIT_ALT_SCREEN = "\e[?25h\e[?1049l"
+# SGR reset first: the fixed status-line colors otherwise persist past
+# leaving the alternate screen and tint the shell prompt underneath.
+EXIT_ALT_SCREEN = "\e[0m\e[?25h\e[?1049l"
 
 # The NTSC NES runs at ~60.0988Hz; 60 exactly is close enough that no
 # separate calibration is needed (unlike DOOM's internal 35Hz pacing, which


### PR DESCRIPTION
## Summary
- Go (ebiten) and Java (Swing) windowed frontends for `doom`/`nes` now show a live FPS reading in the window title and an on-screen dark bar with FPS + the key bindings, since there was previously no way to tell how fast the game was running or what the controls were.
- The bash/ruby/perl/python terminal frontends' existing FPS/controls status line inherited whatever fg/bg color the last-rendered pixel cell left active, flickering along with the game's own palette. It now uses a fixed white-on-black color, and the alternate-screen exit path resets SGR state first so that color doesn't bleed into the shell prompt afterward.

## Test plan
- [x] `go build` + `-smoke` for `examples/doom/go` and `examples/nes/go`
- [x] `javac` + `--smoke` for `examples/doom/java` and `examples/nes/java`
- [x] `--smoke` for `examples/{doom,nes}/{bash,ruby,perl,python}` (all 8 pass)
- [x] `bash -n` / `ruby -c` / `perl -c` / `python3 -m py_compile` on all touched scripts