### PR TITLE
Prefix dewasm_test_helper:: at call sites instead of wide use-imports

### DIFF
--- a/crates/dewasm-backend-bash/tests/convert.rs
+++ b/crates/dewasm-backend-bash/tests/convert.rs
@@ -4,6 +4,5 @@
 //! `dewasm-test-helper`.
 
 use dewasm_backend_bash::BashBackend;
-use dewasm_test_helper::apps_convert_suite;
 
-apps_convert_suite!(BashBackend);
+dewasm_test_helper::apps_convert_suite!(BashBackend);

--- a/crates/dewasm-backend-bash/tests/e2e.rs
+++ b/crates/dewasm-backend-bash/tests/e2e.rs
@@ -5,12 +5,7 @@ use std::path::PathBuf;
 
 use dewasm_backend::Backend;
 use dewasm_backend_bash::{find_bash5, BashBackend};
-use dewasm_test_helper::{
-    cowsay_args_e2e, cowsay_stdin_e2e, doom_frame_e2e, examples_dir, gzip_e2e, library_add_e2e,
-    nes_frame_e2e, qjs_eval_e2e, qjs_file_io_e2e, qjs_repl_pty_e2e, shared_table_e2e,
-    sqlite3_shell_dbfile_e2e, sqlite3_shell_e2e, standalone_dir_e2e, wasi_import_override_e2e,
-    wasi_root_containment_e2e, wasi_suite, BackendUnderTest,
-};
+use dewasm_test_helper::BackendUnderTest;
 
 pub struct Bash;
 
@@ -38,7 +33,8 @@ impl BackendUnderTest for Bash {
         let mut units = BTreeSet::new();
         let mut decls = Vec::new();
         for (wat, name) in modules {
-            let bytes = wat::parse_file(examples_dir().join(wat)).expect("parse wat");
+            let bytes =
+                wat::parse_file(dewasm_test_helper::examples_dir().join(wat)).expect("parse wat");
             let module = dewasm_core::build_module(&bytes).expect("build IR");
             let prefix = dewasm_backend_bash::func_prefix(name);
             let (src, u) = dewasm_backend_bash::generate_module_with_units(&module, &prefix, false)
@@ -244,35 +240,35 @@ exit 0
 
 // --------------------------------------------------------------------- Suite wiring (ADR-27): each per-case macro invocation declares participation.
 
-library_add_e2e!(Bash, BASH_ADD_GLUE);
-wasi_import_override_e2e!(Bash, BASH_OVERRIDE_GLUE);
+dewasm_test_helper::library_add_e2e!(Bash, BASH_ADD_GLUE);
+dewasm_test_helper::wasi_import_override_e2e!(Bash, BASH_OVERRIDE_GLUE);
 // custom_wasi_provider_e2e! / partial_override_e2e! / stdio_capture_e2e!: not invoked — Bash has no host-language object model to replace WASI wholesale, probe its lazy construction, or redirect stdio into an in-memory object (ADR-12).
 
-wasi_suite!(Bash, Stdio);
-wasi_suite!(Bash, ArgsEnv);
-wasi_suite!(Bash, Poll);
-wasi_suite!(Bash, Fs, BASH_FS_GLUE);
-wasi_root_containment_e2e!(Bash, BASH_CONTAINMENT_GLUE);
-standalone_dir_e2e!(Bash);
+dewasm_test_helper::wasi_suite!(Bash, Stdio);
+dewasm_test_helper::wasi_suite!(Bash, ArgsEnv);
+dewasm_test_helper::wasi_suite!(Bash, Poll);
+dewasm_test_helper::wasi_suite!(Bash, Fs, BASH_FS_GLUE);
+dewasm_test_helper::wasi_root_containment_e2e!(Bash, BASH_CONTAINMENT_GLUE);
+dewasm_test_helper::standalone_dir_e2e!(Bash);
 
-cowsay_args_e2e!(Bash);
-cowsay_stdin_e2e!(Bash);
+dewasm_test_helper::cowsay_args_e2e!(Bash);
+dewasm_test_helper::cowsay_stdin_e2e!(Bash);
 // qjs_eval_e2e! / sqlite3_shell_e2e!: invoked, but slow — Bash's softfloat makes QuickJS/SQLite take tens of seconds, so the generated tests are `#[ignore]`d by default; `--features slow_test` or `-- --include-ignored` runs them anyway (same as every other backend, ADR-27 revision).
-qjs_eval_e2e!(Bash);
-sqlite3_shell_e2e!(Bash);
+dewasm_test_helper::qjs_eval_e2e!(Bash);
+dewasm_test_helper::sqlite3_shell_e2e!(Bash);
 // minigzip is integer-only (no softfloat), so it runs under Bash by default, unlike the slow floating-point apps (QuickJS/SQLite).
-gzip_e2e!(Bash);
+dewasm_test_helper::gzip_e2e!(Bash);
 
 // Filesystem app cases (ADR-34): Bash's WASI filesystem now covers preopens, path_open, and positioned I/O, so the three small-fixture fs apps are wired (all slow, softfloat-bound QuickJS/SQLite — see qjs_eval_e2e! above).
-qjs_file_io_e2e!(Bash, BASH_QJS_FILE_IO_GLUE);
-sqlite3_shell_dbfile_e2e!(Bash, BASH_SQLITE3_SHELL_DBFILE_GLUE);
+dewasm_test_helper::qjs_file_io_e2e!(Bash, BASH_QJS_FILE_IO_GLUE);
+dewasm_test_helper::sqlite3_shell_dbfile_e2e!(Bash, BASH_SQLITE3_SHELL_DBFILE_GLUE);
 // qjs_repl_pty is not a filesystem case (no preopens) but is wired here alongside them: it shares their standalone-mode QuickJS conversion. It is markedly slower than every other case — every keystroke of the scripted session re-enters QuickJS's interactive line editor (redraw/completion), and each successive evaluation measured slower than the last (first prompt ~135s, then +~65s, then +~330s for `[3,1,2].sort()`), so it exceeds the shared 180s per-prompt `PTY_TIMEOUT` (`crates/dewasm-test-helper/src/qjs_repl.rs`) and timed out on CI (#22). It is therefore pinned to the `ultra` tier (ADR-48): kept out of CI's `slow_test` sweep and run only under `--features ultra_slow_test` or `-- --include-ignored`, in local pre-release verification. Left wired rather than unwired per ADR-15 (fail loud, not silently skip): a timeout is still an honest signal.
-qjs_repl_pty_e2e!(Bash, ultra);
+dewasm_test_helper::qjs_repl_pty_e2e!(Bash, ultra);
 // rg_search_e2e! / cpython_hello_e2e! / cruby_hello_e2e! / cruby_packed_hello_e2e!: not invoked — these wasm binaries are tens of MB; the Bash backend's per-instruction lowering (ADR-11) would generate a hundreds-of-MB script, well beyond what bash's own parser can load in practice (ADR-13's softfloat perf figures already put a single arithmetic op at bash-interpreter speed, and these apps are orders of magnitude larger than QuickJS/SQLite) — parse feasibility, not just runtime speed, is the blocker.
 
-doom_frame_e2e!(Bash, BASH_DOOM_FRAME_GLUE, ultra);
+dewasm_test_helper::doom_frame_e2e!(Bash, BASH_DOOM_FRAME_GLUE, ultra);
 // Ultra tier (ADR-48): tens of seconds per tick locally (mem_init's own copy loop over the 41 KB ROM, then agnes's per-frame interpretation), ~20 min for the full 40-frame run — well past the ~1-minute CI-runner line, like the DOOM case above. (It was ~25 min before issue #117 moved the per-pixel frame composition out of the guest.)
-nes_frame_e2e!(Bash, BASH_NES_FRAME_GLUE, ultra);
+dewasm_test_helper::nes_frame_e2e!(Bash, BASH_NES_FRAME_GLUE, ultra);
 
-shared_table_e2e!(Bash, BASH_SHARED_TABLE_GLUE);
+dewasm_test_helper::shared_table_e2e!(Bash, BASH_SHARED_TABLE_GLUE);
 // libsqlite3_c_api_e2e! / sqlite3_file_c_api_e2e! / sqlite3_callback_binding_e2e! / pcap_compile_e2e! / treesitter_parse_e2e!: not invoked — Bash has no host-language C API to plumb a pointer-returning binding through (ADR-12), and the multi-MB reactor artifacts are far past what Bash's parser can load in practice. embedded_coexist_e2e!: not invoked — Bash has one flat global namespace (no nested runtime/class construct), so two independently-generated runtimes cannot coexist in one process without their rt_*/mem_* function names colliding (ADR-11).

--- a/crates/dewasm-backend-bash/tests/spec.rs
+++ b/crates/dewasm-backend-bash/tests/spec.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use dewasm_backend::Backend;
 use dewasm_backend_bash::BashBackend;
 use dewasm_core::ir;
-use dewasm_test_helper::{spec_suite, BackendUnderTest, Converted, SpecBackend};
+use dewasm_test_helper::BackendUnderTest;
 use wast::core::{NanPattern, WastArgCore, WastRetCore};
 use wast::{WastArg, WastRet};
 
@@ -133,7 +133,7 @@ impl BackendUnderTest for BashSpec {
     }
 }
 
-impl SpecBackend for BashSpec {
+impl dewasm_test_helper::SpecBackend for BashSpec {
     fn expected_failures(&self) -> &'static [(&'static str, u32, &'static str)] {
         EXPECTED_FAILURES
     }
@@ -146,12 +146,16 @@ impl SpecBackend for BashSpec {
         &[]
     }
 
-    fn generate(&self, module: &ir::Module, counter: u32) -> anyhow::Result<Converted> {
+    fn generate(
+        &self,
+        module: &ir::Module,
+        counter: u32,
+    ) -> anyhow::Result<dewasm_test_helper::Converted> {
         let prefix = format!("m{counter}_");
         let (source, units) = dewasm_backend_bash::generate_module_with_units(
             module, &prefix, false, // spec modules import spectest, never WASI
         )?;
-        Ok(Converted {
+        Ok(dewasm_test_helper::Converted {
             source,
             handle: prefix,
             units,
@@ -166,7 +170,7 @@ impl SpecBackend for BashSpec {
         &self,
         script: &mut String,
         _decls: &mut String,
-        conv: &Converted,
+        conv: &dewasm_test_helper::Converted,
         _var_id: u32,
         registered: &[(String, String)],
     ) -> String {
@@ -186,7 +190,7 @@ impl SpecBackend for BashSpec {
         &self,
         script: &mut String,
         _decls: &mut String,
-        conv: &Converted,
+        conv: &dewasm_test_helper::Converted,
         registered: &[(String, String)],
     ) -> String {
         script.push_str(&conv.source);
@@ -447,4 +451,4 @@ const POSTAMBLE: &str = r#"
 echo "RESULT pass=$PASS fail=$FAIL"
 "#;
 
-spec_suite!(BashSpec);
+dewasm_test_helper::spec_suite!(BashSpec);

--- a/crates/dewasm-backend-bash/tests/wasi_fs_regressions.rs
+++ b/crates/dewasm-backend-bash/tests/wasi_fs_regressions.rs
@@ -8,7 +8,6 @@ use std::process::Command;
 
 use dewasm_backend::Mode;
 use dewasm_backend_bash::{find_bash5, BashBackend};
-use dewasm_test_helper::convert_bytes;
 
 /// A fresh, empty scratch directory keyed by `name`, so cases running in parallel never share host state (the `wasi.rs` helper's shape).
 fn scratch_dir(name: &str) -> PathBuf {
@@ -22,7 +21,7 @@ fn scratch_dir(name: &str) -> PathBuf {
 fn run_module(name: &str, wat_src: &str, glue: &str) -> String {
     let bash = find_bash5().expect("bash >= 5 not found — see docs/testing.md");
     let bytes = wat::parse_str(wat_src).expect("parse wat");
-    let src = convert_bytes(&BashBackend, &bytes, Mode::Library, "prog");
+    let src = dewasm_test_helper::convert_bytes(&BashBackend, &bytes, Mode::Library, "prog");
     let script_path = std::env::temp_dir().join(format!(
         "dewasm-bash-wasi-reg-{name}-{}.sh",
         std::process::id()

--- a/crates/dewasm-backend-bash/tests/wasi_testsuite.rs
+++ b/crates/dewasm-backend-bash/tests/wasi_testsuite.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use dewasm_backend::Backend;
 use dewasm_backend_bash::BashBackend;
-use dewasm_test_helper::{wasi_testsuite_suite, BackendUnderTest, WasiTestsuiteBackend};
+use dewasm_test_helper::BackendUnderTest;
 
 /// Known trial failures with their attribution (ADR-8, policy in ADR-36): `(trial, tag)` — out-of-scope syscalls (timestamps, sockets), the D3 file-symlink-follow limit (pure bash has no `readlink` for path resolution, ADR-34), stat-precision gaps with no `stat` license (dev/ino), the D1 whole-file-buffer divergence, and environ entries bash itself exports (PWD/SHLVL/_), which count-exact `environ_*` assertions cannot absorb (ADR-40).
 const WASI_TESTSUITE_EXPECTED_FAILURES: &[(&str, &str)] = &[
@@ -74,10 +74,10 @@ impl BackendUnderTest for BashWasi {
     }
 }
 
-impl WasiTestsuiteBackend for BashWasi {
+impl dewasm_test_helper::WasiTestsuiteBackend for BashWasi {
     fn expected_failures(&self) -> &'static [(&'static str, &'static str)] {
         WASI_TESTSUITE_EXPECTED_FAILURES
     }
 }
 
-wasi_testsuite_suite!(BashWasi);
+dewasm_test_helper::wasi_testsuite_suite!(BashWasi);

--- a/crates/dewasm-backend-go/tests/convert.rs
+++ b/crates/dewasm-backend-go/tests/convert.rs
@@ -4,6 +4,5 @@
 //! lives in `dewasm-test-helper`.
 
 use dewasm_backend_go::GoBackend;
-use dewasm_test_helper::apps_convert_suite;
 
-apps_convert_suite!(GoBackend);
+dewasm_test_helper::apps_convert_suite!(GoBackend);

--- a/crates/dewasm-backend-go/tests/e2e.rs
+++ b/crates/dewasm-backend-go/tests/e2e.rs
@@ -10,15 +10,7 @@ use std::process::{Command, Output};
 
 use dewasm_backend::Backend;
 use dewasm_backend_go::{find_go, GoBackend};
-use dewasm_test_helper::{
-    alter_ego_rom_path, cowsay_args_e2e, cowsay_stdin_e2e, cpython_hello_e2e, doom_frame_e2e,
-    examples_dir, gzip_e2e, library_add_e2e, libsqlite3_c_api_e2e, nes_frame_e2e, pcap_compile_e2e,
-    qjs_eval_e2e, qjs_file_io_e2e, qjs_repl_pty_e2e, rg_search_e2e, run_command_bytes,
-    shared_table_e2e, sqlite3_callback_binding_e2e, sqlite3_file_c_api_e2e,
-    sqlite3_shell_dbfile_e2e, sqlite3_shell_e2e, standalone_dir_e2e, treesitter_parse_e2e,
-    wasi_import_override_e2e, wasi_root_containment_e2e, wasi_suite, BackendUnderTest, PtyCommand,
-    NES_FRAMES,
-};
+use dewasm_test_helper::BackendUnderTest;
 
 pub struct Go;
 
@@ -36,19 +28,19 @@ impl BackendUnderTest for Go {
         match build_go(source) {
             // A build failure is surfaced as the build `Output` so the caller's `status.success()` assertion reports the compile error.
             Err(build) => build,
-            Ok(bin) => run_command_bytes(Command::new(&bin).args(args), stdin),
+            Ok(bin) => dewasm_test_helper::run_command_bytes(Command::new(&bin).args(args), stdin),
         }
     }
 
     /// Build `source` to the cache binary and run it under a pty. A build failure fails loud (ADR-15): there is no `status` for the caller to inspect on the pty path, so panic with the compiler output.
-    fn pty_command(&self, source: &str, args: &[&str]) -> PtyCommand {
+    fn pty_command(&self, source: &str, args: &[&str]) -> dewasm_test_helper::PtyCommand {
         let bin = build_go(source).unwrap_or_else(|build| {
             panic!(
                 "go build failed for the pty run:\n{}",
                 String::from_utf8_lossy(&build.stderr)
             )
         });
-        PtyCommand {
+        dewasm_test_helper::PtyCommand {
             program: bin,
             args: args.iter().map(|a| a.to_string()).collect(),
             cwd: None,
@@ -64,7 +56,8 @@ impl BackendUnderTest for Go {
         let mut units = BTreeSet::new();
         let mut decls = Vec::new();
         for (wat, name) in modules {
-            let bytes = wat::parse_file(examples_dir().join(wat)).expect("parse wat");
+            let bytes =
+                wat::parse_file(dewasm_test_helper::examples_dir().join(wat)).expect("parse wat");
             let module = dewasm_core::build_module(&bytes).expect("build IR");
             let (src, u) =
                 dewasm_backend_go::generate_program_with_units(&module, name).expect("generate");
@@ -630,7 +623,7 @@ const GO_DOOM_FRAME_GLUE: &str = r#"func main() {
 /// data segments (`Rt.unhex`, `f0`'s `p.memory.init` call in a converted
 /// `nes.wasm`).
 fn go_nes_frame_glue() -> String {
-    let rom = std::fs::read(alter_ego_rom_path())
+    let rom = std::fs::read(dewasm_test_helper::alter_ego_rom_path())
         .expect("read alter_ego_rom_path — see examples/apps/scripts/nes.sh");
     let mut literal = String::with_capacity(rom.len() * 4 + 2);
     literal.push('"');
@@ -669,45 +662,45 @@ fn go_nes_frame_glue() -> String {
 }}
 "#,
         literal = literal,
-        frames = NES_FRAMES,
+        frames = dewasm_test_helper::NES_FRAMES,
     )
 }
 
 // --------------------------------------------------------------------- Suite wiring (ADR-27): each per-case macro invocation declares participation.
 
-library_add_e2e!(Go, GO_ADD_GLUE);
-wasi_import_override_e2e!(Go, GO_OVERRIDE_GLUE);
+dewasm_test_helper::library_add_e2e!(Go, GO_ADD_GLUE);
+dewasm_test_helper::wasi_import_override_e2e!(Go, GO_OVERRIDE_GLUE);
 // custom_wasi_provider_e2e! / partial_override_e2e!: not invoked — Go's bundled WASI is eagerly constructed in the ctor and there is no provider-object import form (ADR-29), so the lazy-construction observable cannot hold. stdio_capture_e2e!: not invoked — Go's WASI fds hold *os.File only; no io.Writer indirection to inject an in-memory buffer (ADR-29).
 
-wasi_suite!(Go, Stdio);
-wasi_suite!(Go, ArgsEnv);
-wasi_suite!(Go, Poll);
-wasi_suite!(Go, Fs, GO_FS_GLUE);
-wasi_root_containment_e2e!(Go, GO_CONTAINMENT_GLUE);
-standalone_dir_e2e!(Go);
+dewasm_test_helper::wasi_suite!(Go, Stdio);
+dewasm_test_helper::wasi_suite!(Go, ArgsEnv);
+dewasm_test_helper::wasi_suite!(Go, Poll);
+dewasm_test_helper::wasi_suite!(Go, Fs, GO_FS_GLUE);
+dewasm_test_helper::wasi_root_containment_e2e!(Go, GO_CONTAINMENT_GLUE);
+dewasm_test_helper::standalone_dir_e2e!(Go);
 
-cowsay_args_e2e!(Go);
-cowsay_stdin_e2e!(Go);
+dewasm_test_helper::cowsay_args_e2e!(Go);
+dewasm_test_helper::cowsay_stdin_e2e!(Go);
 // The `ultra`-tier cases (ADR-48) are the giant-generated-program `go build`s that individually ran ~1 min+ and collectively exhausted a 4-core CI runner's memory (SIGTERM, #23): kept out of CI's `slow_test` sweep, run only under `--features ultra_slow_test` or `-- --include-ignored`. The other giant builds (`qjs_repl_pty`, `sqlite3_shell_dbfile`, `pcap_compile`, `treesitter_parse`) stayed under the ~1-min bar and remain at the `slow` tier.
-qjs_eval_e2e!(Go, ultra);
-sqlite3_shell_e2e!(Go, ultra);
-gzip_e2e!(Go);
+dewasm_test_helper::qjs_eval_e2e!(Go, ultra);
+dewasm_test_helper::sqlite3_shell_e2e!(Go, ultra);
+dewasm_test_helper::gzip_e2e!(Go);
 
-qjs_file_io_e2e!(Go, GO_QJS_FILE_IO_GLUE, ultra);
-sqlite3_shell_dbfile_e2e!(Go, GO_SQLITE3_SHELL_GLUE);
-rg_search_e2e!(Go, GO_RG_SEARCH_GLUE, ultra);
-cpython_hello_e2e!(Go, GO_CPYTHON_GLUE, ultra);
+dewasm_test_helper::qjs_file_io_e2e!(Go, GO_QJS_FILE_IO_GLUE, ultra);
+dewasm_test_helper::sqlite3_shell_dbfile_e2e!(Go, GO_SQLITE3_SHELL_GLUE);
+dewasm_test_helper::rg_search_e2e!(Go, GO_RG_SEARCH_GLUE, ultra);
+dewasm_test_helper::cpython_hello_e2e!(Go, GO_CPYTHON_GLUE, ultra);
 // cruby_hello_e2e! / cruby_packed_hello_e2e!: not invoked — the ~35 MB CRuby wasm's ~242 MB Go source exceeds the ADR-24 ~5-minute practicality bar under `go build` (measured >6 min), and the 49 MB wasi-vfs-packed variant (ADR-61) is the same interpreter plus embedded stdlib, strictly larger; see docs/apps-audit.md.
-qjs_repl_pty_e2e!(Go);
+dewasm_test_helper::qjs_repl_pty_e2e!(Go);
 
-libsqlite3_c_api_e2e!(Go, GO_LIBSQLITE3_MEM, ultra);
-sqlite3_file_c_api_e2e!(Go, GO_LIBSQLITE3_FILE, ultra);
-sqlite3_callback_binding_e2e!(Go, GO_SQLITE3_CALLBACK, ultra);
-pcap_compile_e2e!(Go, GO_PCAP_COMPILE);
-treesitter_parse_e2e!(Go, GO_TREESITTER_PARSE);
+dewasm_test_helper::libsqlite3_c_api_e2e!(Go, GO_LIBSQLITE3_MEM, ultra);
+dewasm_test_helper::sqlite3_file_c_api_e2e!(Go, GO_LIBSQLITE3_FILE, ultra);
+dewasm_test_helper::sqlite3_callback_binding_e2e!(Go, GO_SQLITE3_CALLBACK, ultra);
+dewasm_test_helper::pcap_compile_e2e!(Go, GO_PCAP_COMPILE);
+dewasm_test_helper::treesitter_parse_e2e!(Go, GO_TREESITTER_PARSE);
 
-doom_frame_e2e!(Go, GO_DOOM_FRAME_GLUE);
-nes_frame_e2e!(Go, &go_nes_frame_glue());
+dewasm_test_helper::doom_frame_e2e!(Go, GO_DOOM_FRAME_GLUE);
+dewasm_test_helper::nes_frame_e2e!(Go, &go_nes_frame_glue());
 
-shared_table_e2e!(Go, GO_SHARED_TABLE_GLUE);
+dewasm_test_helper::shared_table_e2e!(Go, GO_SHARED_TABLE_GLUE);
 // embedded_coexist_e2e!: not invoked — a single flat top-level runtime is shared by all modules (ADR-29); two independent runtimes cannot coexist.

--- a/crates/dewasm-backend-go/tests/spec.rs
+++ b/crates/dewasm-backend-go/tests/spec.rs
@@ -14,7 +14,7 @@ use std::process::{Command, Output};
 use dewasm_backend::Backend;
 use dewasm_backend_go::{find_go, GoBackend};
 use dewasm_core::ir;
-use dewasm_test_helper::{run_command_bytes, spec_suite, BackendUnderTest, Converted, SpecBackend};
+use dewasm_test_helper::BackendUnderTest;
 use wast::core::{AbstractHeapType, HeapType, NanPattern, WastArgCore, WastRetCore};
 use wast::{WastArg, WastRet};
 
@@ -160,13 +160,13 @@ impl BackendUnderTest for GoSpec {
             let _ = std::fs::rename(&tmp_bin, &bin);
         }
 
-        run_command_bytes(Command::new(&bin).args(args), stdin)
+        dewasm_test_helper::run_command_bytes(Command::new(&bin).args(args), stdin)
     }
 }
 
 static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
-impl SpecBackend for GoSpec {
+impl dewasm_test_helper::SpecBackend for GoSpec {
     fn expected_failures(&self) -> &'static [(&'static str, u32, &'static str)] {
         EXPECTED_FAILURES
     }
@@ -190,10 +190,14 @@ impl SpecBackend for GoSpec {
         ]
     }
 
-    fn generate(&self, module: &ir::Module, counter: u32) -> anyhow::Result<Converted> {
+    fn generate(
+        &self,
+        module: &ir::Module,
+        counter: u32,
+    ) -> anyhow::Result<dewasm_test_helper::Converted> {
         let type_name = format!("WastMod{counter}");
         let (source, units) = dewasm_backend_go::generate_program_with_units(module, &type_name)?;
-        Ok(Converted {
+        Ok(dewasm_test_helper::Converted {
             source,
             handle: type_name,
             units,
@@ -208,7 +212,7 @@ impl SpecBackend for GoSpec {
         &self,
         script: &mut String,
         decls: &mut String,
-        conv: &Converted,
+        conv: &dewasm_test_helper::Converted,
         var_id: u32,
         registered: &[(String, String)],
     ) -> String {
@@ -229,7 +233,7 @@ impl SpecBackend for GoSpec {
         &self,
         script: &mut String,
         decls: &mut String,
-        conv: &Converted,
+        conv: &dewasm_test_helper::Converted,
         registered: &[(String, String)],
     ) -> String {
         let _ = script;
@@ -587,4 +591,4 @@ var _spectest = map[string]any{
 }
 "#;
 
-spec_suite!(GoSpec);
+dewasm_test_helper::spec_suite!(GoSpec);

--- a/crates/dewasm-backend-go/tests/wasi_testsuite.rs
+++ b/crates/dewasm-backend-go/tests/wasi_testsuite.rs
@@ -7,9 +7,7 @@ use std::process::{Command, Output};
 
 use dewasm_backend::Backend;
 use dewasm_backend_go::{find_go, GoBackend};
-use dewasm_test_helper::{
-    wasi_testsuite_suite, BackendUnderTest, PtyCommand, WasiTestsuiteBackend,
-};
+use dewasm_test_helper::BackendUnderTest;
 
 /// Known trial failures with their attribution (ADR-8, policy in ADR-40): `(trial, tag)` — out-of-scope syscalls and the one std-portability gap the full WASI p1 filesystem support (ADR-40) cannot close on Go.
 const WASI_TESTSUITE_EXPECTED_FAILURES: &[(&str, &str)] = &[
@@ -37,14 +35,14 @@ impl BackendUnderTest for GoWasi {
     }
 
     /// Build `source` to the content-addressed cache binary and return the run recipe. A missing `go` toolchain fails loud (ADR-15); a build failure panics (generated code that does not compile is a bug, not a WASI gap).
-    fn pty_command(&self, source: &str, args: &[&str]) -> PtyCommand {
+    fn pty_command(&self, source: &str, args: &[&str]) -> dewasm_test_helper::PtyCommand {
         let bin = build_go(source).unwrap_or_else(|build| {
             panic!(
                 "go build failed:\n{}",
                 String::from_utf8_lossy(&build.stderr)
             )
         });
-        PtyCommand {
+        dewasm_test_helper::PtyCommand {
             program: bin,
             args: args.iter().map(|a| a.to_string()).collect(),
             cwd: None,
@@ -89,10 +87,10 @@ fn build_go(source: &str) -> Result<PathBuf, Output> {
     Ok(bin)
 }
 
-impl WasiTestsuiteBackend for GoWasi {
+impl dewasm_test_helper::WasiTestsuiteBackend for GoWasi {
     fn expected_failures(&self) -> &'static [(&'static str, &'static str)] {
         WASI_TESTSUITE_EXPECTED_FAILURES
     }
 }
 
-wasi_testsuite_suite!(GoWasi);
+dewasm_test_helper::wasi_testsuite_suite!(GoWasi);

--- a/crates/dewasm-backend-java/tests/convert.rs
+++ b/crates/dewasm-backend-java/tests/convert.rs
@@ -4,6 +4,5 @@
 //! lives in `dewasm-test-helper`.
 
 use dewasm_backend_java::JavaBackend;
-use dewasm_test_helper::apps_convert_suite;
 
-apps_convert_suite!(JavaBackend);
+dewasm_test_helper::apps_convert_suite!(JavaBackend);

--- a/crates/dewasm-backend-java/tests/e2e.rs
+++ b/crates/dewasm-backend-java/tests/e2e.rs
@@ -6,14 +6,7 @@ use std::process::{Command, Output};
 
 use dewasm_backend::Backend;
 use dewasm_backend_java::{find_java, JavaBackend};
-use dewasm_test_helper::{
-    cowsay_args_e2e, cowsay_stdin_e2e, doom_frame_e2e, examples_dir, gzip_e2e, library_add_e2e,
-    libsqlite3_c_api_e2e, nes_frame_e2e, qjs_eval_e2e, qjs_file_io_e2e, qjs_repl_pty_e2e,
-    rg_search_e2e, run_command_bytes, shared_table_e2e, sqlite3_callback_binding_e2e,
-    sqlite3_file_c_api_e2e, sqlite3_shell_dbfile_e2e, sqlite3_shell_e2e, standalone_dir_e2e,
-    stdio_capture_e2e, wasi_import_override_e2e, wasi_root_containment_e2e, wasi_suite,
-    BackendUnderTest, PtyCommand,
-};
+use dewasm_test_helper::BackendUnderTest;
 
 mod common;
 
@@ -37,7 +30,7 @@ impl BackendUnderTest for Java {
         match build_java(source) {
             // A compile failure is surfaced as the `javac` `Output` so the caller's `status.success()` assertion reports it.
             Err(build) => build,
-            Ok(classdir) => run_command_bytes(
+            Ok(classdir) => dewasm_test_helper::run_command_bytes(
                 Command::new(&java)
                     .arg("-cp")
                     .arg(&classdir)
@@ -49,7 +42,7 @@ impl BackendUnderTest for Java {
     }
 
     /// Compile `source` and run `java -cp <classdir> Main <args...>` under a pty. A compile failure fails loud (ADR-15): there is no `status` for the caller to inspect on the pty path, so panic with the `javac` output.
-    fn pty_command(&self, source: &str, args: &[&str]) -> PtyCommand {
+    fn pty_command(&self, source: &str, args: &[&str]) -> dewasm_test_helper::PtyCommand {
         let java =
             find_java().expect("java not found on PATH (or $DEWASM_JAVA) — see docs/testing.md");
         let classdir = build_java(source).unwrap_or_else(|build| {
@@ -64,7 +57,7 @@ impl BackendUnderTest for Java {
             "Main".to_string(),
         ];
         argv.extend(args.iter().map(|a| a.to_string()));
-        PtyCommand {
+        dewasm_test_helper::PtyCommand {
             program: java,
             args: argv,
             cwd: None,
@@ -80,7 +73,8 @@ impl BackendUnderTest for Java {
         let mut units = std::collections::BTreeSet::new();
         let mut classes = Vec::new();
         for (wat, name) in modules {
-            let bytes = wat::parse_file(examples_dir().join(wat)).expect("parse wat");
+            let bytes =
+                wat::parse_file(dewasm_test_helper::examples_dir().join(wat)).expect("parse wat");
             let module = dewasm_core::build_module(&bytes).expect("build IR");
             let (src, u) =
                 dewasm_backend_java::generate_program_with_units(&module, name).expect("generate");
@@ -519,36 +513,36 @@ const JAVA_NES_FRAME_GLUE: &str = r#"public class Main {
 
 // --------------------------------------------------------------------- Suite wiring (ADR-27): each per-case macro invocation declares participation.
 
-library_add_e2e!(Java, JAVA_ADD_GLUE);
-wasi_import_override_e2e!(Java, JAVA_OVERRIDE_GLUE);
-stdio_capture_e2e!(Java, JAVA_STDIO_CAPTURE_GLUE);
+dewasm_test_helper::library_add_e2e!(Java, JAVA_ADD_GLUE);
+dewasm_test_helper::wasi_import_override_e2e!(Java, JAVA_OVERRIDE_GLUE);
+dewasm_test_helper::stdio_capture_e2e!(Java, JAVA_STDIO_CAPTURE_GLUE);
 // custom_wasi_provider_e2e! / partial_override_e2e!: not invoked — Java's bundled WASI is eagerly constructed in the ctor and there is no provider-object import form (ADR-30), so the lazy-construction observable cannot hold.
 
-wasi_suite!(Java, Stdio);
-wasi_suite!(Java, ArgsEnv);
-wasi_suite!(Java, Poll);
-wasi_suite!(Java, Fs, JAVA_FS_GLUE);
-wasi_root_containment_e2e!(Java, JAVA_CONTAINMENT_GLUE);
-standalone_dir_e2e!(Java);
+dewasm_test_helper::wasi_suite!(Java, Stdio);
+dewasm_test_helper::wasi_suite!(Java, ArgsEnv);
+dewasm_test_helper::wasi_suite!(Java, Poll);
+dewasm_test_helper::wasi_suite!(Java, Fs, JAVA_FS_GLUE);
+dewasm_test_helper::wasi_root_containment_e2e!(Java, JAVA_CONTAINMENT_GLUE);
+dewasm_test_helper::standalone_dir_e2e!(Java);
 
-cowsay_args_e2e!(Java);
-cowsay_stdin_e2e!(Java);
-qjs_eval_e2e!(Java);
-sqlite3_shell_e2e!(Java);
-gzip_e2e!(Java);
+dewasm_test_helper::cowsay_args_e2e!(Java);
+dewasm_test_helper::cowsay_stdin_e2e!(Java);
+dewasm_test_helper::qjs_eval_e2e!(Java);
+dewasm_test_helper::sqlite3_shell_e2e!(Java);
+dewasm_test_helper::gzip_e2e!(Java);
 
-qjs_file_io_e2e!(Java, JAVA_QJS_FILE_IO_GLUE);
-sqlite3_shell_dbfile_e2e!(Java, JAVA_SQLITE3_SHELL_GLUE);
-rg_search_e2e!(Java, JAVA_RG_SEARCH_GLUE);
+dewasm_test_helper::qjs_file_io_e2e!(Java, JAVA_QJS_FILE_IO_GLUE);
+dewasm_test_helper::sqlite3_shell_dbfile_e2e!(Java, JAVA_SQLITE3_SHELL_GLUE);
+dewasm_test_helper::rg_search_e2e!(Java, JAVA_RG_SEARCH_GLUE);
 // cpython_hello_e2e!: not invoked — a CPython interpreter method overflows the JVM 64 KB per-method bytecode limit (`code too large`); the ADR-30 class-splitter does not subdivide individual methods (a hard limit; see docs/apps-audit.md). cruby_hello_e2e! / cruby_packed_hello_e2e!: not invoked — the CRuby element-segment `Elem` class overflows the JVM 64 K constant-pool limit (`too many constants`), a hard limit shared by the wasi-vfs-packed variant (ADR-61), whose element segments are the same interpreter's (docs/apps-audit.md).
-qjs_repl_pty_e2e!(Java);
+dewasm_test_helper::qjs_repl_pty_e2e!(Java);
 
-libsqlite3_c_api_e2e!(Java, JAVA_LIBSQLITE3_MEM);
-sqlite3_file_c_api_e2e!(Java, JAVA_LIBSQLITE3_FILE);
-sqlite3_callback_binding_e2e!(Java, JAVA_SQLITE3_CALLBACK);
+dewasm_test_helper::libsqlite3_c_api_e2e!(Java, JAVA_LIBSQLITE3_MEM);
+dewasm_test_helper::sqlite3_file_c_api_e2e!(Java, JAVA_LIBSQLITE3_FILE);
+dewasm_test_helper::sqlite3_callback_binding_e2e!(Java, JAVA_SQLITE3_CALLBACK);
 
-doom_frame_e2e!(Java, JAVA_DOOM_FRAME_GLUE);
-nes_frame_e2e!(Java, JAVA_NES_FRAME_GLUE);
+dewasm_test_helper::doom_frame_e2e!(Java, JAVA_DOOM_FRAME_GLUE);
+dewasm_test_helper::nes_frame_e2e!(Java, JAVA_NES_FRAME_GLUE);
 
-shared_table_e2e!(Java, JAVA_SHARED_TABLE_GLUE);
+dewasm_test_helper::shared_table_e2e!(Java, JAVA_SHARED_TABLE_GLUE);
 // embedded_coexist_e2e!: not invoked — a single flat top-level runtime is shared by all modules (ADR-30); two independent runtimes cannot coexist.

--- a/crates/dewasm-backend-java/tests/memory_grow.rs
+++ b/crates/dewasm-backend-java/tests/memory_grow.rs
@@ -6,7 +6,6 @@ use std::process::{Command, Output};
 
 use dewasm_backend::Mode;
 use dewasm_backend_java::{find_java, JavaBackend};
-use dewasm_test_helper::convert_bytes;
 
 mod common;
 
@@ -17,7 +16,7 @@ fn convert_and_run(wat: &str, glue: &str) -> Output {
     let bytes = wat::parse_str(wat).expect("parse wat");
     let source = format!(
         "{}\n{glue}",
-        convert_bytes(&JavaBackend, &bytes, Mode::Library, "prog")
+        dewasm_test_helper::convert_bytes(&JavaBackend, &bytes, Mode::Library, "prog")
     );
 
     let classdir = common::build_java(&source).unwrap_or_else(|build| {

--- a/crates/dewasm-backend-java/tests/spec.rs
+++ b/crates/dewasm-backend-java/tests/spec.rs
@@ -11,7 +11,7 @@ use std::process::{Command, Output};
 use dewasm_backend::Backend;
 use dewasm_backend_java::{find_java, JavaBackend};
 use dewasm_core::ir;
-use dewasm_test_helper::{run_command_bytes, spec_suite, BackendUnderTest, Converted, SpecBackend};
+use dewasm_test_helper::BackendUnderTest;
 use wast::core::{AbstractHeapType, HeapType, NanPattern, WastArgCore, WastRetCore};
 use wast::{WastArg, WastRet};
 
@@ -133,7 +133,7 @@ impl BackendUnderTest for JavaSpec {
             Ok(classdir) => classdir,
         };
 
-        run_command_bytes(
+        dewasm_test_helper::run_command_bytes(
             // A generous per-thread stack keeps genuinely deep but terminating recursions (fac, deep br chains) under the limit while a runaway still overflows into a catchable StackOverflowError (ADR-30).
             Command::new(&java)
                 .arg("-Xss16m")
@@ -146,7 +146,7 @@ impl BackendUnderTest for JavaSpec {
     }
 }
 
-impl SpecBackend for JavaSpec {
+impl dewasm_test_helper::SpecBackend for JavaSpec {
     fn expected_failures(&self) -> &'static [(&'static str, u32, &'static str)] {
         EXPECTED_FAILURES
     }
@@ -167,10 +167,14 @@ impl SpecBackend for JavaSpec {
         ]
     }
 
-    fn generate(&self, module: &ir::Module, counter: u32) -> anyhow::Result<Converted> {
+    fn generate(
+        &self,
+        module: &ir::Module,
+        counter: u32,
+    ) -> anyhow::Result<dewasm_test_helper::Converted> {
         let type_name = format!("WastMod{counter}");
         let (source, units) = dewasm_backend_java::generate_program_with_units(module, &type_name)?;
-        Ok(Converted {
+        Ok(dewasm_test_helper::Converted {
             source,
             handle: type_name,
             units,
@@ -185,7 +189,7 @@ impl SpecBackend for JavaSpec {
         &self,
         script: &mut String,
         decls: &mut String,
-        conv: &Converted,
+        conv: &dewasm_test_helper::Converted,
         var_id: u32,
         registered: &[(String, String)],
     ) -> String {
@@ -204,7 +208,7 @@ impl SpecBackend for JavaSpec {
         &self,
         script: &mut String,
         decls: &mut String,
-        conv: &Converted,
+        conv: &dewasm_test_helper::Converted,
         registered: &[(String, String)],
     ) -> String {
         let _ = script;
@@ -532,4 +536,4 @@ const POSTAMBLE: &str = r#"        System.out.println("RESULT pass=" + _pass + "
 }
 "#;
 
-spec_suite!(JavaSpec);
+dewasm_test_helper::spec_suite!(JavaSpec);

--- a/crates/dewasm-backend-java/tests/wasi_testsuite.rs
+++ b/crates/dewasm-backend-java/tests/wasi_testsuite.rs
@@ -2,9 +2,7 @@
 
 use dewasm_backend::Backend;
 use dewasm_backend_java::{find_java, JavaBackend};
-use dewasm_test_helper::{
-    wasi_testsuite_suite, BackendUnderTest, PtyCommand, WasiTestsuiteBackend,
-};
+use dewasm_test_helper::BackendUnderTest;
 
 mod common;
 
@@ -51,7 +49,7 @@ impl BackendUnderTest for JavaWasi {
     }
 
     /// Compile `source` (one `Main.java`) to the content-addressed class-dir cache and return the run recipe. A missing `javac`/`java` fails loud (ADR-15); a compile failure panics (generated code that does not compile is a bug, not a WASI gap).
-    fn pty_command(&self, source: &str, args: &[&str]) -> PtyCommand {
+    fn pty_command(&self, source: &str, args: &[&str]) -> dewasm_test_helper::PtyCommand {
         let java =
             find_java().expect("java not found on PATH (or $DEWASM_JAVA) — see docs/testing.md");
         let classdir = build_java(source).unwrap_or_else(|build| {
@@ -64,7 +62,7 @@ impl BackendUnderTest for JavaWasi {
             "Main".to_string(),
         ];
         argv.extend(args.iter().map(|a| a.to_string()));
-        PtyCommand {
+        dewasm_test_helper::PtyCommand {
             program: java,
             args: argv,
             cwd: None,
@@ -72,7 +70,7 @@ impl BackendUnderTest for JavaWasi {
     }
 }
 
-impl WasiTestsuiteBackend for JavaWasi {
+impl dewasm_test_helper::WasiTestsuiteBackend for JavaWasi {
     fn expected_failures(&self) -> &'static [(&'static str, &'static str)] {
         WASI_TESTSUITE_EXPECTED_FAILURES
     }
@@ -86,4 +84,4 @@ impl WasiTestsuiteBackend for JavaWasi {
     }
 }
 
-wasi_testsuite_suite!(JavaWasi);
+dewasm_test_helper::wasi_testsuite_suite!(JavaWasi);

--- a/crates/dewasm-backend-perl/tests/convert.rs
+++ b/crates/dewasm-backend-perl/tests/convert.rs
@@ -4,6 +4,5 @@
 //! `dewasm-test-helper`.
 
 use dewasm_backend_perl::PerlBackend;
-use dewasm_test_helper::apps_convert_suite;
 
-apps_convert_suite!(PerlBackend);
+dewasm_test_helper::apps_convert_suite!(PerlBackend);

--- a/crates/dewasm-backend-perl/tests/e2e.rs
+++ b/crates/dewasm-backend-perl/tests/e2e.rs
@@ -4,17 +4,7 @@ use std::path::PathBuf;
 
 use dewasm_backend::{Backend, Mode, RuntimeLinkage};
 use dewasm_backend_perl::{find_perl, PerlBackend};
-use dewasm_test_helper::{
-    convert, cowsay_args_e2e, cowsay_stdin_e2e, cpython_hello_e2e, cruby_hello_e2e,
-    cruby_packed_hello_e2e, custom_wasi_provider_e2e, deep_recursion_e2e, doom_frame_e2e,
-    embedded_coexist_e2e, examples_dir, exiftool_extract_e2e, gzip_e2e, library_add_e2e,
-    libsqlite3_c_api_e2e, nes_frame_e2e, partial_override_e2e, pcap_compile_e2e, qjs_eval_e2e,
-    qjs_file_io_e2e, qjs_repl_pty_e2e, rg_search_e2e, shared_table_e2e,
-    sqlite3_callback_binding_e2e, sqlite3_file_c_api_e2e, sqlite3_shell_dbfile_e2e,
-    sqlite3_shell_e2e, standalone_dir_e2e, stdio_capture_e2e, treesitter_parse_e2e,
-    wasi_import_override_e2e, wasi_root_containment_e2e, wasi_suite, zeroperl_eval_e2e,
-    BackendUnderTest,
-};
+use dewasm_test_helper::BackendUnderTest;
 
 pub struct Perl;
 
@@ -38,7 +28,8 @@ impl BackendUnderTest for Perl {
             let mut units = std::collections::BTreeSet::new();
             let mut pkgs = Vec::new();
             for (wat, name) in modules {
-                let bytes = wat::parse_file(examples_dir().join(wat)).expect("parse wat");
+                let bytes = wat::parse_file(dewasm_test_helper::examples_dir().join(wat))
+                    .expect("parse wat");
                 let module = dewasm_core::build_module(&bytes).expect("build IR");
                 let (src, u) = dewasm_backend_perl::generate_package_with_units(
                     &module,
@@ -59,7 +50,12 @@ impl BackendUnderTest for Perl {
             modules
                 .iter()
                 .map(|(wat, name)| {
-                    convert(&PerlBackend, &examples_dir().join(wat), Mode::Library, name)
+                    dewasm_test_helper::convert(
+                        &PerlBackend,
+                        &dewasm_test_helper::examples_dir().join(wat),
+                        Mode::Library,
+                        name,
+                    )
                 })
                 .collect::<Vec<_>>()
                 .join("\n")
@@ -547,48 +543,48 @@ print "trapped\n" if ref($e) && $e->isa('Alpha::Rt::Trap');
 
 // --------------------------------------------------------------------- Suite wiring (ADR-27): each per-case macro invocation declares participation.
 
-library_add_e2e!(Perl, PERL_ADD_GLUE);
-wasi_import_override_e2e!(Perl, PERL_OVERRIDE_GLUE);
-custom_wasi_provider_e2e!(Perl, PERL_CUSTOM_PROVIDER_GLUE);
-partial_override_e2e!(Perl, PERL_PARTIAL_OVERRIDE_GLUE);
-stdio_capture_e2e!(Perl, PERL_STDIO_CAPTURE_GLUE);
+dewasm_test_helper::library_add_e2e!(Perl, PERL_ADD_GLUE);
+dewasm_test_helper::wasi_import_override_e2e!(Perl, PERL_OVERRIDE_GLUE);
+dewasm_test_helper::custom_wasi_provider_e2e!(Perl, PERL_CUSTOM_PROVIDER_GLUE);
+dewasm_test_helper::partial_override_e2e!(Perl, PERL_PARTIAL_OVERRIDE_GLUE);
+dewasm_test_helper::stdio_capture_e2e!(Perl, PERL_STDIO_CAPTURE_GLUE);
 
-wasi_suite!(Perl, Stdio);
-wasi_suite!(Perl, ArgsEnv);
-wasi_suite!(Perl, Poll);
-wasi_suite!(Perl, Fs, PERL_FS_GLUE);
-wasi_root_containment_e2e!(Perl, PERL_CONTAINMENT_GLUE);
-standalone_dir_e2e!(Perl);
+dewasm_test_helper::wasi_suite!(Perl, Stdio);
+dewasm_test_helper::wasi_suite!(Perl, ArgsEnv);
+dewasm_test_helper::wasi_suite!(Perl, Poll);
+dewasm_test_helper::wasi_suite!(Perl, Fs, PERL_FS_GLUE);
+dewasm_test_helper::wasi_root_containment_e2e!(Perl, PERL_CONTAINMENT_GLUE);
+dewasm_test_helper::standalone_dir_e2e!(Perl);
 // Perl recursion is heap-allocated (no host stack to overflow, ADR-55); the case pins that the entrypoint still surfaces proc_exit(42) through deep guest recursion.
-deep_recursion_e2e!(Perl);
+dewasm_test_helper::deep_recursion_e2e!(Perl);
 
-cowsay_args_e2e!(Perl);
-cowsay_stdin_e2e!(Perl);
-qjs_eval_e2e!(Perl);
-sqlite3_shell_e2e!(Perl);
-gzip_e2e!(Perl);
+dewasm_test_helper::cowsay_args_e2e!(Perl);
+dewasm_test_helper::cowsay_stdin_e2e!(Perl);
+dewasm_test_helper::qjs_eval_e2e!(Perl);
+dewasm_test_helper::sqlite3_shell_e2e!(Perl);
+dewasm_test_helper::gzip_e2e!(Perl);
 
-qjs_file_io_e2e!(Perl, PERL_QJS_FILE_IO_GLUE);
-sqlite3_shell_dbfile_e2e!(Perl, PERL_SQLITE3_SHELL_GLUE);
-rg_search_e2e!(Perl, PERL_RG_SEARCH_GLUE);
-cpython_hello_e2e!(Perl, PERL_CPYTHON_GLUE);
+dewasm_test_helper::qjs_file_io_e2e!(Perl, PERL_QJS_FILE_IO_GLUE);
+dewasm_test_helper::sqlite3_shell_dbfile_e2e!(Perl, PERL_SQLITE3_SHELL_GLUE);
+dewasm_test_helper::rg_search_e2e!(Perl, PERL_RG_SEARCH_GLUE);
+dewasm_test_helper::cpython_hello_e2e!(Perl, PERL_CPYTHON_GLUE);
 // Ultra tier (ADR-48): measured ~57s locally (CRuby-on-Perl), which crosses the ~1-minute CI-runner line the other backends' cruby cases stay under. The packed variant is the same interpreter plus the wizer-embedded stdlib (ADR-61), so it inherits the tier.
-cruby_hello_e2e!(Perl, PERL_CRUBY_GLUE, ultra);
-cruby_packed_hello_e2e!(Perl, ultra);
-qjs_repl_pty_e2e!(Perl);
+dewasm_test_helper::cruby_hello_e2e!(Perl, PERL_CRUBY_GLUE, ultra);
+dewasm_test_helper::cruby_packed_hello_e2e!(Perl, ultra);
+dewasm_test_helper::qjs_repl_pty_e2e!(Perl);
 
-libsqlite3_c_api_e2e!(Perl, PERL_LIBSQLITE3_MEM);
-sqlite3_file_c_api_e2e!(Perl, PERL_LIBSQLITE3_FILE);
-sqlite3_callback_binding_e2e!(Perl, PERL_SQLITE3_CALLBACK);
-pcap_compile_e2e!(Perl, PERL_PCAP_COMPILE);
-treesitter_parse_e2e!(Perl, PERL_TREESITTER_PARSE);
-zeroperl_eval_e2e!(Perl, PERL_ZEROPERL_EVAL);
+dewasm_test_helper::libsqlite3_c_api_e2e!(Perl, PERL_LIBSQLITE3_MEM);
+dewasm_test_helper::sqlite3_file_c_api_e2e!(Perl, PERL_LIBSQLITE3_FILE);
+dewasm_test_helper::sqlite3_callback_binding_e2e!(Perl, PERL_SQLITE3_CALLBACK);
+dewasm_test_helper::pcap_compile_e2e!(Perl, PERL_PCAP_COMPILE);
+dewasm_test_helper::treesitter_parse_e2e!(Perl, PERL_TREESITTER_PARSE);
+dewasm_test_helper::zeroperl_eval_e2e!(Perl, PERL_ZEROPERL_EVAL);
 // Ultra tier (ADR-48): measured ~75s locally (ExifTool-on-zeroperl-on-Perl), well past the ~1-minute CI-runner line; the zeroperl_eval case above (~7s: same convert + host-perl compile, tiny guest program) pins the embedding path at the slow tier.
-exiftool_extract_e2e!(Perl, PERL_EXIFTOOL, ultra);
+dewasm_test_helper::exiftool_extract_e2e!(Perl, PERL_EXIFTOOL, ultra);
 
 // Slow tier like Ruby/Python (ADR-53): measured ~10s locally (convert + initGame + 2 ticks), nowhere near the ~1-minute ultra line.
-doom_frame_e2e!(Perl, PERL_DOOM_FRAME_GLUE);
-nes_frame_e2e!(Perl, PERL_NES_FRAME_GLUE);
+dewasm_test_helper::doom_frame_e2e!(Perl, PERL_DOOM_FRAME_GLUE);
+dewasm_test_helper::nes_frame_e2e!(Perl, PERL_NES_FRAME_GLUE);
 
-shared_table_e2e!(Perl, PERL_SHARED_TABLE_GLUE);
-embedded_coexist_e2e!(Perl, PERL_EMBEDDED_COEXIST_GLUE);
+dewasm_test_helper::shared_table_e2e!(Perl, PERL_SHARED_TABLE_GLUE);
+dewasm_test_helper::embedded_coexist_e2e!(Perl, PERL_EMBEDDED_COEXIST_GLUE);

--- a/crates/dewasm-backend-perl/tests/spec.rs
+++ b/crates/dewasm-backend-perl/tests/spec.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 use dewasm_backend::{Backend, RuntimeLinkage};
 use dewasm_backend_perl::PerlBackend;
 use dewasm_core::ir;
-use dewasm_test_helper::{spec_suite, BackendUnderTest, Converted, SpecBackend};
+use dewasm_test_helper::BackendUnderTest;
 use wast::core::{AbstractHeapType, HeapType, NanPattern, WastArgCore, WastRetCore};
 use wast::{WastArg, WastRet};
 
@@ -123,7 +123,7 @@ impl BackendUnderTest for PerlSpec {
     }
 }
 
-impl SpecBackend for PerlSpec {
+impl dewasm_test_helper::SpecBackend for PerlSpec {
     fn expected_failures(&self) -> &'static [(&'static str, u32, &'static str)] {
         EXPECTED_FAILURES
     }
@@ -149,7 +149,11 @@ impl SpecBackend for PerlSpec {
         ]
     }
 
-    fn generate(&self, module: &ir::Module, counter: u32) -> anyhow::Result<Converted> {
+    fn generate(
+        &self,
+        module: &ir::Module,
+        counter: u32,
+    ) -> anyhow::Result<dewasm_test_helper::Converted> {
         let package_name = format!("WastMod{counter}");
         let (source, units) = dewasm_backend_perl::generate_package_with_units(
             module,
@@ -157,7 +161,7 @@ impl SpecBackend for PerlSpec {
             &RuntimeLinkage::Alias("Rt".to_string()),
             false, // spec modules import spectest, never WASI
         )?;
-        Ok(Converted {
+        Ok(dewasm_test_helper::Converted {
             source,
             handle: package_name,
             units,
@@ -172,7 +176,7 @@ impl SpecBackend for PerlSpec {
         &self,
         script: &mut String,
         _decls: &mut String,
-        conv: &Converted,
+        conv: &dewasm_test_helper::Converted,
         var_id: u32,
         registered: &[(String, String)],
     ) -> String {
@@ -191,7 +195,7 @@ impl SpecBackend for PerlSpec {
         &self,
         script: &mut String,
         _decls: &mut String,
-        conv: &Converted,
+        conv: &dewasm_test_helper::Converted,
         registered: &[(String, String)],
     ) -> String {
         script.push_str(&conv.source);
@@ -504,4 +508,4 @@ my $spectest = {
 };
 "#;
 
-spec_suite!(PerlSpec);
+dewasm_test_helper::spec_suite!(PerlSpec);

--- a/crates/dewasm-backend-perl/tests/wasi_testsuite.rs
+++ b/crates/dewasm-backend-perl/tests/wasi_testsuite.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use dewasm_backend::Backend;
 use dewasm_backend_perl::PerlBackend;
-use dewasm_test_helper::{wasi_testsuite_suite, BackendUnderTest, WasiTestsuiteBackend};
+use dewasm_test_helper::BackendUnderTest;
 
 /// Known trial failures with their attribution (ADR-8, policy in ADR-36): `(trial, tag)` — the out-of-scope `sock_shutdown` syscall (docs/support.md), like Ruby/Python. Unlike the Ruby/Python hosts, perl injects no environ entries of its own, so the `environ_*` trials pass without host-scoped entries.
 const WASI_TESTSUITE_EXPECTED_FAILURES: &[(&str, &str)] = &[
@@ -44,10 +44,10 @@ impl BackendUnderTest for PerlWasi {
     }
 }
 
-impl WasiTestsuiteBackend for PerlWasi {
+impl dewasm_test_helper::WasiTestsuiteBackend for PerlWasi {
     fn expected_failures(&self) -> &'static [(&'static str, &'static str)] {
         WASI_TESTSUITE_EXPECTED_FAILURES
     }
 }
 
-wasi_testsuite_suite!(PerlWasi);
+dewasm_test_helper::wasi_testsuite_suite!(PerlWasi);

--- a/crates/dewasm-backend-python/tests/convert.rs
+++ b/crates/dewasm-backend-python/tests/convert.rs
@@ -4,6 +4,5 @@
 //! lives in `dewasm-test-helper`.
 
 use dewasm_backend_python::PythonBackend;
-use dewasm_test_helper::apps_convert_suite;
 
-apps_convert_suite!(PythonBackend);
+dewasm_test_helper::apps_convert_suite!(PythonBackend);

--- a/crates/dewasm-backend-python/tests/e2e.rs
+++ b/crates/dewasm-backend-python/tests/e2e.rs
@@ -4,16 +4,7 @@ use std::path::PathBuf;
 
 use dewasm_backend::{Backend, Mode, RuntimeLinkage};
 use dewasm_backend_python::{find_python, PythonBackend};
-use dewasm_test_helper::{
-    convert, cowsay_args_e2e, cowsay_stdin_e2e, cpython_hello_e2e, cruby_hello_e2e,
-    cruby_packed_hello_e2e, custom_wasi_provider_e2e, deep_recursion_e2e, doom_frame_e2e,
-    examples_dir, gzip_e2e, library_add_e2e, libsqlite3_c_api_e2e, nes_frame_e2e,
-    partial_override_e2e, pcap_compile_e2e, qjs_eval_e2e, qjs_file_io_e2e, qjs_repl_pty_e2e,
-    rg_search_e2e, shared_table_e2e, sqlite3_callback_binding_e2e, sqlite3_file_c_api_e2e,
-    sqlite3_shell_dbfile_e2e, sqlite3_shell_e2e, standalone_dir_e2e, stdio_capture_e2e,
-    treesitter_parse_e2e, wasi_import_override_e2e, wasi_root_containment_e2e, wasi_suite,
-    BackendUnderTest,
-};
+use dewasm_test_helper::BackendUnderTest;
 
 pub struct Python;
 
@@ -36,7 +27,8 @@ impl BackendUnderTest for Python {
             let mut units = std::collections::BTreeSet::new();
             let mut classes = Vec::new();
             for (wat, name) in modules {
-                let bytes = wat::parse_file(examples_dir().join(wat)).expect("parse wat");
+                let bytes = wat::parse_file(dewasm_test_helper::examples_dir().join(wat))
+                    .expect("parse wat");
                 let module = dewasm_core::build_module(&bytes).expect("build IR");
                 let (src, u) = dewasm_backend_python::generate_class_with_units(
                     &module,
@@ -57,9 +49,9 @@ impl BackendUnderTest for Python {
             modules
                 .iter()
                 .map(|(wat, name)| {
-                    convert(
+                    dewasm_test_helper::convert(
                         &PythonBackend,
-                        &examples_dir().join(wat),
+                        &dewasm_test_helper::examples_dir().join(wat),
                         Mode::Library,
                         name,
                     )
@@ -528,43 +520,43 @@ out.flush()
 
 // --------------------------------------------------------------------- Suite wiring (ADR-27): each per-case macro invocation declares participation.
 
-library_add_e2e!(Python, PYTHON_ADD_GLUE);
-wasi_import_override_e2e!(Python, PYTHON_OVERRIDE_GLUE);
-custom_wasi_provider_e2e!(Python, PYTHON_CUSTOM_PROVIDER_GLUE);
-partial_override_e2e!(Python, PYTHON_PARTIAL_OVERRIDE_GLUE);
-stdio_capture_e2e!(Python, PYTHON_STDIO_CAPTURE_GLUE);
+dewasm_test_helper::library_add_e2e!(Python, PYTHON_ADD_GLUE);
+dewasm_test_helper::wasi_import_override_e2e!(Python, PYTHON_OVERRIDE_GLUE);
+dewasm_test_helper::custom_wasi_provider_e2e!(Python, PYTHON_CUSTOM_PROVIDER_GLUE);
+dewasm_test_helper::partial_override_e2e!(Python, PYTHON_PARTIAL_OVERRIDE_GLUE);
+dewasm_test_helper::stdio_capture_e2e!(Python, PYTHON_STDIO_CAPTURE_GLUE);
 
-wasi_suite!(Python, Stdio);
-wasi_suite!(Python, ArgsEnv);
-wasi_suite!(Python, Poll);
-wasi_suite!(Python, Fs, PYTHON_FS_GLUE);
-wasi_root_containment_e2e!(Python, PYTHON_CONTAINMENT_GLUE);
-standalone_dir_e2e!(Python);
+dewasm_test_helper::wasi_suite!(Python, Stdio);
+dewasm_test_helper::wasi_suite!(Python, ArgsEnv);
+dewasm_test_helper::wasi_suite!(Python, Poll);
+dewasm_test_helper::wasi_suite!(Python, Fs, PYTHON_FS_GLUE);
+dewasm_test_helper::wasi_root_containment_e2e!(Python, PYTHON_CONTAINMENT_GLUE);
+dewasm_test_helper::standalone_dir_e2e!(Python);
 // The standalone entrypoint's ADR-28 recursion mitigation (issue #31).
-deep_recursion_e2e!(Python);
+dewasm_test_helper::deep_recursion_e2e!(Python);
 
-cowsay_args_e2e!(Python);
-cowsay_stdin_e2e!(Python);
-qjs_eval_e2e!(Python);
-sqlite3_shell_e2e!(Python);
-gzip_e2e!(Python);
+dewasm_test_helper::cowsay_args_e2e!(Python);
+dewasm_test_helper::cowsay_stdin_e2e!(Python);
+dewasm_test_helper::qjs_eval_e2e!(Python);
+dewasm_test_helper::sqlite3_shell_e2e!(Python);
+dewasm_test_helper::gzip_e2e!(Python);
 
-qjs_file_io_e2e!(Python, PYTHON_QJS_FILE_IO_GLUE);
-sqlite3_shell_dbfile_e2e!(Python, PYTHON_SQLITE3_SHELL_GLUE);
-rg_search_e2e!(Python, PYTHON_RG_SEARCH_GLUE);
-cpython_hello_e2e!(Python, PYTHON_CPYTHON_GLUE);
-cruby_hello_e2e!(Python, PYTHON_CRUBY_GLUE);
-cruby_packed_hello_e2e!(Python);
-qjs_repl_pty_e2e!(Python);
+dewasm_test_helper::qjs_file_io_e2e!(Python, PYTHON_QJS_FILE_IO_GLUE);
+dewasm_test_helper::sqlite3_shell_dbfile_e2e!(Python, PYTHON_SQLITE3_SHELL_GLUE);
+dewasm_test_helper::rg_search_e2e!(Python, PYTHON_RG_SEARCH_GLUE);
+dewasm_test_helper::cpython_hello_e2e!(Python, PYTHON_CPYTHON_GLUE);
+dewasm_test_helper::cruby_hello_e2e!(Python, PYTHON_CRUBY_GLUE);
+dewasm_test_helper::cruby_packed_hello_e2e!(Python);
+dewasm_test_helper::qjs_repl_pty_e2e!(Python);
 
-libsqlite3_c_api_e2e!(Python, PYTHON_LIBSQLITE3_MEM);
-sqlite3_file_c_api_e2e!(Python, PYTHON_LIBSQLITE3_FILE);
-sqlite3_callback_binding_e2e!(Python, PYTHON_SQLITE3_CALLBACK);
-pcap_compile_e2e!(Python, PYTHON_PCAP_COMPILE);
-treesitter_parse_e2e!(Python, PYTHON_TREESITTER_PARSE);
+dewasm_test_helper::libsqlite3_c_api_e2e!(Python, PYTHON_LIBSQLITE3_MEM);
+dewasm_test_helper::sqlite3_file_c_api_e2e!(Python, PYTHON_LIBSQLITE3_FILE);
+dewasm_test_helper::sqlite3_callback_binding_e2e!(Python, PYTHON_SQLITE3_CALLBACK);
+dewasm_test_helper::pcap_compile_e2e!(Python, PYTHON_PCAP_COMPILE);
+dewasm_test_helper::treesitter_parse_e2e!(Python, PYTHON_TREESITTER_PARSE);
 
-doom_frame_e2e!(Python, PYTHON_DOOM_FRAME_GLUE);
-nes_frame_e2e!(Python, PYTHON_NES_FRAME_GLUE);
+dewasm_test_helper::doom_frame_e2e!(Python, PYTHON_DOOM_FRAME_GLUE);
+dewasm_test_helper::nes_frame_e2e!(Python, PYTHON_NES_FRAME_GLUE);
 
-shared_table_e2e!(Python, PYTHON_SHARED_TABLE_GLUE);
+dewasm_test_helper::shared_table_e2e!(Python, PYTHON_SHARED_TABLE_GLUE);
 // embedded_coexist_e2e!: not invoked — Python's library Embedded output emits one top-level `class Rt:` (a sibling, redefined on concatenation), not a per-class nested runtime, so two independent runtimes cannot coexist (docs/apps-audit.md).

--- a/crates/dewasm-backend-python/tests/spec.rs
+++ b/crates/dewasm-backend-python/tests/spec.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 use dewasm_backend::{Backend, RuntimeLinkage};
 use dewasm_backend_python::PythonBackend;
 use dewasm_core::ir;
-use dewasm_test_helper::{spec_suite, BackendUnderTest, Converted, SpecBackend};
+use dewasm_test_helper::BackendUnderTest;
 use wast::core::{AbstractHeapType, HeapType, NanPattern, WastArgCore, WastRetCore};
 use wast::{WastArg, WastRet};
 
@@ -123,7 +123,7 @@ impl BackendUnderTest for PythonSpec {
     }
 }
 
-impl SpecBackend for PythonSpec {
+impl dewasm_test_helper::SpecBackend for PythonSpec {
     fn expected_failures(&self) -> &'static [(&'static str, u32, &'static str)] {
         EXPECTED_FAILURES
     }
@@ -149,7 +149,11 @@ impl SpecBackend for PythonSpec {
         ]
     }
 
-    fn generate(&self, module: &ir::Module, counter: u32) -> anyhow::Result<Converted> {
+    fn generate(
+        &self,
+        module: &ir::Module,
+        counter: u32,
+    ) -> anyhow::Result<dewasm_test_helper::Converted> {
         let class_name = format!("WastMod{counter}");
         let (source, units) = dewasm_backend_python::generate_class_with_units(
             module,
@@ -162,7 +166,7 @@ impl SpecBackend for PythonSpec {
             .strip_prefix("Rt = Rt\n\n\n")
             .unwrap_or(&source)
             .to_string();
-        Ok(Converted {
+        Ok(dewasm_test_helper::Converted {
             source,
             handle: class_name,
             units,
@@ -177,7 +181,7 @@ impl SpecBackend for PythonSpec {
         &self,
         script: &mut String,
         _decls: &mut String,
-        conv: &Converted,
+        conv: &dewasm_test_helper::Converted,
         var_id: u32,
         registered: &[(String, String)],
     ) -> String {
@@ -196,7 +200,7 @@ impl SpecBackend for PythonSpec {
         &self,
         script: &mut String,
         _decls: &mut String,
-        conv: &Converted,
+        conv: &dewasm_test_helper::Converted,
         registered: &[(String, String)],
     ) -> String {
         script.push_str(&conv.source);
@@ -564,4 +568,4 @@ _t.start()
 _t.join()
 "#;
 
-spec_suite!(PythonSpec);
+dewasm_test_helper::spec_suite!(PythonSpec);

--- a/crates/dewasm-backend-python/tests/wasi_testsuite.rs
+++ b/crates/dewasm-backend-python/tests/wasi_testsuite.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use dewasm_backend::Backend;
 use dewasm_backend_python::PythonBackend;
-use dewasm_test_helper::{wasi_testsuite_suite, BackendUnderTest, WasiTestsuiteBackend};
+use dewasm_test_helper::BackendUnderTest;
 
 /// Known trial failures with their attribution (ADR-8, policy in ADR-36): `(trial, tag)` — the out-of-scope `sock_shutdown` syscall and the environ entries the CPython host injects itself, which count-exact `environ_*` assertions cannot absorb (ADR-40). The filesystem-rights, symlink, times, renumber, advise/allocate and path-semantics syscalls are now implemented (runtime/python/units/wasi/), so their former rows are gone.
 const WASI_TESTSUITE_EXPECTED_FAILURES: &[(&str, &str)] = &[
@@ -43,10 +43,10 @@ impl BackendUnderTest for PythonWasi {
     }
 }
 
-impl WasiTestsuiteBackend for PythonWasi {
+impl dewasm_test_helper::WasiTestsuiteBackend for PythonWasi {
     fn expected_failures(&self) -> &'static [(&'static str, &'static str)] {
         WASI_TESTSUITE_EXPECTED_FAILURES
     }
 }
 
-wasi_testsuite_suite!(PythonWasi);
+dewasm_test_helper::wasi_testsuite_suite!(PythonWasi);

--- a/crates/dewasm-backend-ruby/tests/convert.rs
+++ b/crates/dewasm-backend-ruby/tests/convert.rs
@@ -4,6 +4,5 @@
 //! `dewasm-test-helper`.
 
 use dewasm_backend_ruby::RubyBackend;
-use dewasm_test_helper::apps_convert_suite;
 
-apps_convert_suite!(RubyBackend);
+dewasm_test_helper::apps_convert_suite!(RubyBackend);

--- a/crates/dewasm-backend-ruby/tests/e2e.rs
+++ b/crates/dewasm-backend-ruby/tests/e2e.rs
@@ -4,16 +4,7 @@ use std::path::PathBuf;
 
 use dewasm_backend::{Backend, Mode, RuntimeLinkage};
 use dewasm_backend_ruby::{find_ruby, RubyBackend};
-use dewasm_test_helper::{
-    convert, cowsay_args_e2e, cowsay_stdin_e2e, cpython_hello_e2e, cruby_hello_e2e,
-    cruby_packed_hello_e2e, custom_wasi_provider_e2e, doom_frame_e2e, embedded_coexist_e2e,
-    examples_dir, exiftool_extract_e2e, gzip_e2e, library_add_e2e, libsqlite3_c_api_e2e,
-    nes_frame_e2e, partial_override_e2e, pcap_compile_e2e, qjs_eval_e2e, qjs_file_io_e2e,
-    qjs_repl_pty_e2e, rg_search_e2e, shared_table_e2e, sqlite3_callback_binding_e2e,
-    sqlite3_file_c_api_e2e, sqlite3_shell_dbfile_e2e, sqlite3_shell_e2e, standalone_dir_e2e,
-    stdio_capture_e2e, treesitter_parse_e2e, wasi_import_override_e2e, wasi_root_containment_e2e,
-    wasi_suite, zeroperl_eval_e2e, BackendUnderTest,
-};
+use dewasm_test_helper::BackendUnderTest;
 
 pub struct Ruby;
 
@@ -36,7 +27,8 @@ impl BackendUnderTest for Ruby {
             let mut units = std::collections::BTreeSet::new();
             let mut classes = Vec::new();
             for (wat, name) in modules {
-                let bytes = wat::parse_file(examples_dir().join(wat)).expect("parse wat");
+                let bytes = wat::parse_file(dewasm_test_helper::examples_dir().join(wat))
+                    .expect("parse wat");
                 let module = dewasm_core::build_module(&bytes).expect("build IR");
                 let (src, u) = dewasm_backend_ruby::generate_class_with_units(
                     &module,
@@ -57,7 +49,12 @@ impl BackendUnderTest for Ruby {
             modules
                 .iter()
                 .map(|(wat, name)| {
-                    convert(&RubyBackend, &examples_dir().join(wat), Mode::Library, name)
+                    dewasm_test_helper::convert(
+                        &RubyBackend,
+                        &dewasm_test_helper::examples_dir().join(wat),
+                        Mode::Library,
+                        name,
+                    )
                 })
                 .collect::<Vec<_>>()
                 .join("\n")
@@ -557,43 +554,43 @@ $stdout.write(rgb.pack("C*"))
 
 // --------------------------------------------------------------------- Suite wiring (ADR-27): each per-case macro invocation declares participation.
 
-library_add_e2e!(Ruby, RUBY_ADD_GLUE);
-wasi_import_override_e2e!(Ruby, RUBY_OVERRIDE_GLUE);
-custom_wasi_provider_e2e!(Ruby, RUBY_CUSTOM_PROVIDER_GLUE);
-partial_override_e2e!(Ruby, RUBY_PARTIAL_OVERRIDE_GLUE);
-stdio_capture_e2e!(Ruby, RUBY_STDIO_CAPTURE_GLUE);
+dewasm_test_helper::library_add_e2e!(Ruby, RUBY_ADD_GLUE);
+dewasm_test_helper::wasi_import_override_e2e!(Ruby, RUBY_OVERRIDE_GLUE);
+dewasm_test_helper::custom_wasi_provider_e2e!(Ruby, RUBY_CUSTOM_PROVIDER_GLUE);
+dewasm_test_helper::partial_override_e2e!(Ruby, RUBY_PARTIAL_OVERRIDE_GLUE);
+dewasm_test_helper::stdio_capture_e2e!(Ruby, RUBY_STDIO_CAPTURE_GLUE);
 
-wasi_suite!(Ruby, Stdio);
-wasi_suite!(Ruby, ArgsEnv);
-wasi_suite!(Ruby, Poll);
-wasi_suite!(Ruby, Fs, RUBY_FS_GLUE);
-wasi_root_containment_e2e!(Ruby, RUBY_CONTAINMENT_GLUE);
-standalone_dir_e2e!(Ruby);
+dewasm_test_helper::wasi_suite!(Ruby, Stdio);
+dewasm_test_helper::wasi_suite!(Ruby, ArgsEnv);
+dewasm_test_helper::wasi_suite!(Ruby, Poll);
+dewasm_test_helper::wasi_suite!(Ruby, Fs, RUBY_FS_GLUE);
+dewasm_test_helper::wasi_root_containment_e2e!(Ruby, RUBY_CONTAINMENT_GLUE);
+dewasm_test_helper::standalone_dir_e2e!(Ruby);
 
-cowsay_args_e2e!(Ruby);
-cowsay_stdin_e2e!(Ruby);
-qjs_eval_e2e!(Ruby);
-sqlite3_shell_e2e!(Ruby);
-gzip_e2e!(Ruby);
+dewasm_test_helper::cowsay_args_e2e!(Ruby);
+dewasm_test_helper::cowsay_stdin_e2e!(Ruby);
+dewasm_test_helper::qjs_eval_e2e!(Ruby);
+dewasm_test_helper::sqlite3_shell_e2e!(Ruby);
+dewasm_test_helper::gzip_e2e!(Ruby);
 
-qjs_file_io_e2e!(Ruby, RUBY_QJS_FILE_IO_GLUE);
-sqlite3_shell_dbfile_e2e!(Ruby, RUBY_SQLITE3_SHELL_GLUE);
-rg_search_e2e!(Ruby, RUBY_RG_SEARCH_GLUE);
-cpython_hello_e2e!(Ruby, RUBY_CPYTHON_GLUE);
-cruby_hello_e2e!(Ruby, RUBY_CRUBY_GLUE);
-cruby_packed_hello_e2e!(Ruby);
-qjs_repl_pty_e2e!(Ruby);
+dewasm_test_helper::qjs_file_io_e2e!(Ruby, RUBY_QJS_FILE_IO_GLUE);
+dewasm_test_helper::sqlite3_shell_dbfile_e2e!(Ruby, RUBY_SQLITE3_SHELL_GLUE);
+dewasm_test_helper::rg_search_e2e!(Ruby, RUBY_RG_SEARCH_GLUE);
+dewasm_test_helper::cpython_hello_e2e!(Ruby, RUBY_CPYTHON_GLUE);
+dewasm_test_helper::cruby_hello_e2e!(Ruby, RUBY_CRUBY_GLUE);
+dewasm_test_helper::cruby_packed_hello_e2e!(Ruby);
+dewasm_test_helper::qjs_repl_pty_e2e!(Ruby);
 
-libsqlite3_c_api_e2e!(Ruby, RUBY_LIBSQLITE3_MEM);
-sqlite3_file_c_api_e2e!(Ruby, RUBY_LIBSQLITE3_FILE);
-sqlite3_callback_binding_e2e!(Ruby, RUBY_SQLITE3_CALLBACK);
-pcap_compile_e2e!(Ruby, RUBY_PCAP_COMPILE);
-treesitter_parse_e2e!(Ruby, RUBY_TREESITTER_PARSE);
-zeroperl_eval_e2e!(Ruby, RUBY_ZEROPERL_EVAL);
-exiftool_extract_e2e!(Ruby, RUBY_EXIFTOOL);
+dewasm_test_helper::libsqlite3_c_api_e2e!(Ruby, RUBY_LIBSQLITE3_MEM);
+dewasm_test_helper::sqlite3_file_c_api_e2e!(Ruby, RUBY_LIBSQLITE3_FILE);
+dewasm_test_helper::sqlite3_callback_binding_e2e!(Ruby, RUBY_SQLITE3_CALLBACK);
+dewasm_test_helper::pcap_compile_e2e!(Ruby, RUBY_PCAP_COMPILE);
+dewasm_test_helper::treesitter_parse_e2e!(Ruby, RUBY_TREESITTER_PARSE);
+dewasm_test_helper::zeroperl_eval_e2e!(Ruby, RUBY_ZEROPERL_EVAL);
+dewasm_test_helper::exiftool_extract_e2e!(Ruby, RUBY_EXIFTOOL);
 
-doom_frame_e2e!(Ruby, RUBY_DOOM_FRAME_GLUE);
-nes_frame_e2e!(Ruby, RUBY_NES_FRAME_GLUE);
+dewasm_test_helper::doom_frame_e2e!(Ruby, RUBY_DOOM_FRAME_GLUE);
+dewasm_test_helper::nes_frame_e2e!(Ruby, RUBY_NES_FRAME_GLUE);
 
-shared_table_e2e!(Ruby, RUBY_SHARED_TABLE_GLUE);
-embedded_coexist_e2e!(Ruby, RUBY_EMBEDDED_COEXIST_GLUE);
+dewasm_test_helper::shared_table_e2e!(Ruby, RUBY_SHARED_TABLE_GLUE);
+dewasm_test_helper::embedded_coexist_e2e!(Ruby, RUBY_EMBEDDED_COEXIST_GLUE);

--- a/crates/dewasm-backend-ruby/tests/spec.rs
+++ b/crates/dewasm-backend-ruby/tests/spec.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use dewasm_backend::{Backend, RuntimeLinkage};
 use dewasm_backend_ruby::RubyBackend;
 use dewasm_core::ir;
-use dewasm_test_helper::{spec_suite, BackendUnderTest, Converted, SpecBackend};
+use dewasm_test_helper::BackendUnderTest;
 use wast::core::{AbstractHeapType, HeapType, NanPattern, WastArgCore, WastRetCore};
 use wast::{WastArg, WastRet};
 
@@ -39,7 +39,7 @@ impl BackendUnderTest for RubySpec {
     }
 }
 
-impl SpecBackend for RubySpec {
+impl dewasm_test_helper::SpecBackend for RubySpec {
     fn expected_failures(&self) -> &'static [(&'static str, u32, &'static str)] {
         EXPECTED_FAILURES
     }
@@ -66,7 +66,11 @@ impl SpecBackend for RubySpec {
         ]
     }
 
-    fn generate(&self, module: &ir::Module, counter: u32) -> anyhow::Result<Converted> {
+    fn generate(
+        &self,
+        module: &ir::Module,
+        counter: u32,
+    ) -> anyhow::Result<dewasm_test_helper::Converted> {
         let class_name = format!("WastMod{counter}");
         let (source, units) = dewasm_backend_ruby::generate_class_with_units(
             module,
@@ -74,7 +78,7 @@ impl SpecBackend for RubySpec {
             &RuntimeLinkage::Alias("::Rt".to_string()),
             false, // spec modules import spectest, never WASI
         )?;
-        Ok(Converted {
+        Ok(dewasm_test_helper::Converted {
             source,
             handle: class_name,
             units,
@@ -89,7 +93,7 @@ impl SpecBackend for RubySpec {
         &self,
         script: &mut String,
         _decls: &mut String,
-        conv: &Converted,
+        conv: &dewasm_test_helper::Converted,
         var_id: u32,
         registered: &[(String, String)],
     ) -> String {
@@ -108,7 +112,7 @@ impl SpecBackend for RubySpec {
         &self,
         script: &mut String,
         _decls: &mut String,
-        conv: &Converted,
+        conv: &dewasm_test_helper::Converted,
         registered: &[(String, String)],
     ) -> String {
         script.push_str(&conv.source);
@@ -414,4 +418,4 @@ const POSTAMBLE: &str = r#"
 puts "RESULT pass=#{$pass} fail=#{$fail}"
 "#;
 
-spec_suite!(RubySpec);
+dewasm_test_helper::spec_suite!(RubySpec);

--- a/crates/dewasm-backend-ruby/tests/wasi_testsuite.rs
+++ b/crates/dewasm-backend-ruby/tests/wasi_testsuite.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use dewasm_backend::Backend;
 use dewasm_backend_ruby::RubyBackend;
-use dewasm_test_helper::{wasi_testsuite_suite, BackendUnderTest, WasiTestsuiteBackend};
+use dewasm_test_helper::BackendUnderTest;
 
 /// Known trial failures with their attribution (ADR-8, policy in ADR-36): `(trial, tag)`. Two kinds remain, both attributed honestly: * declared out-of-scope syscalls (`sock_shutdown`; docs/support.md) — filling the gap later flips the entry to a hard failure, exactly ADR-8's contract; * environment variables the host interpreter itself injects (macOS CoreFoundation's `__CF_USER_TEXT_ENCODING`), which the guest legitimately observes, so count-exact `environ_*` assertions cannot hold even though the harness runs trials with a cleared environment (ADR-40).
 ///
@@ -47,7 +47,7 @@ impl BackendUnderTest for RubyWasi {
     }
 }
 
-impl WasiTestsuiteBackend for RubyWasi {
+impl dewasm_test_helper::WasiTestsuiteBackend for RubyWasi {
     fn expected_failures(&self) -> &'static [(&'static str, &'static str)] {
         WASI_TESTSUITE_EXPECTED_FAILURES
     }
@@ -57,4 +57,4 @@ impl WasiTestsuiteBackend for RubyWasi {
     }
 }
 
-wasi_testsuite_suite!(RubyWasi);
+dewasm_test_helper::wasi_testsuite_suite!(RubyWasi);

--- a/crates/dewasm-test-helper/tests/apps_wasmtime.rs
+++ b/crates/dewasm-test-helper/tests/apps_wasmtime.rs
@@ -8,13 +8,6 @@
 //! $ cargo test -p dewasm-test-helper --features wasmtime_test --test apps_wasmtime
 //! ```
 
-use dewasm_test_helper::{
-    assert_transcript_eq, capture_qjs_repl_transcript, qjs_repl_snapshot_path, run_app_case,
-    run_fs_app_case, run_gzip_cases, run_slow_app_case, run_standalone_dir, Wasmtime, COWSAY_ARGS,
-    COWSAY_STDIN, CPYTHON_HELLO, CRUBY_HELLO, CRUBY_PACKED_HELLO, QJS_EVAL, QJS_FILE_IO, RG_SEARCH,
-    SQLITE3_SHELL, SQLITE3_SHELL_DBFILE,
-};
-
 // The wasmtime-backed `BackendUnderTest` (`Wasmtime`, plus the `NeverBackend` stand-in it uses to satisfy `BackendUnderTest::backend()`) lives in `dewasm_test_helper::wasmtime_backend` so `cargo xtask update-snapshots` can drive it too; see that module for the implementation.
 
 // Hand-written `#[test]` fns rather than the per-case `*_e2e!` macros: those macros take a bare `$lang:expr` and forwarding an optional leading attribute onto the generated fn is a local macro-parsing ambiguity (`#` can begin an expr fragment). Calling the shared runners directly is the simplest honest way to attach the `wasmtime_test` ignore gate while still routing through the exact same runners the real backends use. The runners themselves are ungated (the slow per-case macros carry their own `slow_test`-feature `#[ignore]` instead, ADR-27 revision), so `wasmtime_test` alone gates every test in this file.
@@ -22,72 +15,108 @@ use dewasm_test_helper::{
 #[cfg_attr(not(feature = "wasmtime_test"), ignore)]
 #[test]
 fn cowsay_args() {
-    run_app_case(&Wasmtime, &COWSAY_ARGS);
+    dewasm_test_helper::run_app_case(
+        &dewasm_test_helper::Wasmtime,
+        &dewasm_test_helper::COWSAY_ARGS,
+    );
 }
 
 #[cfg_attr(not(feature = "wasmtime_test"), ignore)]
 #[test]
 fn cowsay_stdin() {
-    run_app_case(&Wasmtime, &COWSAY_STDIN);
+    dewasm_test_helper::run_app_case(
+        &dewasm_test_helper::Wasmtime,
+        &dewasm_test_helper::COWSAY_STDIN,
+    );
 }
 
 #[cfg_attr(not(feature = "wasmtime_test"), ignore)]
 #[test]
 fn qjs_eval() {
-    run_slow_app_case(&Wasmtime, &QJS_EVAL);
+    dewasm_test_helper::run_slow_app_case(
+        &dewasm_test_helper::Wasmtime,
+        &dewasm_test_helper::QJS_EVAL,
+    );
 }
 
 #[cfg_attr(not(feature = "wasmtime_test"), ignore)]
 #[test]
 fn sqlite3_shell() {
-    run_slow_app_case(&Wasmtime, &SQLITE3_SHELL);
+    dewasm_test_helper::run_slow_app_case(
+        &dewasm_test_helper::Wasmtime,
+        &dewasm_test_helper::SQLITE3_SHELL,
+    );
 }
 
 // The wasi-vfs-packed CRuby (ADR-61): its `AppCase` expectation is an inline string (deterministic one-liner, same convention as the interpreter fs hellos), so this run is what validates it against a live engine — with zero preopens, which is the point of the packed shape.
 #[cfg_attr(not(feature = "wasmtime_test"), ignore)]
 #[test]
 fn cruby_packed_hello() {
-    run_slow_app_case(&Wasmtime, &CRUBY_PACKED_HELLO);
+    dewasm_test_helper::run_slow_app_case(
+        &dewasm_test_helper::Wasmtime,
+        &dewasm_test_helper::CRUBY_PACKED_HELLO,
+    );
 }
 
 #[cfg_attr(not(feature = "wasmtime_test"), ignore)]
 #[test]
 fn gzip() {
-    run_gzip_cases(&Wasmtime);
+    dewasm_test_helper::run_gzip_cases(&dewasm_test_helper::Wasmtime);
 }
 
 // The filesystem app cases: the `wasmtime_test` feature is already the opt-in, and `run_fs_app_case` is ungated, so wasmtime runs the full set with no per-case exclusion; its `run_app_fs` override ignores the glue, so each case is driven with an empty glue string. Hand-written rather than via the per-case `*_e2e!` macros because those cannot carry the `wasmtime_test` ignore gate (the same reason `apps`/`gzip` above are hand-written).
 #[cfg_attr(not(feature = "wasmtime_test"), ignore)]
 #[test]
 fn fs_apps() {
-    run_fs_app_case(&Wasmtime, &QJS_FILE_IO, "");
-    run_fs_app_case(&Wasmtime, &SQLITE3_SHELL_DBFILE, "");
-    run_fs_app_case(&Wasmtime, &RG_SEARCH, "");
-    run_fs_app_case(&Wasmtime, &CPYTHON_HELLO, "");
-    run_fs_app_case(&Wasmtime, &CRUBY_HELLO, "");
+    dewasm_test_helper::run_fs_app_case(
+        &dewasm_test_helper::Wasmtime,
+        &dewasm_test_helper::QJS_FILE_IO,
+        "",
+    );
+    dewasm_test_helper::run_fs_app_case(
+        &dewasm_test_helper::Wasmtime,
+        &dewasm_test_helper::SQLITE3_SHELL_DBFILE,
+        "",
+    );
+    dewasm_test_helper::run_fs_app_case(
+        &dewasm_test_helper::Wasmtime,
+        &dewasm_test_helper::RG_SEARCH,
+        "",
+    );
+    dewasm_test_helper::run_fs_app_case(
+        &dewasm_test_helper::Wasmtime,
+        &dewasm_test_helper::CPYTHON_HELLO,
+        "",
+    );
+    dewasm_test_helper::run_fs_app_case(
+        &dewasm_test_helper::Wasmtime,
+        &dewasm_test_helper::CRUBY_HELLO,
+        "",
+    );
 }
 
 // The standalone `--dir` interface (ADR-31) run against wasmtime as ground truth: `run_standalone_dir`'s wasmtime path consumes `--dir` as a host flag (`wasmtime run --dir HOST::GUEST <wasm>`), the exact behavior the generated backends' own `--dir` parsing must reproduce. Uses no cached app, only the committed `wasi_standalone_dir.wat`, so it needs only wasmtime on PATH.
 #[cfg_attr(not(feature = "wasmtime_test"), ignore)]
 #[test]
 fn standalone_dir() {
-    run_standalone_dir(&Wasmtime);
+    dewasm_test_helper::run_standalone_dir(&dewasm_test_helper::Wasmtime);
 }
 
 // Snapshot freshness for the interactive-REPL transcript (Fix 4): re-capture the bare qjs REPL under a real pty from a live wasmtime and require it to equal the checked-in `qjs_repl_interactive.transcript`. Compare-only; regenerate with `cargo xtask update-snapshots` when the pinned qjs binary or the scripted session changes.
 #[cfg_attr(not(feature = "wasmtime_test"), ignore)]
 #[test]
 fn qjs_repl_interactive_snapshot() {
-    let snapshot = std::fs::read(qjs_repl_snapshot_path()).unwrap_or_else(|e| {
-        panic!(
-            "qjs repl snapshot {:?} not readable ({e}) — regenerate with \
+    let snapshot =
+        std::fs::read(dewasm_test_helper::qjs_repl_snapshot_path()).unwrap_or_else(|e| {
+            panic!(
+                "qjs repl snapshot {:?} not readable ({e}) — regenerate with \
              `cargo xtask update-snapshots` (see docs/testing.md)",
-            qjs_repl_snapshot_path()
-        )
-    });
-    let got = capture_qjs_repl_transcript(&Wasmtime);
+                dewasm_test_helper::qjs_repl_snapshot_path()
+            )
+        });
+    let got = dewasm_test_helper::capture_qjs_repl_transcript(&dewasm_test_helper::Wasmtime);
     // Linux wasmtime emits one extra trailing CRLF on pty teardown that macOS wasmtime (which captured the snapshot) does not; the converted backends match the snapshot byte-for-byte on both hosts, so the difference is wasmtime's own exit behavior, outside the transcript's meaningful content (it ends at the `\q` echo). Compare modulo trailing CRLFs here only — the per-backend comparison stays exact (issue #33).
-    assert_transcript_eq(
+    dewasm_test_helper::assert_transcript_eq(
         trim_trailing_crlfs(&got),
         trim_trailing_crlfs(&snapshot),
         "wasmtime",

--- a/crates/xtask/src/doom_snapshot.rs
+++ b/crates/xtask/src/doom_snapshot.rs
@@ -7,9 +7,6 @@
 //! DOOM README); only the PPM is the compared oracle.
 
 use anyhow::{ensure, Context, Result};
-use dewasm_test_helper::{
-    doom_wasm_path, frame_to_ppm, DOOM_CLOCK_STEP_MS, DOOM_FRAME_H, DOOM_FRAME_W, DOOM_TICKS,
-};
 use wasmtime::{Caller, Engine, Linker, Module, Store};
 
 /// Host state threaded through the imports: the synthetic clock, the last
@@ -72,7 +69,7 @@ fn capture_frame(bytes: &[u8]) -> wasmtime::Result<(Vec<u8>, u32, u32)> {
         "timeInMilliseconds",
         |mut caller: Caller<'_, DoomState>| -> i64 {
             let s = caller.data_mut();
-            s.ms += DOOM_CLOCK_STEP_MS;
+            s.ms += dewasm_test_helper::DOOM_CLOCK_STEP_MS;
             s.ms
         },
     )?;
@@ -113,7 +110,7 @@ fn capture_frame(bytes: &[u8]) -> wasmtime::Result<(Vec<u8>, u32, u32)> {
     // initGame (fires onGameInit), then N ticks — no key events. The clock
     // self-advances on every read, so nothing is stepped here.
     init.call(&mut store, ())?;
-    for _ in 0..DOOM_TICKS {
+    for _ in 0..dewasm_test_helper::DOOM_TICKS {
         tick.call(&mut store, ())?;
     }
 
@@ -136,7 +133,7 @@ fn capture_frame(bytes: &[u8]) -> wasmtime::Result<(Vec<u8>, u32, u32)> {
 /// `Wasmtime` CLI backend the other snapshots use — because `doom.wasm`'s
 /// custom-import interface can't be driven through `wasmtime run` (ADR-53).
 pub fn capture_doom_frame() -> Result<(Vec<u8>, Vec<u8>)> {
-    let wasm_path = doom_wasm_path();
+    let wasm_path = dewasm_test_helper::doom_wasm_path();
     let bytes = std::fs::read(&wasm_path).with_context(|| {
         format!(
             "read {} — run examples/apps/scripts/doom.sh first",
@@ -146,8 +143,10 @@ pub fn capture_doom_frame() -> Result<(Vec<u8>, Vec<u8>)> {
 
     let (frame, w, h) = capture_frame(&bytes).map_err(anyhow::Error::msg)?;
     ensure!(
-        w == DOOM_FRAME_W && h == DOOM_FRAME_H,
-        "onGameInit reported {w}x{h}, expected {DOOM_FRAME_W}x{DOOM_FRAME_H} (pin bump?)"
+        w == dewasm_test_helper::DOOM_FRAME_W && h == dewasm_test_helper::DOOM_FRAME_H,
+        "onGameInit reported {w}x{h}, expected {}x{} (pin bump?)",
+        dewasm_test_helper::DOOM_FRAME_W,
+        dewasm_test_helper::DOOM_FRAME_H
     );
 
     // Guard against a degenerate (blank/near-blank) capture: DOOM's paletted
@@ -162,7 +161,10 @@ pub fn capture_doom_frame() -> Result<(Vec<u8>, Vec<u8>)> {
         "captured frame looks degenerate ({distinct} distinct colors) — check the tick count/clock"
     );
 
-    Ok((frame_to_ppm(&frame, w, h), frame_to_png(&frame, w, h)?))
+    Ok((
+        dewasm_test_helper::frame_to_ppm(&frame, w, h),
+        frame_to_png(&frame, w, h)?,
+    ))
 }
 
 /// Encode a `B,G,R,A` framebuffer (row-major, alpha padding dropped) as an 8-bit

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -14,7 +14,6 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Result};
 use dewasm_cli::support_docs::render_support_docs;
-use dewasm_test_helper::{doom_frame_snapshot_path, nes_frame_snapshot_path, wasmtime_snapshots};
 
 use crate::doom_snapshot::capture_doom_frame;
 use crate::nes_snapshot::capture_nes_frame;
@@ -113,7 +112,7 @@ struct SnapshotTarget {
 
 /// Every execution snapshot `update-snapshots` regenerates: the nine wasmtime-CLI targets from the shared registry (`dewasm_test_helper::wasmtime_snapshots`) plus the embedded-wasmtime DOOM frame, folded in here rather than in the helper crate so that crate keeps no `wasmtime`-crate dependency (ADR-53). The DOOM target emits two files — the compared `doom_frame.ppm` and a `doom_frame.png` rendering of the same frame for human inspection (never compared by a test).
 fn snapshot_targets() -> Vec<SnapshotTarget> {
-    let mut targets: Vec<SnapshotTarget> = wasmtime_snapshots()
+    let mut targets: Vec<SnapshotTarget> = dewasm_test_helper::wasmtime_snapshots()
         .into_iter()
         .map(|snap| SnapshotTarget {
             label: snap.label,
@@ -125,7 +124,7 @@ fn snapshot_targets() -> Vec<SnapshotTarget> {
     targets.push(SnapshotTarget {
         label: "examples/apps/snapshots/doom_frame.ppm".to_string(),
         capture: Box::new(|| {
-            let ppm_path = doom_frame_snapshot_path();
+            let ppm_path = dewasm_test_helper::doom_frame_snapshot_path();
             let png_path = ppm_path.with_extension("png");
             let (ppm, png) = capture_doom_frame()?;
             Ok(vec![(ppm_path, ppm), (png_path, png)])
@@ -134,7 +133,7 @@ fn snapshot_targets() -> Vec<SnapshotTarget> {
     targets.push(SnapshotTarget {
         label: "examples/apps/snapshots/nes_frame.ppm".to_string(),
         capture: Box::new(|| {
-            let ppm_path = nes_frame_snapshot_path();
+            let ppm_path = dewasm_test_helper::nes_frame_snapshot_path();
             let png_path = ppm_path.with_extension("png");
             let (ppm, png) = capture_nes_frame()?;
             Ok(vec![(ppm_path, ppm), (png_path, png)])

--- a/crates/xtask/src/nes_snapshot.rs
+++ b/crates/xtask/src/nes_snapshot.rs
@@ -11,10 +11,6 @@
 //! exports. The ROM is copied into guest memory through `allocRom`.
 
 use anyhow::{ensure, Context, Result};
-use dewasm_test_helper::{
-    alter_ego_rom_path, nes_frame_to_ppm, nes_wasm_path, NES_FRAMES, NES_FRAME_H, NES_FRAME_W,
-    NES_PALETTE_ENTRIES,
-};
 use wasmtime::{Engine, Instance, Linker, Module, Store};
 
 /// Instantiate and drive `nes.wasm` under the deterministic contract, returning
@@ -51,7 +47,7 @@ fn capture_frame(bytes: &[u8], rom: &[u8]) -> wasmtime::Result<(Vec<u8>, Vec<u8>
     }
 
     // N frames, no input.
-    for _ in 0..NES_FRAMES {
+    for _ in 0..dewasm_test_helper::NES_FRAMES {
         tick.call(&mut store, ())?;
     }
 
@@ -80,7 +76,8 @@ fn read_frame(
         .call(&mut *store, ())? as usize;
     let data = memory.data(&*store);
     let screen = data[screen_off..screen_off + (w * h) as usize].to_vec();
-    let palette = data[palette_off..palette_off + NES_PALETTE_ENTRIES * 4].to_vec();
+    let palette =
+        data[palette_off..palette_off + dewasm_test_helper::NES_PALETTE_ENTRIES * 4].to_vec();
     Ok((screen, palette, w, h))
 }
 
@@ -89,14 +86,14 @@ fn read_frame(
 /// compared oracle) and a PNG of the same frame for `nes_frame.png` (human
 /// inspection — never compared by a test).
 pub fn capture_nes_frame() -> Result<(Vec<u8>, Vec<u8>)> {
-    let wasm_path = nes_wasm_path();
+    let wasm_path = dewasm_test_helper::nes_wasm_path();
     let bytes = std::fs::read(&wasm_path).with_context(|| {
         format!(
             "read {} — run examples/apps/scripts/nes.sh first",
             wasm_path.display()
         )
     })?;
-    let rom_path = alter_ego_rom_path();
+    let rom_path = dewasm_test_helper::alter_ego_rom_path();
     let rom = std::fs::read(&rom_path).with_context(|| {
         format!(
             "read {} — run examples/apps/scripts/nes.sh first",
@@ -106,8 +103,10 @@ pub fn capture_nes_frame() -> Result<(Vec<u8>, Vec<u8>)> {
 
     let (screen, palette, w, h) = capture_frame(&bytes, &rom).map_err(anyhow::Error::msg)?;
     ensure!(
-        w == NES_FRAME_W && h == NES_FRAME_H,
-        "frame is {w}x{h}, expected {NES_FRAME_W}x{NES_FRAME_H} (pin bump?)"
+        w == dewasm_test_helper::NES_FRAME_W && h == dewasm_test_helper::NES_FRAME_H,
+        "frame is {w}x{h}, expected {}x{} (pin bump?)",
+        dewasm_test_helper::NES_FRAME_W,
+        dewasm_test_helper::NES_FRAME_H
     );
 
     // Guard against a degenerate (blank/near-blank) capture. NES palettes are
@@ -116,7 +115,7 @@ pub fn capture_nes_frame() -> Result<(Vec<u8>, Vec<u8>)> {
     // boot frame is a single color. A >4 threshold cleanly separates the two.
     // Counted over colors, not raw indices: distinct indices can alias onto one
     // palette entry (the mask, plus repeated black entries).
-    let ppm = nes_frame_to_ppm(&screen, &palette, w, h);
+    let ppm = dewasm_test_helper::nes_frame_to_ppm(&screen, &palette, w, h);
     let distinct = screen
         .iter()
         .map(|&ix| &palette[(ix as usize & 0x3f) * 4..(ix as usize & 0x3f) * 4 + 3])


### PR DESCRIPTION
## Summary
- Each backend's e2e/spec/convert/wasi_testsuite test files (plus xtask's snapshot/bench code and dewasm-test-helper's own apps_wasmtime test) used to `use dewasm_test_helper::{A, B, C, ...};` with long, growing import lists, which made diffs hard to read (a use-list change didn't show which helper was actually touched).
- Only `BackendUnderTest` stays `use`-imported (it's referenced by bare name constantly, as the trait each backend's marker struct implements); every other function, macro, type, and const from `dewasm-test-helper` is now called with an explicit `dewasm_test_helper::` prefix at its call site.
- Purely mechanical, no behavior change. Done per-backend in parallel worktrees (go, ruby, python, java, perl, bash, xtask+test-helper), each verified independently with `cargo fmt`/`cargo check --tests --all-features`/`cargo clippy --tests --all-features -- -D warnings`, then all merged into this one branch.

## Test plan
- [x] `cargo fmt --check`
- [x] Per-track `cargo check --tests --all-features` / `cargo clippy --tests --all-features -- -D warnings` (done in each source worktree before merging)
- [ ] CI (`cargo test`)