### PR TITLE
Mask signed stat fields to u64 in the Python filestat packing

### DIFF
--- a/runtime/python/units/wasi/pack_filestat.py
+++ b/runtime/python/units/wasi/pack_filestat.py
@@ -1,15 +1,19 @@
 # requires: wasi/wasi_filetype
 # Packs an os.stat_result into a WASI filestat (64 bytes): dev, ino, filetype
 # (+7 pad), nlink, size, atim/mtim/ctim (all u64, times in nanoseconds).
+# The host fields are signed — dev_t is signed and macOS reports negative
+# st_dev for pipes and devfs nodes; timestamps can sit before the epoch — and
+# wasmtime copies the bits (ADR-49), so each 64-bit field is masked to u64
+# rather than letting struct.pack range-check it (issue #132).
 def pack_filestat(self, st):
     return struct.pack(
         "<QQBxxxxxxxQQQQQ",
-        st.st_dev,
-        st.st_ino,
+        st.st_dev & 0xFFFFFFFFFFFFFFFF,
+        st.st_ino & 0xFFFFFFFFFFFFFFFF,
         self.wasi_filetype(st),
-        st.st_nlink,
-        st.st_size,
-        st.st_atime_ns,
-        st.st_mtime_ns,
-        st.st_ctime_ns,
+        st.st_nlink & 0xFFFFFFFFFFFFFFFF,
+        st.st_size & 0xFFFFFFFFFFFFFFFF,
+        st.st_atime_ns & 0xFFFFFFFFFFFFFFFF,
+        st.st_mtime_ns & 0xFFFFFFFFFFFFFFFF,
+        st.st_ctime_ns & 0xFFFFFFFFFFFFFFFF,
     )


### PR DESCRIPTION
Closes #132.

`struct.pack` range-checks `'Q'` fields, and several `os.stat_result` fields are signed in the host API — `dev_t` is signed (macOS reports negative `st_dev` for pipes and devfs nodes) and nanosecond timestamps can sit before the epoch. A converted program whose guest calls `fd_filestat_get` on such a file dies with `struct.error`; observed intermittently on the packed-CRuby boot depending on what backs the std fds, with output generated from current main (pre-dating the #128 work — not a lowering regression). wasmtime copies the bits, so per ADR-49 each 64-bit field is masked to u64. Ruby's and Perl's `pack('Q<')` already wrap silently, so this is Python-only.

Verified: python wasi-testsuite 72/72, units lint green, and a direct probe — a stat with `st_dev = -42` now packs to the bit-copied `2^64−42` instead of raising.

(The AGENTS.md wording fix this PR briefly carried was superseded by #135 and dropped in the rebase.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)