### PR TITLE
Wire deep_recursion_e2e on Ruby, Go, Java, and Bash

### DIFF
--- a/crates/dewasm-backend-bash/tests/e2e.rs
+++ b/crates/dewasm-backend-bash/tests/e2e.rs
@@ -250,6 +250,8 @@ dewasm_test_helper::wasi_suite!(Bash, Poll);
 dewasm_test_helper::wasi_suite!(Bash, Fs, BASH_FS_GLUE);
 dewasm_test_helper::wasi_root_containment_e2e!(Bash, BASH_CONTAINMENT_GLUE);
 dewasm_test_helper::standalone_dir_e2e!(Bash);
+// The standalone entrypoint already raises the process stack rlimit before running any guest code (ADR-11); that covers 5000 guest frames too.
+dewasm_test_helper::deep_recursion_e2e!(Bash);
 
 dewasm_test_helper::cowsay_args_e2e!(Bash);
 dewasm_test_helper::cowsay_stdin_e2e!(Bash);

--- a/crates/dewasm-backend-go/tests/e2e.rs
+++ b/crates/dewasm-backend-go/tests/e2e.rs
@@ -678,6 +678,8 @@ dewasm_test_helper::wasi_suite!(Go, Poll);
 dewasm_test_helper::wasi_suite!(Go, Fs, GO_FS_GLUE);
 dewasm_test_helper::wasi_root_containment_e2e!(Go, GO_CONTAINMENT_GLUE);
 dewasm_test_helper::standalone_dir_e2e!(Go);
+// Goroutine stacks start small and grow dynamically, so 5000 guest frames need no entrypoint mitigation.
+dewasm_test_helper::deep_recursion_e2e!(Go);
 
 dewasm_test_helper::cowsay_args_e2e!(Go);
 dewasm_test_helper::cowsay_stdin_e2e!(Go);

--- a/crates/dewasm-backend-java/src/lib.rs
+++ b/crates/dewasm-backend-java/src/lib.rs
@@ -347,7 +347,7 @@ fn reindent(src: &str, levels: usize) -> String {
     out
 }
 
-/// The standalone entry point: parse the runtime interface (ADR-31) — `--dir HOST::GUEST` preopens, then the guest argv with argv[0] the program name — instantiate, run `_start`, and map `proc_exit`/trap to a process exit code (a trap prints to stderr and exits 134, mirroring Ruby/Python/Go).
+/// The standalone entry point: parse the runtime interface (ADR-31) — `--dir HOST::GUEST` preopens, then the guest argv with argv[0] the program name — instantiate, run `_start` on a dedicated large-stack thread, and map `proc_exit`/trap to a process exit code (a trap prints to stderr and exits 134, mirroring Ruby/Python/Go). The dedicated thread mirrors Python's ADR-28 mitigation: deep-but-valid guest recursion (issue #137) can exceed the JVM's default main-thread stack on some hosts, so `_start` runs on a 64 MiB thread instead. Exceptions thrown on that thread do not cross `Thread.join()`, so the runnable catches everything and hands the result back through `failure`.
 fn main_class(type_name: &str, wasi: bool) -> String {
     let args = if wasi { "wasiArgs" } else { "null" };
     let env = if wasi { "wasiEnv" } else { "new String[0]" };
@@ -405,14 +405,31 @@ fn main_class(type_name: &str, wasi: bool) -> String {
     out.push_str(&format!(
         "        {type_name} p = new {type_name}(null, {args}, {env}, {preopens});\n"
     ));
+    out.push_str("        Throwable[] failure = new Throwable[1];\n");
+    out.push_str("        Runnable guestRun = () -> {\n");
+    out.push_str("            try {\n");
+    out.push_str("                ((Rt.Fn) p.Exports.get(\"_start\")).invoke(new Object[]{});\n");
+    out.push_str("            } catch (Throwable e) {\n");
+    out.push_str("                failure[0] = e;\n");
+    out.push_str("            }\n");
+    out.push_str("        };\n");
+    out.push_str("        Thread guest = new Thread(null, guestRun, \"guest\", 64L << 20);\n");
+    out.push_str("        guest.start();\n");
     out.push_str("        try {\n");
-    out.push_str("            ((Rt.Fn) p.Exports.get(\"_start\")).invoke(new Object[]{});\n");
-    out.push_str("        } catch (Rt.Exit e) {\n");
-    out.push_str("            System.exit(e.code);\n");
-    out.push_str("        } catch (Rt.Trap e) {\n");
-    out.push_str("            System.err.print(\"trap: \" + e.getMessage() + \"\\n\");\n");
+    out.push_str("            guest.join();\n");
+    out.push_str("        } catch (InterruptedException e) {\n");
+    out.push_str("            Thread.currentThread().interrupt();\n");
+    out.push_str("        }\n");
+    out.push_str("        if (failure[0] instanceof Rt.Exit) {\n");
+    out.push_str("            System.exit(((Rt.Exit) failure[0]).code);\n");
+    out.push_str("        } else if (failure[0] instanceof Rt.Trap) {\n");
+    out.push_str("            System.err.print(\"trap: \" + failure[0].getMessage() + \"\\n\");\n");
     out.push_str("            System.err.flush();\n");
     out.push_str("            System.exit(134);\n");
+    out.push_str("        } else if (failure[0] instanceof RuntimeException) {\n");
+    out.push_str("            throw (RuntimeException) failure[0];\n");
+    out.push_str("        } else if (failure[0] instanceof Error) {\n");
+    out.push_str("            throw (Error) failure[0];\n");
     out.push_str("        }\n");
     out.push_str("        System.exit(0);\n");
     out.push_str("    }\n");

--- a/crates/dewasm-backend-java/tests/e2e.rs
+++ b/crates/dewasm-backend-java/tests/e2e.rs
@@ -524,6 +524,8 @@ dewasm_test_helper::wasi_suite!(Java, Poll);
 dewasm_test_helper::wasi_suite!(Java, Fs, JAVA_FS_GLUE);
 dewasm_test_helper::wasi_root_containment_e2e!(Java, JAVA_CONTAINMENT_GLUE);
 dewasm_test_helper::standalone_dir_e2e!(Java);
+// The standalone entrypoint runs the guest on a dedicated 64 MiB thread (mirroring Python's ADR-28 mitigation), since Linux CI's 1 MiB default main-thread stack is marginal for 5000 guest frames.
+dewasm_test_helper::deep_recursion_e2e!(Java);
 
 dewasm_test_helper::cowsay_args_e2e!(Java);
 dewasm_test_helper::cowsay_stdin_e2e!(Java);

--- a/crates/dewasm-backend-ruby/tests/e2e.rs
+++ b/crates/dewasm-backend-ruby/tests/e2e.rs
@@ -566,6 +566,8 @@ dewasm_test_helper::wasi_suite!(Ruby, Poll);
 dewasm_test_helper::wasi_suite!(Ruby, Fs, RUBY_FS_GLUE);
 dewasm_test_helper::wasi_root_containment_e2e!(Ruby, RUBY_CONTAINMENT_GLUE);
 dewasm_test_helper::standalone_dir_e2e!(Ruby);
+// 5000 guest frames fit the host stack Ruby's entrypoint already runs on; no mitigation needed (measured).
+dewasm_test_helper::deep_recursion_e2e!(Ruby);
 
 dewasm_test_helper::cowsay_args_e2e!(Ruby);
 dewasm_test_helper::cowsay_stdin_e2e!(Ruby);

--- a/crates/dewasm-test-helper/src/lib.rs
+++ b/crates/dewasm-test-helper/src/lib.rs
@@ -227,7 +227,7 @@ macro_rules! standalone_dir_e2e {
     };
 }
 
-/// One `#[test]` requiring the standalone entrypoint to survive deep-but-valid guest recursion for `$lang`: convert `deep_recursion.wat` (5000-frame recursion) standalone, run it, and require the guest's `proc_exit(42)` as the exit code — see [`run_deep_recursion`](crate::run_deep_recursion). No glue — this exercises the emitted entrypoint itself. Wired by Python, whose entrypoint applies ADR-28's mitigation (issue #31); each other backend's host recursion depth is its own concern — it invokes this once its entrypoint needs (and has) such a mitigation.
+/// One `#[test]` requiring the standalone entrypoint to survive deep-but-valid guest recursion for `$lang`: convert `deep_recursion.wat` (5000-frame recursion) standalone, run it, and require the guest's `proc_exit(42)` as the exit code — see [`run_deep_recursion`](crate::run_deep_recursion). No glue — this exercises the emitted entrypoint itself. Wired by all six backends; each callsite notes whether its entrypoint needed a mitigation for this depth (Python's ADR-28 big-stack thread, issue #31; Java's equivalent, issue #137) or survives unmitigated (Ruby's host stack, Go's growable goroutine stacks, Bash's `ulimit -s` line, Perl's heap-allocated recursion, ADR-55).
 #[macro_export]
 macro_rules! deep_recursion_e2e {
     ($lang:expr) => {


### PR DESCRIPTION
Closes #137.

Only Python and Perl exercised the standalone entrypoint's survival of 5000-frame guest recursion. Measured: Ruby, Go, and Bash pass unmitigated (host-stack headroom, growable goroutine stacks, and the already-emitted `ulimit -s` line respectively), so they just gain the invocation.

Java gets the one real change: plain `java` gives the main thread a 1 MiB default stack on Linux, marginal for 5000 generated frames, so the generated standalone main now runs `_start` on a dedicated 64 MiB thread (mirroring Python's ADR-28 mitigation) and replays the guest outcome — `Rt.Exit` → exit code, `Rt.Trap` → stderr + 134, anything else rethrown — from a hand-back slot, since exceptions don't cross `Thread.join()`.

Verified: fmt/clippy clean; full `cargo test` green (spec harness 257 passed; the four e2e suites each grew by one test, 0 failed).