### PR TITLE
Build Bash's bundled WASI state only when an import falls back

### DIFF
--- a/crates/dewasm-backend-bash/src/lib.rs
+++ b/crates/dewasm-backend-bash/src/lib.rs
@@ -399,16 +399,10 @@ impl<'a> Gen<'a> {
             w.line(format!("{p}t{idx}ty=()"));
             w.line(format!("{p}t{idx}sz={}", table.min));
         }
-        if wasi_bundled(m, self.default_wasi) {
-            // Callers set the WASI_ARGS/WASI_ENV/WASI_DIRS arrays before init (the bash analogue of Ruby's args:/env:/preopens: keywords); stdio fds are preopened and fd_read/fd_write track per-fd offsets. wnext is the next fd; wpush is the stdin pushback buffer (a space-separated byte-ordinal list) shared by fd_read and poll_oneoff; init_preopens registers the --dir mounts and the filesystem fd-table arrays, failing init loudly on an unresolvable host (ADR-34).
-            w.line(format!("{p}wargs=(\"${{WASI_ARGS[@]}}\")"));
-            w.line(format!("{p}wenv=(\"${{WASI_ENV[@]}}\")"));
-            w.line(format!("{p}wfds=([0]=1 [1]=1 [2]=1)"));
-            w.line(format!("{p}wtell=([0]=0 [1]=0 [2]=0)"));
-            w.line(format!("{p}wnext=3"));
-            w.line(format!("{p}wpush=''"));
-            self.use_unit("wasi/init_preopens");
-            w.line(format!("wasi_init_preopens {p} || return 1"));
+        // The bundled WASI's state is only *needed* by an import that actually falls back to it (ADR-7): one the embedder supplied through IMPORTS/PROVIDERS never reads a `<p>w*` variable. So the import loop below records whether any fallback happened, and the state is built iff one did — the shell-variable counterpart of the other backends' lazy `@wasi ||=` construction, and the observable the `custom_wasi_provider`/`partial_override` cases turn on. Still eager within `<p>init`: nothing is deferred to the first syscall, so ADR-34's preopen validation keeps failing instantiation rather than a later call.
+        let wasi_state = wasi_bundled(m, self.default_wasi);
+        if wasi_state {
+            w.line("local __wasi_fb=0");
         }
         for (i, import) in m.imported_funcs.iter().enumerate() {
             self.use_unit("rt/resolve_import");
@@ -422,7 +416,7 @@ impl<'a> Gen<'a> {
                 if bundler().has_unit(&unit) {
                     self.use_unit(&unit);
                     w.line(format!(
-                        "[[ -n ${p}if{i} ]] || {p}if{i}={p}wasi_{}",
+                        "[[ -n ${p}if{i} ]] || {{ {p}if{i}={p}wasi_{}; __wasi_fb=1; }}",
                         import.name
                     ));
                 } else {
@@ -436,6 +430,21 @@ impl<'a> Gen<'a> {
                     "[[ -n ${p}if{i} ]] || {{ rt_link_err {msg}; return $?; }}"
                 ));
             }
+        }
+        if wasi_state {
+            // Callers set the WASI_ARGS/WASI_ENV/WASI_DIRS arrays before init (the bash analogue of Ruby's args:/env:/preopens: keywords); stdio fds are preopened and fd_read/fd_write track per-fd offsets. wnext is the next fd; wpush is the stdin pushback buffer (a space-separated byte-ordinal list) shared by fd_read and poll_oneoff; init_preopens registers the --dir mounts and the filesystem fd-table arrays, failing init loudly on an unresolvable host (ADR-34).
+            w.line("if (( __wasi_fb )); then");
+            w.indent();
+            w.line(format!("{p}wargs=(\"${{WASI_ARGS[@]}}\")"));
+            w.line(format!("{p}wenv=(\"${{WASI_ENV[@]}}\")"));
+            w.line(format!("{p}wfds=([0]=1 [1]=1 [2]=1)"));
+            w.line(format!("{p}wtell=([0]=0 [1]=0 [2]=0)"));
+            w.line(format!("{p}wnext=3"));
+            w.line(format!("{p}wpush=''"));
+            self.use_unit("wasi/init_preopens");
+            w.line(format!("wasi_init_preopens {p} || return 1"));
+            w.dedent();
+            w.line("fi");
         }
         // Imported globals: resolve the provider's cell and alias it in under the unified index with a `declare -gn` nameref, so reads (`(( x = <p>g<i> ))`), mutable writes (`(( <p>g<i> = v ))`), and init-expr `global.get` offsets all reach the shared cell (ADR-35).
         for (i, import) in m.imported_globals.iter().enumerate() {

--- a/crates/dewasm-backend-bash/tests/e2e.rs
+++ b/crates/dewasm-backend-bash/tests/e2e.rs
@@ -87,6 +87,65 @@ prog_init || { echo "init failed" >&2; exit 1; }
 prog_invoke '_start'
 "#;
 
+/// The `custom_wasi_provider` glue: a provider *prefix* replaces the bundled WASI wholesale — `PROVIDERS[wasi_snapshot_preview1]` points at `my_`, whose `my_EXPORTS` map covers both imports (the bash shape of a provider object, ADR-35), so no import falls back and `<p>init` never builds the bundled WASI's prefix-scoped state. The probe is a real existence test on one of those variables (`declare -p prog_wfds`), the bash counterpart of Ruby's `@wasi.nil?`.
+const BASH_CUSTOM_PROVIDER_GLUE: &str = r#"my_fd_write() {
+  # Same interception and byte-reconstruction as `BASH_OVERRIDE_GLUE`.
+  mem_i32_load prog_ "$2" || return $?
+  local ptr=$R0
+  mem_i32_load prog_ $(( $2 + 4 )) || return $?
+  local len=$R0
+  local -n mem=prog_mem
+  local out='' chunk bytes=() j k
+  for (( j = 0; j < len; j++ )); do
+    k=$(( ptr + j ))
+    bytes+=("$(( mem[$k] ))")
+  done
+  printf -v chunk '\\x%02x' "${bytes[@]}"
+  out+=$chunk
+  printf "$out"
+  mem_i32_store prog_ "$4" "$len" || return $?
+  R0=0
+  return 0
+}
+my_random_get() {
+  R0=0
+  return 0
+}
+declare -A my_EXPORTS=([fd_write]=my_fd_write [random_get]=my_random_get)
+declare -A PROVIDERS=([wasi_snapshot_preview1]=my_)
+prog_init || { echo "init failed" >&2; exit 1; }
+prog_invoke '_start'
+if declare -p prog_wfds &>/dev/null; then built=true; else built=false; fi
+echo "bundled wasi constructed: $built"
+"#;
+
+/// The `partial_override_falls_back_to_bundled_wasi` glue: `BASH_OVERRIDE_GLUE` (fd_write intercepted through IMPORTS, random_get falling back) plus the same probe, which now finds the state — `<p>init` builds it for that one fallback.
+const BASH_PARTIAL_OVERRIDE_GLUE: &str = r#"my_fd_write() {
+  # Same interception and byte-reconstruction as `BASH_OVERRIDE_GLUE`.
+  mem_i32_load prog_ "$2" || return $?
+  local ptr=$R0
+  mem_i32_load prog_ $(( $2 + 4 )) || return $?
+  local len=$R0
+  local -n mem=prog_mem
+  local out='' chunk bytes=() j k
+  for (( j = 0; j < len; j++ )); do
+    k=$(( ptr + j ))
+    bytes+=("$(( mem[$k] ))")
+  done
+  printf -v chunk '\\x%02x' "${bytes[@]}"
+  out+=$chunk
+  printf "$out"
+  mem_i32_store prog_ "$4" "$len" || return $?
+  R0=0
+  return 0
+}
+declare -A IMPORTS=(['wasi_snapshot_preview1.fd_write']=my_fd_write)
+prog_init || { echo "init failed" >&2; exit 1; }
+prog_invoke '_start' # random_get falls back to the bundled WASI
+if declare -p prog_wfds &>/dev/null; then built=true; else built=false; fi
+echo "bundled wasi constructed: $built"
+"#;
+
 /// The `wasi_stdio_capture` glue: bash's embedder-controlled sink is a command substitution — run init and `_start` inside `$( … )` and the guest's fd 1 writes land in a shell variable instead of the script's stdout, the same fd-level redirect Perl's glue uses rather than an in-memory object. `$()` strips the trailing newlines, so the captured text is printed back with `%s\n` to restore the one the guest wrote. The subshell's `_start` ends in `proc_exit`, i.e. the status-133 cascade (ADR-12), which is simply not propagated: this case asserts stdout only.
 const BASH_STDIO_CAPTURE_GLUE: &str = r#"captured=$(
   prog_init || { echo "init failed" >&2; exit 1; }
@@ -590,7 +649,8 @@ exit 0
 dewasm_test_helper::library_add_e2e!(Bash, BASH_ADD_GLUE);
 dewasm_test_helper::wasi_import_override_e2e!(Bash, BASH_OVERRIDE_GLUE);
 dewasm_test_helper::stdio_capture_e2e!(Bash, BASH_STDIO_CAPTURE_GLUE);
-// custom_wasi_provider_e2e! / partial_override_e2e!: not invoked — both cases turn on the observable "was the bundled WASI constructed?", and Bash has no bundled-WASI object to have been constructed. Replacing WASI wholesale is not the blocker: `IMPORTS[wasi_snapshot_preview1.<name>]` overrides each function and `PROVIDERS[wasi_snapshot_preview1]` points a whole module at another prefix's export maps (ADR-35). What is missing is the *lazy* half: the WASI state is a set of prefix-scoped variables (`<p>wargs`/`<p>wfds`/`<p>wtell`/`<p>wnext`/`<p>wpush` plus `wasi_init_preopens`), initialized unconditionally by `<p>init` before any import resolves (ADR-12), so there is nothing whose absence a glue could print.
+dewasm_test_helper::custom_wasi_provider_e2e!(Bash, BASH_CUSTOM_PROVIDER_GLUE);
+dewasm_test_helper::partial_override_e2e!(Bash, BASH_PARTIAL_OVERRIDE_GLUE);
 
 dewasm_test_helper::wasi_suite!(Bash, Stdio);
 dewasm_test_helper::wasi_suite!(Bash, ArgsEnv);

--- a/crates/dewasm-test-helper/src/library.rs
+++ b/crates/dewasm-test-helper/src/library.rs
@@ -31,7 +31,7 @@ pub const WASI_IMPORT_OVERRIDE: LibraryCase = LibraryCase {
     expect: "ok\n",
 };
 
-/// A provider *object* (ADR-7) replaces the bundled WASI wholesale: `import`/`wasm_import`/`WasmImport`/`wasmImport` resolves every function, `attach` binds the memory, and — because every import is covered — the bundled WASI is never lazily constructed. The glue prints the intercepted bytes plus the "not constructed" observable. Every backend with a bundled-WASI *object* to construct invokes `custom_wasi_provider_e2e!` — Ruby, Python, Perl, Go and Java; Bash, whose WASI is prefix-scoped shell variables initialized unconditionally, has no such observable.
+/// A provider *object* (ADR-7) replaces the bundled WASI wholesale: `import`/`wasm_import`/`WasmImport`/`wasmImport` resolves every function, `attach` binds the memory, and — because every import is covered — the bundled WASI is never lazily constructed. The glue prints the intercepted bytes plus the "not constructed" observable. Every backend invokes `custom_wasi_provider_e2e!`; Bash's provider is a prefix whose export map covers both imports, and its bundled WASI is prefix-scoped shell variables built only when an import falls back, so `declare -p <p>wfds` is the same observable.
 pub const CUSTOM_WASI_PROVIDER: LibraryCase = LibraryCase {
     name: "custom_wasi_provider",
     wat: "wasi_imports.wat",

--- a/docs/backends/bash.md
+++ b/docs/backends/bash.md
@@ -28,7 +28,7 @@ Wasm core 1.0 plus the universal baseline, with f32/f64 on the pure-Bash softflo
 
 ## Providers and library usage
 
-The import table is the `IMPORTS` associative array keyed `module.name`; there is no duck-typed provider *object* as on Ruby/Python. Set an entry to a shell function name to override an import; unset entries fall back to the bundled WASI. The e2e override glue (`crates/dewasm-backend-bash/tests/e2e.rs`) is the worked reference.
+The import table is the `IMPORTS` associative array keyed `module.name`; set an entry to a shell function name to override an import. A whole import module is served by pointing `PROVIDERS[module]` at another prefix `<q>` owning the per-kind export maps `<q>EXPORTS` / `<q>GLOBAL_EXPORTS` / `<q>TABLE_EXPORTS` / `<q>MEMORY_EXPORTS` ([ADR-35](../adr/35-bash-cross-module-linking.md)) — the shell counterpart of Ruby's provider object, and what a wholesale WASI replacement uses. Unset entries fall back to the bundled WASI, and `<p>init` builds the bundled WASI's prefix-scoped state (`<p>wargs`, `<p>wfds`, …) only if at least one import actually fell back, so covering every WASI import leaves none of it behind. The e2e override, custom-provider and partial-override glue (`crates/dewasm-backend-bash/tests/e2e.rs`) are the worked references.
 
 ## Caveats
 

--- a/runtime/bash/units/wasi/init_preopens.sh
+++ b/runtime/bash/units/wasi/init_preopens.sh
@@ -5,8 +5,10 @@
 # physically via `cd -P` (a non-directory host through its parent), and a host
 # path that does not exist is a loud init failure (nonzero return, so <p>init
 # fails). Dir fds start at 3 (past stdio) and <p>wnext is left pointing past
-# the last one. Always called from <p>init when WASI is bundled; an
-# unset/empty WASI_DIRS just initializes the arrays.
+# the last one. Called from <p>init whenever at least one WASI import actually
+# fell back to a bundled unit (an embedder that supplied them all through
+# IMPORTS/PROVIDERS never gets this state); an unset/empty WASI_DIRS just
+# initializes the arrays.
 #
 # Per-fd rights (ADR-40): <p>wrbase / <p>wrinh hold the u64 rights masks a fd
 # exposes through fd_fdstat_get and enforces on fd_read/write/seek/readdir/


### PR DESCRIPTION
Follow-up to #140, stacked on #150 (base: `provider-protocol`) — retarget once that merges. With this, no macro is permanently excluded on any backend for the custom_wasi_provider / partial_override pair.

#150 left Bash unwired on the grounds that the "bundled wasi constructed" observable cannot exist — but the observable was never about an object, it is about whether the bundled implementation was engaged. `<p>init` now emits the bundled-WASI state block (`<p>w*` variables + `wasi_init_preopens`) after the import-wiring loop, guarded by a flag the fallback branch sets — so the state exists iff at least one wasi_snapshot_preview1 import actually fell back to the bundled function, the exact semantics Ruby/Python/Perl/Go/Java have. The `rt_enosys` branch deliberately does not set the flag; ADR-34's loud preopen failure still fires at instantiation whenever the bundled WASI is genuinely linked. ADR-7 already lists unconditional eager construction as a rejected alternative, so Bash now conforms rather than diverges — no ADR edit needed (checked 7/11/12/34/35).

Glue: a provider prefix (`PROVIDERS[wasi_snapshot_preview1]=my_` + `my_EXPORTS`) replaces WASI wholesale for the custom-provider case; `IMPORTS['wasi_snapshot_preview1.fd_write']` overrides one function for the partial case. Both probe with a real existence test (`declare -p prog_wfds`) — the bash counterpart of Ruby's `@wasi.nil?` — never a hard-coded string.

Every ultra glue was read (not run): the interpreter giants and zeroperl cases wire no wasi provider, so their first WASI import trips the fallback and the state builds exactly as before; DOOM/NES import no WASI at all and never had the state. No existing test reads `<p>w*` without a fallback.

Verified: fmt/clippy clean; full fast `cargo test` green; bash spec 257/257, wasi-testsuite 72/72, fs regressions 10/10, slow e2e 26 passed 0 failed including the two new cases.