### PR TITLE
Spill pendings whose temp operands are about to be clobbered

### DIFF
--- a/crates/dewasm-backend-bash/tests/e2e.rs
+++ b/crates/dewasm-backend-bash/tests/e2e.rs
@@ -694,6 +694,7 @@ dewasm_test_helper::wasi_root_containment_e2e!(Bash, BASH_CONTAINMENT_GLUE);
 dewasm_test_helper::standalone_dir_e2e!(Bash);
 // The standalone entrypoint already raises the process stack rlimit before running any guest code; that covers 5000 guest frames too.
 dewasm_test_helper::deep_recursion_e2e!(Bash);
+dewasm_test_helper::folded_temp_reuse_e2e!(Bash);
 
 dewasm_test_helper::cowsay_args_e2e!(Bash);
 dewasm_test_helper::cowsay_stdin_e2e!(Bash);

--- a/crates/dewasm-backend-go/tests/e2e.rs
+++ b/crates/dewasm-backend-go/tests/e2e.rs
@@ -872,6 +872,7 @@ dewasm_test_helper::wasi_root_containment_e2e!(Go, GO_CONTAINMENT_GLUE);
 dewasm_test_helper::standalone_dir_e2e!(Go);
 // Goroutine stacks start small and grow dynamically, so 5000 guest frames need no entrypoint mitigation.
 dewasm_test_helper::deep_recursion_e2e!(Go);
+dewasm_test_helper::folded_temp_reuse_e2e!(Go);
 
 dewasm_test_helper::cowsay_args_e2e!(Go);
 dewasm_test_helper::cowsay_stdin_e2e!(Go);

--- a/crates/dewasm-backend-java/tests/e2e.rs
+++ b/crates/dewasm-backend-java/tests/e2e.rs
@@ -850,6 +850,7 @@ dewasm_test_helper::wasi_root_containment_e2e!(Java, JAVA_CONTAINMENT_GLUE);
 dewasm_test_helper::standalone_dir_e2e!(Java);
 // The standalone entrypoint runs the guest on a dedicated 64 MiB thread (mirroring Python's mitigation), since Linux CI's 1 MiB default main-thread stack is marginal for 5000 guest frames.
 dewasm_test_helper::deep_recursion_e2e!(Java);
+dewasm_test_helper::folded_temp_reuse_e2e!(Java);
 
 dewasm_test_helper::cowsay_args_e2e!(Java);
 dewasm_test_helper::cowsay_stdin_e2e!(Java);

--- a/crates/dewasm-backend-perl/tests/e2e.rs
+++ b/crates/dewasm-backend-perl/tests/e2e.rs
@@ -566,6 +566,7 @@ dewasm_test_helper::wasi_root_containment_e2e!(Perl, PERL_CONTAINMENT_GLUE);
 dewasm_test_helper::standalone_dir_e2e!(Perl);
 // Perl recursion is heap-allocated (no host stack to overflow); the case pins that the entrypoint still surfaces proc_exit(42) through deep guest recursion.
 dewasm_test_helper::deep_recursion_e2e!(Perl);
+dewasm_test_helper::folded_temp_reuse_e2e!(Perl);
 
 dewasm_test_helper::cowsay_args_e2e!(Perl);
 dewasm_test_helper::cowsay_stdin_e2e!(Perl);

--- a/crates/dewasm-backend-python/tests/e2e.rs
+++ b/crates/dewasm-backend-python/tests/e2e.rs
@@ -621,6 +621,7 @@ dewasm_test_helper::wasi_root_containment_e2e!(Python, PYTHON_CONTAINMENT_GLUE);
 dewasm_test_helper::standalone_dir_e2e!(Python);
 // The standalone entrypoint's recursion mitigation (issue #31).
 dewasm_test_helper::deep_recursion_e2e!(Python);
+dewasm_test_helper::folded_temp_reuse_e2e!(Python);
 
 dewasm_test_helper::cowsay_args_e2e!(Python);
 dewasm_test_helper::cowsay_stdin_e2e!(Python);

--- a/crates/dewasm-backend-ruby/tests/e2e.rs
+++ b/crates/dewasm-backend-ruby/tests/e2e.rs
@@ -578,6 +578,7 @@ dewasm_test_helper::wasi_root_containment_e2e!(Ruby, RUBY_CONTAINMENT_GLUE);
 dewasm_test_helper::standalone_dir_e2e!(Ruby);
 // 5000 guest frames fit the host stack Ruby's entrypoint already runs on; no mitigation needed (measured).
 dewasm_test_helper::deep_recursion_e2e!(Ruby);
+dewasm_test_helper::folded_temp_reuse_e2e!(Ruby);
 
 dewasm_test_helper::cowsay_args_e2e!(Ruby);
 dewasm_test_helper::cowsay_stdin_e2e!(Ruby);

--- a/crates/dewasm-core/src/func.rs
+++ b/crates/dewasm-core/src/func.rs
@@ -1,6 +1,6 @@
 //! Translate a wasm function body (stack machine) into structured IR with build-time expression folding.
 //!
-//! The operand stack is modeled as a stack of `Slot`s. Each pushed value is kept as a *pending* expression (with its read/trap `Effects` and node count) rather than being materialized into a temp immediately. A pending is spilled to a temp (`sN = <expr>`) only when a later statement's effects could be observed by it, when it crosses a control-flow boundary, or when a consumer would grow it past `MAX_FOLD_SIZE` nodes. Single-use values thus fold directly into their consumer, cutting the statement count for every backend. Evaluation order and trap points are preserved by the spill discipline. Dead code after an unconditional branch is skipped while tracking block nesting only.
+//! The operand stack is modeled as a stack of `Slot`s. Each pushed value is kept as a *pending* expression (with its read/trap `Effects` and node count) rather than being materialized into a temp immediately. A pending is spilled to a temp (`sN = <expr>`) only when a later statement's effects could be observed by it, when a temp slot it reads is about to be written (`spill_clobbered`), when it crosses a control-flow boundary, or when a consumer would grow it past `MAX_FOLD_SIZE` nodes. Single-use values thus fold directly into their consumer, cutting the statement count for every backend. Evaluation order and trap points are preserved by the spill discipline. Dead code after an unconditional branch is skipped while tracking block nesting only.
 
 use std::collections::BTreeSet;
 
@@ -30,6 +30,8 @@ struct Effects {
     memory: bool,
     /// May trap (a load, a divide/remainder, or a non-saturating float->int truncation).
     trap: bool,
+    /// Deepest temp slot the expression reads, if it reads any. Temps are keyed by stack depth and a depth is reused as soon as it is free, while folding a k-ary operator pushes its result at the depth of its *first* operand — so a pending at depth d legitimately keeps reading temps at depths above d. Writing a temp at a depth this pending still reads would silently replace an operand, so `spill_clobbered` materializes the pending first.
+    max_temp_read: Option<u32>,
 }
 
 impl Effects {
@@ -53,6 +55,7 @@ impl Effects {
         self.globals |= o.globals;
         self.memory |= o.memory;
         self.trap |= o.trap;
+        self.max_temp_read = self.max_temp_read.max(o.max_temp_read);
     }
 
     fn reads_local(&self, idx: u32) -> bool {
@@ -208,10 +211,9 @@ impl<'a> FuncBuilder<'a> {
 
     /// Push a materialized value: allocate a temp for the top slot and record it in `self.temps`. Used for values that are never folded (call results, `memory.grow`) and by `spill`.
     fn push_temp(&mut self, ty: ValType) -> Temp {
-        let temp = Temp {
-            depth: self.stack.len() as u32,
-            ty,
-        };
+        let depth = self.stack.len() as u32;
+        self.spill_clobbered(depth);
+        let temp = Temp { depth, ty };
         self.temps.insert(temp);
         self.stack.push(Slot { ty, pending: None });
         temp
@@ -230,14 +232,17 @@ impl<'a> FuncBuilder<'a> {
         let slot = self.stack.pop().expect("value stack is not empty");
         match slot.pending {
             Some(p) => (p.expr, p.fx, p.size),
-            None => (
-                Expr::Temp(Temp {
-                    depth: self.stack.len() as u32,
-                    ty: slot.ty,
-                }),
-                Effects::default(),
-                1,
-            ),
+            None => {
+                let depth = self.stack.len() as u32;
+                (
+                    Expr::Temp(Temp { depth, ty: slot.ty }),
+                    Effects {
+                        max_temp_read: Some(depth),
+                        ..Effects::default()
+                    },
+                    1,
+                )
+            }
         }
     }
 
@@ -251,17 +256,38 @@ impl<'a> FuncBuilder<'a> {
 
     /// Materialize the pending value at stack index `idx` into its temp, emitting the assignment. A no-op if already materialized.
     fn spill(&mut self, idx: usize) {
+        if self.stack[idx].pending.is_none() {
+            return;
+        }
+        self.spill_clobbered(idx as u32);
         let ty = self.stack[idx].ty;
-        if let Some(p) = self.stack[idx].pending.take() {
-            let temp = Temp {
-                depth: idx as u32,
-                ty,
-            };
-            self.temps.insert(temp);
-            self.emit(Stmt::Assign {
-                dst: temp,
-                expr: p.expr,
-            });
+        let p = self.stack[idx]
+            .pending
+            .take()
+            .expect("the pending is still there");
+        let temp = Temp {
+            depth: idx as u32,
+            ty,
+        };
+        self.temps.insert(temp);
+        self.emit(Stmt::Assign {
+            dst: temp,
+            expr: p.expr,
+        });
+    }
+
+    /// A temp at depth `depth` (or above) is about to be written: spill every pending that still reads a temp that deep, so its operand is read before the write replaces it. Every temp write goes through `push_temp` (results of a call, `memory.grow`) or `spill` (the assignment it emits), so those two call this and nothing else has to.
+    ///
+    /// Only slots below `depth` can be at risk: a pending at depth d is built from slots at depths >= d, so it never reads a temp below its own slot. Spilling one of them writes its own, shallower temp, which is why `spill` re-enters here; the recursion walks strictly downwards and each level emits before its caller, keeping the assignments in ascending-depth (= wasm evaluation) order.
+    fn spill_clobbered(&mut self, depth: u32) {
+        for idx in 0..self.stack.len().min(depth as usize) {
+            let hit = self.stack[idx]
+                .pending
+                .as_ref()
+                .is_some_and(|p| p.fx.max_temp_read.is_some_and(|d| d >= depth));
+            if hit {
+                self.spill(idx);
+            }
         }
     }
 

--- a/crates/dewasm-core/tests/folding.rs
+++ b/crates/dewasm-core/tests/folding.rs
@@ -244,3 +244,88 @@ fn return_value_is_inlined_and_temps_track_materialization() {
         other => panic!("unexpected call/return shape: {other:?}"),
     }
 }
+
+#[test]
+fn a_call_result_spills_a_pending_that_reads_its_slot() {
+    // `(one() + two())` is pending at depth 0 and reads the temp at depth 1, which the third call's result then takes: the pending must be spilled before that call, or the addition would read 100 twice.
+    let f = func(
+        "(module
+            (func $one (result i32) i32.const 1)
+            (func $two (result i32) i32.const 2)
+            (func $big (result i32) i32.const 100)
+            (func (result i32)
+                call $one call $two i32.add
+                call $big i32.add))",
+        3,
+    );
+    let add_spill = f
+        .body
+        .iter()
+        .position(|s| {
+            matches!(
+                s,
+                Stmt::Assign {
+                    expr: Expr::Bin(BinOp::I32Add, ..),
+                    ..
+                }
+            )
+        })
+        .expect("the pending addition is spilled");
+    let calls_before = f.body[..add_spill]
+        .iter()
+        .filter(|s| matches!(s, Stmt::Call { .. }))
+        .count();
+    assert_eq!(
+        calls_before, 2,
+        "the spill sits between the second and third call: {:?}",
+        f.body
+    );
+}
+
+#[test]
+fn a_spill_flushes_a_pending_that_reads_the_reused_slot() {
+    // Same shape without a call: the store spills the pending load into the temp at depth 1, which the pending addition at depth 0 reads, so that addition has to be spilled first.
+    let f = func(
+        "(module
+            (memory 1)
+            (func $one (result i32) i32.const 1)
+            (func $two (result i32) i32.const 2)
+            (func (result i32)
+                call $one call $two i32.add
+                i32.const 0 i32.load
+                i32.const 4 i32.const 7 i32.store
+                i32.add))",
+        2,
+    );
+    let add_spill = f
+        .body
+        .iter()
+        .position(|s| {
+            matches!(
+                s,
+                Stmt::Assign {
+                    expr: Expr::Bin(BinOp::I32Add, ..),
+                    ..
+                }
+            )
+        })
+        .expect("the pending addition is spilled");
+    let load_spill = f
+        .body
+        .iter()
+        .position(|s| {
+            matches!(
+                s,
+                Stmt::Assign {
+                    expr: Expr::Load { .. },
+                    ..
+                }
+            )
+        })
+        .expect("the pending load is spilled by the store");
+    assert!(
+        add_spill < load_spill,
+        "the addition is read out before the load overwrites its operand slot: {:?}",
+        f.body
+    );
+}

--- a/crates/dewasm-test-helper/src/folding.rs
+++ b/crates/dewasm-test-helper/src/folding.rs
@@ -1,0 +1,24 @@
+//! Core expression-folding semantics observed through the generated code of every backend. The folding lives in `dewasm-core` and its IR shapes are asserted there; these cases run the result, because a mis-folded operand is only visible once the code executes.
+
+use dewasm_backend::Mode;
+
+use crate::backend::BackendUnderTest;
+use crate::fixtures::{convert, examples_dir};
+
+/// Run the folded-temp-reuse case (`folded_temp_reuse_e2e!`): convert `folded_temp_reuse.wat` in *standalone* mode and run it. The fixture computes two pure-arithmetic expressions whose operands sit in temp slots that a later call result / spill reuses, checks both against their constant results and reports through `proc_exit`, so the exit code alone says which one was clobbered (1 or 2; 42 means both are right). No glue — the fixture checks itself.
+pub fn run_folded_temp_reuse(lang: &dyn BackendUnderTest) {
+    let src = convert(
+        lang.backend(),
+        &examples_dir().join("folded_temp_reuse.wat"),
+        Mode::Standalone,
+        "folded_temp_reuse",
+    );
+    let output = lang.run(&src, &[], "");
+    assert_eq!(
+        output.status.code(),
+        Some(42),
+        "folded_temp_reuse under {}: exit code (1 = the call-result shape, 2 = the spill shape)\n{}",
+        lang.name(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/crates/dewasm-test-helper/src/lib.rs
+++ b/crates/dewasm-test-helper/src/lib.rs
@@ -7,6 +7,7 @@ mod apps_fs;
 mod backend;
 mod doom;
 mod fixtures;
+mod folding;
 mod glue;
 mod library;
 mod multimodule;
@@ -44,6 +45,7 @@ pub use fixtures::{
     apps_cache_dir, apps_fixtures_dir, apps_snapshot_dir, convert, convert_bytes,
     convert_on_big_stack, examples_dir, fresh_scratch_dir,
 };
+pub use folding::run_folded_temp_reuse;
 pub use library::{
     run_library_case, LibraryCase, CUSTOM_WASI_PROVIDER, LIBRARY_ADD, PARTIAL_OVERRIDE,
     STDIO_CAPTURE, WASI_IMPORT_OVERRIDE,
@@ -314,6 +316,17 @@ macro_rules! deep_recursion_e2e {
         #[test]
         fn deep_recursion() {
             $crate::run_deep_recursion(&$lang);
+        }
+    };
+}
+
+/// One `#[test]` requiring `$lang`'s generated code to keep folded operands alive across temp-slot reuse: convert `folded_temp_reuse.wat` standalone, run it, and require the guest's `proc_exit(42)` — see [`run_folded_temp_reuse`](crate::run_folded_temp_reuse). No glue — the fixture checks its own arithmetic. Core folding is language-independent, so every backend wires this.
+#[macro_export]
+macro_rules! folded_temp_reuse_e2e {
+    ($lang:expr) => {
+        #[test]
+        fn folded_temp_reuse() {
+            $crate::run_folded_temp_reuse(&$lang);
         }
     };
 }

--- a/examples/wat/folded_temp_reuse.wat
+++ b/examples/wat/folded_temp_reuse.wat
@@ -1,0 +1,40 @@
+;; Two shapes in which a folded operand can be overwritten by the reuse of the
+;; temp slot it reads: a call result taking the slot, and a spill writing it.
+;; Both are pure arithmetic, so any wrong result is a folding bug. _start
+;; reports via proc_exit: 42 when both check out, 1 or 2 for the failing one.
+(module
+  (import "wasi_snapshot_preview1" "proc_exit" (func $proc_exit (param i32)))
+  ;; Exported so wasmtime can run this fixture as ground truth: its WASI host
+  ;; functions require the guest memory to be exported.
+  (memory (export "memory") 1)
+  (func $one (result i32) i32.const 1)
+  (func $two (result i32) i32.const 2)
+  (func $big (result i32) i32.const 100)
+
+  ;; (T0 + T1) is still pending at depth 0 when $big's result takes depth 1.
+  (func $call_result (result i32)
+    call $one
+    call $two
+    i32.add
+    call $big
+    i32.add)
+
+  ;; The store spills the memory-reading pending at depth 1 into T1, which
+  ;; (T0 + T1), still pending at depth 0, reads.
+  (func $spilled (result i32)
+    call $one
+    call $two
+    i32.add
+    i32.const 0
+    i32.load
+    i32.const 4
+    i32.const 7
+    i32.store
+    i32.add)
+
+  (func (export "_start")
+    (if (i32.ne (call $call_result) (i32.const 103))
+      (then (call $proc_exit (i32.const 1))))
+    (if (i32.ne (call $spilled) (i32.const 3))
+      (then (call $proc_exit (i32.const 2))))
+    (call $proc_exit (i32.const 42))))


### PR DESCRIPTION
Closes #175.

Core folding bug, present on main, affecting every backend identically: a pending expression's temp operands were invisible to the interference model, so reusing a temp slot (call/call_indirect results, memory.grow, or any spill) could silently replace an operand of a still-pending expression. Found by converting pozeiden (a Zig mermaid renderer) — its classDiagram output was corrupt on Ruby, Python, and Perl alike while wasmtime rendered it correctly; the wire was a Zig error-union-of-slice return whose length arrived as a rodata address.

The fix (crates/dewasm-core/src/func.rs): `Effects.max_temp_read` records the deepest temp depth an expression reads (max is the precise bound: a pending at depth d only reads depths ≥ d), and `spill_clobbered(depth)` — the single statement of the invariant — spills every pending that still reads a depth about to be written. Called from the two temp-writing sites, `push_temp` and `spill`; the recursion walks strictly downward and emits spills in wasm evaluation order.

- Reproducers: `examples/wat/folded_temp_reuse.wat`, a self-checking fixture (exit 42 on success; wasmtime-verified) covering both the call-result clobber (was: 201 instead of 103) and the call-free spill variant (was: 1 instead of 3). Run by all six backends via `folded_temp_reuse_e2e!`, plus two IR-level tests in `crates/dewasm-core/tests/folding.rs` that fail on the pre-fix builder.
- Collateral: the extra spilling is essentially free — cowsay's Ruby output +16 bytes (one line), qjs unchanged.
- Verification: workspace suite passes; full spec (`--include-ignored`) 257/257 on Ruby and Python; `--features slow_test` on Ruby (qjs, sqlite3, cpython, NES frame) passes; the pozeiden classDiagram that exposed the bug now renders a real SVG on the fixed backend.

Review notes, spelled out in the code where they bind: the downward-only scan in `spill_clobbered` rests on "a pending at depth d never reads below d" (holds by the push/pop discipline); call arguments may read the depths the call's results overwrite, which is safe because operands are evaluated before results within one statement — pre-existing, unchanged.