### PR TITLE
Restructure AGENTS.md around explicit style rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,48 +7,72 @@
 
 # AGENTS.md
 
-Agent contract for dewasm. Project docs are written in English; `tests/spec` is an upstream submodule: never edit it.
+Agent contract for dewasm.
+Project docs are written in English; `tests/spec` and `tests/wasi-testsuite` are upstream submodules: never edit them.
 
 ## Development environment
 
-Rust toolchain is pinned by `rust-toolchain.toml` (stable); plain `cargo` commands pick it up. Required tools/setup for the test suite (ruby >= 3.4, bash >= 5, the spec submodule, the `apps` cache) and the fail-loud-not-skip policy behind it are documented in [`docs/testing.md`](docs/testing.md). Read it before wondering why a test panics with a setup instruction instead of skipping.
+The Rust toolchain is pinned by `rust-toolchain.toml`; plain `cargo` commands pick it up.
+Everything else the test suite needs (interpreters, submodules, the apps cache) and the fail-loud-not-skip policy behind it are in [`docs/testing.md`](docs/testing.md).
 
 ## Common commands
 
 | Command | What it does |
 | --- | --- |
-| `cargo test` | **The baseline check for every change**: unit + e2e + curated spec harness. The spec harness is a libtest-mimic test (one trial per `.wast` file); each backend crate owns its own conformance suites, only cross-backend tests live in `dewasm-cli`. |
+| `cargo test` | The baseline check for every change: unit + e2e + curated spec harness. |
 | `cargo fmt --check` | Verify Rust code formatting. |
-| `cargo clippy --all-targets -- -D warnings` | Run linter on all targets, failing on any warnings. |
-| `cargo test -p dewasm-backend-ruby --test spec i32` | Spec harness on `.wast` files whose name matches (cargo's built-in test-name filter: substring, add `--exact` for one file). Swap the crate (`-p dewasm-backend-bash`) to switch language. |
-| `cargo test -p dewasm-backend-bash --test spec -- --include-ignored` | Full-testsuite run for bash (curated files are the default; the rest are `#[ignore]`d trials); trials run in parallel. Use `-- --ignored` to run only the non-curated files. |
-| `cargo test -p dewasm-backend-ruby --test convert` | Whole-cache convert suite: converts every cached app with the backend, no run. One trial per app (name = cache stem); `ruby`/`cpython` are `slow_test`-conditional. Swap the crate to switch language. |
+| `cargo clippy --all-targets -- -D warnings` | Run the linter on all targets, failing on any warning. |
+| `cargo test -p dewasm-backend-ruby --test spec i32` | Spec harness on `.wast` files whose name contains the filter; swap the crate to switch backend. |
+| `cargo test -p dewasm-backend-ruby --test convert` | Convert every cached app with that backend, without running the output. |
 | `cargo run -p dewasm-cli -- input.wasm --mode standalone -o out.rb` | Convert; `.wat` input works too, `-o -` for stdout. |
-| `cargo xtask bench [filter]` | Run the cross-runtime benchmark suite: every backend, wasmtime and the other native runtimes (wasmer, wasmedge, wazero, wasm3), and the pywasm/wardite interpreters, over the `benchmarks/wat/` and `benchmarks/c/` microbenchmarks and the app cases. Writes a dated result file to `benchmarks/results/` and regenerates `docs/benchmarks/results.md` together with the SVG charts it embeds (`docs/benchmarks/figs/`, one per workload; charts the record no longer covers are pruned): a measurement, not a snapshot, so no freshness test guards it. `--list` prints the matrix and each runner's availability without running anything; `--reps`/`--target-ms`/`--timeout` tune the measurement; `--render benchmarks/results/<file>.json` regenerates the doc from a stored record, since a full benchmark run takes tens of minutes and a wording change must not require re-measuring. Needs `wasmtime` plus `benchmarks/wat/build.sh`, `benchmarks/c/build.sh` and `benchmarks/setup.sh`; anything missing is reported as skipped-with-reason. |
-| `cargo xtask size` | Run the size record, the distribution-size counterpart of the benchmark suite: per cached app (cowsay, sqlite3-shell, qjs, ruby) the wasm binary and every backend's converted standalone source, beside the installed size of each native runtime on the host (wasmtime, wasmer, wasmedge, wazero, wasm3). Raw bytes, never compressed. Writes a dated record to `benchmarks/results/<timestamp>Z-size.json`, beside the speed records, and regenerates `docs/sizes/results.md` together with the SVG figures it embeds (`docs/sizes/figs/`; figures the record no longer covers are pruned): a measurement, not a snapshot, so no freshness test guards it. `docs/sizes/README.md` is hand-written: how to run this and how to read the numbers. `--render benchmarks/results/<file>-size.json` regenerates the document from a stored record without measuring. Needs the apps cache (`examples/apps/setup.sh`); a missing app or an uninstalled runtime is reported as skipped-with-reason. |
-| `examples/apps/setup.sh` | Fetch/build the pinned real-world apps (cowsay, QuickJS, the three sqlite3 shapes, minigzip, libpcap, tree-sitter, ripgrep, zeroperl, CPython, CRuby plus its wasi-vfs-packed shape) into the gitignored cache; needs a few build tools on PATH (`zig`, the `wasm32-wasip1` rustup target, `wasi-vfs`; see docs/testing.md). Enables the `apps` cases of the `e2e` test. |
+| `cargo xtask bench [filter]` | The cross-runtime benchmark suite; see [`docs/benchmarks/README.md`](docs/benchmarks/README.md). |
+| `cargo xtask size` | The distribution-size record; see [`docs/sizes/README.md`](docs/sizes/README.md). |
+| `examples/apps/setup.sh` | Fetch/build the pinned real-world apps into the gitignored cache; tool requirements are in docs/testing.md. |
 
-## Verification
-
-After any non-trivial change, run `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test`. Tests are divided by execution time: `cargo test` is the fast test. `--features slow_test` adds each backend's slow app cases (QuickJS, SQLite, the filesystem/C-API apps, the interactive-REPL pty case) plus the full spec-testsuite run. This is CI's main run, controlled by that backend's `slow_test` cargo feature rather than an environment variable. `--features ultra_slow_test` (or the everything-included `cargo test -- --include-ignored`) additionally runs the ultra-slow category: the cases a CI runner cannot afford, by wall time (~1 minute or more: the bash interactive-REPL pty case, go's giant generated-program builds) or by memory (the packed-CRuby case on Python, issue #126), which are deliberately kept out of CI and run only in local pre-release verification (the DOOM and NES framebuffer snapshots under Bash also live here; the same cases run in the slow category on the other backends). Spec-harness failures mean a semantics bug: fix the cause. Adding to a per-backend `EXPECTED_FAILURES` list in `crates/dewasm-backend-<lang>/tests/spec.rs` is a last resort and requires an attribution tag plus a reason. When support declarations or WASI units change, regenerate the matrix: `cargo xtask update-support-docs` (`cargo test -p dewasm-cli --test support_docs` fails while docs/support.md is stale).
-
-## Implementation guidelines
-
-- Where the WASI spec is silent (trailing-slash paths, errno flavors), behavior copies wasmtime as measured on both CI hosts, and the wasi-testsuite Rust suite runs under host-pinned strict errno modes.
-- **The spec testsuite binds.** Correctness of generated code outranks its readability; readability improvements go into optional passes, never into semantics-relevant lowering.
-- Numeric representation conventions (masked-unsigned integers, f32 re-rounding, NaN bit paths) are shared across backends; new backends follow them. Each backend also has fixed lowering shapes. Ruby: a branch crossing ≥16 frames is addressed by value, shallower ones relay, uncrossed frames stay structured, and expression parens are emitted only where precedence requires them. Bash: the status-cascade trap protocol, the `return 0` discipline the units lint enforces, WASI conventions of status-133 proc_exit and byte-wise binary stdio, and a softfloat of bit-pattern floats under the round_pack contract (Rust-oracle test in `crates/dewasm-backend-bash/tests/softfloat.rs`). Ruby's WASI filesystem support is complete to full WASI p1: the `preopens:` provider kwarg, the fd-table model, the symlink family, the enforced per-fd rights model, and the accepted TOCTOU sandboxing caveat.
-- Runtime code lives as per-method units under `runtime/<lang>/units/` with `# requires:` headers, referenced as `Rt`; keep the headers in sync when editing a unit. The units lint test enforces most of it. `Embedded` linkage must isolate that runtime per artifact so two artifacts coexist in one namespace; `embedded_coexist_e2e!` is the check, and a backend that does not invoke it is unfinished, not incapable.
-- A new backend is done when the shared spec harness passes for it, not before.
-- Backends declare their capabilities directly: feature support (`Backend::feature_status`) and per-function WASI p1 coverage (`Backend::has_wasi_p1`), rendered flat into `docs/support.md`; there is no per-backend support maturity level. The standard goal for a new backend is wasm 1.0 + full WASI p1. Wasm 2.0+ proposals and the component model are rejected outright, not a backend opt-in.
-- Unsupported wasm features must fail at conversion time with a clear error, never at runtime. Non-function imports, multiple tables, and table bulk ops are accepted by the core IR unconditionally; a backend that hasn't implemented one must reject it itself via `dewasm_backend::check_module_support`, which also covers the `Rt::Global` box, the import-kind check, and the spec harness's `register` support.
-- A library-mode `--module-name` is used verbatim or rejected with its grammar; a standalone artifact's internal name is fixed (`Program`/`program_`) and `--module-name` is refused there. Validate in `Backend::generate` only, never in the `*_with_units` APIs the spec harness drives. Test tables carry kebab-case names and convert them with `dewasm_test_helper::derive_module_name`; no transformation belongs in the product.
+After any non-trivial change, run `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test`.
+The slower test categories are opt-in cargo features: `--features slow_test` (CI's main run) adds each backend's slow app cases and the full spec-testsuite run; `--features ultra_slow_test` adds the cases CI cannot afford, run in local pre-release verification.
+Which case sits in which category, and why, is pinned at its callsite in that backend's `e2e.rs`; the mechanism is in docs/testing.md.
+When support declarations or WASI units change, regenerate `docs/support.md` with `cargo xtask update-support-docs`.
 
 ## ADRs
 
-Significant decisions, anything with real alternatives, are recorded in [`docs/adr/`](docs/adr/README.md): its README holds the index and the quality bar, and the `adr-author` skill holds the procedure (numbering, the skeleton, the index update). Docs and code comments do not cite ADRs. State the constraint in place, and let the ADR link out to the code it governs.
+Significant decisions, anything with real alternatives, are recorded in [`docs/adr/`](docs/adr/README.md): its README holds the index and the quality bar, and the `adr-author` skill holds the procedure.
+An ADR is agent-facing memory, so only agent-facing documents (this file) may cite one.
+Code and user-facing docs state their constraints in place, and the ADR links out to the code it governs, never the reverse.
+
+## Writing style
+
+Applies to all prose: docs, comments, PR text.
+
+- Do not wrap lines at a fixed column; start each sentence on its own line. (Commit message bodies keep their ~72-column convention.)
+- Do not coin metaphor-based vocabulary: write "CI passes", not "CI is green"; "snapshot test", not "golden test". A term must be understandable without knowing the image behind it.
+- Use one term per concept; do not vary wording for style.
+- One paragraph explains one thing. A side note worth keeping gets its own paragraph; usually it is worth deleting instead.
+- Prefer a self-contained example, a table, or a figure over prose describing one.
+
+## Coding style
+
+- Express behavior through names, types, and control structure before reaching for a comment; a comment never describes what the code does.
+- The comments that remain state constraints the code cannot express: an external spec's requirement, a compatibility target, a non-obvious invariant.
+- A doc comment is the minimal statement of contract. If the name, parameters, and return type cannot carry a function's meaning, the function may be doing too much.
 
 ## Commit etiquette
 
 - Imperative subject in sentence case; **no** Conventional-Commits `type:` prefixes.
 - Body explains the *why*, wrapped at ~72 columns; the diff already shows the what.
 - Do not commit or push unless asked.
+
+## Implementation guidelines
+
+Each rule is stated here in full; the cited ADR holds its rationale and rejected alternatives.
+
+- The spec testsuite binds (ADR-3). Correctness of generated code outranks its readability; readability improvements go into optional passes, never into semantics-relevant lowering.
+- Where the WASI spec is silent, copy wasmtime's behavior as measured on both CI hosts (ADR-49).
+- Numeric representation conventions — masked-unsigned integers, f32 re-rounding, NaN bit paths — are shared across backends (ADR-2).
+- Each backend's lowering shapes are fixed; follow them rather than restructuring in passing. They are recorded per backend: Ruby ADR-4/42-44/58/60/65, Bash ADR-5/11-13/34/35/51/52, Python ADR-28, Go ADR-29, Java ADR-30, Perl ADR-55.
+- Runtime code lives as per-method units under `runtime/<lang>/units/` with `# requires:` headers, referenced as `Rt` (ADR-6); keep the headers in sync when editing a unit (the units lint enforces most of it).
+- `Embedded` linkage isolates the runtime per artifact so two artifacts coexist in one namespace (ADR-62); `embedded_coexist_e2e!` is the check, and a backend that does not invoke it is unfinished, not incapable.
+- A new backend is done when the shared spec harness passes for it, not before. The standard goal is wasm 1.0 + full WASI p1 (ADR-24); wasm 2.0+ proposals and the component model are rejected outright, not per backend.
+- Backends declare their capabilities directly, `Backend::feature_status` and `Backend::has_wasi_p1`, rendered into `docs/support.md` (ADR-25); there is no per-backend support maturity level.
+- An unsupported wasm feature fails at conversion time with a clear error, never at runtime; a backend rejects what the core IR accepts but it has not implemented via `dewasm_backend::check_module_support`.
+- A library-mode `--module-name` is used verbatim or rejected with its grammar; a standalone artifact's internal name is fixed, and the option is refused there (ADR-63). Validate in `Backend::generate` only, never in the `*_with_units` APIs. Test tables carry kebab-case names, converted with `dewasm_test_helper::derive_module_name`; no name transformation belongs in the product.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -86,7 +86,7 @@ When a decision with real alternatives is made:
 1. Take the next free number and create `docs/adr/<N>-<slug>.md`.
 2. Follow the structural contract: an opening **Status** paragraph (state, date, what landed / what remains), then **Context**, **Decision**, **Rejected alternatives**, **Consequences**.
 3. Add a row to the index table above, in ascending order.
-4. Cross-reference: link related ADRs, and link from the ADR out to the code and docs it governs. The reverse direction does not exist: docs and code comments state their constraints in place and never cite an ADR.
+4. Cross-reference: link related ADRs, and link from the ADR out to the code and docs it governs. Code and user-facing docs never cite an ADR; they state their constraints in place. The one inbound citer is `AGENTS.md`.
 
 Quality bar:
 
@@ -98,7 +98,7 @@ Quality bar:
 
 ## Relationship to other documents
 
-- **`AGENTS.md`**: the development contract for agents (and humans) working in this repository; it states each rule directly and cites no ADR.
+- **`AGENTS.md`**: the development contract for agents (and humans) working in this repository; it states each rule in full and cites the ADR that holds the rationale.
 - **`README.md`**: user-facing overview. It points onward to `docs/getting-started.md`, `docs/backends/`, and `docs/support.md`, not into this directory.
 - **`docs/getting-started.md`** and **`docs/backends/`**: the user tutorial and per-target reference. They state the lowering rules in place and name no ADR, per `docs/docs-policy.md`; the rationale behind those rules lives here (ADR-4, ADR-11 to ADR-13, ADR-28 to ADR-30, ADR-55).
 - **`docs/docs-policy.md`**: the doc taxonomy (which file each kind of content belongs in, and why `docs/support.md` is generated, never hand-edited).

--- a/docs/docs-policy.md
+++ b/docs/docs-policy.md
@@ -21,7 +21,7 @@ The taxonomy of dewasm's docs, so new content lands in one obvious place and not
 ## Rules
 
 - **`docs/support.md` is generated** from the backend declarations. Never edit it by hand; regenerate with `cargo xtask update-support-docs` (`cargo test -p dewasm-cli --test support_docs` fails while the file is stale). Everywhere else, **link** to it rather than copying the matrix.
-- **Decisions go in an ADR, not in prose docs.** Anything with real alternatives is recorded under `docs/adr/` (the `adr-author` skill carries the procedure). Docs and code comments do not reference ADRs at all: a doc or comment states its constraint in place, and the decision record links outward to the code and docs it governs, never the other way around.
+- **Decisions go in an ADR, not in prose docs.** Anything with real alternatives is recorded under `docs/adr/` (the `adr-author` skill carries the procedure). Code and user-facing docs do not reference ADRs: they state their constraint in place, and the decision record links outward to the code and docs it governs. The one exception is `AGENTS.md`, which is agent-facing memory like the ADRs themselves and cites the ADR that holds a rule's rationale.
 - **Tutorial commands must be verified by running them.** getting-started and the backend docs claim exact output; keep them true.
 
 ## Where new content goes

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -87,6 +87,9 @@ Each backend's spec integration test (`crates/dewasm-backend-<lang>/tests/spec.r
 
 A passing trial is quiet; a failing one carries that file's `pass/fail/skip` summary plus the failing assertion lines. Per-file failure counts are checked against each backend's `EXPECTED_FAILURES` list inside the trial.
 
+A failing trial means a semantics bug: fix the cause.
+Extending a backend's `EXPECTED_FAILURES` list (in its `tests/spec.rs`) is a last resort and requires an attribution tag plus a reason.
+
 The slow app cases (QuickJS, SQLite, the filesystem apps, the C-API cases, the interactive-REPL pty case) are divided into two speed categories controlled by cargo features rather than an environment variable:
 
 - **`slow_test`**: CI's main run. Each backend crate declares it; the per-case macros expand their generated `#[test]` as `#[ignore]`d unless it is enabled, and it also runs the full spec-testsuite run. Run one backend's slow category with `--features slow_test` (e.g. `cargo test -p dewasm-backend-bash --features slow_test --test e2e`).


### PR DESCRIPTION
Closes #178.

- Add **Writing style** (sentence per line, no metaphor-based vocabulary, one term per concept, one topic per paragraph, prefer examples over prose) and **Coding style** (comments never describe what the code does; the ones that remain state constraints the code cannot express; minimal doc comments).
- Merge Verification into Common commands and drop detail already owned by docs/testing.md and the benchmark/size READMEs; the `EXPECTED_FAILURES` policy moves to docs/testing.md beside the harness it governs.
- Reduce Implementation guidelines to one rule per line, citing the ADR that holds the rationale. The ADR-citation rule is rescoped accordingly in docs-policy and the ADR README: an ADR is agent-facing memory, and only agent-facing documents cite one.
- Section order: Common commands → ADRs → Writing style → Coding style → Commit etiquette → Implementation guidelines.

Follow-ups: #179 (docs conformance), #180 (code comment audit).