### PR TITLE
Drop comments that narrate the code they sit above

### DIFF
--- a/crates/dewasm-backend-bash/src/lib.rs
+++ b/crates/dewasm-backend-bash/src/lib.rs
@@ -76,7 +76,7 @@ pub fn prefix_runtime_names(bundle: &str, prefix: &str) -> String {
     let bytes = bundle.as_bytes();
     let is_word = |b: u8| b.is_ascii_alphanumeric() || b == b'_';
     let mut out = String::with_capacity(bundle.len());
-    // Everything before `copied` is already in `out`; a match copies the run before it, then the prefix, and skips past the name.
+    // Invariant: everything before `copied` is already in `out`.
     let mut copied = 0;
     let mut i = 0;
     while i < bytes.len() {
@@ -256,7 +256,7 @@ impl Backend for BashBackend {
             // Each wasm call nests one native bash function call, and a deeply recursive guest (e.g. QuickJS's interactive REPL, whose startup alone reaches tens of thousands of frames) can exhaust the *process's* C stack — not the bounded, trappable wasm one (FUNCNEST) — and crash with a real SIGSEGV rather than a caught wasm trap. Raise the soft rlimit to the max this process is allowed before running any guest code; both attempts degrade silently (`|| true`) since a sandboxed environment may refuse both, in which case behavior is unchanged from before this line existed.
             w.line("ulimit -s unlimited 2>/dev/null || ulimit -s \"$(ulimit -Hs)\" 2>/dev/null || true");
             if wasi_bundled(module, opts.default_wasi, bundler()) {
-                // Standalone runtime interface: consume a leading run of `--dir HOST::GUEST` flags into WASI_DIRS (wasmtime-style), stopping at `--` or the first non-flag token; the rest is the guest's argv[1..]. The Bash backend now honors --dir with real filesystem support, mirroring the Ruby standalone parser.
+                // Standalone runtime interface, mirroring the Ruby standalone parser: consume a leading run of `--dir HOST::GUEST` flags into WASI_DIRS (wasmtime-style), stopping at `--` or the first non-flag token; the rest is the guest's argv[1..].
                 w.line("WASI_DIRS=()");
                 w.line("while (( $# )); do");
                 w.line("\tcase \"$1\" in");
@@ -398,7 +398,7 @@ impl<'a> Gen<'a> {
         let link_err = self.rt("rt_link_err");
         w.line(format!("{p}init() {{"));
         w.indent();
-        // Emission order mirrors the Ruby backend: import registries, memory, tables, WASI state, then imports resolved kind by kind, then defined state, then export maps, then start.
+        // Emission order mirrors the Ruby backend.
         let num_imported_globals = m.imported_globals.len();
         let has_imports = !m.imported_funcs.is_empty()
             || !m.imported_globals.is_empty()

--- a/crates/dewasm-backend-bash/tests/softfloat.rs
+++ b/crates/dewasm-backend-bash/tests/softfloat.rs
@@ -551,7 +551,6 @@ fn softfloat_conversions() {
         );
     }
 
-    // promote / demote
     let mut f32s: Vec<i64> = F32_EDGES.iter().map(|&v| v as i64).collect();
     let mut f64s: Vec<i64> = F64_EDGES.iter().map(|&v| v as i64).collect();
     for _ in 0..1500 {
@@ -577,7 +576,6 @@ fn softfloat_conversions() {
         cases.push("f32_demote", a, 0, expect);
     }
 
-    // truncations, f64 and f32 sources
     let mut trunc64: Vec<i64> = F64_EDGES.iter().map(|&v| v as i64).collect();
     trunc64.extend(TRUNC_EDGES64.iter().map(|&v| v as i64));
     for _ in 0..1000 {

--- a/crates/dewasm-backend-go/src/lib.rs
+++ b/crates/dewasm-backend-go/src/lib.rs
@@ -73,7 +73,8 @@ pub fn bundler() -> &'static RuntimeBundler {
     })
 }
 
-/// Locate a `go` toolchain able to compile generated programs. Honors `$DEWASM_GO`, then `go` on `PATH` (a missing toolchain is a loud failure at the call site, not here — this only reports what qualifies).
+/// Locate a `go` toolchain able to compile generated programs: `$DEWASM_GO` first, then `go` on `PATH`.
+/// A missing toolchain is a loud failure at the call site, not here.
 pub fn find_go() -> Option<std::path::PathBuf> {
     static GO: OnceLock<Option<std::path::PathBuf>> = OnceLock::new();
     GO.get_or_init(find_go_uncached).clone()
@@ -127,7 +128,6 @@ impl Backend for GoBackend {
         match feature {
             // Go floats are native IEEE float32/float64, and the NaN paths are bit-exact via `math.Float32bits`/`Float64bits`.
             Feature::Floats => SupportStatus::Supported,
-            // Wasm-1.0 completion: imported globals/memories/tables through the provider map with a Go type-assertion kind+type check, multiple tables, and the table half of bulk memory (passive/declared element segments, table.init/copy, elem.drop).
             Feature::ImportedGlobals
             | Feature::ImportedMemories
             | Feature::ImportedTables
@@ -205,7 +205,7 @@ fn generate_source(module: &Module, opts: &GenOptions) -> Result<String> {
         data_offsets: data_offsets(module),
     };
 
-    // Body: the generated struct + constructor + methods, into its own writer so the `uses` set is fully populated before we bundle the runtime.
+    // Into its own writer: the `uses` set must be complete before the runtime bundle is assembled.
     let mut body = CodeWriter::new("\t");
     gen.emit_program(&mut body);
 
@@ -416,7 +416,7 @@ fn validate_library_module_name(name: &str) -> Result<()> {
     }
 }
 
-/// The package clause of a library artifact: the module name lowercased. Total on a validated name.
+/// The package clause of a library artifact. Total on a validated name.
 fn package_name(module_name: &str) -> String {
     module_name.to_ascii_lowercase()
 }
@@ -1795,7 +1795,6 @@ mod units {
 
         let rt_call = Regex::new(r"Rt\.([a-z_][a-z0-9_]*)").unwrap();
         let memory_call = Regex::new(r"\.memory\.([a-z_][a-z0-9_]*)").unwrap();
-        // One precompiled sibling-call matcher per non-rt unit (`<recv>.<name>(`).
         let recv_of = |scope: &str| -> Option<&'static str> {
             match scope {
                 "memory" => Some("m"),

--- a/crates/dewasm-backend-go/tests/common/mod.rs
+++ b/crates/dewasm-backend-go/tests/common/mod.rs
@@ -90,7 +90,7 @@ pub fn build_go_dir(dir: &std::path::Path) -> Result<PathBuf, Output> {
     Ok(bin)
 }
 
-/// `go build -o out target`, optionally from `cwd` (the temp module root for the package layout).
+/// `cwd`, when given, is the temp module root the package layout is built from.
 fn run_build(
     go: &std::path::Path,
     out: &std::path::Path,

--- a/crates/dewasm-backend-java/src/lib.rs
+++ b/crates/dewasm-backend-java/src/lib.rs
@@ -180,7 +180,6 @@ impl Backend for JavaBackend {
         match feature {
             // Java floats are native IEEE float/double; NaN paths mirror Ruby's numeric conventions.
             Feature::Floats => SupportStatus::Supported,
-            // Wasm-1.0 completion, mirroring Go's model: imported globals/memories/tables through the provider map with an `instanceof` kind check, multiple tables, and the table half of bulk memory (passive/declared element segments, table.init/copy, elem.drop).
             Feature::ImportedGlobals
             | Feature::ImportedMemories
             | Feature::ImportedTables
@@ -290,7 +289,7 @@ fn generate_source(module: &Module, opts: &GenOptions) -> Result<String> {
     gen.partitioned
         .set(module.funcs.len() > FN_PARTITION_THRESHOLD);
 
-    // Emit the module class body into its own writer so `uses` is populated before the runtime bundle is assembled.
+    // Into its own writer: `uses` must be complete before the runtime bundle is assembled.
     let mut body = CodeWriter::new("\t");
     gen.constructor(&mut body);
     // Externalized data blob: a static field loaded once from the sidecar next to this program, sliced by the generated `Arrays.copyOfRange(DATA_BLOB, …)` calls. Only emitted when there is data to externalize (otherwise the generated code never reads it).
@@ -339,7 +338,7 @@ fn generate_source(module: &Module, opts: &GenOptions) -> Result<String> {
     Ok(out)
 }
 
-/// Re-indent a block of source by `levels` (four spaces each), leaving blank lines empty.
+/// Re-indent a block of source by `levels`, leaving blank lines empty.
 fn reindent(src: &str, levels: usize) -> String {
     let pad = "\t".repeat(levels);
     let mut out = String::new();
@@ -1156,7 +1155,6 @@ impl<'a> Gen<'a> {
         let m = self.module;
         let ty = &m.types[import.type_idx as usize];
 
-        // Whether the fallback below needs the bundled WASI built first (its `__w` local).
         let mut needs_wasi = false;
         let fallback = if is_wasi_module(&import.module) && self.default_wasi {
             let unit = format!("wasi/{}", import.name);
@@ -1896,7 +1894,6 @@ impl<'a> Gen<'a> {
             0 => {}
             1 => w.line(format!("{} = {};", self.ret(), self.expr(&values[0]))),
             _ => {
-                // Multi-value: box each into the function's `Object[]` register.
                 let vs = values
                     .iter()
                     .map(|v| self.expr(v))
@@ -2202,7 +2199,6 @@ fn ret_slot_init(results: &[ValType]) -> String {
     }
 }
 
-/// Box an `Object` back to a Java primitive of the wasm value type.
 fn unbox(ty: ValType, expr: &str) -> String {
     match ty {
         ValType::I32 => format!("(int)(Integer) {expr}"),

--- a/crates/dewasm-backend-perl/src/lib.rs
+++ b/crates/dewasm-backend-perl/src/lib.rs
@@ -109,7 +109,7 @@ fn find_perl_uncached() -> Option<std::path::PathBuf> {
     None
 }
 
-/// Generate one package for `module`. Returns the package source and the set of runtime units it needs (already bundled inside for `Embedded`).
+/// Returns the package source and the set of runtime units it needs (already bundled inside for `Embedded`).
 pub fn generate_package_with_units(
     module: &Module,
     package_name: &str,
@@ -173,7 +173,7 @@ fn generate_package_inner(
             }
         }
         RuntimeLinkage::Alias(path) => {
-            // Generated code references the runtime as `Rt` directly; a shared runtime under any other name is aliased in via a stash alias.
+            // Generated code references the runtime as `Rt` directly.
             if path != "Rt" {
                 out.push_str(&format!("BEGIN {{ *Rt:: = \\%{path}::; }}\n\n"));
             }
@@ -842,7 +842,7 @@ impl<'a> Gen<'a> {
             self.rt("exhausted"),
             self.rt_name
         ));
-        // A run of consecutive locals sharing one default is declared in a single statement — a list assignment of that many copies, or, where the default is `undef`, the bare declaration a fresh lexical already satisfies.
+        // A fresh perl lexical is already `undef`, so a run defaulting to `undef` needs no initializer.
         for run in local_runs(&func.locals, default_value) {
             let default = default_value(func.locals[run.start]);
             let names: Vec<String> = run.map(|k| format!("$l{}", ty.params.len() + k)).collect();
@@ -1054,7 +1054,6 @@ impl<'a> Gen<'a> {
                 w.line(format!("{}('unreachable');", self.rt("trap")));
             }
             Stmt::SourceLine(pos) => {
-                // A source-position back-mapping comment; inert.
                 let file = &self.module.debug_files[pos.file as usize];
                 w.line(format!("# {file}:{}", pos.line));
             }
@@ -1399,9 +1398,7 @@ mod branch_shape {
                   (local.set 1 (i32.const 7)))
                 (local.get 1)))"#,
         );
-        // The loop is a labeled `while (1)`; both blocks are labeled bare blocks.
         assert!(source.contains(": while (1) {"), "loop frame:\n{source}");
-        // Branches are direct label exits/continues: the back-edge is a `next`, the block exits are `last`s at two different depths.
         assert!(source.contains("next L"), "loop back-edge:\n{source}");
         let lasts = source.matches("last L").count();
         assert!(lasts >= 3, "multi-level exits (got {lasts}):\n{source}");
@@ -1555,7 +1552,6 @@ mod units {
                 demand(dep, &format!("Rt::{name}"));
             }
 
-            // Sibling calls within the same scope's package.
             for (sibling, re) in &sibling_calls {
                 let Some(name) = sibling.strip_prefix(&format!("{scope}/")) else {
                     continue;

--- a/crates/dewasm-backend-perl/tests/e2e.rs
+++ b/crates/dewasm-backend-perl/tests/e2e.rs
@@ -80,7 +80,6 @@ impl BackendUnderTest for Perl {
     }
 }
 
-/// `add.wat`: call the exported functions and print each result.
 const PERL_ADD_GLUE: &str = r#"my $inst = Add->new({});
 print $inst->invoke('add', 2, 3), "\n";
 print $inst->invoke('add', 0xffffffff, 1), "\n";

--- a/crates/dewasm-backend-python/src/lib.rs
+++ b/crates/dewasm-backend-python/src/lib.rs
@@ -119,7 +119,7 @@ fn find_python_uncached() -> Option<std::path::PathBuf> {
     None
 }
 
-/// Generate one class for `module`. Returns the class source and the set of runtime units it needs (already bundled inside for `Embedded`).
+/// Returns the class source and the set of runtime units it needs (already bundled inside for `Embedded`).
 pub fn generate_class_with_units(
     module: &Module,
     class_name: &str,
@@ -942,7 +942,7 @@ impl<'a> Gen<'a> {
         }
         w.line(format!("def _f{idx}(self{params}):"));
         w.indent();
-        // Consecutive locals sharing one default are initialized in a single chained assignment — the defaults are immutable literals, so every name ends up bound to its own value, not to a shared object.
+        // The defaults are immutable literals, so a chained assignment binds every name to its own value rather than to one shared object.
         for run in local_runs(&func.locals, default_value) {
             let default = default_value(func.locals[run.start]);
             let names = run
@@ -978,7 +978,7 @@ impl<'a> Gen<'a> {
                 self.emit_seq(w, &func.body, &mut guarded, true);
             }
             Some(n) => {
-                // Each state is rendered into its own writer, then stitched under its arm of the dispatch. Every state body ends in a transition, a `return` or a trap (see `flat_seq`), so no arm falls through to the next round with the same state.
+                // Every state body ends in a transition, a `return` or a trap (see `flat_seq`), so no arm falls through to the next round with the same state.
                 let mut st: Vec<CodeWriter> = (0..n).map(|_| CodeWriter::new("\t")).collect();
                 let last = self.flat_seq(&mut st, 0, &func.body);
                 // Falling off the body ends the function; leave the dispatch loop through its `else`. A body that cannot fall off needs no such exit.
@@ -1001,7 +1001,7 @@ impl<'a> Gen<'a> {
     ///
     /// A run starts unguarded: every frame enclosing a sequence `flat_seq` walks is dissolved (dissolution is transitive up the spine), so every branch escaping the run is addressed by state and leaves `_br` alone.
     fn flat_seq(&self, st: &mut [CodeWriter], mut cur: usize, stmts: &[Stmt]) -> usize {
-        let mut run = 0; // start of the pending run of non-dissolved statements
+        let mut pending_start = 0;
         for (i, stmt) in stmts.iter().enumerate() {
             let plan_hit = {
                 let p = self.flat.borrow();
@@ -1020,11 +1020,11 @@ impl<'a> Gen<'a> {
             let Some((target, after)) = plan_hit else {
                 continue;
             };
-            if run < i {
+            if pending_start < i {
                 let mut guarded = false;
-                self.emit_seq(&mut st[cur], &stmts[run..i], &mut guarded, false);
+                self.emit_seq(&mut st[cur], &stmts[pending_start..i], &mut guarded, false);
             }
-            run = i + 1;
+            pending_start = i + 1;
             match stmt {
                 Stmt::Block { body, .. } => {
                     cur = self.flat_seq(st, cur, body);
@@ -1072,9 +1072,9 @@ impl<'a> Gen<'a> {
                 _ => unreachable!("only frames are dissolved"),
             }
         }
-        if run < stmts.len() {
+        if pending_start < stmts.len() {
             let mut guarded = false;
-            self.emit_seq(&mut st[cur], &stmts[run..], &mut guarded, false);
+            self.emit_seq(&mut st[cur], &stmts[pending_start..], &mut guarded, false);
         }
         cur
     }
@@ -1414,7 +1414,6 @@ impl<'a> Gen<'a> {
                 w.line(format!("{}(\"unreachable\")", self.rt("trap")));
             }
             Stmt::SourceLine(pos) => {
-                // A source-position back-mapping comment; inert.
                 let file = &self.module.debug_files[pos.file as usize];
                 w.line(format!("# {file}:{}", pos.line));
             }
@@ -1848,7 +1847,6 @@ mod cascade {
     #[test]
     fn deep_multi_level_br_is_addressed_by_value() {
         let src = convert(&tower(flat::DEEP_CROSSING + 2));
-        // The dispatch loop, and a branch that names its target as a number.
         assert!(src.contains("_state = 0"), "no dispatch entry in:\n{src}");
         assert!(src.contains("if _state < "), "no dispatch tree in:\n{src}");
         assert!(src.contains("; continue"), "no transition in:\n{src}");
@@ -2033,7 +2031,6 @@ mod units {
                 );
             }
 
-            // Sibling calls within the same scope's nested class.
             for (sibling, re) in &sibling_calls {
                 let Some(name) = sibling.strip_prefix(&format!("{scope}/")) else {
                     continue;

--- a/crates/dewasm-backend-python/tests/e2e.rs
+++ b/crates/dewasm-backend-python/tests/e2e.rs
@@ -80,7 +80,6 @@ impl BackendUnderTest for Python {
     }
 }
 
-/// `add.wat`: call the exported functions and print each result.
 const PYTHON_ADD_GLUE: &str = r#"inst = Add()
 print(inst.invoke("add", 2, 3))
 print(inst.invoke("add", 0xffffffff, 1))

--- a/crates/dewasm-backend-ruby/src/lib.rs
+++ b/crates/dewasm-backend-ruby/src/lib.rs
@@ -140,7 +140,6 @@ fn generate_class_inner(
             _ => None,
         }))
         .collect();
-    // Prefix sums: `data_offsets[i]` is where segment `i` begins in the concatenated sidecar blob. Only consulted when externalizing.
     let mut data_offsets = Vec::with_capacity(module.datas.len());
     let mut acc = 0usize;
     for data in &module.datas {
@@ -473,8 +472,8 @@ fn walk_frame_sets(
 fn record_target(target: &BrTarget, stack: &[(u32, bool)], sets: &mut FrameSets) {
     if let BrTarget::Label { label, .. } = target {
         if let Some(pos) = stack.iter().position(|(id, _)| id == label) {
-            // Outward branch (target is not the innermost frame): mark the whole inclusive path from the target to the innermost frame.
-            if pos + 1 < stack.len() {
+            let outward = pos + 1 < stack.len();
+            if outward {
                 // Unless it is Ruby's `break`: crossing exactly one loop that
                 // ends the block being targeted. That already lands where the
                 // branch wants to go, at O(1), so nothing on the path dissolves.
@@ -672,7 +671,7 @@ impl<'a> Gen<'a> {
             .collect::<Vec<_>>()
             .join(", ");
         w.line(format!("MEMORY_EXPORTS = [{memory_entries}].freeze"));
-        // Externalized data blob: read once at class-definition time, kept binary (ASCII-8BIT, as File.binread returns). Only emitted when there is data to externalize.
+        // Externalized data blob: read once at class-definition time, kept binary (ASCII-8BIT, as File.binread returns).
         if let Some(name) = &self.data_file {
             if !m.datas.is_empty() {
                 w.line(format!(
@@ -891,7 +890,7 @@ impl<'a> Gen<'a> {
             format!("def _f{idx}({params})")
         };
         w.block(header, "end", |w| {
-            // Consecutive locals sharing one default are initialized in a single chained assignment — the defaults are immutable literals, so every name ends up bound to its own value, not to a shared object.
+            // The chained assignment is sound only because the defaults are immutable literals: every name ends up bound to its own value, not to one shared object.
             for run in local_runs(&func.locals, default_value) {
                 let default = default_value(func.locals[run.start]);
                 let names = run
@@ -1270,7 +1269,6 @@ impl<'a> Gen<'a> {
                 w.line(format!("{}(\"unreachable\")", self.rt("trap")));
             }
             Stmt::SourceLine(pos) => {
-                // A source-position back-mapping comment; inert.
                 let file = &self.module.debug_files[pos.file as usize];
                 w.line(format!("# {file}:{}", pos.line));
             }
@@ -1435,7 +1433,6 @@ impl<'a> Gen<'a> {
         Rendered::atom(format!("{}({})", self.rt(name), a.free()))
     }
 
-    /// A two-argument call to a runtime helper.
     fn call2(&self, name: &str, a: Rendered, b: Rendered) -> Rendered {
         Rendered::atom(format!("{}({}, {})", self.rt(name), a.free(), b.free()))
     }
@@ -1719,7 +1716,6 @@ fn not(a: Rendered) -> Rendered {
     }
 }
 
-/// `x & 0xffffffff`, the i32 wrap.
 fn mask32(a: Rendered) -> Rendered {
     infix(a, "&", Rendered::atom("0xffffffff".to_string()), BIT_AND)
 }
@@ -1729,7 +1725,7 @@ fn shift_count(b: Rendered, mask: u32) -> Rendered {
     infix(b, "&", Rendered::atom(mask.to_string()), BIT_AND)
 }
 
-/// `x.to_f`. A receiver binds as tightly as a call, so anything looser is parenthesized.
+/// A receiver binds as tightly as a call, so anything looser is parenthesized.
 fn to_f(a: Rendered) -> Rendered {
     Rendered::atom(format!("{}.to_f", a.at(Prec::Atom)))
 }
@@ -1789,7 +1785,6 @@ mod units {
         let rt_call = Regex::new(r"Rt\.([a-z_][a-z0-9_]*)").unwrap();
         let rt_const = Regex::new(r"Rt::([A-Z]\w*)").unwrap();
         let memory_call = Regex::new(r"@memory\.([a-z_][a-z0-9_]*)").unwrap();
-        // One precompiled bare-call matcher per unit name.
         let bare_calls: Vec<(&str, Regex)> = unit_ids
             .iter()
             .map(|id| {
@@ -2021,7 +2016,6 @@ mod cascade {
     #[test]
     fn deep_multi_level_br_is_addressed_by_value() {
         let src = convert(&tower(flat::DEEP_CROSSING + 2));
-        // The dispatch loop, and a branch that names its target as a number.
         assert!(src.contains("state = 0"), "no dispatch entry in:\n{src}");
         assert!(src.contains("case state"), "no dispatch in:\n{src}");
         assert!(src.contains("; next"), "no state transition in:\n{src}");

--- a/crates/dewasm-backend/src/flat.rs
+++ b/crates/dewasm-backend/src/flat.rs
@@ -58,16 +58,10 @@ pub fn plan(body: &[Stmt], paths: &[Vec<u32>], deep_crossing: usize) -> Option<P
     }
     // Two closures, to a joint fixpoint.
     //
-    // *Paths.* A `state = N; next` must not be captured on its way to the
-    // dispatch loop, so once any frame a branch crosses is dissolved, every
-    // frame it crosses has to go — the branch can no longer be a relay.
+    // *Paths.* A `state = N; next` must not be captured on its way to the dispatch loop, so once any frame a branch crosses is dissolved, every frame it crosses has to go — the branch can no longer be a relay.
     //
-    // *Ancestors.* Dissolution is transitive up the spine for the same reason:
-    // a frame that still exists would capture a jump aimed at the dispatch
-    // loop, and would have to run its landing marker after a body that no
-    // longer falls out of it. What survives is the leaves: loops and blocks
-    // with no escaping branch anywhere inside them — which is precisely where
-    // keeping the structured form was measured to matter.
+    // *Ancestors.* Dissolution is transitive up the spine for the same reason: a frame that still exists would capture a jump aimed at the dispatch loop, and would have to run its landing marker after a body that no longer falls out of it.
+    // What survives is the leaves: loops and blocks with no escaping branch anywhere inside them — which is precisely where keeping the structured form was measured to matter.
     loop {
         let before = dissolved.len();
         for path in paths {
@@ -146,9 +140,7 @@ fn assign(stmts: &[Stmt], plan: &mut Plan) {
             Stmt::If {
                 label, then, els, ..
             } => {
-                // `if` is not a loop, so a jump inside it already reaches the
-                // dispatch loop; it only needs a landing state when it is
-                // itself a branch target that something escapes.
+                // `if` is not a loop, so a jump inside it already reaches the dispatch loop; it only needs a landing state when it is itself a branch target that something escapes.
                 assign(then, plan);
                 assign(els, plan);
                 if plan.dissolved.contains(&label.id) {

--- a/crates/dewasm-backend/src/lib.rs
+++ b/crates/dewasm-backend/src/lib.rs
@@ -44,7 +44,6 @@ pub struct GenOptions {
     pub data_file: Option<DataFileConfig>,
 }
 
-/// Configuration for data-segment externalization.
 #[derive(Clone, Debug)]
 pub struct DataFileConfig {
     /// The filename the generated program references relative to itself (e.g. via `__dir__`/`//go:embed`). The matching sidecar `OutputFile` carries this exact `name`; the CLI routes it to the requested path.

--- a/crates/dewasm-cli/Cargo.toml
+++ b/crates/dewasm-cli/Cargo.toml
@@ -11,10 +11,7 @@ repository.workspace = true
 workspace = true
 
 [features]
-# Opt-in: expands the slow cross-backend `--data-file` real-app cases
-# (tests/data_file.rs — convert + run/build the cached qjs.wasm) as active
-# `#[test]`s instead of `#[ignore]`d ones. CI's main run; see
-# docs/testing.md.
+# Opt-in: expands the slow cross-backend `--data-file` real-app cases (tests/data_file.rs — convert + run/build the cached qjs.wasm) as active `#[test]`s instead of `#[ignore]`d ones. CI's main run; see docs/testing.md.
 slow_test = []
 
 [lib]

--- a/crates/dewasm-cli/src/support_docs.rs
+++ b/crates/dewasm-cli/src/support_docs.rs
@@ -21,7 +21,6 @@ const IN_SCOPE_FEATURES: &[Feature] = &[
     Feature::Floats,
 ];
 
-/// Render `docs/support.md` from the backends' own capability declarations.
 pub fn render_support_docs() -> String {
     let backends: Vec<&dyn Backend> = vec![
         &RubyBackend,

--- a/crates/dewasm-cli/tests/dwarf_line.rs
+++ b/crates/dewasm-cli/tests/dwarf_line.rs
@@ -100,7 +100,6 @@ fn run_go(prog: &Path) -> (String, i32) {
     )
 }
 
-/// Run a Ruby program, returning (stdout, exit code).
 fn run_ruby(prog: &Path) -> (String, i32) {
     let ruby = find_ruby().expect("ruby >= 3.4 not found on PATH — see docs/testing.md");
     let out = Command::new(ruby)
@@ -148,7 +147,6 @@ fn go_dwarf_line_markers_are_neutral_and_build() {
     let plain = convert("go", &plain_path, false);
     let dwarf = convert("go", &dwarf_path, true);
 
-    // The flag must actually produce fixture markers.
     let fixture_markers: Vec<&str> = dwarf
         .lines()
         .filter(|l| l.starts_with("//line ") && l.contains("dwarf_fixture.c"))
@@ -170,14 +168,12 @@ fn go_dwarf_line_markers_are_neutral_and_build() {
         assert_ne!(after, "0", "//line must never carry line 0: {l:?}");
     }
 
-    // Neutrality: stripping every `//line` directive reproduces the plain file.
     let stripped = strip_markers(&dwarf, |l| l.starts_with("//line "));
     assert_eq!(
         stripped, plain,
         "flagged Go source must equal plain after stripping //line"
     );
 
-    // Same runtime behavior.
     let (out_p, code_p) = run_go(&plain_path);
     let (out_d, code_d) = run_go(&dwarf_path);
     assert_eq!(out_p, FIXTURE_STDOUT);
@@ -200,7 +196,6 @@ fn ruby_dwarf_line_markers_are_neutral_and_run() {
         "expected a Ruby comment marker into dwarf_fixture.c"
     );
 
-    // Neutrality: markers are the only additions.
     let stripped = strip_markers(&dwarf, is_comment_marker);
     assert_eq!(
         stripped, plain,

--- a/crates/dewasm-core/src/data_merge.rs
+++ b/crates/dewasm-core/src/data_merge.rs
@@ -16,7 +16,6 @@ use crate::ir::{DataSegment, Expr, Module, Stmt};
 /// Largest gap worth bridging with zero fill. Tuned to the always-on inline cost (the core cannot see `GenOptions`), not wasm2go's externalize-only 4096.
 const MAX_MERGE_GAP: u64 = 64;
 
-/// Merge runs of adjacent active data segments in `module`, in place.
 pub(crate) fn merge_adjacent_data_segments(module: &mut Module) {
     // Property 1: any body that references a segment by index (bulk memory) makes renumbering unsafe.
     if module.funcs.iter().any(|f| body_refs_segment(&f.body)) {

--- a/crates/dewasm-core/src/debug_line.rs
+++ b/crates/dewasm-core/src/debug_line.rs
@@ -106,7 +106,6 @@ impl LineTable {
     }
 }
 
-/// Intern a file path, returning its index in `files`.
 fn intern(files: &mut Vec<String>, map: &mut HashMap<String, u32>, name: String) -> u32 {
     if let Some(&id) = map.get(&name) {
         return id;

--- a/crates/dewasm-core/src/func.rs
+++ b/crates/dewasm-core/src/func.rs
@@ -75,7 +75,7 @@ struct Pending {
     size: u32,
 }
 
-/// One operand-stack slot: its type, and a pending expression when the value has not been spilled to a temp yet.
+/// One operand-stack slot. `pending` is `None` once the value has been spilled to its temp.
 struct Slot {
     ty: ValType,
     pending: Option<Pending>,
@@ -198,7 +198,7 @@ impl<'a> FuncBuilder<'a> {
         }
     }
 
-    /// The [`Stmt::SourceLine`] marker to place before the statement about to be emitted, or `None` when the current source position is unchanged from the last marker emitted (change points only) or back-mapping is off. The caller pushes the returned marker; the two emit paths (`emit` and the function's fallthrough return) share this so both are annotated.
+    /// The [`Stmt::SourceLine`] marker to place before the statement about to be emitted, or `None` when the current source position is unchanged from the last marker emitted (change points only) or back-mapping is off.
     fn source_marker(&mut self) -> Option<Stmt> {
         self.line_table?;
         let pos = self.cur_pos?;
@@ -209,7 +209,7 @@ impl<'a> FuncBuilder<'a> {
         Some(Stmt::SourceLine(pos))
     }
 
-    /// Push a materialized value: allocate a temp for the top slot and record it in `self.temps`. Used for values that are never folded (call results, `memory.grow`) and by `spill`.
+    /// Push a value that is materialized immediately: the ones that never fold (call results, `memory.grow`), and `spill`'s.
     fn push_temp(&mut self, ty: ValType) -> Temp {
         let depth = self.stack.len() as u32;
         self.spill_clobbered(depth);
@@ -219,7 +219,6 @@ impl<'a> FuncBuilder<'a> {
         temp
     }
 
-    /// Push a folded (pending) value. Does not touch `self.temps`.
     fn push_pending(&mut self, ty: ValType, expr: Expr, fx: Effects, size: u32) {
         self.stack.push(Slot {
             ty,
@@ -227,7 +226,6 @@ impl<'a> FuncBuilder<'a> {
         });
     }
 
-    /// Pop the top slot as an expression: its pending expression if any, else a reference to the temp it was materialized into.
     fn pop_expr(&mut self) -> (Expr, Effects, u32) {
         let slot = self.stack.pop().expect("value stack is not empty");
         match slot.pending {
@@ -254,7 +252,6 @@ impl<'a> FuncBuilder<'a> {
         self.stack[idx].pending.as_ref().is_some_and(|p| p.fx.trap)
     }
 
-    /// Materialize the pending value at stack index `idx` into its temp, emitting the assignment. A no-op if already materialized.
     fn spill(&mut self, idx: usize) {
         if self.stack[idx].pending.is_none() {
             return;
@@ -304,7 +301,6 @@ impl<'a> FuncBuilder<'a> {
         }
     }
 
-    /// Spill the whole stack (used at control-flow boundaries).
     fn spill_all(&mut self) {
         for idx in 0..self.stack.len() {
             self.spill(idx);

--- a/crates/dewasm-core/src/module.rs
+++ b/crates/dewasm-core/src/module.rs
@@ -43,7 +43,7 @@ pub fn build_module(bytes: &[u8]) -> Result<ir::Module> {
     build_module_with_options(bytes, &BuildOptions::default())
 }
 
-/// Pre-pass (only when DWARF line back-mapping is requested): scan the payloads for `.debug_*` custom sections and the code section's content start, then build the line table. It runs before the main loop because `.debug_line` custom sections normally appear *after* the code section, so the table must exist before any function body is translated.
+/// Build the line table in a pre-pass of its own, because `.debug_line` custom sections normally appear *after* the code section: the table must exist before any function body is translated.
 fn collect_line_table(bytes: &[u8]) -> Result<Option<LineTable>> {
     let mut debug_sections: HashMap<String, Vec<u8>> = HashMap::new();
     let mut code_section_start: u64 = 0;
@@ -71,7 +71,6 @@ pub fn build_module_with_options(bytes: &[u8], options: &BuildOptions) -> Result
         }));
     }
 
-    // Build the DWARF line table up front (pre-pass), so every function body can resolve its operator offsets while translating.
     let line_table = if options.debug_line {
         collect_line_table(bytes)?
     } else {

--- a/crates/dewasm-test-helper/src/apps.rs
+++ b/crates/dewasm-test-helper/src/apps.rs
@@ -16,7 +16,6 @@ pub struct AppCase {
     pub expect_code: i32,
 }
 
-/// cowsay driven purely by argv.
 pub const COWSAY_ARGS: AppCase = AppCase {
     name: "cowsay",
     args: &["Hello", "from", "dewasm!"],
@@ -25,7 +24,6 @@ pub const COWSAY_ARGS: AppCase = AppCase {
     expect_code: 0,
 };
 
-/// cowsay reading its message from stdin.
 pub const COWSAY_STDIN: AppCase = AppCase {
     name: "cowsay",
     args: &[],

--- a/crates/dewasm-test-helper/src/apps_fs.rs
+++ b/crates/dewasm-test-helper/src/apps_fs.rs
@@ -205,7 +205,6 @@ pub(crate) fn stage_into(fixtures: &Path, scratch: &Path, stage: &[Stage]) {
     }
 }
 
-/// Recursively copy the contents of `src` into `dst`, creating `dst`.
 fn copy_tree(src: &Path, dst: &Path) {
     std::fs::create_dir_all(dst).unwrap();
     for entry in std::fs::read_dir(src).unwrap() {
@@ -267,7 +266,6 @@ fn drive_fs_app_case(
     let bytes = std::fs::read(&wasm_path).expect("read wasm");
     // Convert under `class`, not the cache stem: the two diverge for CRuby (see the field). `class` is already a valid module name for every backend, so it is passed verbatim rather than derived. wasmtime ignores the name (it runs the bytes directly).
     let program = lang.convert_app(&bytes, Mode::Library, case.class);
-    // Resolve the runtime host paths the glue const left as placeholders. The scratch preopen and the cache root are all any current case needs.
     let filled_glue = fill(
         glue,
         &[

--- a/crates/dewasm-test-helper/src/backend.rs
+++ b/crates/dewasm-test-helper/src/backend.rs
@@ -206,7 +206,6 @@ fn resolve_in_parent_path(program: &Path) -> PathBuf {
     program.to_path_buf()
 }
 
-/// Spawn `cmd` with `stdin` piped in and both output streams captured, returning the raw `Output`.
 pub fn run_command(cmd: &mut Command, stdin: &str) -> Output {
     run_command_bytes(cmd, stdin.as_bytes())
 }
@@ -224,7 +223,6 @@ pub fn run_command_bytes(cmd: &mut Command, stdin: &[u8]) -> Output {
     child.wait_with_output().expect("wait")
 }
 
-/// Write `script` to a temp file (extension `ext`) and run it under `interpreter`, returning the raw `Output`.
 pub fn run_script(
     interpreter: &Path,
     script: &str,
@@ -263,7 +261,7 @@ pub fn write_temp_script(script: &str, ext: &str) -> PathBuf {
 mod tests {
     use super::{derive_module_name, module_name_style, ModuleNameStyle};
 
-    /// The derivation reproduces exactly the names the deleted per-backend sanitizers produced for these inputs, which is what lets the glue consts stay untouched.
+    /// The glue consts spell these names literally, so the derivation must keep producing them.
     #[test]
     fn kebab_derivation_matches_the_names_the_glue_consts_spell() {
         for (kebab, pascal, snake) in [

--- a/crates/dewasm-test-helper/src/fixtures.rs
+++ b/crates/dewasm-test-helper/src/fixtures.rs
@@ -32,7 +32,6 @@ pub fn fresh_scratch_dir(name: &str) -> PathBuf {
     dir
 }
 
-/// Convert raw wasm bytes with `backend`.
 pub fn convert_bytes(backend: &dyn Backend, bytes: &[u8], mode: Mode, name: &str) -> String {
     let module = dewasm_core::build_module(bytes).expect("build IR");
     let source = backend
@@ -53,7 +52,6 @@ pub fn convert_bytes(backend: &dyn Backend, bytes: &[u8], mode: Mode, name: &str
     String::from_utf8(source).expect("generated source is valid UTF-8")
 }
 
-/// Convert a `.wat` fixture with `backend`.
 pub fn convert(backend: &dyn Backend, wat_path: &Path, mode: Mode, name: &str) -> String {
     let bytes = wat::parse_file(wat_path).expect("parse wat");
     convert_bytes(backend, &bytes, mode, name)

--- a/crates/dewasm-test-helper/src/lib.rs
+++ b/crates/dewasm-test-helper/src/lib.rs
@@ -298,7 +298,7 @@ macro_rules! wasi_suite {
     };
 }
 
-/// One `#[test]` exercising the standalone `--dir` interface for `$lang`: convert `wasi_standalone_dir.wat` standalone, run it with a `--dir` mount, and require the file round-trip to succeed. No glue — standalone needs none. Wired by every filesystem backend (and re-run under wasmtime as ground truth); Bash joined once its WASI filesystem landed.
+/// One `#[test]` exercising the standalone `--dir` interface for `$lang`: convert `wasi_standalone_dir.wat` standalone, run it with a `--dir` mount, and require the file round-trip to succeed. No glue — standalone needs none. Wired by every filesystem backend, and re-run under wasmtime as ground truth.
 #[macro_export]
 macro_rules! standalone_dir_e2e {
     ($lang:expr) => {

--- a/crates/dewasm-test-helper/src/spec.rs
+++ b/crates/dewasm-test-helper/src/spec.rs
@@ -203,7 +203,6 @@ pub fn nullable_heap_type(hty: &HeapType<'_>) -> bool {
     )
 }
 
-/// The tests/spec submodule directory (upstream testsuite).
 fn spec_dir() -> std::path::PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/spec")
 }
@@ -240,7 +239,6 @@ pub fn spec_trials(lang: &'static dyn SpecBackend, slow_test: bool) -> Vec<Trial
     names
         .into_iter()
         .map(|name| {
-            // Nothing curated => nothing ignored (the whole suite is the default); otherwise files outside the curated set are ignored.
             let ignored = curated
                 .as_ref()
                 .is_some_and(|set| !set.contains(name.as_str()));
@@ -563,7 +561,7 @@ fn run_directives(
                 let call = match exec {
                     WastExecute::Invoke(inv) => gen.invoke_expr(&inv),
                     WastExecute::Wat(wat) => {
-                        // instantiation trap: convert the module inline
+                        // assert_trap on a module: the instantiation itself is what must trap.
                         gen.convert_quote_wat(QuoteWat::Wat(wat), &desc)
                             .map(|conv| {
                                 let registered = gen.registered_pairs();

--- a/crates/dewasm-test-helper/src/wasi_testsuite.rs
+++ b/crates/dewasm-test-helper/src/wasi_testsuite.rs
@@ -37,7 +37,6 @@ pub trait WasiTestsuiteBackend: BackendUnderTest {
 /// The three prebuilt suites we drive, all `wasm32-wasip1` (the standard goal for a dewasm backend: wasm 1.0 + full WASI p1). The Rust suite's `wasm32-wasip3` tree is deliberately excluded — preview 3 is component-model territory, rejected outright.
 const SUITES: &[&str] = &["c", "rust", "assemblyscript"];
 
-/// The `tests/wasi-testsuite` submodule directory.
 fn testsuite_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/wasi-testsuite")
 }
@@ -61,7 +60,6 @@ impl Manifest {
     }
 }
 
-/// A single enumerated test: the module path, its manifest, and the trial name.
 struct Case {
     trial_name: String,
     wasm: PathBuf,
@@ -280,7 +278,6 @@ fn attribute(err: &anyhow::Error) -> Attribution {
     }
 }
 
-/// Convert `bytes` to a standalone program with `backend`, returning the source text or an attributed refusal.
 fn convert_standalone(backend: &(dyn Backend + Sync), bytes: &[u8]) -> Result<String, Attribution> {
     let module = dewasm_core::build_module(bytes).map_err(|e| attribute(&e))?;
     let mut units = backend

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
-# Dev tooling, never published.
 publish = false
 
 [lints]

--- a/crates/xtask/src/bench/chart.rs
+++ b/crates/xtask/src/bench/chart.rs
@@ -123,7 +123,6 @@ impl Theme {
     }
 }
 
-/// One plotted row.
 pub struct Row {
     pub label: String,
     /// In whatever unit the chart's [`Units`] spells; seconds here, bytes in the size record.
@@ -142,7 +141,6 @@ const SECONDS: Units = Units {
     tick: fmt_tick,
 };
 
-/// The four families named in every benchmark chart's legend.
 const BENCH_LEGEND: [(Family, &str); 4] = [
     (Family::Baseline, "wasmtime (baseline)"),
     (Family::Dewasm, "dewasm backends"),

--- a/crates/xtask/src/bench/measure.rs
+++ b/crates/xtask/src/bench/measure.rs
@@ -14,7 +14,6 @@ use anyhow::{Context, Result};
 
 use crate::bench::runner::Launch;
 
-/// One process execution.
 pub struct RunOutcome {
     /// Wall time from just before `spawn` to the child's exit.
     pub wall: Duration,

--- a/crates/xtask/src/bench/mod.rs
+++ b/crates/xtask/src/bench/mod.rs
@@ -37,7 +37,6 @@ const DEFAULT_TARGET_MS: u64 = 300;
 /// Default per-process wall-clock ceiling. Generous — a Bash sample legitimately takes minutes — but finite, so a runner that turns out slower than expected costs one timeout instead of hanging the suite.
 const DEFAULT_TIMEOUT_S: u64 = 900;
 
-/// Parsed `cargo xtask bench` arguments.
 struct Options {
     filter: Option<String>,
     reps: usize,
@@ -140,14 +139,12 @@ fn matches(filter: &Option<String>, workload: &Workload, runners: &[Runner]) -> 
             .any(|runner| runner.label.contains(needle.as_str()))
 }
 
-/// Whether one (workload, runner) pair is selected.
 fn pair_matches(filter: &Option<String>, workload: &Workload, runner: &Runner) -> bool {
     filter.as_ref().is_none_or(|needle| {
         workload.label.contains(needle.as_str()) || runner.label.contains(needle.as_str())
     })
 }
 
-/// `--list`: the matrix and each runner's availability, without running anything.
 fn list(opts: &Options, runners: &[Runner], workloads: &[Workload]) -> Result<()> {
     println!("Runners ({}):", runners.len());
     for runner in runners {
@@ -205,7 +202,6 @@ fn list(opts: &Options, runners: &[Runner], workloads: &[Workload]) -> Result<()
     Ok(())
 }
 
-/// One line describing a ready workload for `--list`.
 fn describe(workload: &Workload) -> String {
     match &workload.kind {
         workload::Kind::Micro { iter_cap } => {
@@ -217,7 +213,6 @@ fn describe(workload: &Workload) -> String {
     }
 }
 
-/// The measuring run: every selected pair, then the two output files.
 fn run(opts: &Options, runners: &[Runner], workloads: &[Workload]) -> Result<()> {
     // wasmtime is not optional: it is both the ceiling every ratio is taken against and the oracle every runner's stdout is diffed against. Without it the suite would produce numbers with nothing to check them, so it fails loud instead.
     if let Err(reason) = runners
@@ -297,7 +292,7 @@ fn run(opts: &Options, runners: &[Runner], workloads: &[Workload]) -> Result<()>
     );
 }
 
-/// The doc half of the output: the charts under `docs/benchmarks/figs/`, then `docs/benchmarks/results.md` embedding them. Both the measuring run and `--render` go through here, so a stored record regenerates the charts as well as the prose.
+/// Both the measuring run and `--render` go through here, so a stored record regenerates the charts as well as the prose.
 ///
 /// Charts not covered by the record are deleted: an orphan SVG looks current while nothing links it. The doc and its charts are one output; re-rendering a full record puts everything back.
 fn write_doc(report: &report::Report) -> Result<()> {
@@ -320,7 +315,6 @@ fn write_doc(report: &report::Report) -> Result<()> {
     )
 }
 
-/// Remove every `.svg` under `docs/benchmarks/` that this render did not write.
 fn prune_charts(written: &[String]) -> Result<()> {
     let Ok(entries) = std::fs::read_dir(charts_dir()) else {
         return Ok(());
@@ -342,7 +336,7 @@ fn prune_charts(written: &[String]) -> Result<()> {
     Ok(())
 }
 
-/// Measure every selected runner for one workload, appending a [`Cell`] per pair — including the skips, which is what keeps a gap from reading as coverage.
+/// Appends a [`Cell`] per (workload, runner) pair, the skips included: a gap must never read as coverage.
 fn measure_workload(
     opts: &Options,
     runners: &[Runner],
@@ -415,7 +409,7 @@ fn skipped(workload: &Workload, runner: &Runner, reason: String) -> Cell {
     }
 }
 
-/// The whole measurement of one (workload, runner) pair. A microbenchmark times the zero run, calibrates the iteration count against it, then takes the timed repetitions; an app just takes the timed repetitions of one whole run. Either way the resulting stdout is diffed against wasmtime at the same iteration count.
+/// The whole measurement of one (workload, runner) pair. The resulting stdout is diffed against wasmtime at the same iteration count.
 fn measure_cell(
     opts: &Options,
     workload: &Workload,

--- a/crates/xtask/src/bench/report.rs
+++ b/crates/xtask/src/bench/report.rs
@@ -115,7 +115,7 @@ impl Report {
     }
 }
 
-/// Render `docs/benchmarks/results.md`: the house style of `docs/related-work.md` and `docs/backends/*.md` — no front matter, plain `##` headings, markdown tables, inline ADR links — plus the generated-file marker `docs/support.md` carries.
+/// Render `docs/benchmarks/results.md`: the house style of `docs/related-work.md` and `docs/backends/*.md` — no front matter, plain `##` headings, markdown tables — plus the generated-file marker `docs/support.md` carries.
 ///
 /// `charts` are the SVGs the caller has written under `docs/benchmarks/figs/`; each one is embedded above the table for its own workload. Passing an empty slice renders the doc unchanged, which is what makes the charts additive rather than load-bearing.
 pub fn render_doc(report: &Report, charts: &[Chart]) -> String {

--- a/crates/xtask/src/bench/runner.rs
+++ b/crates/xtask/src/bench/runner.rs
@@ -357,7 +357,6 @@ impl Driver {
         }
     }
 
-    /// The driver script this runner executes.
     fn script(&self) -> PathBuf {
         match self {
             Driver::PywasmCPython | Driver::PywasmPyPy => drivers_dir().join("pywasm.py"),
@@ -374,7 +373,6 @@ pub struct Workshop {
     artifacts: HashMap<(u64, &'static str), Artifact>,
 }
 
-/// What a backend's output is once it is ready to run.
 #[derive(Clone)]
 enum Artifact {
     /// An interpreted backend: a generated script on disk.
@@ -665,7 +663,7 @@ fn ruby_jit_available(ruby: &Path, flag: &str) -> Result<(), String> {
         })
 }
 
-/// Whether `program args...` runs and exits 0. Used for every availability probe.
+/// Whether `program args...` runs and exits 0.
 fn probe(program: &Path, args: &[&str]) -> bool {
     Command::new(program)
         .args(args)

--- a/crates/xtask/src/bench/workload.rs
+++ b/crates/xtask/src/bench/workload.rs
@@ -42,7 +42,6 @@ SELECT count(*) FROM t WHERE name LIKE '%7%';
 .quit
 ";
 
-/// What a workload is and how to invoke it.
 pub enum Kind {
     /// A `<module> <iterations>` microbenchmark from either family (`wat`, `c`). `iter_cap` bounds the harness's calibration.
     Micro { iter_cap: u64 },
@@ -50,7 +49,6 @@ pub enum Kind {
     App { args: Vec<String>, stdin: String },
 }
 
-/// One benchmarkable program.
 pub struct Workload {
     /// The filter/report label, e.g. `wat/i32_alu`, `c/sha256` or `app/sqlite3_query`. The part before the slash is the family, which is also the source directory for a microbenchmark.
     pub label: String,
@@ -67,7 +65,6 @@ impl Workload {
         if self.wasm.is_file() {
             return None;
         }
-        // Each microbenchmark family has its own build script, named by the family segment of the label.
         let build = match self.kind {
             Kind::Micro { .. } => format!("benchmarks/{}/build.sh", self.family()),
             Kind::App { .. } => "examples/apps/setup.sh".to_string(),
@@ -83,7 +80,6 @@ impl Workload {
         self.label.split('/').next().unwrap_or(&self.label)
     }
 
-    /// The exclusion reason for `runner`, if this workload declares one.
     pub fn excluded(&self, runner: &str) -> Option<&'static str> {
         self.exclude
             .iter()

--- a/crates/xtask/src/nes_snapshot.rs
+++ b/crates/xtask/src/nes_snapshot.rs
@@ -51,9 +51,7 @@ fn capture_frame(bytes: &[u8], rom: &[u8]) -> wasmtime::Result<(Vec<u8>, Vec<u8>
     read_frame(&mut store, &instance, memory)
 }
 
-/// Read `frameWidth`/`frameHeight`/`screenOffset`/`paletteOffset` and slice the
-/// index buffer and the palette out of guest memory. Split out so `memory` is
-/// not borrowed across the export calls above.
+/// Split out so `memory` is not borrowed across the export calls above.
 fn read_frame(
     store: &mut Store<()>,
     instance: &Instance,

--- a/crates/xtask/src/size/mod.rs
+++ b/crates/xtask/src/size/mod.rs
@@ -23,7 +23,6 @@ use crate::size::report::{App, Cell, Component, Outcome};
 /// The corpus, in report order: a small utility, a database shell, a JavaScript engine, a whole Ruby. Fixed rather than "everything in the cache" — these four span two orders of magnitude of wasm size, and a record whose contents depend on which apps happen to be built is not comparable with the next one.
 const CORPUS: [&str; 4] = ["cowsay.wasm", "sqlite3-shell.wasm", "qjs.wasm", "ruby.wasm"];
 
-/// Parsed `cargo xtask size` arguments.
 struct Options {
     /// Re-render `docs/sizes/results.md` and its figures from a stored record instead of measuring. Converting the corpus with six backends takes minutes, so a wording fix must not require re-measuring — the JSON is the record, the markdown is a view of it.
     render: Option<PathBuf>,
@@ -72,7 +71,6 @@ fn backends() -> Vec<(&'static str, &'static (dyn Backend + Sync))> {
     ]
 }
 
-/// The measuring run: the runtimes, then the corpus, then the two output files.
 fn run() -> Result<()> {
     let runtimes = measure_runtimes();
     let apps: Vec<App> = CORPUS.iter().map(|file| measure_app(file)).collect();
@@ -118,7 +116,7 @@ fn run() -> Result<()> {
     );
 }
 
-/// The doc half of the output: the figures under `docs/sizes/figs/`, then `docs/sizes/results.md` embedding them. Both the measuring run and `--render` go through here, so a stored record regenerates the figures as well as the prose.
+/// Both the measuring run and `--render` go through here, so a stored record regenerates the figures as well as the prose.
 ///
 /// Figures the record no longer covers are deleted: an orphan SVG looks current while nothing links it.
 fn write_doc(report: &report::Report) -> Result<()> {
@@ -138,7 +136,6 @@ fn write_doc(report: &report::Report) -> Result<()> {
     )
 }
 
-/// Remove every `.svg` under `docs/sizes/figs/` that this render did not write.
 fn prune_figs(written: &[String]) -> Result<()> {
     let Ok(entries) = std::fs::read_dir(figs_dir()) else {
         return Ok(());

--- a/runtime/bash/units/wasi/fd_flush.sh
+++ b/runtime/bash/units/wasi/fd_flush.sh
@@ -1,8 +1,7 @@
 # requires: wasi/file_flush
 # wasi_fd_flush <p> <fd>: flush a file fd's buffer to disk if it is dirty, then
-# clear the dirty flag. A no-op for non-file fds or a clean buffer.
-# Shared by fd_close and, in later steps, fd_sync/fd_datasync. R0 is the errno
-# (from file_flush; 0 for the no-op paths).
+# clear the dirty flag. A no-op for non-file fds or a clean buffer. R0 is the
+# errno (from file_flush; 0 for the no-op paths).
 wasi_fd_flush() {
   local __p=$1 __fd=$2
   local -n __fds=${__p}wfds

--- a/runtime/go/units/rt/b2i.go
+++ b/runtime/go/units/rt/b2i.go
@@ -1,5 +1,4 @@
-// wasm comparisons yield an i32 0/1; Go comparisons yield bool. This is the
-// bridge, used at every relational operator.
+// wasm comparisons yield an i32 0/1; Go comparisons yield bool.
 func (rt) b2i(c bool) uint32 {
     if c {
         return 1

--- a/runtime/go/units/rt/select.go
+++ b/runtime/go/units/rt/select.go
@@ -1,6 +1,5 @@
 // wasm `select`: both operands are pre-evaluated (no short-circuit), so a
-// plain value pick suffices. Generic over the value type since select works
-// on any numeric type. Called as `rtSelect(cond, a, b)`.
+// plain value pick suffices.
 func rtSelect[T any](c uint32, a, b T) T {
     if c != 0 {
         return a

--- a/runtime/go/units/table/call.go
+++ b/runtime/go/units/table/call.go
@@ -1,6 +1,6 @@
 // requires: rt/trap
-// Bounds/null/type-check the slot and return its Go func value; the caller
-// type-asserts it to the exact signature of the call site.
+// The caller type-asserts the returned func value to the exact signature of the
+// call site.
 func (t *Table) call(i uint32, typeKey string) any {
     if i >= uint32(len(t.slots)) {
         Rt.trap("undefined element")

--- a/runtime/go/units/wasi/fd_fdstat_set_flags.go
+++ b/runtime/go/units/wasi/fd_fdstat_set_flags.go
@@ -1,6 +1,6 @@
-// Set the fdflags on an fd. Only APPEND is acted on (fd_write reads
-// it back and seeks to end); the store here is what lets a guest turn append
-// mode off at runtime, which an O_APPEND OS handle could not.
+// Only APPEND is acted on (fd_write reads it back and seeks to end); storing it
+// here is what lets a guest turn append mode off at runtime, which an O_APPEND
+// OS handle could not.
 func (w *WASI) wasi_fd_fdstat_set_flags(fd, flags uint32) uint32 {
     m, ok := w.meta[fd]
     if !ok {

--- a/runtime/go/units/wasi/fd_renumber.go
+++ b/runtime/go/units/wasi/fd_renumber.go
@@ -1,8 +1,6 @@
-// Renumber `from` onto `to`: both must be live descriptors (BADF otherwise,
-// matching the reference table.renumber). The resource currently at `to` is
-// released (a real file handle is closed; a preopen/dir has none, and stdio
-// must never be closed), then `from`'s entry and its rights meta move to `to`
-// and `from` is retired. Used to overwrite stdio and preopen slots.
+// Both endpoints must be live descriptors, else BADF (matching the reference
+// table.renumber). The descriptor being overwritten is released, except stdio,
+// which must never be closed, and a preopen/dir, which has no OS handle.
 func (w *WASI) wasi_fd_renumber(from, to uint32) uint32 {
     fromEntry, ok := w.fds[from]
     if !ok {

--- a/runtime/go/units/wasi/path_link.go
+++ b/runtime/go/units/wasi/path_link.go
@@ -1,7 +1,6 @@
 // requires: memory/read_string, wasi/resolve_path, wasi/errno_fs
-// Create a hard link new = old, both endpoints contained. Both endpoints are
-// resolved NOFOLLOW and LOOKUPFLAGS_SYMLINK_FOLLOW is rejected as EINVAL like
-// the other backends.
+// Both endpoints are resolved NOFOLLOW, and LOOKUPFLAGS_SYMLINK_FOLLOW is
+// rejected as EINVAL like the other backends.
 func (w *WASI) wasi_path_link(oldDirfd, oldFlags, oldPathPtr, oldPathLen, newDirfd, newPathPtr, newPathLen uint32) uint32 {
     if oldFlags&0x1 != 0 { // lookupflags::SYMLINK_FOLLOW
         return wasiInval

--- a/runtime/go/units/wasi/path_readlink.go
+++ b/runtime/go/units/wasi/path_readlink.go
@@ -1,7 +1,6 @@
 // requires: memory/read_string, memory/init, memory/i32_store, wasi/resolve_path, wasi/errno_fs
-// Read the target of the symlink at (fd, path) into the guest buffer, returning
-// the number of bytes written. readlink never follows the final component, and
-// the result is truncated (not an error) to buf_len.
+// readlink never follows the final component, and the result is truncated (not
+// an error) to buf_len.
 func (w *WASI) wasi_path_readlink(fd, pathPtr, pathLen, bufPtr, bufLen, bufusedPtr uint32) uint32 {
     rel := string(w.memory.read_string(uint64(pathPtr), uint64(pathLen)))
     hostPath, err := w.resolve_path(fd, rel, false)

--- a/runtime/java/units/memory/copy.java
+++ b/runtime/java/units/memory/copy.java
@@ -1,4 +1,4 @@
-// memory.copy: overlapping-safe copy of `length` bytes from `src` to `dst`.
+// memory.copy must be overlap-safe; System.arraycopy is, like memmove.
 void copy(long dst, long src, long length) {
     int da = at(dst, length);
     int sa = at(src, length);

--- a/runtime/java/units/memory/fill.java
+++ b/runtime/java/units/memory/fill.java
@@ -1,4 +1,3 @@
-// memory.fill: set `length` bytes at `addr` to the low byte of `value`.
 void fill(long addr, long value, long length) {
     int a = at(addr, length);
     java.util.Arrays.fill(d, a, a + (int) length, (byte) value);

--- a/runtime/java/units/memory/init.java
+++ b/runtime/java/units/memory/init.java
@@ -1,6 +1,6 @@
 // requires: rt/trap
-// Copy `length` bytes from a source blob (a data segment, or a WASI buffer)
-// into memory at `addr`. Bounds-checked on both sides.
+// Also used to initialize active data segments at instantiation time, and to
+// copy a WASI buffer in.
 void init(long addr, byte[] src, long srcOff, long length) {
     int a = at(addr, length);
     if (srcOff < 0 || srcOff + length > src.length) {

--- a/runtime/java/units/memory/read_string.java
+++ b/runtime/java/units/memory/read_string.java
@@ -1,5 +1,4 @@
 // requires: rt/trap
-// Copy `length` bytes out of memory (WASI stdio / string reads).
 byte[] read_string(long addr, long length) {
     int a = at(addr, length);
     byte[] out = new byte[(int) length];

--- a/runtime/java/units/table/call.java
+++ b/runtime/java/units/table/call.java
@@ -1,6 +1,5 @@
 // requires: rt/trap
-// call_indirect dispatch: bounds-check, null-check, structural-type-check, and
-// return the Fn to invoke. The type string is a structural key so a table
+// The type string is a structural key, not a module-local type index, so a table
 // shared across modules stays consistent.
 Rt.Fn call(int index, String ty) {
     if (index < 0 || index >= slots.length) {

--- a/runtime/java/units/table/copy.java
+++ b/runtime/java/units/table/copy.java
@@ -1,7 +1,6 @@
 // requires: rt/trap
-// table.copy: move `length` funcref slots from `other` (possibly this table)
-// at `src` to this table at `dst`. Both ranges are bounds-checked before any
-// write; System.arraycopy handles overlap like memmove.
+// Both ranges are bounds-checked before any write, and `other` may be this
+// table: System.arraycopy handles overlap like memmove.
 void copy(int dst, Table other, int src, int length) {
     long d = Integer.toUnsignedLong(dst);
     long s = Integer.toUnsignedLong(src);

--- a/runtime/java/units/table/init.java
+++ b/runtime/java/units/table/init.java
@@ -1,6 +1,5 @@
 // requires: rt/trap
-// Copy `length` funcrefs from `src` into the table at `dst` (active element
-// segment at instantiation).
+// Also used to initialize active element segments at instantiation time.
 void init(int dst, Rt.Funcref[] src, int srcOff, int length) {
     long d = Integer.toUnsignedLong(dst);
     long s = Integer.toUnsignedLong(srcOff);

--- a/runtime/java/units/wasi/fd_close.java
+++ b/runtime/java/units/wasi/fd_close.java
@@ -1,5 +1,5 @@
-// Close a file fd (its FileChannel) and drop it from the table. Stdio and
-// directory fds carry no OS handle to close. Fds are never reused after close.
+// Stdio and directory fds carry no OS handle to close. Fds are never reused
+// after close.
 int wasi_fd_close(int fd) {
     if (!fds.containsKey(fd)) {
         return WASI_BADF;

--- a/runtime/java/units/wasi/fd_fdstat_set_flags.java
+++ b/runtime/java/units/wasi/fd_fdstat_set_flags.java
@@ -1,8 +1,7 @@
-// Update an fd's open fdflags. Only APPEND is behaviorally honored:
-// fd_write seeks to end before each write when Handle.append is set, so
-// toggling APPEND here flips that. The remaining flags (DSYNC/RSYNC/SYNC,
-// NONBLOCK) are stored so fd_fdstat_get reflects them but carry no distinct
-// behavior in this runtime.
+// Only APPEND is behaviorally honored: fd_write seeks to end before each write
+// when Handle.append is set, so toggling APPEND here flips that. The remaining
+// flags (DSYNC/RSYNC/SYNC, NONBLOCK) are stored so fd_fdstat_get reflects them
+// but carry no distinct behavior in this runtime.
 int wasi_fd_fdstat_set_flags(int fd, int flags) {
     Object e = fds.get(fd);
     if (!fds.containsKey(fd)) {

--- a/runtime/java/units/wasi/fd_filestat_set_times.java
+++ b/runtime/java/units/wasi/fd_filestat_set_times.java
@@ -1,7 +1,7 @@
-// Set the atim/mtim of an open fd. fst_flags selects which of atim and
-// mtim to set and whether to "now"; setting a timestamp both explicitly and to
-// "now" is EINVAL. A null FileTime leaves that timestamp untouched, so a guest
-// can change one without disturbing the other.
+// fst_flags selects which of atim and mtim to set and whether to "now"; setting
+// a timestamp both explicitly and to "now" is EINVAL. A null FileTime leaves
+// that timestamp untouched, so a guest can change one without disturbing the
+// other.
 int wasi_fd_filestat_set_times(int fd, long atim, long mtim, int fstflags) {
     Object e = fds.get(fd);
     java.nio.file.Path p;

--- a/runtime/java/units/wasi/fd_renumber.java
+++ b/runtime/java/units/wasi/fd_renumber.java
@@ -1,9 +1,6 @@
-// Move the fd `from` onto the number `to`, closing whatever `to` held first.
-// Both must currently be open (renumbering onto an invalid target is EBADF);
-// the table entry and its rights meta move together, and `from` is
-// then closed. Renumbering onto stdio or a preopen is allowed — the target's
-// old entry is simply replaced (only a guest-opened file carries a channel to
-// close).
+// Both endpoints must currently be open: renumbering onto an unused number is
+// EBADF. Renumbering onto stdio or a preopen is allowed — the target's old entry
+// is simply replaced (only a guest-opened file carries a channel to close).
 int wasi_fd_renumber(int from, int to) {
     if (!fds.containsKey(from) || !fds.containsKey(to)) {
         return WASI_BADF;

--- a/runtime/java/units/wasi/path_readlink.java
+++ b/runtime/java/units/wasi/path_readlink.java
@@ -1,8 +1,8 @@
 // requires: memory/read_string, memory/init, memory/i32_store, wasi/resolve_path, wasi/errno_fs
-// Read a symlink's target into the guest buffer. The link itself is
-// resolved NOFOLLOW; the target string is returned verbatim (as the guest wrote
-// it at symlink time), truncated to buf_len — a short buffer takes the leading
-// bytes, matching the WASI contract, with bufused reporting what was written.
+// The link itself is resolved NOFOLLOW; the target string is returned verbatim
+// (as the guest wrote it at symlink time), truncated to buf_len — a short buffer
+// takes the leading bytes, matching the WASI contract, with bufused reporting
+// what was written.
 int wasi_path_readlink(int fd, int pathPtr, int pathLen, int bufPtr, int bufLen, int bufusedPtr) {
     String rel = new String(
         memory.read_string(Integer.toUnsignedLong(pathPtr), Integer.toUnsignedLong(pathLen)),

--- a/runtime/java/units/wasi/write_string_list.java
+++ b/runtime/java/units/wasi/write_string_list.java
@@ -1,6 +1,6 @@
 // requires: memory/i32_store, memory/i32_store8, memory/init
-// Shared by args_get/environ_get: lay out a NUL-terminated string list, writing
-// each element's pointer into the pointer array and the bytes into the buffer.
+// The WASI two-part layout shared by args_get/environ_get: a pointer array plus
+// NUL-terminated bytes in a separate buffer.
 int write_string_list(byte[][] xs, int listPtr, int bufPtr) {
     long lp = Integer.toUnsignedLong(listPtr);
     long bp = Integer.toUnsignedLong(bufPtr);

--- a/runtime/perl/units/wasi/fd_renumber.pl
+++ b/runtime/perl/units/wasi/fd_renumber.pl
@@ -1,9 +1,7 @@
 # requires:
 sub wasi_fd_renumber {
     my ($self, $fd, $to) = @_;
-    # Both descriptors must currently be open; the destination's own
-    # resource is closed, then the source is moved onto it and the source
-    # number retired (works onto stdio and preopens too).
+    # Both endpoints must be open fds: renumbering onto an unused number is BADF.
     return ERRNO_BADF unless exists $self->{fds}{$fd} && exists $self->{fds}{$to};
     my $dst = $self->{fds}{$to};
     close($dst->{fh}) if !$dst->{dir} && !defined($dst->{std});

--- a/runtime/perl/units/wasi/path_open.pl
+++ b/runtime/perl/units/wasi/path_open.pl
@@ -42,9 +42,7 @@ sub wasi_path_open {
     }
     my ($base, $inheriting);
     if (($st[2] & 0170000) == 0040000) {  # a directory
-        # Opening a directory: keep a dir entry (sysread on it is not
-        # meaningful), narrow to the directory rights, and drop the
-        # throwaway OS handle.
+        # sysread on a directory is not meaningful, so keep a dir entry instead.
         close($fh);
         my $real = Cwd::realpath($host);
         return $self->fs_errno(0 + $!) unless defined $real;

--- a/runtime/python/units/wasi/fd_renumber.py
+++ b/runtime/python/units/wasi/fd_renumber.py
@@ -1,7 +1,5 @@
 def wasi_fd_renumber(self, fd, to):
-    # Both descriptors must currently be open; the destination's own resource is
-    # closed, then the source is moved onto it and the source number retired
-    # (works onto stdio and preopens too).
+    # Both endpoints must be open fds: renumbering onto an unused number is BADF.
     if fd not in self.fds or to not in self.fds:
         return self.ERRNO_BADF
     dst = self.fds[to]

--- a/runtime/python/units/wasi/path_open.py
+++ b/runtime/python/units/wasi/path_open.py
@@ -46,8 +46,7 @@ def wasi_path_open(self, dirfd, dirflags, path_ptr, path_len, oflags, fs_rights_
     try:
         st = os.fstat(fd)
         if (st.st_mode & 0o170000) == 0o040000:  # a directory
-            # Opening a directory: keep a WasiDir (os.fdopen would raise on it),
-            # narrow to the directory rights, and drop the throwaway os handle.
+            # os.fdopen would raise on a directory, so keep a WasiDir instead.
             os.close(fd)
             self.fds[self.next_fd] = self.WasiDir(os.path.realpath(host_path), None, None)
             base = fs_rights_base & self.fd_meta[dirfd][1] & self.DIR_RIGHTS_BASE

--- a/runtime/ruby/units/memory/f32_load.rb
+++ b/runtime/ruby/units/memory/f32_load.rb
@@ -1,4 +1,3 @@
 # requires: memory/i32_load, rt/f32_from_bits
-# Goes through the bit-exact conversion helpers to preserve NaN
-# sign/payload (see rt/f32_bits).
+# The bit path preserves a NaN's sign and payload.
 def f32_load(a) = Rt.f32_from_bits(i32_load(a))

--- a/runtime/ruby/units/table/call0.rb
+++ b/runtime/ruby/units/table/call0.rb
@@ -1,7 +1,5 @@
 # requires: rt/trap
-# Fixed-arity `call_indirect` for a 0-argument signature: same
-# dispatch and trap contract as `call`, but no `*args`/splat array is
-# built on either the caller or the callee side.
+# Same dispatch and trap contract as `call`, with no `*args`/splat array built on either side.
 def call0(i, type_key)
   Rt.trap("undefined element") if i >= @slots.size
   slot = @slots[i]

--- a/runtime/ruby/units/table/call1.rb
+++ b/runtime/ruby/units/table/call1.rb
@@ -1,7 +1,5 @@
 # requires: rt/trap
-# Fixed-arity `call_indirect` for a 1-argument signature: same
-# dispatch and trap contract as `call`, but no `*args`/splat array is
-# built on either the caller or the callee side.
+# Same dispatch and trap contract as `call`, with no `*args`/splat array built on either side.
 def call1(i, type_key, a0)
   Rt.trap("undefined element") if i >= @slots.size
   slot = @slots[i]

--- a/runtime/ruby/units/table/call2.rb
+++ b/runtime/ruby/units/table/call2.rb
@@ -1,7 +1,5 @@
 # requires: rt/trap
-# Fixed-arity `call_indirect` for a 2-argument signature: same
-# dispatch and trap contract as `call`, but no `*args`/splat array is
-# built on either the caller or the callee side.
+# Same dispatch and trap contract as `call`, with no `*args`/splat array built on either side.
 def call2(i, type_key, a0, a1)
   Rt.trap("undefined element") if i >= @slots.size
   slot = @slots[i]

--- a/runtime/ruby/units/table/call3.rb
+++ b/runtime/ruby/units/table/call3.rb
@@ -1,7 +1,5 @@
 # requires: rt/trap
-# Fixed-arity `call_indirect` for a 3-argument signature: same
-# dispatch and trap contract as `call`, but no `*args`/splat array is
-# built on either the caller or the callee side.
+# Same dispatch and trap contract as `call`, with no `*args`/splat array built on either side.
 def call3(i, type_key, a0, a1, a2)
   Rt.trap("undefined element") if i >= @slots.size
   slot = @slots[i]

--- a/runtime/ruby/units/table/call4.rb
+++ b/runtime/ruby/units/table/call4.rb
@@ -1,7 +1,5 @@
 # requires: rt/trap
-# Fixed-arity `call_indirect` for a 4-argument signature: same
-# dispatch and trap contract as `call`, but no `*args`/splat array is
-# built on either the caller or the callee side.
+# Same dispatch and trap contract as `call`, with no `*args`/splat array built on either side.
 def call4(i, type_key, a0, a1, a2, a3)
   Rt.trap("undefined element") if i >= @slots.size
   slot = @slots[i]

--- a/runtime/ruby/units/table/call5.rb
+++ b/runtime/ruby/units/table/call5.rb
@@ -1,7 +1,5 @@
 # requires: rt/trap
-# Fixed-arity `call_indirect` for a 5-argument signature: same
-# dispatch and trap contract as `call`, but no `*args`/splat array is
-# built on either the caller or the callee side.
+# Same dispatch and trap contract as `call`, with no `*args`/splat array built on either side.
 def call5(i, type_key, a0, a1, a2, a3, a4)
   Rt.trap("undefined element") if i >= @slots.size
   slot = @slots[i]

--- a/runtime/ruby/units/table/call6.rb
+++ b/runtime/ruby/units/table/call6.rb
@@ -1,7 +1,5 @@
 # requires: rt/trap
-# Fixed-arity `call_indirect` for a 6-argument signature: same
-# dispatch and trap contract as `call`, but no `*args`/splat array is
-# built on either the caller or the callee side.
+# Same dispatch and trap contract as `call`, with no `*args`/splat array built on either side.
 def call6(i, type_key, a0, a1, a2, a3, a4, a5)
   Rt.trap("undefined element") if i >= @slots.size
   slot = @slots[i]

--- a/runtime/ruby/units/table/call7.rb
+++ b/runtime/ruby/units/table/call7.rb
@@ -1,7 +1,5 @@
 # requires: rt/trap
-# Fixed-arity `call_indirect` for a 7-argument signature: same
-# dispatch and trap contract as `call`, but no `*args`/splat array is
-# built on either the caller or the callee side.
+# Same dispatch and trap contract as `call`, with no `*args`/splat array built on either side.
 def call7(i, type_key, a0, a1, a2, a3, a4, a5, a6)
   Rt.trap("undefined element") if i >= @slots.size
   slot = @slots[i]

--- a/runtime/ruby/units/table/call8.rb
+++ b/runtime/ruby/units/table/call8.rb
@@ -1,7 +1,5 @@
 # requires: rt/trap
-# Fixed-arity `call_indirect` for a 8-argument signature: same
-# dispatch and trap contract as `call`, but no `*args`/splat array is
-# built on either the caller or the callee side.
+# Same dispatch and trap contract as `call`, with no `*args`/splat array built on either side.
 def call8(i, type_key, a0, a1, a2, a3, a4, a5, a6, a7)
   Rt.trap("undefined element") if i >= @slots.size
   slot = @slots[i]


### PR DESCRIPTION
Closes #180. Applies the coding style rules introduced in #181 across `crates/`, `xtask/`, and `runtime/`.

- 70 what-comments deleted, 68 rewritten or trimmed to the constraint they state, 2 replaced by a rename (`run` → `pending_start` in the Python backend's `flat_seq`; a named `outward` binding in the Ruby backend's `record_target`). Those two renames are the only non-comment tokens in the diff.
- Constraint comments stay: spec/IEEE requirements, wasmtime-compatibility notes, split thresholds, the bash softfloat and status-cascade notes, every speed-category and `EXPECTED_FAILURES` attribution, and all `# requires:` unit headers (verified unchanged).
- Two stale doc claims corrected in passing: the Java `reindent` doc said four spaces while the body emits tabs, and an xtask comment promised inline ADR links no generated document contains.

Verification: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` (1375 tests, 64 suites) all pass.