### PR TITLE
Stop recommending -- --include-ignored, add DEWASM_RUBY override

### DIFF
--- a/agents/decisions/48-slow-test-speeds.md
+++ b/agents/decisions/48-slow-test-speeds.md
@@ -17,7 +17,7 @@ Two explicit speed categories, named for what they test:
 - `slow_test` (renamed from `heavy_test`): cases CI verifies on every push to main.
   The feature also un-ignores the spec harness's non-curated run, so the CI switch from `--include-ignored` to `--features slow_test` drops nothing unintended.
 - `ultra_slow_test = ["slow_test"]`: cases CI deliberately does not run.
-  **Criterion: roughly one minute per test on a CI runner** (observed, not estimated — a case is promoted on evidence from a real run).
+  **Criterion: roughly one minute per test, measured locally** (observed, not estimated — a case is promoted on evidence from a real run).
   The speed category is chosen per callsite in each backend's `tests/e2e.rs`, so the same case can be ultra for go (compiling a CPython-sized program) and slow for java.
 
 Local speeds: `cargo test` (fast test) → `--features slow_test` (what CI's main run runs) → `--features ultra_slow_test` (everything); `-- --include-ignored` remains the feature-independent way to run everything.

--- a/crates/dewasm-backend-bash/Cargo.toml
+++ b/crates/dewasm-backend-bash/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 # per-case macros (dewasm-test-helper) as active `#[test]`s
 # instead of `#[ignore]`d ones and runs the full spec testsuite — CI's
 # main run. `ultra_slow_test` additionally un-ignores the cases measured
-# at ~1 min+ on a CI runner (the interactive qjs REPL pty case), which are kept
+# at ~1 min+ locally (the interactive qjs REPL pty case), which are kept
 # out of CI and run only in local pre-release verification.
 slow_test = []
 ultra_slow_test = ["slow_test"]

--- a/crates/dewasm-backend-bash/tests/e2e.rs
+++ b/crates/dewasm-backend-bash/tests/e2e.rs
@@ -698,7 +698,7 @@ dewasm_test_helper::folded_temp_reuse_e2e!(Bash);
 
 dewasm_test_helper::cowsay_args_e2e!(Bash);
 dewasm_test_helper::cowsay_stdin_e2e!(Bash);
-// qjs_eval_e2e! / sqlite3_shell_e2e!: invoked, but slow — Bash's softfloat makes QuickJS/SQLite take tens of seconds, so the generated tests are `#[ignore]`d by default; `--features slow_test` or `-- --include-ignored` runs them anyway (same as every other backend).
+// qjs_eval_e2e! / sqlite3_shell_e2e!: invoked, but slow — Bash's softfloat makes QuickJS/SQLite take tens of seconds, so the generated tests are `#[ignore]`d by default; `--features slow_test` runs them anyway (same as every other backend).
 dewasm_test_helper::qjs_eval_e2e!(Bash);
 dewasm_test_helper::sqlite3_shell_e2e!(Bash);
 // minigzip is integer-only (no softfloat), so it runs under Bash by default, unlike the slow floating-point apps (QuickJS/SQLite).

--- a/crates/dewasm-backend-bash/tests/spec.rs
+++ b/crates/dewasm-backend-bash/tests/spec.rs
@@ -1,6 +1,6 @@
 //! Bash side of the shared spec harness: converts modules with the Bash backend, phrases assertions as bash (`ck`/`ckt`/`cke` helpers over the R0..Rn result globals and the status-134 trap protocol), and runs the script with a discovered bash >= 5 (macOS system bash is 3.2).
 //!
-//! Bash executes wasm orders of magnitude slower than Ruby, so `cargo test` runs a curated file list; the rest are `#[ignore]`d trials, so `cargo test -- --include-ignored` runs everything. The generic harness lives in `dewasm-test-helper`.
+//! Bash executes wasm orders of magnitude slower than Ruby, so `cargo test` runs a curated file list; the rest are `#[ignore]`d trials, unless the `slow_test` feature is on. The generic harness lives in `dewasm-test-helper`.
 
 use std::collections::BTreeSet;
 use std::fmt::Write as _;
@@ -25,7 +25,7 @@ const EXPECTED_FAILURES: &[(&str, u32, &str)] = &[
     ("load1", 5, "multi-memory"),
 ];
 
-/// Files `cargo test` runs by default; every other file is an `#[ignore]`d trial (`--include-ignored` or `slow_test` runs everything). Curated separately from the shared list: the heavy float files stay out because every float op runs on the softfloat.
+/// Files `cargo test` runs by default; every other file is an `#[ignore]`d trial (`slow_test` runs everything). Curated separately from the shared list: the heavy float files stay out because every float op runs on the softfloat.
 const CURATED_FILES: &[&str] = &[
     "address",
     "address0",

--- a/crates/dewasm-backend-go/Cargo.toml
+++ b/crates/dewasm-backend-go/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 # per-case macros (dewasm-test-helper) as active `#[test]`s
 # instead of `#[ignore]`d ones and runs the full spec testsuite — CI's
 # main run. `ultra_slow_test` additionally un-ignores the cases measured
-# at ~1 min+ on a CI runner (the giant-generated-program `go build` cases),
+# at ~1 min+ locally (the giant-generated-program `go build` cases),
 # which are kept out of CI and run only in local pre-release verification.
 slow_test = []
 ultra_slow_test = ["slow_test"]

--- a/crates/dewasm-backend-java/Cargo.toml
+++ b/crates/dewasm-backend-java/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 # slow per-case macros (dewasm-test-helper) as active
 # `#[test]`s instead of `#[ignore]`d ones, and runs the full spec testsuite —
 # CI's main run. `ultra_slow_test` additionally un-ignores the cases measured
-# at ~1 min+ on a CI runner (the zeroperl reactor cases, whose ~99 MB generated
+# at ~1 min+ locally (the zeroperl reactor cases, whose ~99 MB generated
 # source `javac`s for ~45 s even on a fast laptop), which are kept out of CI
 # and run only in local pre-release verification.
 slow_test = []

--- a/crates/dewasm-backend-ruby/Cargo.toml
+++ b/crates/dewasm-backend-ruby/Cargo.toml
@@ -15,6 +15,10 @@ workspace = true
 # `#[test]`s instead of `#[ignore]`d ones, and runs the full spec testsuite —
 # CI's main run. See docs/testing.md.
 slow_test = []
+# The ultra-slow category: cases measured at ~1 minute or more locally, kept
+# out of CI and run only in local pre-release verification. No Ruby case
+# sits in this category yet.
+ultra_slow_test = ["slow_test"]
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/dewasm-backend-ruby/Cargo.toml
+++ b/crates/dewasm-backend-ruby/Cargo.toml
@@ -15,9 +15,8 @@ workspace = true
 # `#[test]`s instead of `#[ignore]`d ones, and runs the full spec testsuite —
 # CI's main run. See docs/testing.md.
 slow_test = []
-# The ultra-slow category: cases measured at ~1 minute or more locally, kept
-# out of CI and run only in local pre-release verification. No Ruby case
-# sits in this category yet.
+# The ultra-slow category: cases measured at ~1 minute or more locally, kept out of CI and run only in local pre-release verification.
+# No Ruby case sits in this category yet.
 ultra_slow_test = ["slow_test"]
 
 [dependencies]

--- a/crates/dewasm-backend-ruby/src/lib.rs
+++ b/crates/dewasm-backend-ruby/src/lib.rs
@@ -85,7 +85,9 @@ pub fn shared_runtime(seeds: &BTreeSet<String>) -> Result<String> {
     Ok(format!("module Rt\n{}end\n", bundler().bundle(seeds, 1)?))
 }
 
-/// Locate a ruby interpreter able to run generated scripts: at least 3.4, because the generated runtime's memory is `IO::Buffer`-backed. Honors `$DEWASM_RUBY`, then `ruby` on `PATH`. A missing or too-old interpreter fails loud with a setup instruction rather than silently skipping.
+/// Locate a ruby interpreter able to run generated scripts: at least 3.4, because the generated runtime's memory is `IO::Buffer`-backed.
+/// Honors `$DEWASM_RUBY`, then `ruby` on `PATH`.
+/// A missing or too-old interpreter fails loud with a setup instruction rather than silently skipping.
 pub fn find_ruby() -> Option<std::path::PathBuf> {
     static RUBY: OnceLock<Option<std::path::PathBuf>> = OnceLock::new();
     RUBY.get_or_init(find_ruby_uncached).clone()

--- a/crates/dewasm-backend-ruby/src/lib.rs
+++ b/crates/dewasm-backend-ruby/src/lib.rs
@@ -85,26 +85,43 @@ pub fn shared_runtime(seeds: &BTreeSet<String>) -> Result<String> {
     Ok(format!("module Rt\n{}end\n", bundler().bundle(seeds, 1)?))
 }
 
-/// Locate a ruby interpreter able to run generated scripts: the `ruby` on `PATH`, and at least 3.4, because the generated runtime's memory is `IO::Buffer`-backed. A missing or too-old interpreter fails loud with a setup instruction rather than silently skipping.
+/// Locate a ruby interpreter able to run generated scripts: at least 3.4, because the generated runtime's memory is `IO::Buffer`-backed. Honors `$DEWASM_RUBY`, then `ruby` on `PATH`. A missing or too-old interpreter fails loud with a setup instruction rather than silently skipping.
 pub fn find_ruby() -> Option<std::path::PathBuf> {
     static RUBY: OnceLock<Option<std::path::PathBuf>> = OnceLock::new();
     RUBY.get_or_init(find_ruby_uncached).clone()
 }
 
-/// The probe behind [`find_ruby`], memoized there: it spawns a process per call, and the interpreter cannot change under a running process.
+/// The probe behind [`find_ruby`], memoized there: it spawns a process per candidate per call, and the interpreter cannot change under a running process.
 fn find_ruby_uncached() -> Option<std::path::PathBuf> {
-    let out = std::process::Command::new("ruby")
-        .args(["-e", "print RUBY_VERSION"])
-        .output()
-        .ok()?;
-    if !out.status.success() {
-        return None;
+    use std::path::PathBuf;
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    if let Ok(env) = std::env::var("DEWASM_RUBY") {
+        candidates.push(PathBuf::from(env));
     }
-    let version = String::from_utf8_lossy(&out.stdout);
-    let mut parts = version.trim().split('.');
-    let major: u32 = parts.next()?.parse().ok()?;
-    let minor: u32 = parts.next()?.parse().ok()?;
-    ((major, minor) >= (3, 4)).then(|| std::path::PathBuf::from("ruby"))
+    candidates.push(PathBuf::from("ruby"));
+    for candidate in candidates {
+        let Ok(out) = std::process::Command::new(&candidate)
+            .args(["-e", "print RUBY_VERSION"])
+            .output()
+        else {
+            continue;
+        };
+        if !out.status.success() {
+            continue;
+        }
+        let version = String::from_utf8_lossy(&out.stdout);
+        let mut parts = version.trim().split('.');
+        let (Some(major), Some(minor)) = (
+            parts.next().and_then(|p| p.parse::<u32>().ok()),
+            parts.next().and_then(|p| p.parse::<u32>().ok()),
+        ) else {
+            continue;
+        };
+        if (major, minor) >= (3, 4) {
+            return Some(candidate);
+        }
+    }
+    None
 }
 
 /// Generate one class for `module`. Returns the class source and the set of runtime units it needs (already bundled inside for `Embedded`).

--- a/crates/dewasm-backend-ruby/tests/e2e.rs
+++ b/crates/dewasm-backend-ruby/tests/e2e.rs
@@ -18,7 +18,7 @@ impl BackendUnderTest for Ruby {
     }
 
     fn interpreter(&self) -> PathBuf {
-        find_ruby().expect("ruby not found on PATH — see docs/testing.md")
+        find_ruby().expect("ruby not found on PATH (or $DEWASM_RUBY) — see docs/testing.md")
     }
 
     /// Write each `.wat` module of a multi-module case into `dir` as its own `.rb` file and return the `require_relative` preamble that loads them. `shared_runtime` emits each module against a single top-level `::Rt` (Alias linkage) written to `rt.rb`, so an imported table crosses modules (as the spec harness's `register` path does) — each module file requires it first, since its class body resolves `::Rt` at load time. Otherwise each file is a self-contained Embedded conversion carrying its own nested `Rt`.

--- a/crates/dewasm-backend-ruby/tests/module_name.rs
+++ b/crates/dewasm-backend-ruby/tests/module_name.rs
@@ -17,7 +17,8 @@ dewasm_test_helper::module_name_policy_suite!(
 
 /// Run `source` under ruby and return its stdout, failing loud on a nonzero exit.
 fn run(source: &str) -> String {
-    let ruby = find_ruby().expect("ruby >= 3.4 not found on PATH — see docs/testing.md");
+    let ruby =
+        find_ruby().expect("ruby >= 3.4 not found on PATH (or $DEWASM_RUBY) — see docs/testing.md");
     let out = dewasm_test_helper::run_script(&ruby, source, "rb", &[], "");
     assert!(
         out.status.success(),

--- a/crates/dewasm-backend-ruby/tests/spec.rs
+++ b/crates/dewasm-backend-ruby/tests/spec.rs
@@ -35,7 +35,8 @@ impl BackendUnderTest for RubySpec {
     }
 
     fn interpreter(&self) -> PathBuf {
-        dewasm_backend_ruby::find_ruby().expect("ruby not found on PATH — see docs/testing.md")
+        dewasm_backend_ruby::find_ruby()
+            .expect("ruby not found on PATH (or $DEWASM_RUBY) — see docs/testing.md")
     }
 }
 

--- a/crates/dewasm-backend-ruby/tests/wasi_testsuite.rs
+++ b/crates/dewasm-backend-ruby/tests/wasi_testsuite.rs
@@ -41,7 +41,8 @@ impl BackendUnderTest for RubyWasi {
     }
 
     fn interpreter(&self) -> PathBuf {
-        dewasm_backend_ruby::find_ruby().expect("ruby not found on PATH — see docs/testing.md")
+        dewasm_backend_ruby::find_ruby()
+            .expect("ruby not found on PATH (or $DEWASM_RUBY) — see docs/testing.md")
     }
 }
 

--- a/crates/dewasm-cli/tests/data_file.rs
+++ b/crates/dewasm-cli/tests/data_file.rs
@@ -1,6 +1,6 @@
 //! End-to-end coverage for `--data-file` data-segment externalization. For Ruby, Go, Python, Perl and Java: convert a module both embedded and with a sidecar, run each generated program, and assert byte-identical stdout/exit plus a smaller source file. Also pins the loud rejections (the bash target, `-o -`).
 //!
-//! The inline fixture carries an active segment, a passive segment initialized via `memory.init` + `data.drop`, and a bulky third segment so the sidecar form provably shrinks the source. The slow real-app cases (`qjs.wasm`) are `#[ignore]`d unless the `slow_test` feature is on, matching the project's speed-category convention for cases that pay a multi-second `go build` / interpreter startup (run with `--features slow_test` or `--include-ignored`).
+//! The inline fixture carries an active segment, a passive segment initialized via `memory.init` + `data.drop`, and a bulky third segment so the sidecar form provably shrinks the source. The slow real-app cases (`qjs.wasm`) are `#[ignore]`d unless the `slow_test` feature is on, matching the project's speed-category convention for cases that pay a multi-second `go build` / interpreter startup (run with `--features slow_test`).
 
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
@@ -71,7 +71,8 @@ fn write(path: &Path, contents: &str) {
 
 /// Run a Ruby program from its own directory (so `__dir__`-relative sidecar loads resolve), returning (stdout, exit code).
 fn run_ruby(prog: &Path, args: &[&str]) -> (Vec<u8>, i32) {
-    let ruby = find_ruby().expect("ruby >= 3.4 not found on PATH — see docs/testing.md");
+    let ruby =
+        find_ruby().expect("ruby >= 3.4 not found on PATH (or $DEWASM_RUBY) — see docs/testing.md");
     let out = Command::new(ruby)
         .arg(prog)
         .args(args)
@@ -642,7 +643,7 @@ const QJS_STDOUT: &str = "42\n";
 #[test]
 #[cfg_attr(
     not(feature = "slow_test"),
-    ignore = "slow: converts and runs the cached qjs.wasm (multi-second): --features slow_test or -- --include-ignored"
+    ignore = "slow: converts and runs the cached qjs.wasm (multi-second): --features slow_test"
 )]
 fn ruby_qjs_data_file_matches_embedded() {
     let wasm = qjs_wasm();
@@ -698,7 +699,7 @@ fn ruby_qjs_data_file_matches_embedded() {
 #[test]
 #[cfg_attr(
     not(feature = "slow_test"),
-    ignore = "slow: go build of the cached qjs.wasm source (multi-second): --features slow_test or -- --include-ignored"
+    ignore = "slow: go build of the cached qjs.wasm source (multi-second): --features slow_test"
 )]
 fn go_qjs_data_file_matches_embedded() {
     let wasm = qjs_wasm();
@@ -758,7 +759,7 @@ fn go_qjs_data_file_matches_embedded() {
 #[test]
 #[cfg_attr(
     not(feature = "slow_test"),
-    ignore = "slow: converts and runs the cached qjs.wasm (multi-second): --features slow_test or -- --include-ignored"
+    ignore = "slow: converts and runs the cached qjs.wasm (multi-second): --features slow_test"
 )]
 fn python_qjs_data_file_matches_embedded() {
     let wasm = qjs_wasm();
@@ -814,7 +815,7 @@ fn python_qjs_data_file_matches_embedded() {
 #[test]
 #[cfg_attr(
     not(feature = "slow_test"),
-    ignore = "slow: javac of the cached qjs.wasm source (multi-second): --features slow_test or -- --include-ignored"
+    ignore = "slow: javac of the cached qjs.wasm source (multi-second): --features slow_test"
 )]
 fn java_qjs_data_file_matches_embedded() {
     let wasm = qjs_wasm();

--- a/crates/dewasm-cli/tests/dwarf_line.rs
+++ b/crates/dewasm-cli/tests/dwarf_line.rs
@@ -101,7 +101,8 @@ fn run_go(prog: &Path) -> (String, i32) {
 }
 
 fn run_ruby(prog: &Path) -> (String, i32) {
-    let ruby = find_ruby().expect("ruby >= 3.4 not found on PATH — see docs/testing.md");
+    let ruby =
+        find_ruby().expect("ruby >= 3.4 not found on PATH (or $DEWASM_RUBY) — see docs/testing.md");
     let out = Command::new(ruby)
         .arg(prog)
         .current_dir(prog.parent().unwrap())

--- a/crates/dewasm-test-helper/src/lib.rs
+++ b/crates/dewasm-test-helper/src/lib.rs
@@ -188,7 +188,7 @@ macro_rules! module_name_policy_suite {
 /// Internal: wrap a generated `#[test]` item in the speed-category `#[ignore]` attribute. The per-case app macros below delegate here so a callsite can pick the category without duplicating the cfg_attr. `#[macro_export]` is load-bearing despite the macro being internal: the delegating macros expand inside the backend crates, where `$crate::test_speed!` resolves only to an exported macro (a plain `macro_rules!` cannot even be `pub use`d across crates, E0364) — `#[doc(hidden)]` keeps it out of the public docs instead.
 ///
 /// * `slow` — conditional on the backend crate's `slow_test` feature (CI's main run category). This is the default for every slow-case macro.
-/// * `ultra` — conditional on `ultra_slow_test` (which implies `slow_test`), for a case measured at roughly a minute or more on a CI runner. These are kept out of CI and run only under `--features ultra_slow_test` or `-- --include-ignored`, in local pre-release verification.
+/// * `ultra` — conditional on `ultra_slow_test` (which implies `slow_test`), for a case measured at roughly a minute or more locally. These are kept out of CI and run only under `--features ultra_slow_test`, in local pre-release verification.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! test_speed {
@@ -202,7 +202,7 @@ macro_rules! test_speed {
     (ultra, $item:item) => {
         #[cfg_attr(
             not(feature = "ultra_slow_test"),
-            ignore = "ultra-slow app case (1min+ on a CI runner): --features ultra_slow_test"
+            ignore = "ultra-slow app case: --features ultra_slow_test"
         )]
         $item
     };
@@ -342,7 +342,7 @@ macro_rules! wasi_root_containment_e2e {
     };
 }
 
-/// Per-case app macros: each expands to one `#[test] fn <case>()` running the named [`AppCase`] const for `$lang` (a [`BackendUnderTest`]). No glue argument — these are standalone-mode stdin/args cases, so no host-language glue is needed. `cowsay_args_e2e!` and `cowsay_stdin_e2e!` always run; `qjs_eval_e2e!` and `sqlite3_shell_e2e!` are slow — their generated `#[test]` is `#[ignore]`d unless the expanding backend crate's `slow_test` feature is enabled (run with `--features slow_test` or `cargo test -- --include-ignored`). A callsite may pass a trailing speed token (`slow`, the default, or `ultra`); see [`test_speed!`].
+/// Per-case app macros: each expands to one `#[test] fn <case>()` running the named [`AppCase`] const for `$lang` (a [`BackendUnderTest`]). No glue argument — these are standalone-mode stdin/args cases, so no host-language glue is needed. `cowsay_args_e2e!` and `cowsay_stdin_e2e!` always run; `qjs_eval_e2e!` and `sqlite3_shell_e2e!` are slow — their generated `#[test]` is `#[ignore]`d unless the expanding backend crate's `slow_test` feature is enabled (run with `--features slow_test`). A callsite may pass a trailing speed token (`slow`, the default, or `ultra`); see [`test_speed!`].
 ///
 /// [`AppCase`]: crate::AppCase
 #[macro_export]
@@ -366,7 +366,7 @@ macro_rules! cowsay_stdin_e2e {
     };
 }
 
-/// See [`cowsay_args_e2e!`]. Runs the slow [`QJS_EVAL`](crate::QJS_EVAL) case. Slow: the generated `#[test]` is `#[ignore]`d unless the expanding backend crate's `slow_test` feature is enabled — run it with `--features slow_test` or `cargo test -- --include-ignored`. Pass a trailing `ultra` to promote it to the ultra-slow category ([`test_speed!`]).
+/// See [`cowsay_args_e2e!`]. Runs the slow [`QJS_EVAL`](crate::QJS_EVAL) case. Slow: the generated `#[test]` is `#[ignore]`d unless the expanding backend crate's `slow_test` feature is enabled — run it with `--features slow_test`. Pass a trailing `ultra` to promote it to the ultra-slow category ([`test_speed!`]).
 #[macro_export]
 macro_rules! qjs_eval_e2e {
     ($lang:expr) => {

--- a/crates/dewasm-test-helper/src/spec.rs
+++ b/crates/dewasm-test-helper/src/spec.rs
@@ -19,7 +19,7 @@ use crate::backend::BackendUnderTest;
 pub trait SpecBackend: BackendUnderTest {
     /// Known assertion-level failures: (file, count, attribution tag).
     fn expected_failures(&self) -> &'static [(&'static str, u32, &'static str)];
-    /// The non-ignored set: files run by a plain `cargo test`. Every other `.wast` file still becomes a trial, but marked `#[ignore]`d, so `cargo test -- --ignored` / `--include-ignored` runs the whole testsuite. `None` marks nothing ignored — the whole testsuite runs by default (used by the fast interpreters).
+    /// The non-ignored set: files run by a plain `cargo test`. Every other `.wast` file still becomes a trial, but marked `#[ignore]`d. `None` marks nothing ignored — the whole testsuite runs by default (used by the fast interpreters).
     fn curated_files(&self) -> Option<&'static [&'static str]>;
     /// Units the harness helpers themselves use.
     fn seed_units(&self) -> &'static [&'static str];
@@ -85,7 +85,7 @@ pub struct Converted {
     pub units: BTreeSet<String>,
 }
 
-/// The `.wast` files a plain `cargo test` runs for a backend whose per-file cost makes the whole 257-file testsuite too slow to be the default: one file per semantic area — integers, floats, control flow, memory/table, globals, linking, bulk ops. Every other file is still a trial, `#[ignore]`d, so `--include-ignored` runs everything. The selection is a property of the testsuite rather than of a target language, so the backends that curate at all share it; one that needs more files adds them with [`curated_with`].
+/// The `.wast` files a plain `cargo test` runs for a backend whose per-file cost makes the whole 257-file testsuite too slow to be the default: one file per semantic area — integers, floats, control flow, memory/table, globals, linking, bulk ops. Every other file is still a trial, `#[ignore]`d, unless the backend crate's `slow_test` feature is on. The selection is a property of the testsuite rather than of a target language, so the backends that curate at all share it; one that needs more files adds them with [`curated_with`].
 pub const CURATED_SPEC_FILES: &[&str] = &[
     "address",
     "align",
@@ -207,7 +207,7 @@ fn spec_dir() -> std::path::PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/spec")
 }
 
-/// Build one libtest-mimic [`Trial`] per `.wast` file of the testsuite for `lang` (the `spec_suite!` macro's entry point). The trial name is the file stem, so cargo's own name filter applies: `cargo test --test spec i32` runs the `i32`-named file(s). Files outside the backend's [`SpecBackend::curated_files`] set become `#[ignore]`d trials, so a plain `cargo test` runs the curated set and `--include-ignored` (or `--ignored`) runs the whole testsuite. Trials run on libtest-mimic's thread pool; each owns its per-file state, so the run parallelizes.
+/// Build one libtest-mimic [`Trial`] per `.wast` file of the testsuite for `lang` (the `spec_suite!` macro's entry point). The trial name is the file stem, so cargo's own name filter applies: `cargo test --test spec i32` runs the `i32`-named file(s). Files outside the backend's [`SpecBackend::curated_files`] set become `#[ignore]`d trials, so a plain `cargo test` runs the curated set. Trials run on libtest-mimic's thread pool; each owns its per-file state, so the run parallelizes.
 ///
 /// `slow_test` mirrors the backend crate's feature of the same name (CI's main run): when on, nothing is marked ignored — the whole testsuite runs, the same set the old `--include-ignored` run covered.
 pub fn spec_trials(lang: &'static dyn SpecBackend, slow_test: bool) -> Vec<Trial> {

--- a/crates/xtask/src/bench/runner.rs
+++ b/crates/xtask/src/bench/runner.rs
@@ -210,7 +210,8 @@ impl Target {
         match self {
             Target::Ruby(flag) => {
                 let ruby = dewasm_backend_ruby::find_ruby().ok_or_else(|| {
-                    "ruby >= 3.4 not found on PATH — see docs/testing.md".to_string()
+                    "ruby >= 3.4 not found on PATH (or $DEWASM_RUBY) — see docs/testing.md"
+                        .to_string()
                 })?;
                 ruby_jit_available(&ruby, flag)
             }
@@ -310,7 +311,8 @@ impl Driver {
             }
             Driver::Wardite(flag) => {
                 let ruby = dewasm_backend_ruby::find_ruby().ok_or_else(|| {
-                    "ruby >= 3.4 not found on PATH — see docs/testing.md".to_string()
+                    "ruby >= 3.4 not found on PATH (or $DEWASM_RUBY) — see docs/testing.md"
+                        .to_string()
                 })?;
                 ruby_jit_available(&ruby, flag)?;
                 let gem_home = wardite_gem_home().ok_or_else(|| {

--- a/docs/apps-audit.md
+++ b/docs/apps-audit.md
@@ -37,7 +37,7 @@ Real-world wasip1 binaries would otherwise be uniformly rejected, which would de
 
 ³ **QuickJS deepened.**
 Beyond the one-shot `-e` eval case, e2e cases exercise real WASI filesystem use against a preopened scratch dir and the interactive REPL under a real pty, both byte-identical to `wasmtime`.
-Every backend mirrors the file I/O case against the same fixtures and snapshots on the shared WASI filesystem model, conditional behind the `slow_test` cargo feature in each crate (`#[ignore]`d otherwise; run with `--features slow_test` or `-- --include-ignored`):
+Every backend mirrors the file I/O case against the same fixtures and snapshots on the shared WASI filesystem model, conditional behind the `slow_test` cargo feature in each crate (`#[ignore]`d otherwise; run with `--features slow_test`):
 
 - *File I/O* (`qjs_file_io`): the `qjs:std` module writes a file, reads it back, and prints it; the test asserts the guest stdout snapshot **and** the host-side file content.
   Fixture: `examples/apps/fixtures/qjs_file_io.js`.

--- a/docs/backends/bash.md
+++ b/docs/backends/bash.md
@@ -46,7 +46,7 @@ The e2e override, custom-provider and partial-override glue (`crates/dewasm-back
 
 - **Speed.**
   Bash arithmetic is signed-64 only, and every float operation is softfloat integer arithmetic, so float-heavy programs are slow.
-  The slow apps (QuickJS, SQLite) are `#[ignore]`d for Bash by default and run only under the `slow_test` cargo feature (or `cargo test -- --include-ignored`).
+  The slow apps (QuickJS, SQLite) are `#[ignore]`d for Bash by default and run only under the `slow_test` cargo feature.
   Slower still, in the `ultra_slow_test` category (kept out of CI): the interactive qjs REPL pty case, the interpreter and reactor giants (CPython, CRuby, zeroperl), and the DOOM and NES frame snapshots.
   Integer-only programs (cowsay, minigzip) run fine.
 - Every generated function ends with an explicit `return 0`; a trailing arithmetic statement would otherwise leak status 1 (the units lint enforces this).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -10,7 +10,7 @@ Therefore, the following tools and setup steps are required to run all tests cor
 - **Rust toolchain**: `rustup` applies the pin in `rust-toolchain.toml` automatically; a non-rustup `cargo` ignores the pin.
 - **Each backend's interpreter or toolchain**, at the version its page under [`docs/backends/`](backends/) states; a full `cargo test` needs all of them.
   * Each tool should be found under `PATH` (the `bash` lookup also tries the common Homebrew install paths).
-  * These environment variables override the lookup: `$DEWASM_PYTHON`, `$DEWASM_PERL`, `$DEWASM_BASH`, `$DEWASM_GO`, `$DEWASM_JAVA`, `$DEWASM_JAVAC`. `ruby` has no override.
+  * These environment variables override the lookup: `$DEWASM_RUBY`, `$DEWASM_PYTHON`, `$DEWASM_PERL`, `$DEWASM_BASH`, `$DEWASM_GO`, `$DEWASM_JAVA`, `$DEWASM_JAVAC`.
 - **Testsuite submodules**: initialize them once with `git submodule update --init`.
 - **The `.wasm` apps cache**: initialize it once with `examples/apps/setup.sh`.
   * Cached `.wasm` files are located in `examples/apps/cache`.
@@ -38,7 +38,7 @@ Checked-in snapshots are code-derived, never hand-written; a stale one fails a c
 | Snapshot | Regenerate with |
 | --- | --- |
 | `docs/support.md` | `cargo xtask update-support-docs` |
-| every execution snapshot (`examples/apps/snapshots/*`, incl. the DOOM and NES frames) | `cargo xtask update-snapshots [filter]` |
+| every execution snapshot (`examples/apps/snapshots/*`) | `cargo xtask update-snapshots [filter]` |
 
 A snapshot claims "this is what `wasmtime run` produces", so it can go stale.
 The opt-in freshness check runs the cached binaries under a live `wasmtime` and compares against the checked-in files:


### PR DESCRIPTION
Closes #190.

- Every mention that told the reader to pass `-- --include-ignored` is gone; the `slow_test` / `ultra_slow_test` / `wasmtime_test` features are the only advertised opt-ins. Mentions that merely describe cargo's `#[ignore]`/`--ignored` mechanism, and historical text inside `agents/decisions/`, stay.
- The ultra-slow `#[ignore]` reason is now just `"ultra-slow app case: --features ultra_slow_test"`, and every place that attributed the ~1-minute threshold to "a CI runner" (the `ultra` doc comment, the bash/go/java `Cargo.toml` comments, decision 48's criterion) now attributes it to a local run — CI is what an `ultra` case is excluded from, not where it is timed.
- `dewasm-backend-ruby` gains the `ultra_slow_test = ["slow_test"]` declaration every other backend already has (no Ruby case uses it yet), and `find_ruby` gains the `$DEWASM_RUBY` override following `find_python`'s shape; `docs/testing.md`'s override list drops its "ruby has no override" exception.
- One leftover review edit from #188: the snapshot-table row loses its "incl. the DOOM and NES frames" parenthetical.

Verification: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` all pass; `cargo test -p dewasm-backend-ruby --features ultra_slow_test --test e2e` compiles and runs (36 passed); with the override set to a bogus path and no `ruby` on `PATH`, tests fail loud with `ruby not found on PATH (or $DEWASM_RUBY) — see docs/testing.md` (a spawnable-override-first, PATH-fallback order matching the other backends).