### PR TITLE
Capture and check every snapshot through the embedded wasmtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,15 +166,15 @@ jobs:
           path: examples/apps/cache
           key: ${{ needs.apps-cache.outputs.key }}
           fail-on-cache-miss: true
-      # Speed categories: the `slow_test` feature covers what `--include-ignored`
-      # used to un-ignore. `dewasm-test-helper/wasmtime_test` runs the
-      # apps_wasmtime snapshot-freshness suite (execs `wasmtime run`, installed
-      # below); `dewasm-cli/slow_test` runs the slow cross-backend
-      # `--data-file` real-app cases.
-      - uses: bytecodealliance/actions/wasmtime/setup@v1
+      # Speed categories: the `slow_test` feature covers the slow cases.
+      # `dewasm-test-helper/wasmtime_test` runs the apps_wasmtime
+      # snapshot-freshness suite, which execs the xtask binary (it embeds the
+      # pinned wasmtime crate, so nothing is installed for it) and never builds
+      # it — hence the explicit build step below; `dewasm-cli/slow_test` runs
+      # the slow cross-backend `--data-file` real-app cases.
+      - name: Build the snapshot runner
         if: github.event_name != 'pull_request'
-        with:
-          version: '47.0.2'
+        run: cargo build -p xtask
       - name: Test
         if: github.event_name == 'pull_request'
         run: cargo test -p dewasm-core -p dewasm-backend -p dewasm-cli -p dewasm-test-helper -p xtask --no-fail-fast

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,11 +167,7 @@ jobs:
           key: ${{ needs.apps-cache.outputs.key }}
           fail-on-cache-miss: true
       # Speed categories: the `slow_test` feature covers the slow cases.
-      # `dewasm-test-helper/wasmtime_test` runs the apps_wasmtime
-      # snapshot-freshness suite, which execs the xtask binary (it embeds the
-      # pinned wasmtime crate, so nothing is installed for it) and never builds
-      # it — hence the explicit build step below; `dewasm-cli/slow_test` runs
-      # the slow cross-backend `--data-file` real-app cases.
+      # `dewasm-test-helper/wasmtime_test` runs the apps_wasmtime snapshot-freshness suite, which execs the xtask binary (it embeds the pinned wasmtime crate, so nothing is installed for it) and never builds it — hence the explicit build step below; `dewasm-cli/slow_test` runs the slow cross-backend `--data-file` real-app cases.
       - name: Build the snapshot runner
         if: github.event_name != 'pull_request'
         run: cargo build -p xtask

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,7 +74,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -79,7 +85,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -136,6 +142,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "cap-fs-ext"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78e5a3368ae89b7cb68186411452b4b9fac8b41be9c19bf3f47c2d2c8e36e6b"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "ipnet",
+ "maybe-owned",
+ "rustix",
+ "rustix-linux-procfs",
+ "windows-sys 0.61.2",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7281235d6e96d3544ca18bba9049be92f4190f8d923e3caef1b5f66cfa752608"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "rustix",
+]
+
+[[package]]
 name = "cc"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,6 +210,17 @@ name = "cfg_aliases"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core",
+]
 
 [[package]]
 name = "clap"
@@ -226,6 +291,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -386,6 +460,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,7 +511,7 @@ dependencies = [
  "dewasm-core",
  "dewasm-test-helper",
  "regex",
- "wast",
+ "wast 254.0.0",
  "wat",
 ]
 
@@ -425,7 +524,7 @@ dependencies = [
  "dewasm-core",
  "dewasm-test-helper",
  "regex",
- "wast",
+ "wast 254.0.0",
  "wat",
 ]
 
@@ -438,7 +537,7 @@ dependencies = [
  "dewasm-core",
  "dewasm-test-helper",
  "regex",
- "wast",
+ "wast 254.0.0",
  "wat",
 ]
 
@@ -451,7 +550,7 @@ dependencies = [
  "dewasm-core",
  "dewasm-test-helper",
  "regex",
- "wast",
+ "wast 254.0.0",
  "wat",
 ]
 
@@ -464,7 +563,7 @@ dependencies = [
  "dewasm-core",
  "dewasm-test-helper",
  "regex",
- "wast",
+ "wast 254.0.0",
  "wat",
 ]
 
@@ -477,7 +576,7 @@ dependencies = [
  "dewasm-core",
  "dewasm-test-helper",
  "regex",
- "wast",
+ "wast 254.0.0",
  "wat",
 ]
 
@@ -519,7 +618,7 @@ dependencies = [
  "portable-pty",
  "serde",
  "serde_json",
- "wast",
+ "wast 254.0.0",
  "wat",
 ]
 
@@ -531,6 +630,17 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -558,6 +668,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,7 +689,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -632,6 +751,26 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes 2.0.4",
+ "rustix",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "futures"
@@ -708,6 +847,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "rand_core",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,6 +904,115 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -763,6 +1023,34 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "io-extras"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
+dependencies = [
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io-lifetimes"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
+
+[[package]]
+name = "ipnet"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -790,6 +1078,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
 
 [[package]]
 name = "leb128fmt"
@@ -828,6 +1122,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,6 +1138,12 @@ name = "mach2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
@@ -862,6 +1168,17 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -899,6 +1216,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -953,6 +1276,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -991,6 +1323,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1059,7 +1434,17 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -1123,7 +1508,7 @@ checksum = "9eb6ea5562eeaed6936b8b54e086aa0f88b9e5b1bef45beb038e2519fa1185b1"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1133,7 +1518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -1181,6 +1566,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,6 +1607,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1270,6 +1676,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1288,6 +1749,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1298,6 +1777,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-encoder"
@@ -1368,6 +1853,7 @@ dependencies = [
  "bumpalo",
  "cc",
  "cfg-if",
+ "encoding_rs",
  "futures",
  "libc",
  "log",
@@ -1377,13 +1863,17 @@ dependencies = [
  "once_cell",
  "postcard",
  "pulley-interpreter",
+ "rayon",
  "rustix",
+ "semver",
  "serde",
  "serde_derive",
  "smallvec",
  "target-lexicon",
  "wasmparser 0.252.0",
  "wasmtime-environ",
+ "wasmtime-internal-component-macro",
+ "wasmtime-internal-component-util",
  "wasmtime-internal-core",
  "wasmtime-internal-cranelift",
  "wasmtime-internal-fiber",
@@ -1391,7 +1881,7 @@ dependencies = [
  "wasmtime-internal-jit-icache-coherence",
  "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1423,6 +1913,21 @@ dependencies = [
  "wasmprinter",
  "wasmtime-internal-component-util",
  "wasmtime-internal-core",
+]
+
+[[package]]
+name = "wasmtime-internal-component-macro"
+version = "47.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b627ea698db36fb9110aa77868467f1d23791a76a88a433cb6a43e1242073b77"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-wit-bindgen",
+ "wit-parser",
 ]
 
 [[package]]
@@ -1481,7 +1986,7 @@ dependencies = [
  "rustix",
  "wasmtime-environ",
  "wasmtime-internal-versioned-export-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1503,7 +2008,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasmtime-internal-core",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1531,6 +2036,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtime-internal-wit-bindgen"
+version = "47.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ff41bb1656cbeb7befc42b8a7078b30a5f8393a0c8bca36a6cec94360c1a16"
+dependencies = [
+ "anyhow",
+ "bitflags 2.13.1",
+ "heck",
+ "indexmap",
+ "wit-parser",
+]
+
+[[package]]
+name = "wasmtime-wasi"
+version = "47.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed1750b8e5e5d5b1ee3c0eb602d2c49d6a37a36e9996eaf0708b48ac92b62b06"
+dependencies = [
+ "async-trait",
+ "bitflags 2.13.1",
+ "bytes",
+ "cap-fs-ext",
+ "cap-std",
+ "cfg-if",
+ "futures",
+ "io-lifetimes 3.0.1",
+ "rand",
+ "rustix",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "url",
+ "wasmtime",
+ "wasmtime-wasi-io",
+ "wiggle",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-wasi-io"
+version = "47.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54777d3afeaf3f32cc444df661d9cb4fd57067971e183c2b1f5251f33b939e68"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "tracing",
+ "wasmtime",
+]
+
+[[package]]
+name = "wast"
+version = "35.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ef140f1b49946586078353a453a1d28ba90adfc54dde75710bc1931de204d68"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
 name = "wast"
 version = "254.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1549,7 +2115,47 @@ version = "1.254.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7127f7f9b8f127c879991cecd35f494e4628bae1b0874c681414d8d8831e952c"
 dependencies = [
- "wast",
+ "wast 254.0.0",
+]
+
+[[package]]
+name = "wiggle"
+version = "47.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a23c2dc694dfafb35beb542e172d7c256488912cd84902828f8661723ad0eb7"
+dependencies = [
+ "bitflags 2.13.1",
+ "thiserror 2.0.19",
+ "tracing",
+ "wasmtime",
+ "wasmtime-environ",
+ "wiggle-macro",
+]
+
+[[package]]
+name = "wiggle-generate"
+version = "47.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fe48e5e455e827339d8e65de602cc7839d241bd7063be1fc235e35581788ad"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "wasmtime-environ",
+ "witx",
+]
+
+[[package]]
+name = "wiggle-macro"
+version = "47.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb520c20bed78e5a311d4c9ad883ac3b6d070617d07a19fbe5dc0b408c501b4b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "wiggle-generate",
 ]
 
 [[package]]
@@ -1574,7 +2180,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1591,12 +2197,159 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winreg"
@@ -1606,6 +2359,53 @@ checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags 2.13.1",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.252.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4266bea110371c620ccf3201c5023676046bc4556e5c7cfb5d500bda5ebc162d"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.1",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-ident",
+ "wasmparser 0.252.0",
+]
+
+[[package]]
+name = "witx"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e366f27a5cabcddb2706a78296a40b8fcc451e1a6aba2fc1d94b4a01bdaaef4b"
+dependencies = [
+ "anyhow",
+ "log",
+ "thiserror 1.0.69",
+ "wast 35.0.2",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
@@ -1626,6 +2426,84 @@ dependencies = [
  "serde",
  "serde_json",
  "wasmtime",
+ "wasmtime-wasi",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,22 @@ serde_json = "1"
 
 [workspace.lints.clippy]
 all = { level = "warn", priority = -1 }
+
+# The crates that compile a guest module inside the xtask snapshot runner.
+# Unoptimized they take ~60 s over a 34 MB app rather than ~7 s, which the
+# snapshot capture and the freshness suite pay on every heavy case; the runner
+# itself stays on the plain dev profile the tests resolve it in.
+[profile.dev.package.cranelift-codegen]
+opt-level = 3
+
+[profile.dev.package.cranelift-frontend]
+opt-level = 3
+
+[profile.dev.package.regalloc2]
+opt-level = 3
+
+[profile.dev.package.wasmtime-environ]
+opt-level = 3
+
+[profile.dev.package.wasmtime-internal-cranelift]
+opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,7 @@ serde_json = "1"
 all = { level = "warn", priority = -1 }
 
 # The crates that compile a guest module inside the xtask snapshot runner.
-# Unoptimized they take ~60 s over a 34 MB app rather than ~7 s, which the
-# snapshot capture and the freshness suite pay on every heavy case; the runner
-# itself stays on the plain dev profile the tests resolve it in.
+# Unoptimized they take ~60 s over a 34 MB app rather than ~7 s, which the snapshot capture and the freshness suite pay on every heavy case; the runner itself stays on the plain dev profile the tests resolve it in.
 [profile.dev.package.cranelift-codegen]
 opt-level = 3
 

--- a/agents/test-authoring.md
+++ b/agents/test-authoring.md
@@ -18,7 +18,8 @@ The spec, convert, and WASI-testsuite suites are [libtest-mimic](https://crates.
 - The units lint (`declared_requires_cover_references`, `all_units_bundle`, and the go/java whole-bundle compile checks) lives as `#[cfg(test)] mod units` unit tests at the bottom of each backend's `src/lib.rs`, run with `cargo test -p dewasm-backend-<lang> --lib`.
   **`softfloat.rs`** (bash) is the one backend-local integration oracle.
 - **`crates/dewasm-cli/tests/`**: only `support_docs.rs` (the freshness check that fails while the generated `docs/support.md` is stale, over all backends).
-- **`crates/dewasm-test-helper/tests/apps_wasmtime.rs`**: wasmtime as a `BackendUnderTest`, running the `apps`/`gzip`/`fs_apps` snapshot-freshness checks through the shared runners, plus `qjs_repl_interactive_snapshot`, which re-captures the bare qjs REPL under a pty from a live wasmtime and compares it to the checked-in transcript (compare-only; regenerate with `cargo xtask update-snapshots`).
+- **`crates/dewasm-test-helper/tests/apps_wasmtime.rs`**: wasmtime as a `BackendUnderTest`, running the `apps`/`gzip`/`fs_apps` snapshot-freshness checks through the shared runners, plus `qjs_repl_interactive_snapshot`, which re-captures the bare qjs REPL under a pty and compares it to the checked-in transcript, and `doom_frame`/`nes_frame` (compare-only; regenerate with `cargo xtask update-snapshots`).
+  Every case reaches wasmtime through the `xtask` binary, so build it first (`cargo build -p xtask`).
   All behind the `wasmtime_test` feature, named for a future engine such as wasmer/wasmedge joining it.
 
 ## The `e2e.rs` contract
@@ -58,7 +59,7 @@ Onboarding a new backend to the e2e suites is: implement `BackendUnderTest` (and
 ## Re-pinning an app
 
 After bumping a pin in `examples/apps/setup.sh`: re-run `setup.sh`, regenerate with `cargo xtask update-snapshots [filter]`, re-run the `wasmtime_test` freshness suite, and update the app's `expect_code` in `crates/dewasm-test-helper/src/apps.rs` if the exit status changed.
-The DOOM frame is the one snapshot not captured through the `wasmtime` CLI: `doom.wasm`'s custom-import interface does not run under `wasmtime run`, so `update-snapshots` drives it with the embedded `wasmtime` crate (an xtask-only dependency); after a doom pin bump, re-run the per-backend `doom_frame` cases.
+Every snapshot is captured through the `wasmtime` crate embedded in xtask (an xtask-only dependency); the DOOM and NES frames go through their own capture code rather than the WASI runner, because their custom-import interfaces are not WASI commands. After a doom pin bump, re-run the per-backend `doom_frame` cases.
 
 ## The `EXPECTED_FAILURES` lists
 

--- a/crates/dewasm-test-helper/src/lib.rs
+++ b/crates/dewasm-test-helper/src/lib.rs
@@ -70,7 +70,7 @@ pub use wasi::{
     WasiCase, WasiCheck, WasiKind, WASI_CASES,
 };
 pub use wasi_testsuite::{wasi_testsuite_main, wasi_testsuite_trials, WasiTestsuiteBackend};
-pub use wasmtime_backend::Wasmtime;
+pub use wasmtime_backend::{wasi_runner_argv, wasi_runner_bin, Wasmtime};
 
 /// The `harness = false` `main` of a backend's spec integration test: builds one libtest-mimic trial per `.wast` file for `$lang` (a [`SpecBackend`]) and runs them with cargo's own test arguments (name filter, `--ignored`/`--include-ignored`, thread count). `$lang` must be a promotable-to-`'static` value — the backend `Spec` structs are unit structs, so `spec_suite!(RubySpec)` promotes `&RubySpec` to `&'static`.
 #[macro_export]

--- a/crates/dewasm-test-helper/src/snapshots.rs
+++ b/crates/dewasm-test-helper/src/snapshots.rs
@@ -1,6 +1,7 @@
 //! The execution-snapshot registry: one entry per checked-in snapshot the WASI runner can regenerate, so `cargo xtask update-snapshots` regenerates every one from a single table instead of a per-case manual capture.
 //!
-//! Each [`WasmtimeSnapshot`] pairs a snapshot's write path with a capture closure that reruns the case under the `engine` given to [`wasmtime_snapshots`] and returns the bytes to write. The DOOM and NES frames are deliberately **not** here: each drives a custom-import interface through the `wasmtime` crate directly (issue #114), which this test-only helper crate must not depend on — xtask appends those targets itself.
+//! Each [`WasmtimeSnapshot`] pairs a snapshot's write path with a capture closure that reruns the case under the `engine` given to [`wasmtime_snapshots`] and returns the bytes to write.
+//! The DOOM and NES frames are deliberately **not** here: each drives a custom-import interface through the `wasmtime` crate directly (issue #114), which this test-only helper crate must not depend on — xtask appends those targets itself.
 //!
 //! The compare-only `apps`/`gzip`/`fs_apps` suites never touch this module: capture stays a separate, explicit code path (no env-var "update mode" on the tests), keeping the freshness comparison honest (docs/testing.md).
 
@@ -14,7 +15,8 @@ use crate::backend::BackendUnderTest;
 use crate::fixtures::apps_snapshot_dir;
 use crate::qjs_repl::{capture_qjs_repl_transcript, qjs_repl_snapshot_path};
 
-/// One regenerable execution snapshot: a repo-relative `label` (used for the optional substring filter and the printed line), the absolute `path` to write, and a `capture` closure that reruns the case and returns the bytes. `capture` fails loud on a missing cache or a missing runner — the underlying runners carry the exact setup message.
+/// One regenerable execution snapshot: a repo-relative `label` (used for the optional substring filter and the printed line), the absolute `path` to write, and a `capture` closure that reruns the case and returns the bytes.
+/// `capture` fails loud on a missing cache or a missing runner — the underlying runners carry the exact setup message.
 pub struct WasmtimeSnapshot {
     pub label: String,
     pub path: PathBuf,

--- a/crates/dewasm-test-helper/src/snapshots.rs
+++ b/crates/dewasm-test-helper/src/snapshots.rs
@@ -1,6 +1,6 @@
-//! The execution-snapshot registry: one entry per checked-in snapshot the wasmtime engine can regenerate, so `cargo xtask update-snapshots` regenerates every one from a single table instead of the former per-case manual `wasmtime run … >` redirection.
+//! The execution-snapshot registry: one entry per checked-in snapshot the WASI runner can regenerate, so `cargo xtask update-snapshots` regenerates every one from a single table instead of a per-case manual capture.
 //!
-//! Each [`WasmtimeSnapshot`] pairs a snapshot's write path with a capture closure that reruns the case under the shared [`Wasmtime`] `BackendUnderTest` and returns the bytes to write. The DOOM and NES frames are deliberately **not** here: each needs the embedded `wasmtime` *crate* to drive its custom-import interface (issue #114), which this test-only helper crate must not depend on — xtask appends those targets itself.
+//! Each [`WasmtimeSnapshot`] pairs a snapshot's write path with a capture closure that reruns the case under the `engine` given to [`wasmtime_snapshots`] and returns the bytes to write. The DOOM and NES frames are deliberately **not** here: each drives a custom-import interface through the `wasmtime` crate directly (issue #114), which this test-only helper crate must not depend on — xtask appends those targets itself.
 //!
 //! The compare-only `apps`/`gzip`/`fs_apps` suites never touch this module: capture stays a separate, explicit code path (no env-var "update mode" on the tests), keeping the freshness comparison honest (docs/testing.md).
 
@@ -10,19 +10,19 @@ use crate::apps::{
     capture_app_stdout, capture_gzip_compress, COWSAY_ARGS, COWSAY_STDIN, QJS_EVAL, SQLITE3_SHELL,
 };
 use crate::apps_fs::{capture_fs_app_stdout, QJS_FILE_IO, RG_SEARCH, SQLITE3_SHELL_DBFILE};
+use crate::backend::BackendUnderTest;
 use crate::fixtures::apps_snapshot_dir;
 use crate::qjs_repl::{capture_qjs_repl_transcript, qjs_repl_snapshot_path};
-use crate::wasmtime_backend::Wasmtime;
 
-/// One regenerable execution snapshot: a repo-relative `label` (used for the optional substring filter and the printed line), the absolute `path` to write, and a `capture` closure that reruns the case under wasmtime and returns the bytes. `capture` fails loud on a missing cache or a missing `wasmtime` — the underlying runners carry the exact setup message.
+/// One regenerable execution snapshot: a repo-relative `label` (used for the optional substring filter and the printed line), the absolute `path` to write, and a `capture` closure that reruns the case and returns the bytes. `capture` fails loud on a missing cache or a missing runner — the underlying runners carry the exact setup message.
 pub struct WasmtimeSnapshot {
     pub label: String,
     pub path: PathBuf,
     pub capture: Box<dyn Fn() -> Vec<u8>>,
 }
 
-/// Every execution snapshot the `wasmtime` CLI can regenerate — the nine targets excluding DOOM and NES, each mapped to its snapshot file by the `<case>.stdout`/`.gz`/`.transcript` convention. xtask iterates these (plus the embedded-wasmtime DOOM and NES frames) for `update-snapshots`.
-pub fn wasmtime_snapshots() -> Vec<WasmtimeSnapshot> {
+/// Every execution snapshot the WASI runner can regenerate — the nine targets excluding DOOM and NES, each mapped to its snapshot file by the `<case>.stdout`/`.gz`/`.transcript` convention. xtask iterates these (plus the DOOM and NES frames) for `update-snapshots`, passing the wasmtime `engine` that runs each case.
+pub fn wasmtime_snapshots(engine: &'static dyn BackendUnderTest) -> Vec<WasmtimeSnapshot> {
     let dir = apps_snapshot_dir();
     let app = |file: &str, capture: Box<dyn Fn() -> Vec<u8>>| WasmtimeSnapshot {
         label: format!("examples/apps/snapshots/{file}"),
@@ -32,40 +32,40 @@ pub fn wasmtime_snapshots() -> Vec<WasmtimeSnapshot> {
     vec![
         app(
             "cowsay_args.stdout",
-            Box::new(|| capture_app_stdout(&Wasmtime, &COWSAY_ARGS)),
+            Box::new(|| capture_app_stdout(engine, &COWSAY_ARGS)),
         ),
         app(
             "cowsay_stdin.stdout",
-            Box::new(|| capture_app_stdout(&Wasmtime, &COWSAY_STDIN)),
+            Box::new(|| capture_app_stdout(engine, &COWSAY_STDIN)),
         ),
         app(
             "qjs.stdout",
-            Box::new(|| capture_app_stdout(&Wasmtime, &QJS_EVAL)),
+            Box::new(|| capture_app_stdout(engine, &QJS_EVAL)),
         ),
         app(
             "sqlite3_shell.stdout",
-            Box::new(|| capture_app_stdout(&Wasmtime, &SQLITE3_SHELL)),
+            Box::new(|| capture_app_stdout(engine, &SQLITE3_SHELL)),
         ),
         app(
             "minigzip_compress.gz",
-            Box::new(|| capture_gzip_compress(&Wasmtime)),
+            Box::new(|| capture_gzip_compress(engine)),
         ),
         app(
             "qjs_file_io.stdout",
-            Box::new(|| capture_fs_app_stdout(&Wasmtime, &QJS_FILE_IO)),
+            Box::new(|| capture_fs_app_stdout(engine, &QJS_FILE_IO)),
         ),
         app(
             "sqlite3_shell_dbfile.stdout",
-            Box::new(|| capture_fs_app_stdout(&Wasmtime, &SQLITE3_SHELL_DBFILE)),
+            Box::new(|| capture_fs_app_stdout(engine, &SQLITE3_SHELL_DBFILE)),
         ),
         app(
             "rg_search.stdout",
-            Box::new(|| capture_fs_app_stdout(&Wasmtime, &RG_SEARCH)),
+            Box::new(|| capture_fs_app_stdout(engine, &RG_SEARCH)),
         ),
         WasmtimeSnapshot {
             label: "examples/apps/snapshots/qjs_repl_interactive.transcript".to_string(),
             path: qjs_repl_snapshot_path(),
-            capture: Box::new(|| capture_qjs_repl_transcript(&Wasmtime)),
+            capture: Box::new(|| capture_qjs_repl_transcript(engine)),
         },
     ]
 }

--- a/crates/dewasm-test-helper/src/wasmtime_backend.rs
+++ b/crates/dewasm-test-helper/src/wasmtime_backend.rs
@@ -1,8 +1,10 @@
-//! wasmtime as a [`BackendUnderTest`]: the snapshot-vs-wasmtime freshness checks run through the *same* shared app/gzip runners every real backend uses, rather than a hand-written per-case loop. wasmtime does not generate source — it runs the cached `.wasm` binary directly — so its `convert_app` returns the path to the exact cache binary the snapshots were captured from, and its `run`/`run_bytes` exec `wasmtime run <path>`.
+//! wasmtime as a [`BackendUnderTest`]: the snapshot-vs-wasmtime freshness checks run through the *same* shared app/gzip runners every real backend uses, rather than a hand-written per-case loop. wasmtime does not generate source — it runs the cached `.wasm` binary directly — so its `convert_app` returns the path to the exact cache binary the snapshots were captured from, and its `run`/`run_bytes` spawn the `xtask` WASI runner on it.
+//!
+//! That runner embeds the `wasmtime` crate pinned by `Cargo.lock` (`cargo xtask run-wasi`), so no `wasmtime` CLI has to be installed and the engine behind every snapshot is the same on every host. This crate keeps no `wasmtime` dependency of its own: it only spawns the binary, which the developer builds once with `cargo build -p xtask`.
 //!
 //! Public (not conditional behind the `wasmtime_test` feature, which only applies to the *tests* in `tests/apps_wasmtime.rs`) so that both that test file and `cargo xtask update-snapshots` can drive the same wasmtime-backed [`BackendUnderTest`] to (re)capture the execution snapshots.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
 use dewasm_backend::{Backend, GenOptions, Mode, OutputFile};
@@ -32,7 +34,54 @@ impl Backend for NeverBackend {
     }
 }
 
-/// The wasmtime engine wired into the shared app/gzip runners. `convert_app` hands back the cache-binary path (no codegen); `run_bytes` execs `wasmtime run <path> <args...>` on that exact binary.
+/// The arguments `xtask run-wasi` takes for one run: the preopens, the environment, the wasm path, and the guest's `argv[1..]` (the runner sets `argv[0]` to the wasm file's base name itself). Every wasmtime-engine call site builds its command from this one function — the spawning [`Wasmtime`] here and the in-process engine `cargo xtask update-snapshots` drives — so the two cannot drift apart.
+pub fn wasi_runner_argv(
+    wasm: &str,
+    args: &[&str],
+    env: &[(&str, &str)],
+    preopens: &[(&str, &Path)],
+) -> Vec<String> {
+    let mut argv = Vec::new();
+    for (guest, host) in preopens {
+        argv.push("--dir".to_string());
+        argv.push(format!("{}::{}", host.display(), guest));
+    }
+    for (key, value) in env {
+        argv.push("--env".to_string());
+        argv.push(format!("{key}={value}"));
+    }
+    argv.push(wasm.to_string());
+    argv.extend(args.iter().map(|arg| arg.to_string()));
+    argv
+}
+
+/// The built `xtask` binary that carries the WASI runner. Resolved beside the running test binary (`<target>/<profile>/deps/<test>`), so it honors whatever target directory cargo used, `$CARGO_TARGET_DIR` included, and matches the profile the tests themselves were built with.
+///
+/// The suite never builds it: a missing binary fails loud with the command that produces it, the same way a missing interpreter or an unpopulated apps cache does.
+pub fn wasi_runner_bin() -> PathBuf {
+    let exe = std::env::current_exe().expect("current_exe");
+    let profile_dir = exe
+        .parent()
+        .and_then(Path::parent)
+        .expect("a test binary sits in <target>/<profile>/deps/");
+    let bin = profile_dir.join(format!("xtask{}", std::env::consts::EXE_SUFFIX));
+    assert!(
+        bin.is_file(),
+        "the wasmtime engine runs wasm through the xtask runner, and {} does not exist — \
+         build it once with `cargo build -p xtask` (see docs/testing.md)",
+        bin.display()
+    );
+    bin
+}
+
+/// The command that runs `argv` (from [`wasi_runner_argv`]) through the runner.
+fn runner_command(argv: &[String]) -> Command {
+    let mut cmd = Command::new(wasi_runner_bin());
+    cmd.arg("run-wasi").args(argv);
+    cmd
+}
+
+/// The wasmtime engine wired into the shared app/gzip runners. `convert_app` hands back the cache-binary path (no codegen); `run_bytes` runs the `xtask` WASI runner on that exact binary.
 pub struct Wasmtime;
 
 impl BackendUnderTest for Wasmtime {
@@ -57,26 +106,20 @@ impl BackendUnderTest for Wasmtime {
         path.to_string_lossy().into_owned()
     }
 
-    /// `source` is a cache-binary path (from `convert_app`), not generated code: exec `wasmtime run <path> <args...>` with `stdin` piped in. A missing `wasmtime` fails loud, never skips.
+    /// `source` is a cache-binary path (from `convert_app`), not generated code: run it with `args` and `stdin` piped in.
     fn run_bytes(&self, source: &str, args: &[&str], stdin: &[u8]) -> Output {
         assert!(
-            Command::new("wasmtime").arg("--version").output().is_ok(),
-            "wasmtime not found on PATH — required for the wasmtime-backed suites \
-             (see docs/testing.md)"
-        );
-        let path = Path::new(source);
-        assert!(
-            path.exists(),
+            Path::new(source).exists(),
             "{} not cached — run examples/apps/setup.sh (see docs/testing.md)",
             source
         );
         run_command_bytes(
-            Command::new("wasmtime").arg("run").arg(path).args(args),
+            &mut runner_command(&wasi_runner_argv(source, args, &[], &[])),
             stdin,
         )
     }
 
-    /// Run the filesystem app directly on the cache binary: `program` is the wasm path (from `convert_app`), so ignore the appended `glue` the default composes and instead exec `wasmtime run --dir <host>::<guest>... --env K=V... <wasm> <args[1..]>` (wasmtime injects argv0 itself). A missing `wasmtime` fails loud, never skips.
+    /// Run the filesystem app directly on the cache binary: `program` is the wasm path (from `convert_app`), so ignore the appended `glue` the default composes and instead run the binary under the case's host `preopens` and `env`. `args[0]` is dropped: the runner supplies `argv[0]` itself, exactly as `wasmtime run` does.
     fn run_app_fs(
         &self,
         program: &str,
@@ -86,25 +129,13 @@ impl BackendUnderTest for Wasmtime {
         stdin: &[u8],
         preopens: &[(&str, &Path)],
     ) -> Output {
-        assert!(
-            Command::new("wasmtime").arg("--version").output().is_ok(),
-            "wasmtime not found on PATH — required for the wasmtime-backed suites \
-             (see docs/testing.md)"
-        );
-        let mut cmd = Command::new("wasmtime");
-        cmd.arg("run");
-        for (guest, host) in preopens {
-            cmd.arg("--dir")
-                .arg(format!("{}::{}", host.display(), guest));
-        }
-        for (k, v) in env {
-            cmd.arg("--env").arg(format!("{k}={v}"));
-        }
-        cmd.arg(program).args(&args[1..]);
-        run_command_bytes(&mut cmd, stdin)
+        run_command_bytes(
+            &mut runner_command(&wasi_runner_argv(program, &args[1..], env, preopens)),
+            stdin,
+        )
     }
 
-    /// Standalone `--dir` ground truth: `program` is the wasm path (from `convert_app`), and `--dir` is a wasmtime host flag, so run `wasmtime run --dir HOST::GUEST... <wasm> args`. This is what the generated backends' own `--dir` parsing must reproduce. A missing `wasmtime` fails loud, never skips.
+    /// Standalone `--dir` ground truth: `program` is the wasm path (from `convert_app`), and `--dir` is a host-runtime flag there, so the preopens go to the runner rather than to the guest. This is what the generated backends' own `--dir` parsing must reproduce.
     fn run_standalone_dir(
         &self,
         program: &str,
@@ -112,32 +143,18 @@ impl BackendUnderTest for Wasmtime {
         args: &[&str],
         stdin: &[u8],
     ) -> Output {
-        assert!(
-            Command::new("wasmtime").arg("--version").output().is_ok(),
-            "wasmtime not found on PATH — required for the wasmtime-backed suites \
-             (see docs/testing.md)"
-        );
-        let mut cmd = Command::new("wasmtime");
-        cmd.arg("run");
-        for (guest, host) in preopens {
-            cmd.arg("--dir")
-                .arg(format!("{}::{}", host.display(), guest));
-        }
-        cmd.arg(program).args(args);
-        run_command_bytes(&mut cmd, stdin)
+        run_command_bytes(
+            &mut runner_command(&wasi_runner_argv(program, args, &[], preopens)),
+            stdin,
+        )
     }
 
-    /// Drive the cached wasm binary directly under a pty: `source` is the wasm path (from `convert_app`), so the command is `wasmtime run <path> <args...>` — the ground-truth interactive session the backends must match. wasmtime injects argv0, so a bare no-args call is the interactive REPL invocation.
+    /// Drive the cached wasm binary directly under a pty: the runner inherits the pty slave as its stdio, so the guest reads a character device — the ground-truth interactive session the backends must match. The runner supplies `argv[0]`, so a bare no-args call is the interactive REPL invocation.
     fn pty_command(&self, source: &str, args: &[&str]) -> PtyCommand {
-        assert!(
-            Command::new("wasmtime").arg("--version").output().is_ok(),
-            "wasmtime not found on PATH — required for the wasmtime-backed suites \
-             (see docs/testing.md)"
-        );
-        let mut argv = vec!["run".to_string(), source.to_string()];
-        argv.extend(args.iter().map(|a| a.to_string()));
+        let mut argv = vec!["run-wasi".to_string()];
+        argv.extend(wasi_runner_argv(source, args, &[], &[]));
         PtyCommand {
-            program: "wasmtime".into(),
+            program: wasi_runner_bin(),
             args: argv,
             cwd: None,
         }

--- a/crates/dewasm-test-helper/src/wasmtime_backend.rs
+++ b/crates/dewasm-test-helper/src/wasmtime_backend.rs
@@ -1,6 +1,7 @@
 //! wasmtime as a [`BackendUnderTest`]: the snapshot-vs-wasmtime freshness checks run through the *same* shared app/gzip runners every real backend uses, rather than a hand-written per-case loop. wasmtime does not generate source — it runs the cached `.wasm` binary directly — so its `convert_app` returns the path to the exact cache binary the snapshots were captured from, and its `run`/`run_bytes` spawn the `xtask` WASI runner on it.
 //!
-//! That runner embeds the `wasmtime` crate pinned by `Cargo.lock` (`cargo xtask test-wasmtime-wasi`), so no `wasmtime` CLI has to be installed and the engine behind every snapshot is the same on every host. This crate keeps no `wasmtime` dependency of its own: it only spawns the binary, which the developer builds once with `cargo build -p xtask`.
+//! That runner embeds the `wasmtime` crate pinned by `Cargo.lock` (`cargo xtask test-wasmtime-wasi`), so no `wasmtime` CLI has to be installed and the engine behind every snapshot is the same on every host.
+//! This crate keeps no `wasmtime` dependency of its own: it only spawns the binary, which the developer builds once with `cargo build -p xtask`.
 //!
 //! Public (not conditional behind the `wasmtime_test` feature, which only applies to the *tests* in `tests/apps_wasmtime.rs`) so that both that test file and `cargo xtask update-snapshots` can drive the same wasmtime-backed [`BackendUnderTest`] to (re)capture the execution snapshots.
 
@@ -34,7 +35,8 @@ impl Backend for NeverBackend {
     }
 }
 
-/// The arguments `xtask test-wasmtime-wasi` takes for one run: the preopens, the environment, the wasm path, and the guest's `argv[1..]` (the runner sets `argv[0]` to the wasm file's base name itself). Every wasmtime-engine call site builds its command from this one function — the spawning [`Wasmtime`] here and the in-process engine `cargo xtask update-snapshots` drives — so the two cannot drift apart.
+/// The arguments `xtask test-wasmtime-wasi` takes for one run: the preopens, the environment, the wasm path, and the guest's `argv[1..]` (the runner sets `argv[0]` to the wasm file's base name itself).
+/// Every wasmtime-engine call site builds its command from this one function — the spawning [`Wasmtime`] here and the in-process engine `cargo xtask update-snapshots` drives — so the two cannot drift apart.
 pub fn wasi_runner_argv(
     wasm: &str,
     args: &[&str],
@@ -55,7 +57,8 @@ pub fn wasi_runner_argv(
     argv
 }
 
-/// The built `xtask` binary that carries the WASI runner. Resolved beside the running test binary (`<target>/<profile>/deps/<test>`), so it honors whatever target directory cargo used, `$CARGO_TARGET_DIR` included, and matches the profile the tests themselves were built with.
+/// The built `xtask` binary that carries the WASI runner.
+/// Resolved beside the running test binary (`<target>/<profile>/deps/<test>`), so it honors whatever target directory cargo used, `$CARGO_TARGET_DIR` included, and matches the profile the tests themselves were built with.
 ///
 /// The suite never builds it: a missing binary fails loud with the command that produces it, the same way a missing interpreter or an unpopulated apps cache does.
 pub fn wasi_runner_bin() -> PathBuf {
@@ -81,7 +84,8 @@ fn runner_command(argv: &[String]) -> Command {
     cmd
 }
 
-/// The wasmtime engine wired into the shared app/gzip runners. `convert_app` hands back the cache-binary path (no codegen); `run_bytes` runs the `xtask` WASI runner on that exact binary.
+/// The wasmtime engine wired into the shared app/gzip runners.
+/// `convert_app` hands back the cache-binary path (no codegen); `run_bytes` runs the `xtask` WASI runner on that exact binary.
 pub struct Wasmtime;
 
 impl BackendUnderTest for Wasmtime {
@@ -119,7 +123,8 @@ impl BackendUnderTest for Wasmtime {
         )
     }
 
-    /// Run the filesystem app directly on the cache binary: `program` is the wasm path (from `convert_app`), so ignore the appended `glue` the default composes and instead run the binary under the case's host `preopens` and `env`. `args[0]` is dropped: the runner supplies `argv[0]` itself, exactly as `wasmtime run` does.
+    /// Run the filesystem app directly on the cache binary: `program` is the wasm path (from `convert_app`), so ignore the appended `glue` the default composes and instead run the binary under the case's host `preopens` and `env`.
+    /// `args[0]` is dropped: the runner supplies `argv[0]` itself, exactly as `wasmtime run` does.
     fn run_app_fs(
         &self,
         program: &str,
@@ -135,7 +140,8 @@ impl BackendUnderTest for Wasmtime {
         )
     }
 
-    /// Standalone `--dir` ground truth: `program` is the wasm path (from `convert_app`), and `--dir` is a host-runtime flag there, so the preopens go to the runner rather than to the guest. This is what the generated backends' own `--dir` parsing must reproduce.
+    /// Standalone `--dir` ground truth: `program` is the wasm path (from `convert_app`), and `--dir` is a host-runtime flag there, so the preopens go to the runner rather than to the guest.
+    /// This is what the generated backends' own `--dir` parsing must reproduce.
     fn run_standalone_dir(
         &self,
         program: &str,
@@ -149,7 +155,8 @@ impl BackendUnderTest for Wasmtime {
         )
     }
 
-    /// Drive the cached wasm binary directly under a pty: the runner inherits the pty slave as its stdio, so the guest reads a character device — the ground-truth interactive session the backends must match. The runner supplies `argv[0]`, so a bare no-args call is the interactive REPL invocation.
+    /// Drive the cached wasm binary directly under a pty: the runner inherits the pty slave as its stdio, so the guest reads a character device — the ground-truth interactive session the backends must match.
+    /// The runner supplies `argv[0]`, so a bare no-args call is the interactive REPL invocation.
     fn pty_command(&self, source: &str, args: &[&str]) -> PtyCommand {
         let mut argv = vec!["test-wasmtime-wasi".to_string()];
         argv.extend(wasi_runner_argv(source, args, &[], &[]));

--- a/crates/dewasm-test-helper/src/wasmtime_backend.rs
+++ b/crates/dewasm-test-helper/src/wasmtime_backend.rs
@@ -1,6 +1,6 @@
 //! wasmtime as a [`BackendUnderTest`]: the snapshot-vs-wasmtime freshness checks run through the *same* shared app/gzip runners every real backend uses, rather than a hand-written per-case loop. wasmtime does not generate source — it runs the cached `.wasm` binary directly — so its `convert_app` returns the path to the exact cache binary the snapshots were captured from, and its `run`/`run_bytes` spawn the `xtask` WASI runner on it.
 //!
-//! That runner embeds the `wasmtime` crate pinned by `Cargo.lock` (`cargo xtask run-wasi`), so no `wasmtime` CLI has to be installed and the engine behind every snapshot is the same on every host. This crate keeps no `wasmtime` dependency of its own: it only spawns the binary, which the developer builds once with `cargo build -p xtask`.
+//! That runner embeds the `wasmtime` crate pinned by `Cargo.lock` (`cargo xtask test-wasmtime-wasi`), so no `wasmtime` CLI has to be installed and the engine behind every snapshot is the same on every host. This crate keeps no `wasmtime` dependency of its own: it only spawns the binary, which the developer builds once with `cargo build -p xtask`.
 //!
 //! Public (not conditional behind the `wasmtime_test` feature, which only applies to the *tests* in `tests/apps_wasmtime.rs`) so that both that test file and `cargo xtask update-snapshots` can drive the same wasmtime-backed [`BackendUnderTest`] to (re)capture the execution snapshots.
 
@@ -34,7 +34,7 @@ impl Backend for NeverBackend {
     }
 }
 
-/// The arguments `xtask run-wasi` takes for one run: the preopens, the environment, the wasm path, and the guest's `argv[1..]` (the runner sets `argv[0]` to the wasm file's base name itself). Every wasmtime-engine call site builds its command from this one function — the spawning [`Wasmtime`] here and the in-process engine `cargo xtask update-snapshots` drives — so the two cannot drift apart.
+/// The arguments `xtask test-wasmtime-wasi` takes for one run: the preopens, the environment, the wasm path, and the guest's `argv[1..]` (the runner sets `argv[0]` to the wasm file's base name itself). Every wasmtime-engine call site builds its command from this one function — the spawning [`Wasmtime`] here and the in-process engine `cargo xtask update-snapshots` drives — so the two cannot drift apart.
 pub fn wasi_runner_argv(
     wasm: &str,
     args: &[&str],
@@ -77,7 +77,7 @@ pub fn wasi_runner_bin() -> PathBuf {
 /// The command that runs `argv` (from [`wasi_runner_argv`]) through the runner.
 fn runner_command(argv: &[String]) -> Command {
     let mut cmd = Command::new(wasi_runner_bin());
-    cmd.arg("run-wasi").args(argv);
+    cmd.arg("test-wasmtime-wasi").args(argv);
     cmd
 }
 
@@ -151,7 +151,7 @@ impl BackendUnderTest for Wasmtime {
 
     /// Drive the cached wasm binary directly under a pty: the runner inherits the pty slave as its stdio, so the guest reads a character device — the ground-truth interactive session the backends must match. The runner supplies `argv[0]`, so a bare no-args call is the interactive REPL invocation.
     fn pty_command(&self, source: &str, args: &[&str]) -> PtyCommand {
-        let mut argv = vec!["run-wasi".to_string()];
+        let mut argv = vec!["test-wasmtime-wasi".to_string()];
         argv.extend(wasi_runner_argv(source, args, &[], &[]));
         PtyCommand {
             program: wasi_runner_bin(),

--- a/crates/dewasm-test-helper/tests/apps_wasmtime.rs
+++ b/crates/dewasm-test-helper/tests/apps_wasmtime.rs
@@ -1,8 +1,10 @@
 //! Snapshot freshness: re-validates the checked-in `examples/apps/snapshots/` against wasmtime through the same shared app/gzip/fs runners every backend uses; the per-backend `apps`/`gzip`/`fs_apps` suites cover the other half (generated output vs. snapshot).
 //!
-//! Every case here runs wasm through the `xtask` binary, which embeds the `wasmtime` crate pinned by `Cargo.lock` (`cargo xtask test-wasmtime-wasi`, plus the `test-wasmtime-doom-frame`/`test-wasmtime-nes-frame` captures). Build it once with `cargo build -p xtask`; this suite never builds it and never skips when it is missing.
+//! Every case here runs wasm through the `xtask` binary, which embeds the `wasmtime` crate pinned by `Cargo.lock` (`cargo xtask test-wasmtime-wasi`, plus the `test-wasmtime-doom-frame`/`test-wasmtime-nes-frame` captures).
+//! Build it once with `cargo build -p xtask`; this suite never builds it and never skips when it is missing.
 //!
-//! Named `apps_wasmtime` for the family: a future engine-under-test (wasmer, wasmedge) would join here the same way. Conditional behind the `wasmtime_test` feature and `#[ignore]`d otherwise — this suite exists to check the checker, not to run on every `cargo test`.
+//! Named `apps_wasmtime` for the family: a future engine-under-test (wasmer, wasmedge) would join here the same way.
+//! Conditional behind the `wasmtime_test` feature and `#[ignore]`d otherwise — this suite exists to check the checker, not to run on every `cargo test`.
 //!
 //! Run it with:
 //!
@@ -96,14 +98,16 @@ fn fs_apps() {
     );
 }
 
-// The standalone `--dir` interface run against wasmtime as ground truth: `run_standalone_dir`'s wasmtime path consumes `--dir` as a host flag, the exact behavior the generated backends' own `--dir` parsing must reproduce. Uses no cached app, only the committed `wasi_standalone_dir.wat`.
+// The standalone `--dir` interface run against wasmtime as ground truth: `run_standalone_dir`'s wasmtime path consumes `--dir` as a host flag, the exact behavior the generated backends' own `--dir` parsing must reproduce.
+// Uses no cached app, only the committed `wasi_standalone_dir.wat`.
 #[cfg_attr(not(feature = "wasmtime_test"), ignore)]
 #[test]
 fn standalone_dir() {
     dewasm_test_helper::run_standalone_dir(&dewasm_test_helper::Wasmtime);
 }
 
-// The two framebuffer snapshots: neither module runs as a WASI command (each has its own export/import interface), so the runner exposes their capture as its own subcommand and the frame arrives on stdout. Compare-only, like every other case here.
+// The two framebuffer snapshots: neither module runs as a WASI command (each has its own export/import interface), so the runner exposes their capture as its own subcommand and the frame arrives on stdout.
+// Compare-only, like every other case here.
 #[cfg_attr(not(feature = "wasmtime_test"), ignore)]
 #[test]
 fn doom_frame() {
@@ -154,7 +158,8 @@ fn assert_frame_snapshot(subcommand: &str, path: &std::path::Path) {
     );
 }
 
-// Snapshot freshness for the interactive-REPL transcript: re-capture the bare qjs REPL under a real pty and require it to equal the checked-in `qjs_repl_interactive.transcript`. Compare-only; regenerate with `cargo xtask update-snapshots` when the pinned qjs binary or the scripted session changes.
+// Snapshot freshness for the interactive-REPL transcript: re-capture the bare qjs REPL under a real pty and require it to equal the checked-in `qjs_repl_interactive.transcript`.
+// Compare-only; regenerate with `cargo xtask update-snapshots` when the pinned qjs binary or the scripted session changes.
 #[cfg_attr(not(feature = "wasmtime_test"), ignore)]
 #[test]
 fn qjs_repl_interactive_snapshot() {
@@ -167,7 +172,8 @@ fn qjs_repl_interactive_snapshot() {
             )
         });
     let got = dewasm_test_helper::capture_qjs_repl_transcript(&dewasm_test_helper::Wasmtime);
-    // Under Linux the engine leaves one extra trailing CRLF on pty teardown that macOS (where the snapshot was captured) does not; the converted backends match the snapshot byte-for-byte on both hosts, so the difference is in the engine's exit path, outside the transcript's meaningful content (it ends at the `\q` echo). Compare modulo trailing CRLFs here only — the per-backend comparison stays exact (issue #33).
+    // Under Linux the engine leaves one extra trailing CRLF on pty teardown that macOS (where the snapshot was captured) does not; the converted backends match the snapshot byte-for-byte on both hosts, so the difference is in the engine's exit path, outside the transcript's meaningful content (it ends at the `\q` echo).
+    // Compare modulo trailing CRLFs here only — the per-backend comparison stays exact (issue #33).
     dewasm_test_helper::assert_transcript_eq(
         trim_trailing_crlfs(&got),
         trim_trailing_crlfs(&snapshot),

--- a/crates/dewasm-test-helper/tests/apps_wasmtime.rs
+++ b/crates/dewasm-test-helper/tests/apps_wasmtime.rs
@@ -1,6 +1,6 @@
 //! Snapshot freshness: re-validates the checked-in `examples/apps/snapshots/` against wasmtime through the same shared app/gzip/fs runners every backend uses; the per-backend `apps`/`gzip`/`fs_apps` suites cover the other half (generated output vs. snapshot).
 //!
-//! Every case here runs wasm through the `xtask` binary, which embeds the `wasmtime` crate pinned by `Cargo.lock` (`cargo xtask run-wasi`, plus the `doom-frame`/`nes-frame` captures). Build it once with `cargo build -p xtask`; this suite never builds it and never skips when it is missing.
+//! Every case here runs wasm through the `xtask` binary, which embeds the `wasmtime` crate pinned by `Cargo.lock` (`cargo xtask test-wasmtime-wasi`, plus the `test-wasmtime-doom-frame`/`test-wasmtime-nes-frame` captures). Build it once with `cargo build -p xtask`; this suite never builds it and never skips when it is missing.
 //!
 //! Named `apps_wasmtime` for the family: a future engine-under-test (wasmer, wasmedge) would join here the same way. Conditional behind the `wasmtime_test` feature and `#[ignore]`d otherwise — this suite exists to check the checker, not to run on every `cargo test`.
 //!
@@ -108,7 +108,7 @@ fn standalone_dir() {
 #[test]
 fn doom_frame() {
     assert_frame_snapshot(
-        "doom-frame",
+        "test-wasmtime-doom-frame",
         &dewasm_test_helper::doom_frame_snapshot_path(),
     );
 }
@@ -116,7 +116,10 @@ fn doom_frame() {
 #[cfg_attr(not(feature = "wasmtime_test"), ignore)]
 #[test]
 fn nes_frame() {
-    assert_frame_snapshot("nes-frame", &dewasm_test_helper::nes_frame_snapshot_path());
+    assert_frame_snapshot(
+        "test-wasmtime-nes-frame",
+        &dewasm_test_helper::nes_frame_snapshot_path(),
+    );
 }
 
 /// Run the runner's `subcommand` capture and require its stdout to equal the snapshot at `path`.

--- a/crates/dewasm-test-helper/tests/apps_wasmtime.rs
+++ b/crates/dewasm-test-helper/tests/apps_wasmtime.rs
@@ -1,10 +1,13 @@
-//! Snapshot freshness: re-validates the checked-in `examples/apps/snapshots/` against a live `wasmtime` through the same shared app/gzip/fs runners every backend uses; the per-backend `apps`/`gzip`/`fs_apps` suites cover the other half (generated output vs. snapshot).
+//! Snapshot freshness: re-validates the checked-in `examples/apps/snapshots/` against wasmtime through the same shared app/gzip/fs runners every backend uses; the per-backend `apps`/`gzip`/`fs_apps` suites cover the other half (generated output vs. snapshot).
 //!
-//! Named `apps_wasmtime` for the family: a future engine-under-test (wasmer, wasmedge) would join here the same way. Conditional behind the `wasmtime_test` feature and `#[ignore]`d otherwise, because `wasmtime` is deliberately not one of the default suite's required tools — this suite exists to check the checker, not to run on every `cargo test`.
+//! Every case here runs wasm through the `xtask` binary, which embeds the `wasmtime` crate pinned by `Cargo.lock` (`cargo xtask run-wasi`, plus the `doom-frame`/`nes-frame` captures). Build it once with `cargo build -p xtask`; this suite never builds it and never skips when it is missing.
+//!
+//! Named `apps_wasmtime` for the family: a future engine-under-test (wasmer, wasmedge) would join here the same way. Conditional behind the `wasmtime_test` feature and `#[ignore]`d otherwise — this suite exists to check the checker, not to run on every `cargo test`.
 //!
 //! Run it with:
 //!
 //! ```console
+//! $ cargo build -p xtask
 //! $ cargo test -p dewasm-test-helper --features wasmtime_test --test apps_wasmtime
 //! ```
 
@@ -93,14 +96,62 @@ fn fs_apps() {
     );
 }
 
-// The standalone `--dir` interface run against wasmtime as ground truth: `run_standalone_dir`'s wasmtime path consumes `--dir` as a host flag (`wasmtime run --dir HOST::GUEST <wasm>`), the exact behavior the generated backends' own `--dir` parsing must reproduce. Uses no cached app, only the committed `wasi_standalone_dir.wat`, so it needs only wasmtime on PATH.
+// The standalone `--dir` interface run against wasmtime as ground truth: `run_standalone_dir`'s wasmtime path consumes `--dir` as a host flag, the exact behavior the generated backends' own `--dir` parsing must reproduce. Uses no cached app, only the committed `wasi_standalone_dir.wat`.
 #[cfg_attr(not(feature = "wasmtime_test"), ignore)]
 #[test]
 fn standalone_dir() {
     dewasm_test_helper::run_standalone_dir(&dewasm_test_helper::Wasmtime);
 }
 
-// Snapshot freshness for the interactive-REPL transcript: re-capture the bare qjs REPL under a real pty from a live wasmtime and require it to equal the checked-in `qjs_repl_interactive.transcript`. Compare-only; regenerate with `cargo xtask update-snapshots` when the pinned qjs binary or the scripted session changes.
+// The two framebuffer snapshots: neither module runs as a WASI command (each has its own export/import interface), so the runner exposes their capture as its own subcommand and the frame arrives on stdout. Compare-only, like every other case here.
+#[cfg_attr(not(feature = "wasmtime_test"), ignore)]
+#[test]
+fn doom_frame() {
+    assert_frame_snapshot(
+        "doom-frame",
+        &dewasm_test_helper::doom_frame_snapshot_path(),
+    );
+}
+
+#[cfg_attr(not(feature = "wasmtime_test"), ignore)]
+#[test]
+fn nes_frame() {
+    assert_frame_snapshot("nes-frame", &dewasm_test_helper::nes_frame_snapshot_path());
+}
+
+/// Run the runner's `subcommand` capture and require its stdout to equal the snapshot at `path`.
+fn assert_frame_snapshot(subcommand: &str, path: &std::path::Path) {
+    let output = std::process::Command::new(dewasm_test_helper::wasi_runner_bin())
+        .arg(subcommand)
+        .output()
+        .expect("spawn the xtask runner");
+    assert!(
+        output.status.success(),
+        "xtask {subcommand}: exit {}\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let snapshot = std::fs::read(path).unwrap_or_else(|e| {
+        panic!(
+            "{} not readable ({e}) — regenerate with `cargo xtask update-snapshots` \
+             (see docs/testing.md)",
+            path.display()
+        )
+    });
+    assert!(
+        output.stdout == snapshot,
+        "xtask {subcommand}: frame differs from {} ({} vs {} bytes)",
+        path.display(),
+        output.stdout.len(),
+        snapshot.len()
+    );
+    println!(
+        "{subcommand}: matches the snapshot ({} bytes)",
+        snapshot.len()
+    );
+}
+
+// Snapshot freshness for the interactive-REPL transcript: re-capture the bare qjs REPL under a real pty and require it to equal the checked-in `qjs_repl_interactive.transcript`. Compare-only; regenerate with `cargo xtask update-snapshots` when the pinned qjs binary or the scripted session changes.
 #[cfg_attr(not(feature = "wasmtime_test"), ignore)]
 #[test]
 fn qjs_repl_interactive_snapshot() {
@@ -113,7 +164,7 @@ fn qjs_repl_interactive_snapshot() {
             )
         });
     let got = dewasm_test_helper::capture_qjs_repl_transcript(&dewasm_test_helper::Wasmtime);
-    // Linux wasmtime emits one extra trailing CRLF on pty teardown that macOS wasmtime (which captured the snapshot) does not; the converted backends match the snapshot byte-for-byte on both hosts, so the difference is wasmtime's own exit behavior, outside the transcript's meaningful content (it ends at the `\q` echo). Compare modulo trailing CRLFs here only — the per-backend comparison stays exact (issue #33).
+    // Under Linux the engine leaves one extra trailing CRLF on pty teardown that macOS (where the snapshot was captured) does not; the converted backends match the snapshot byte-for-byte on both hosts, so the difference is in the engine's exit path, outside the transcript's meaningful content (it ends at the `\q` echo). Compare modulo trailing CRLFs here only — the per-backend comparison stays exact (issue #33).
     dewasm_test_helper::assert_transcript_eq(
         trim_trailing_crlfs(&got),
         trim_trailing_crlfs(&snapshot),

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -39,6 +39,10 @@ serde_json.workspace = true
 # settings kept fixed so regeneration is byte-stable.
 png = "0.18.1"
 # std makes `wasmtime::Error` an `anyhow::Error` (so `?` composes with our
-# anyhow flow); cranelift+runtime is the embedder. No wasi/component/gc: the
-# DOOM oracle only instantiates a baseline module and calls exports.
-wasmtime = { version = "47.0.2", default-features = false, features = ["cranelift", "runtime", "std"] }
+# anyhow flow); cranelift+runtime is the embedder. No gc: the snapshot oracles
+# instantiate baseline modules only.
+wasmtime = { version = "47.0.2", default-features = false, features = ["cranelift", "runtime", "std", "parallel-compilation"] }
+# WASI p1 for the `run-wasi` runner. The version tracks `wasmtime` exactly:
+# every snapshot is captured through this crate, so the pin is what makes
+# regeneration reproducible across hosts.
+wasmtime-wasi = { version = "47.0.2", default-features = false, features = ["p1"] }

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -42,7 +42,7 @@ png = "0.18.1"
 # anyhow flow); cranelift+runtime is the embedder. No gc: the snapshot oracles
 # instantiate baseline modules only.
 wasmtime = { version = "47.0.2", default-features = false, features = ["cranelift", "runtime", "std", "parallel-compilation"] }
-# WASI p1 for the `run-wasi` runner. The version tracks `wasmtime` exactly:
+# WASI p1 for the `test-wasmtime-wasi` runner. The version tracks `wasmtime` exactly:
 # every snapshot is captured through this crate, so the pin is what makes
 # regeneration reproducible across hosts.
 wasmtime-wasi = { version = "47.0.2", default-features = false, features = ["p1"] }

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -38,11 +38,9 @@ serde_json.workspace = true
 # Encodes the human-facing PNG sidecar of the DOOM frame snapshot; default
 # settings kept fixed so regeneration is byte-stable.
 png = "0.18.1"
-# std makes `wasmtime::Error` an `anyhow::Error` (so `?` composes with our
-# anyhow flow); cranelift+runtime is the embedder. No gc: the snapshot oracles
-# instantiate baseline modules only.
+# std makes `wasmtime::Error` an `anyhow::Error` (so `?` composes with our anyhow flow); cranelift+runtime is the embedder.
+# No gc: the snapshot oracles instantiate baseline modules only.
 wasmtime = { version = "47.0.2", default-features = false, features = ["cranelift", "runtime", "std", "parallel-compilation"] }
-# WASI p1 for the `test-wasmtime-wasi` runner. The version tracks `wasmtime` exactly:
-# every snapshot is captured through this crate, so the pin is what makes
-# regeneration reproducible across hosts.
+# WASI p1 for the `test-wasmtime-wasi` runner.
+# The version tracks `wasmtime` exactly: every snapshot is captured through this crate, so the pin is what makes regeneration reproducible across hosts.
 wasmtime-wasi = { version = "47.0.2", default-features = false, features = ["p1"] }

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1,6 +1,6 @@
 //! Developer-facing workspace tasks, run as `cargo xtask <command>` (aliased in `.cargo/config.toml`). Replaces the former snapshot-regeneration env-var toggles on the `support_docs` and `apps_wasmtime` tests with explicit subcommands: those tests are now compare-only and point here when they fail.
 //!
-//! `update-snapshots` regenerates *every* checked-in execution snapshot from one command: the nine wasmtime-CLI-driven files (app stdout, the gzip stream, the filesystem-app stdout, the interactive-REPL transcript) plus the DOOM and NES frames, which stay on the embedded `wasmtime` crate because their custom export/import interfaces can't run through `wasmtime run` (issue #114). `update-support-docs` stays separate — `docs/support.md` is generated documentation, not an execution snapshot.
+//! `update-snapshots` regenerates *every* checked-in execution snapshot from one command: the nine WASI-runner files (app stdout, the gzip stream, the filesystem-app stdout, the interactive-REPL transcript) plus the DOOM and NES frames, whose custom export/import interfaces are driven directly instead (issue #114). All of them run on the embedded `wasmtime` crate pinned by `Cargo.lock`, so regeneration reproduces the same bytes on every host. `update-support-docs` stays separate — `docs/support.md` is generated documentation, not an execution snapshot.
 //!
 //! `run-wasi`, `doom-frame` and `nes-frame` are the same executions as commands, for the snapshot freshness suite to spawn: it compares the checked-in files against what this binary produces, and must not embed the engine itself.
 //!
@@ -14,6 +14,7 @@ mod bench;
 mod doom_snapshot;
 mod nes_snapshot;
 mod size;
+mod snapshot_engine;
 mod wasi_run;
 
 use std::io::Write;
@@ -24,6 +25,7 @@ use dewasm_cli::support_docs::render_support_docs;
 
 use crate::doom_snapshot::capture_doom_frame;
 use crate::nes_snapshot::capture_nes_frame;
+use crate::snapshot_engine::EmbeddedWasmtime;
 
 const USAGE: &str = "\
 Usage: cargo xtask <command> [args]
@@ -33,7 +35,7 @@ Commands:
                                capability declarations. Checked by
                                `cargo test -p dewasm-cli --test support_docs`.
     update-snapshots [filter]  Regenerate every checked-in execution snapshot
-                               from a live wasmtime: the app/gzip/filesystem
+                               from the embedded wasmtime: the app/gzip/filesystem
                                stdout files and the interactive-REPL transcript
                                under examples/apps/snapshots/, plus the DOOM
                                and NES frames there (doom_frame.ppm and
@@ -41,13 +43,12 @@ Commands:
                                doom_frame.png/nes_frame.png renderings for
                                human eyes). An optional substring `filter`
                                limits it to matching snapshots (e.g.
-                               `update-snapshots doom`). Needs `wasmtime` on
-                               PATH and the apps cache populated
-                               (examples/apps/setup.sh; the DOOM frame needs
-                               examples/apps/scripts/doom.sh, the NES frame
-                               examples/apps/scripts/nes.sh). Checked by the
-                               compare-only wasmtime freshness suite (`cargo
-                               test -p dewasm-test-helper --features
+                               `update-snapshots doom`). Needs the apps cache
+                               populated (examples/apps/setup.sh; the DOOM
+                               frame needs examples/apps/scripts/doom.sh, the
+                               NES frame examples/apps/scripts/nes.sh).
+                               Checked by the compare-only freshness suite
+                               (`cargo test -p dewasm-test-helper --features
                                wasmtime_test --test apps_wasmtime`) and the
                                per-backend `doom_frame` and `nes_frame` cases.
     run-wasi [opts] <wasm>     Run a WASI command on the embedded wasmtime,
@@ -165,17 +166,18 @@ struct SnapshotTarget {
     capture: Box<dyn Fn() -> Result<CapturedFiles>>,
 }
 
-/// Every execution snapshot `update-snapshots` regenerates: the nine wasmtime-CLI targets from the shared registry (`dewasm_test_helper::wasmtime_snapshots`) plus the embedded-wasmtime DOOM and NES frames, folded in here rather than in the helper crate so that crate keeps no `wasmtime`-crate dependency. Each of those two targets emits two files — the compared PPM (`doom_frame.ppm`, `nes_frame.ppm`) and a PNG rendering of the same frame for human inspection (never compared by a test).
+/// Every execution snapshot `update-snapshots` regenerates: the nine WASI-runner targets from the shared registry (`dewasm_test_helper::wasmtime_snapshots`) plus the DOOM and NES frames, folded in here rather than in the helper crate so that crate keeps no `wasmtime`-crate dependency. Each of those two targets emits two files — the compared PPM (`doom_frame.ppm`, `nes_frame.ppm`) and a PNG rendering of the same frame for human inspection (never compared by a test).
 fn snapshot_targets() -> Vec<SnapshotTarget> {
-    let mut targets: Vec<SnapshotTarget> = dewasm_test_helper::wasmtime_snapshots()
-        .into_iter()
-        .map(|snap| SnapshotTarget {
-            label: snap.label,
-            // Wrap the fail-loud capture (it panics with a setup
-            // message) in `Ok` so every target shares one `Result` signature.
-            capture: Box::new(move || Ok(vec![(snap.path.clone(), (snap.capture)())])),
-        })
-        .collect();
+    let mut targets: Vec<SnapshotTarget> =
+        dewasm_test_helper::wasmtime_snapshots(&EmbeddedWasmtime)
+            .into_iter()
+            .map(|snap| SnapshotTarget {
+                label: snap.label,
+                // Wrap the fail-loud capture (it panics with a setup
+                // message) in `Ok` so every target shares one `Result` signature.
+                capture: Box::new(move || Ok(vec![(snap.path.clone(), (snap.capture)())])),
+            })
+            .collect();
     targets.push(SnapshotTarget {
         label: "examples/apps/snapshots/doom_frame.ppm".to_string(),
         capture: Box::new(|| {

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1,6 +1,8 @@
 //! Developer-facing workspace tasks, run as `cargo xtask <command>` (aliased in `.cargo/config.toml`). Replaces the former snapshot-regeneration env-var toggles on the `support_docs` and `apps_wasmtime` tests with explicit subcommands: those tests are now compare-only and point here when they fail.
 //!
-//! `update-snapshots` regenerates *every* checked-in execution snapshot from one command: the nine WASI-runner files (app stdout, the gzip stream, the filesystem-app stdout, the interactive-REPL transcript) plus the DOOM and NES frames, whose custom export/import interfaces are driven directly instead (issue #114). All of them run on the embedded `wasmtime` crate pinned by `Cargo.lock`, so regeneration reproduces the same bytes on every host. `update-support-docs` stays separate — `docs/support.md` is generated documentation, not an execution snapshot.
+//! `update-snapshots` regenerates *every* checked-in execution snapshot from one command: the nine WASI-runner files (app stdout, the gzip stream, the filesystem-app stdout, the interactive-REPL transcript) plus the DOOM and NES frames, whose custom export/import interfaces are driven directly instead (issue #114).
+//! All of them run on the embedded `wasmtime` crate pinned by `Cargo.lock`, so regeneration reproduces the same bytes on every host.
+//! `update-support-docs` stays separate — `docs/support.md` is generated documentation, not an execution snapshot.
 //!
 //! `test-wasmtime-wasi`, `test-wasmtime-doom-frame` and `test-wasmtime-nes-frame` are the same executions as commands, for the snapshot freshness suite to spawn: it compares the checked-in files against what this binary produces, and must not embed the engine itself.
 //!
@@ -98,7 +100,8 @@ struct SnapshotTarget {
     capture: Box<dyn Fn() -> Result<CapturedFiles>>,
 }
 
-/// Every execution snapshot `update-snapshots` regenerates: the nine WASI-runner targets from the shared registry (`dewasm_test_helper::wasmtime_snapshots`) plus the DOOM and NES frames, folded in here rather than in the helper crate so that crate keeps no `wasmtime`-crate dependency. Each of those two targets emits two files — the compared PPM (`doom_frame.ppm`, `nes_frame.ppm`) and a PNG rendering of the same frame for human inspection (never compared by a test).
+/// Every execution snapshot `update-snapshots` regenerates: the nine WASI-runner targets from the shared registry (`dewasm_test_helper::wasmtime_snapshots`) plus the DOOM and NES frames, folded in here rather than in the helper crate so that crate keeps no `wasmtime`-crate dependency.
+/// Each of those two targets emits two files — the compared PPM (`doom_frame.ppm`, `nes_frame.ppm`) and a PNG rendering of the same frame for human inspection (never compared by a test).
 fn snapshot_targets() -> Vec<SnapshotTarget> {
     let mut targets: Vec<SnapshotTarget> =
         dewasm_test_helper::wasmtime_snapshots(&EmbeddedWasmtime)

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -2,7 +2,7 @@
 //!
 //! `update-snapshots` regenerates *every* checked-in execution snapshot from one command: the nine WASI-runner files (app stdout, the gzip stream, the filesystem-app stdout, the interactive-REPL transcript) plus the DOOM and NES frames, whose custom export/import interfaces are driven directly instead (issue #114). All of them run on the embedded `wasmtime` crate pinned by `Cargo.lock`, so regeneration reproduces the same bytes on every host. `update-support-docs` stays separate — `docs/support.md` is generated documentation, not an execution snapshot.
 //!
-//! `run-wasi`, `doom-frame` and `nes-frame` are the same executions as commands, for the snapshot freshness suite to spawn: it compares the checked-in files against what this binary produces, and must not embed the engine itself.
+//! `test-wasmtime-wasi`, `test-wasmtime-doom-frame` and `test-wasmtime-nes-frame` are the same executions as commands, for the snapshot freshness suite to spawn: it compares the checked-in files against what this binary produces, and must not embed the engine itself.
 //!
 //! `bench` is the cross-runtime benchmark suite: it measures every dewasm backend against wasmtime and against the wasm interpreters written in the same host languages, then writes a dated result file under `benchmarks/results/` and regenerates `docs/benchmarks/results.md`. Unlike the two commands above, neither output is a compared snapshot — a timing is not reproducible byte-for-byte, so no freshness test guards it.
 //!
@@ -31,88 +31,20 @@ const USAGE: &str = "\
 Usage: cargo xtask <command> [args]
 
 Commands:
-    update-support-docs        Regenerate docs/support.md from the backends' own
-                               capability declarations. Checked by
-                               `cargo test -p dewasm-cli --test support_docs`.
-    update-snapshots [filter]  Regenerate every checked-in execution snapshot
-                               from the embedded wasmtime: the app/gzip/filesystem
-                               stdout files and the interactive-REPL transcript
-                               under examples/apps/snapshots/, plus the DOOM
-                               and NES frames there (doom_frame.ppm and
-                               nes_frame.ppm, the compared oracles, and
-                               doom_frame.png/nes_frame.png renderings for
-                               human eyes). An optional substring `filter`
-                               limits it to matching snapshots (e.g.
-                               `update-snapshots doom`). Needs the apps cache
-                               populated (examples/apps/setup.sh; the DOOM
-                               frame needs examples/apps/scripts/doom.sh, the
-                               NES frame examples/apps/scripts/nes.sh).
-                               Checked by the compare-only freshness suite
-                               (`cargo test -p dewasm-test-helper --features
-                               wasmtime_test --test apps_wasmtime`) and the
-                               per-backend `doom_frame` and `nes_frame` cases.
-    run-wasi [opts] <wasm>     Run a WASI command on the embedded wasmtime,
-             [args...]         the `wasmtime run` subset the snapshot cases
-                               use: argv[0] is the wasm file's base name,
-                               stdin/stdout/stderr are inherited, and the
-                               guest's exit status becomes this process's.
-                               Options: --dir HOST::GUEST (preopen, repeatable),
-                               --env KEY=VALUE (repeatable; the guest sees
-                               nothing else of the host environment).
-    doom-frame                 Write the captured DOOM (or NES) framebuffer to
-    nes-frame                  stdout as a binary P6 PPM — the same bytes
-                               `update-snapshots` stores in
-                               examples/apps/snapshots/. Needs
-                               examples/apps/scripts/doom.sh (or nes.sh) run.
-    bench [filter] [options]   Run the cross-runtime benchmark suite: every
-                               workload in benchmarks/ (and the app cases) on
-                               every dewasm backend, on wasmtime and the other
-                               native runtimes (wasmer, wasmedge, wazero,
-                               wasm3), and on the pywasm/wardite interpreters.
-                               Writes a dated result file to benchmarks/results/
-                               and regenerates docs/benchmarks/results.md plus
-                               the SVG charts it embeds (docs/benchmarks/figs/, one per
-                               workload). An optional substring `filter` limits
-                               it to matching workload/runner labels (wasmtime
-                               always runs, as the baseline and the correctness
-                               reference); an unmatched filter is an error.
-                               Needs `wasmtime` on PATH, the microbenchmarks built
-                               (benchmarks/wat/build.sh, benchmarks/c/build.sh),
-                               the interpreter deps installed
-                               (benchmarks/setup.sh) and the apps cache
-                               populated; anything missing is reported as
-                               skipped-with-reason rather than dropped. Not a
-                               compared snapshot: no freshness test.
-                               Options: --list (print the matrix and each
-                               runner's availability, run nothing), --reps N
-                               (timed runs per measurement, default 5),
-                               --target-ms MS (compute time the iteration
-                               calibrator aims at, default 300),
-                               --timeout SECS (per-process ceiling, default
-                               900), --render FILE (re-render
-                               the results doc and its charts from a stored
-                               benchmarks/results/*.json without measuring
-                               anything, for when only the wording changed).
-    size [--render FILE]       Record how big the delivery is: per cached app
-                               (cowsay, sqlite3-shell, qjs, ruby) the wasm
-                               binary and every backend's converted standalone
-                               source, beside the installed size of each native
-                               runtime on the host (wasmtime, wasmer, wasmedge,
-                               wazero, wasm3). Raw bytes, never compressed.
-                               Writes a dated record to
-                               benchmarks/results/<timestamp>Z-size.json, beside
-                               the speed records, and regenerates
-                               docs/sizes/results.md plus the SVG figures it
-                               embeds (docs/sizes/figs/; figures the record no
-                               longer covers are pruned). Needs the apps cache
-                               populated (examples/apps/setup.sh); a missing app
-                               or runtime is reported as skipped-with-reason
-                               rather than dropped. Not a compared snapshot: no
-                               freshness test.
-                               Options: --render FILE (re-render the document
-                               and its figures from a stored
-                               benchmarks/results/*-size.json without measuring
-                               anything).
+    update-support-docs
+        Regenerate docs/support.md from the backends' capability declarations.
+    update-snapshots [filter]
+        Regenerate the checked-in execution snapshots under examples/apps/snapshots/ whose name contains the filter.
+    test-wasmtime-wasi [--dir HOST::GUEST]... [--env K=V]... <wasm> [args...]
+        Run a WASI command on the embedded wasmtime, for the snapshot freshness suite.
+    test-wasmtime-doom-frame
+        Write the captured DOOM framebuffer to stdout as a binary P6 PPM.
+    test-wasmtime-nes-frame
+        Write the captured NES framebuffer to stdout as a binary P6 PPM.
+    bench [filter] [--list] [--reps N] [--target-ms MS] [--timeout SECS] [--render FILE]
+        Run the cross-runtime benchmark suite and regenerate docs/benchmarks/results.md (see docs/benchmarks/README.md).
+    size [--render FILE]
+        Record the distribution sizes and regenerate docs/sizes/results.md (see docs/sizes/README.md).
 ";
 
 fn main() -> Result<()> {
@@ -120,9 +52,9 @@ fn main() -> Result<()> {
     match args.next().as_deref() {
         Some("update-support-docs") => update_support_docs(),
         Some("update-snapshots") => update_snapshots(args.next().as_deref()),
-        Some("run-wasi") => wasi_run::main(args),
-        Some("doom-frame") => write_stdout(&capture_doom_frame()?.0),
-        Some("nes-frame") => write_stdout(&capture_nes_frame()?.0),
+        Some("test-wasmtime-wasi") => wasi_run::main(args),
+        Some("test-wasmtime-doom-frame") => write_stdout(&capture_doom_frame()?.0),
+        Some("test-wasmtime-nes-frame") => write_stdout(&capture_nes_frame()?.0),
         Some("bench") => bench::main(args),
         Some("size") => size::main(args),
         Some("-h") | Some("--help") | Some("help") => {

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -2,6 +2,8 @@
 //!
 //! `update-snapshots` regenerates *every* checked-in execution snapshot from one command: the nine wasmtime-CLI-driven files (app stdout, the gzip stream, the filesystem-app stdout, the interactive-REPL transcript) plus the DOOM and NES frames, which stay on the embedded `wasmtime` crate because their custom export/import interfaces can't run through `wasmtime run` (issue #114). `update-support-docs` stays separate — `docs/support.md` is generated documentation, not an execution snapshot.
 //!
+//! `run-wasi`, `doom-frame` and `nes-frame` are the same executions as commands, for the snapshot freshness suite to spawn: it compares the checked-in files against what this binary produces, and must not embed the engine itself.
+//!
 //! `bench` is the cross-runtime benchmark suite: it measures every dewasm backend against wasmtime and against the wasm interpreters written in the same host languages, then writes a dated result file under `benchmarks/results/` and regenerates `docs/benchmarks/results.md`. Unlike the two commands above, neither output is a compared snapshot — a timing is not reproducible byte-for-byte, so no freshness test guards it.
 //!
 //! `size` is its size counterpart: per app, the wasm binary against every backend's converted source, beside the installed size of each native runtime. Its record joins the timing ones in `benchmarks/results/` and it renders `docs/sizes/results.md`. Also a measurement rather than a snapshot.
@@ -12,7 +14,9 @@ mod bench;
 mod doom_snapshot;
 mod nes_snapshot;
 mod size;
+mod wasi_run;
 
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Result};
@@ -46,6 +50,19 @@ Commands:
                                test -p dewasm-test-helper --features
                                wasmtime_test --test apps_wasmtime`) and the
                                per-backend `doom_frame` and `nes_frame` cases.
+    run-wasi [opts] <wasm>     Run a WASI command on the embedded wasmtime,
+             [args...]         the `wasmtime run` subset the snapshot cases
+                               use: argv[0] is the wasm file's base name,
+                               stdin/stdout/stderr are inherited, and the
+                               guest's exit status becomes this process's.
+                               Options: --dir HOST::GUEST (preopen, repeatable),
+                               --env KEY=VALUE (repeatable; the guest sees
+                               nothing else of the host environment).
+    doom-frame                 Write the captured DOOM (or NES) framebuffer to
+    nes-frame                  stdout as a binary P6 PPM — the same bytes
+                               `update-snapshots` stores in
+                               examples/apps/snapshots/. Needs
+                               examples/apps/scripts/doom.sh (or nes.sh) run.
     bench [filter] [options]   Run the cross-runtime benchmark suite: every
                                workload in benchmarks/ (and the app cases) on
                                every dewasm backend, on wasmtime and the other
@@ -102,6 +119,9 @@ fn main() -> Result<()> {
     match args.next().as_deref() {
         Some("update-support-docs") => update_support_docs(),
         Some("update-snapshots") => update_snapshots(args.next().as_deref()),
+        Some("run-wasi") => wasi_run::main(args),
+        Some("doom-frame") => write_stdout(&capture_doom_frame()?.0),
+        Some("nes-frame") => write_stdout(&capture_nes_frame()?.0),
         Some("bench") => bench::main(args),
         Some("size") => size::main(args),
         Some("-h") | Some("--help") | Some("help") => {
@@ -117,6 +137,14 @@ fn main() -> Result<()> {
             bail!("missing command");
         }
     }
+}
+
+/// Emit captured snapshot bytes on stdout, where the freshness suite reads them.
+fn write_stdout(bytes: &[u8]) -> Result<()> {
+    let mut out = std::io::stdout().lock();
+    out.write_all(bytes)?;
+    out.flush()?;
+    Ok(())
 }
 
 /// Render `docs/support.md` from the backends' own declarations and write it to disk. The corresponding test (`crates/dewasm-cli/tests/support_docs.rs`) is compare-only and names this command in its failure message.

--- a/crates/xtask/src/snapshot_engine.rs
+++ b/crates/xtask/src/snapshot_engine.rs
@@ -1,0 +1,90 @@
+//! The engine `update-snapshots` captures with: the [`BackendUnderTest`] surface the shared case runners expect, backed by [`crate::wasi_run`] in this process. The freshness suite spawns the same runner as a child instead, so capture and comparison execute the identical wasm under the identical WASI configuration.
+//!
+//! The interactive-REPL transcript is the one case that still needs a child process — a pty session has to hand its slave to one — and there it runs this very binary as the runner.
+
+use std::path::Path;
+use std::process::{ExitStatus, Output};
+
+use dewasm_backend::{Backend, Mode};
+use dewasm_test_helper::{wasi_runner_argv, BackendUnderTest, PtyCommand, Wasmtime};
+
+use crate::wasi_run::WasiRun;
+
+/// The wasmtime engine behind every regenerated execution snapshot.
+pub struct EmbeddedWasmtime;
+
+impl BackendUnderTest for EmbeddedWasmtime {
+    fn name(&self) -> &'static str {
+        Wasmtime.name()
+    }
+
+    fn backend(&self) -> &'static (dyn Backend + Sync) {
+        Wasmtime.backend()
+    }
+
+    fn convert_app(&self, bytes: &[u8], mode: Mode, name: &str) -> String {
+        Wasmtime.convert_app(bytes, mode, name)
+    }
+
+    fn run_bytes(&self, source: &str, args: &[&str], stdin: &[u8]) -> Output {
+        capture(wasi_runner_argv(source, args, &[], &[]), stdin)
+    }
+
+    fn run_app_fs(
+        &self,
+        program: &str,
+        _glue: &str,
+        args: &[&str],
+        env: &[(&str, &str)],
+        stdin: &[u8],
+        preopens: &[(&str, &Path)],
+    ) -> Output {
+        capture(wasi_runner_argv(program, &args[1..], env, preopens), stdin)
+    }
+
+    fn run_standalone_dir(
+        &self,
+        program: &str,
+        preopens: &[(&str, &Path)],
+        args: &[&str],
+        stdin: &[u8],
+    ) -> Output {
+        capture(wasi_runner_argv(program, args, &[], preopens), stdin)
+    }
+
+    fn pty_command(&self, source: &str, args: &[&str]) -> PtyCommand {
+        let mut argv = vec!["run-wasi".to_string()];
+        argv.extend(wasi_runner_argv(source, args, &[], &[]));
+        PtyCommand {
+            program: std::env::current_exe().expect("current_exe"),
+            args: argv,
+            cwd: None,
+        }
+    }
+}
+
+/// Run `argv` (as built for `xtask run-wasi`) in this process and shape the result like a child process's [`Output`], which is what the shared runners compare.
+fn capture(argv: Vec<String>, stdin: &[u8]) -> Output {
+    let run = WasiRun::parse(argv.into_iter()).expect("runner arguments");
+    let captured = run
+        .capture(stdin)
+        .unwrap_or_else(|err| panic!("capture {} failed: {err:?}", run.wasm.display()));
+    Output {
+        status: exit_status(captured.code),
+        stdout: captured.stdout,
+        stderr: captured.stderr,
+    }
+}
+
+/// An [`ExitStatus`] carrying `code`. It has no portable constructor, so each platform builds the raw status its `code()` decodes.
+#[cfg(unix)]
+fn exit_status(code: i32) -> ExitStatus {
+    use std::os::unix::process::ExitStatusExt;
+    ExitStatus::from_raw(code << 8)
+}
+
+#[cfg(windows)]
+fn exit_status(code: i32) -> ExitStatus {
+    use std::os::windows::process::ExitStatusExt;
+    ExitStatus::from_raw(code as u32)
+}

--- a/crates/xtask/src/snapshot_engine.rs
+++ b/crates/xtask/src/snapshot_engine.rs
@@ -53,7 +53,7 @@ impl BackendUnderTest for EmbeddedWasmtime {
     }
 
     fn pty_command(&self, source: &str, args: &[&str]) -> PtyCommand {
-        let mut argv = vec!["run-wasi".to_string()];
+        let mut argv = vec!["test-wasmtime-wasi".to_string()];
         argv.extend(wasi_runner_argv(source, args, &[], &[]));
         PtyCommand {
             program: std::env::current_exe().expect("current_exe"),
@@ -63,7 +63,7 @@ impl BackendUnderTest for EmbeddedWasmtime {
     }
 }
 
-/// Run `argv` (as built for `xtask run-wasi`) in this process and shape the result like a child process's [`Output`], which is what the shared runners compare.
+/// Run `argv` (as built for `xtask test-wasmtime-wasi`) in this process and shape the result like a child process's [`Output`], which is what the shared runners compare.
 fn capture(argv: Vec<String>, stdin: &[u8]) -> Output {
     let run = WasiRun::parse(argv.into_iter()).expect("runner arguments");
     let captured = run

--- a/crates/xtask/src/snapshot_engine.rs
+++ b/crates/xtask/src/snapshot_engine.rs
@@ -1,4 +1,5 @@
-//! The engine `update-snapshots` captures with: the [`BackendUnderTest`] surface the shared case runners expect, backed by [`crate::wasi_run`] in this process. The freshness suite spawns the same runner as a child instead, so capture and comparison execute the identical wasm under the identical WASI configuration.
+//! The engine `update-snapshots` captures with: the [`BackendUnderTest`] surface the shared case runners expect, backed by [`crate::wasi_run`] in this process.
+//! The freshness suite spawns the same runner as a child instead, so capture and comparison execute the identical wasm under the identical WASI configuration.
 //!
 //! The interactive-REPL transcript is the one case that still needs a child process — a pty session has to hand its slave to one — and there it runs this very binary as the runner.
 
@@ -76,7 +77,8 @@ fn capture(argv: Vec<String>, stdin: &[u8]) -> Output {
     }
 }
 
-/// An [`ExitStatus`] carrying `code`. It has no portable constructor, so each platform builds the raw status its `code()` decodes.
+/// An [`ExitStatus`] carrying `code`.
+/// It has no portable constructor, so each platform builds the raw status its `code()` decodes.
 #[cfg(unix)]
 fn exit_status(code: i32) -> ExitStatus {
     use std::os::unix::process::ExitStatusExt;

--- a/crates/xtask/src/wasi_run.rs
+++ b/crates/xtask/src/wasi_run.rs
@@ -1,0 +1,130 @@
+//! The WASI command runner behind `cargo xtask run-wasi`.
+//!
+//! The flags mirror the `wasmtime run` subset the snapshot cases were captured with, so the runner is a drop-in replacement for a `wasmtime` CLI on `PATH`:
+//!
+//! * `argv[0]` is the wasm file's base name, the rest of the command line is guest `argv[1..]`;
+//! * the guest environment holds exactly what `--env K=V` passes, nothing of the host's;
+//! * `--dir HOST::GUEST` preopens `HOST` at guest path `GUEST` with full permissions;
+//! * a guest `proc_exit` status becomes the process's exit status.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use wasmtime::{Engine, Linker, Module, Store};
+use wasmtime_wasi::p1::{self, WasiP1Ctx};
+use wasmtime_wasi::{DirPerms, FilePerms, I32Exit, WasiCtxBuilder};
+
+/// One WASI command invocation: a wasm file plus the guest-visible environment `wasmtime run` would build for it.
+pub struct WasiRun {
+    pub wasm: PathBuf,
+    /// Guest `argv[1..]`.
+    pub args: Vec<String>,
+    pub env: Vec<(String, String)>,
+    /// `(host, guest)` preopen pairs.
+    pub dirs: Vec<(PathBuf, String)>,
+}
+
+impl WasiRun {
+    /// Parse the `run-wasi` command line: option flags first, then the wasm path, then guest `argv[1..]` verbatim (a guest argument may repeat an option name).
+    pub fn parse(mut argv: impl Iterator<Item = String>) -> Result<Self> {
+        let mut env = Vec::new();
+        let mut dirs = Vec::new();
+        let wasm = loop {
+            let Some(arg) = argv.next() else {
+                bail!("run-wasi: missing the wasm file to run");
+            };
+            match arg.as_str() {
+                "--dir" => {
+                    let spec = argv
+                        .next()
+                        .context("run-wasi: --dir needs a HOST::GUEST argument")?;
+                    let (host, guest) = match spec.split_once("::") {
+                        Some((host, guest)) => (host.to_string(), guest.to_string()),
+                        None => (spec.clone(), spec),
+                    };
+                    dirs.push((PathBuf::from(host), guest));
+                }
+                "--env" => {
+                    let spec = argv
+                        .next()
+                        .context("run-wasi: --env needs a KEY=VALUE argument")?;
+                    let (key, value) = spec
+                        .split_once('=')
+                        .with_context(|| format!("run-wasi: --env {spec:?} is not KEY=VALUE"))?;
+                    env.push((key.to_string(), value.to_string()));
+                }
+                flag if flag.starts_with("--") => bail!("run-wasi: unknown option {flag}"),
+                _ => break PathBuf::from(arg),
+            }
+        };
+        Ok(Self {
+            wasm,
+            args: argv.collect(),
+            env,
+            dirs,
+        })
+    }
+
+    /// Run with the host's stdin/stdout/stderr, returning the guest's exit status. The guest sees whatever those three descriptors are — a pty slave included, which is what makes the interactive-REPL transcript reproducible.
+    pub fn run_inheriting_stdio(&self) -> Result<i32> {
+        let mut builder = self.builder()?;
+        builder.inherit_stdio();
+        execute(builder.build_p1(), &self.wasm).map_err(from_wasmtime)
+    }
+
+    /// The guest-visible context minus the stdio wiring: argv, environment, preopens.
+    fn builder(&self) -> Result<WasiCtxBuilder> {
+        let argv0 = self
+            .wasm
+            .file_name()
+            .with_context(|| format!("run-wasi: {} has no file name", self.wasm.display()))?
+            .to_string_lossy()
+            .into_owned();
+        let mut builder = WasiCtxBuilder::new();
+        builder.arg(argv0).args(&self.args);
+        for (key, value) in &self.env {
+            builder.env(key, value);
+        }
+        for (host, guest) in &self.dirs {
+            builder
+                .preopened_dir(host, guest, DirPerms::all(), FilePerms::all())
+                .map_err(from_wasmtime)
+                .with_context(|| format!("run-wasi: preopen {}", host.display()))?;
+        }
+        builder.allow_blocking_current_thread(true);
+        Ok(builder)
+    }
+}
+
+/// wasmtime carries its own error type; its debug rendering is what holds the context chain behind a trap.
+fn from_wasmtime(err: wasmtime::Error) -> anyhow::Error {
+    anyhow::anyhow!("{err:?}")
+}
+
+/// Instantiate `wasm` against WASI p1 and call `_start`, returning the guest's exit status (a `proc_exit` unwinds as [`I32Exit`]; a normal return is 0). Kept in `wasmtime::Result` so wasmtime's `?` composes; the callers lift it to anyhow.
+fn execute(ctx: WasiP1Ctx, wasm: &Path) -> wasmtime::Result<i32> {
+    let engine = Engine::default();
+    let module = Module::from_file(&engine, wasm)?;
+    let mut linker: Linker<WasiP1Ctx> = Linker::new(&engine);
+    p1::add_to_linker_sync(&mut linker, |ctx| ctx)?;
+    let mut store = Store::new(&engine, ctx);
+    let instance = linker.instantiate(&mut store, &module)?;
+    let start = instance.get_typed_func::<(), ()>(&mut store, "_start")?;
+    match start.call(&mut store, ()) {
+        Ok(()) => Ok(0),
+        Err(trap) => match trap.downcast_ref::<I32Exit>() {
+            Some(I32Exit(code)) => Ok(*code),
+            None => Err(trap),
+        },
+    }
+}
+
+/// `cargo xtask run-wasi [--dir HOST::GUEST]... [--env K=V]... <wasm> [args...]`.
+pub fn main(argv: impl Iterator<Item = String>) -> Result<()> {
+    let code = WasiRun::parse(argv)?.run_inheriting_stdio()?;
+    // Rust's stdout is line-buffered, so a guest's trailing partial line (a binary stream has none at all) would be lost across `exit`, which runs no destructors.
+    std::io::stdout().flush()?;
+    std::io::stderr().flush()?;
+    std::process::exit(code);
+}

--- a/crates/xtask/src/wasi_run.rs
+++ b/crates/xtask/src/wasi_run.rs
@@ -1,4 +1,4 @@
-//! The WASI command runner behind `cargo xtask run-wasi`.
+//! The WASI command runner behind `cargo xtask run-wasi`, and the in-process entry point the snapshot capture uses.
 //!
 //! The flags mirror the `wasmtime run` subset the snapshot cases were captured with, so the runner is a drop-in replacement for a `wasmtime` CLI on `PATH`:
 //!
@@ -13,7 +13,11 @@ use std::path::{Path, PathBuf};
 use anyhow::{bail, Context, Result};
 use wasmtime::{Engine, Linker, Module, Store};
 use wasmtime_wasi::p1::{self, WasiP1Ctx};
+use wasmtime_wasi::p2::pipe::{MemoryInputPipe, MemoryOutputPipe};
 use wasmtime_wasi::{DirPerms, FilePerms, I32Exit, WasiCtxBuilder};
+
+/// A cap on what one captured run may write. `MemoryOutputPipe` allocates nothing up front, and a guest that exceeds the cap traps instead of silently truncating, so this only has to be larger than any snapshot.
+const CAPTURE_CAPACITY: usize = 256 << 20;
 
 /// One WASI command invocation: a wasm file plus the guest-visible environment `wasmtime run` would build for it.
 pub struct WasiRun {
@@ -23,6 +27,13 @@ pub struct WasiRun {
     pub env: Vec<(String, String)>,
     /// `(host, guest)` preopen pairs.
     pub dirs: Vec<(PathBuf, String)>,
+}
+
+/// What a captured run produced: the in-process counterpart of [`std::process::Output`].
+pub struct Captured {
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+    pub code: i32,
 }
 
 impl WasiRun {
@@ -71,6 +82,23 @@ impl WasiRun {
         let mut builder = self.builder()?;
         builder.inherit_stdio();
         execute(builder.build_p1(), &self.wasm).map_err(from_wasmtime)
+    }
+
+    /// Run with `stdin` fed from memory and both output streams captured.
+    pub fn capture(&self, stdin: &[u8]) -> Result<Captured> {
+        let stdout = MemoryOutputPipe::new(CAPTURE_CAPACITY);
+        let stderr = MemoryOutputPipe::new(CAPTURE_CAPACITY);
+        let mut builder = self.builder()?;
+        builder
+            .stdin(MemoryInputPipe::new(stdin.to_vec()))
+            .stdout(stdout.clone())
+            .stderr(stderr.clone());
+        let code = execute(builder.build_p1(), &self.wasm).map_err(from_wasmtime)?;
+        Ok(Captured {
+            stdout: stdout.contents().to_vec(),
+            stderr: stderr.contents().to_vec(),
+            code,
+        })
     }
 
     /// The guest-visible context minus the stdio wiring: argv, environment, preopens.

--- a/crates/xtask/src/wasi_run.rs
+++ b/crates/xtask/src/wasi_run.rs
@@ -1,4 +1,4 @@
-//! The WASI command runner behind `cargo xtask run-wasi`, and the in-process entry point the snapshot capture uses.
+//! The WASI command runner behind `cargo xtask test-wasmtime-wasi`, and the in-process entry point the snapshot capture uses.
 //!
 //! The flags mirror the `wasmtime run` subset the snapshot cases were captured with, so the runner is a drop-in replacement for a `wasmtime` CLI on `PATH`:
 //!
@@ -37,19 +37,19 @@ pub struct Captured {
 }
 
 impl WasiRun {
-    /// Parse the `run-wasi` command line: option flags first, then the wasm path, then guest `argv[1..]` verbatim (a guest argument may repeat an option name).
+    /// Parse the `test-wasmtime-wasi` command line: option flags first, then the wasm path, then guest `argv[1..]` verbatim (a guest argument may repeat an option name).
     pub fn parse(mut argv: impl Iterator<Item = String>) -> Result<Self> {
         let mut env = Vec::new();
         let mut dirs = Vec::new();
         let wasm = loop {
             let Some(arg) = argv.next() else {
-                bail!("run-wasi: missing the wasm file to run");
+                bail!("test-wasmtime-wasi: missing the wasm file to run");
             };
             match arg.as_str() {
                 "--dir" => {
                     let spec = argv
                         .next()
-                        .context("run-wasi: --dir needs a HOST::GUEST argument")?;
+                        .context("test-wasmtime-wasi: --dir needs a HOST::GUEST argument")?;
                     let (host, guest) = match spec.split_once("::") {
                         Some((host, guest)) => (host.to_string(), guest.to_string()),
                         None => (spec.clone(), spec),
@@ -59,13 +59,15 @@ impl WasiRun {
                 "--env" => {
                     let spec = argv
                         .next()
-                        .context("run-wasi: --env needs a KEY=VALUE argument")?;
-                    let (key, value) = spec
-                        .split_once('=')
-                        .with_context(|| format!("run-wasi: --env {spec:?} is not KEY=VALUE"))?;
+                        .context("test-wasmtime-wasi: --env needs a KEY=VALUE argument")?;
+                    let (key, value) = spec.split_once('=').with_context(|| {
+                        format!("test-wasmtime-wasi: --env {spec:?} is not KEY=VALUE")
+                    })?;
                     env.push((key.to_string(), value.to_string()));
                 }
-                flag if flag.starts_with("--") => bail!("run-wasi: unknown option {flag}"),
+                flag if flag.starts_with("--") => {
+                    bail!("test-wasmtime-wasi: unknown option {flag}")
+                }
                 _ => break PathBuf::from(arg),
             }
         };
@@ -106,7 +108,12 @@ impl WasiRun {
         let argv0 = self
             .wasm
             .file_name()
-            .with_context(|| format!("run-wasi: {} has no file name", self.wasm.display()))?
+            .with_context(|| {
+                format!(
+                    "test-wasmtime-wasi: {} has no file name",
+                    self.wasm.display()
+                )
+            })?
             .to_string_lossy()
             .into_owned();
         let mut builder = WasiCtxBuilder::new();
@@ -118,7 +125,7 @@ impl WasiRun {
             builder
                 .preopened_dir(host, guest, DirPerms::all(), FilePerms::all())
                 .map_err(from_wasmtime)
-                .with_context(|| format!("run-wasi: preopen {}", host.display()))?;
+                .with_context(|| format!("test-wasmtime-wasi: preopen {}", host.display()))?;
         }
         builder.allow_blocking_current_thread(true);
         Ok(builder)
@@ -148,7 +155,7 @@ fn execute(ctx: WasiP1Ctx, wasm: &Path) -> wasmtime::Result<i32> {
     }
 }
 
-/// `cargo xtask run-wasi [--dir HOST::GUEST]... [--env K=V]... <wasm> [args...]`.
+/// `cargo xtask test-wasmtime-wasi [--dir HOST::GUEST]... [--env K=V]... <wasm> [args...]`.
 pub fn main(argv: impl Iterator<Item = String>) -> Result<()> {
     let code = WasiRun::parse(argv)?.run_inheriting_stdio()?;
     // Rust's stdout is line-buffered, so a guest's trailing partial line (a binary stream has none at all) would be lost across `exit`, which runs no destructors.

--- a/crates/xtask/src/wasi_run.rs
+++ b/crates/xtask/src/wasi_run.rs
@@ -16,7 +16,8 @@ use wasmtime_wasi::p1::{self, WasiP1Ctx};
 use wasmtime_wasi::p2::pipe::{MemoryInputPipe, MemoryOutputPipe};
 use wasmtime_wasi::{DirPerms, FilePerms, I32Exit, WasiCtxBuilder};
 
-/// A cap on what one captured run may write. `MemoryOutputPipe` allocates nothing up front, and a guest that exceeds the cap traps instead of silently truncating, so this only has to be larger than any snapshot.
+/// A cap on what one captured run may write.
+/// `MemoryOutputPipe` allocates nothing up front, and a guest that exceeds the cap traps instead of silently truncating, so this only has to be larger than any snapshot.
 const CAPTURE_CAPACITY: usize = 256 << 20;
 
 /// One WASI command invocation: a wasm file plus the guest-visible environment `wasmtime run` would build for it.
@@ -79,7 +80,8 @@ impl WasiRun {
         })
     }
 
-    /// Run with the host's stdin/stdout/stderr, returning the guest's exit status. The guest sees whatever those three descriptors are — a pty slave included, which is what makes the interactive-REPL transcript reproducible.
+    /// Run with the host's stdin/stdout/stderr, returning the guest's exit status.
+    /// The guest sees whatever those three descriptors are — a pty slave included, which is what makes the interactive-REPL transcript reproducible.
     pub fn run_inheriting_stdio(&self) -> Result<i32> {
         let mut builder = self.builder()?;
         builder.inherit_stdio();
@@ -137,7 +139,8 @@ fn from_wasmtime(err: wasmtime::Error) -> anyhow::Error {
     anyhow::anyhow!("{err:?}")
 }
 
-/// Instantiate `wasm` against WASI p1 and call `_start`, returning the guest's exit status (a `proc_exit` unwinds as [`I32Exit`]; a normal return is 0). Kept in `wasmtime::Result` so wasmtime's `?` composes; the callers lift it to anyhow.
+/// Instantiate `wasm` against WASI p1 and call `_start`, returning the guest's exit status (a `proc_exit` unwinds as [`I32Exit`]; a normal return is 0).
+/// Kept in `wasmtime::Result` so wasmtime's `?` composes; the callers lift it to anyhow.
 fn execute(ctx: WasiP1Ctx, wasm: &Path) -> wasmtime::Result<i32> {
     let engine = Engine::default();
     let module = Module::from_file(&engine, wasm)?;
@@ -155,7 +158,8 @@ fn execute(ctx: WasiP1Ctx, wasm: &Path) -> wasmtime::Result<i32> {
     }
 }
 
-/// `cargo xtask test-wasmtime-wasi [--dir HOST::GUEST]... [--env K=V]... <wasm> [args...]`.
+/// `cargo xtask test-wasmtime-wasi [--dir HOST::GUEST]...
+/// [--env K=V]... <wasm> [args...]`.
 pub fn main(argv: impl Iterator<Item = String>) -> Result<()> {
     let code = WasiRun::parse(argv)?.run_inheriting_stdio()?;
     // Rust's stdout is line-buffered, so a guest's trailing partial line (a binary stream has none at all) would be lost across `exit`, which runs no destructors.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -29,7 +29,7 @@ There are some features for testing:
 | --- | --- |
 | `slow_test` | CI's main run: the slow app cases and the full spec testsuite. |
 | `ultra_slow_test` | Implies `slow_test`; the cases CI cannot afford by wall time or memory, run in local pre-release verification. |
-| `wasmtime_test` | The snapshot freshness checks, which need a live `wasmtime`; see below. |
+| `wasmtime_test` | The snapshot freshness checks, which need the `xtask` binary built; see below. |
 
 ## Snapshots
 
@@ -40,12 +40,14 @@ Checked-in snapshots are code-derived, never hand-written; a stale one fails a c
 | `docs/support.md` | `cargo xtask update-support-docs` |
 | every execution snapshot (`examples/apps/snapshots/*`, incl. the DOOM and NES frames) | `cargo xtask update-snapshots [filter]` |
 
-A snapshot claims "this is what `wasmtime run` produces", so it can go stale.
-The opt-in freshness check runs the cached binaries under a live `wasmtime` and compares against the checked-in files:
+A snapshot claims "this is what wasmtime produces", so it can go stale.
+The opt-in freshness check reruns the cached binaries and compares against the checked-in files.
+Both it and the capture embed the `wasmtime` crate pinned by `Cargo.lock` — no `wasmtime` install is involved — and reach it through the `xtask` binary, which the suite never builds for you:
 
 ```console
+$ cargo build -p xtask
 $ cargo test -p dewasm-test-helper --features wasmtime_test --test apps_wasmtime
 ```
 
-`cargo xtask update-snapshots [filter]` captures the execution snapshots the same way, so it also needs `wasmtime` on `PATH` and the apps cache.
+`cargo xtask update-snapshots [filter]` captures the execution snapshots the same way, so it needs only the apps cache.
 On a clean tree it must reproduce every file byte-for-byte: a resulting `git status` diff is a capture bug or genuine nondeterminism, not a routine update.


### PR DESCRIPTION
Closes #191.

`cargo xtask` gains test-oriented runner entry points wrapping the embedded `wasmtime` crate — `run-wasi` (mirroring the `wasmtime run` flag subset the cases use: `--dir HOST::GUEST`, `--env K=V`, guest argv, inherited stdio, exit-code propagation) plus `doom-frame` / `nes-frame` — and everything that used to spawn a `wasmtime` CLI now uses them:

- The `wasmtime_test` freshness suite spawns the **already-built** xtask binary, resolved relative to the test executable (honors `$CARGO_TARGET_DIR`, cross-target dirs, and the active profile) — tests never build it and never go through `cargo run`; a missing binary fails loud with `cargo build -p xtask`. The pty transcript case spawns the same runner on the pty slave, so the guest still sees a character device via ordinary stdio inheritance.
- `update-snapshots` runs the cases in-process through the same code; the DOOM and NES frames stop being special cases and join the freshness suite (11 tests total).
- The `wasmtime` crate stays xtask-only; `dewasm-test-helper` gains no dependency. The captured bytes now come from the Cargo.lock-pinned wasmtime rather than whatever CLI a host has installed.
- CI drops the `bytecodealliance/actions/wasmtime/setup` step for an explicit `cargo build -p xtask`; docs/testing.md's prerequisite changes the same way. The `$DEWASM_WASMTIME` bench path is untouched (bench still measures the real CLI).
- To keep the runner on the plain dev profile without paying unoptimized Cranelift (~60 s per heavy case), the workspace pins `opt-level = 3` for the five guest-compilation crates and enables wasmtime's `parallel-compilation`: 34 MB `ruby.wasm` compiles in ~7 s; the whole freshness suite runs in ~14 s.

Verification: fmt / clippy / plain `cargo test` all pass (plain run proven not to touch the xtask binary); the freshness suite passes against the **unchanged** checked-in snapshots, and again with `wasmtime` absent from `PATH`; `cargo xtask update-snapshots` rewrites all 13 files byte-identically (`git status` clean, pty transcript and gzip stream included); no wasmtime-binary spawn remains outside `crates/xtask/src/bench/`.