### PR TITLE
Raise the three costliest doc caveats to Markdown alerts

### DIFF
--- a/docs/backends/bash.md
+++ b/docs/backends/bash.md
@@ -17,7 +17,11 @@ In **standalone** mode the prefix is always `program_` and `--module-name` is re
 
 ## Requirements
 
-`bash` **5 or newer** (associative arrays and namerefs; macOS's system `/bin/bash` is 3.2 and does **not** qualify, so `brew install bash`).
+`bash` **5 or newer** (associative arrays and namerefs).
+
+> [!IMPORTANT]
+> macOS ships bash 3.2 as `/bin/bash`, which cannot run the generated script.
+> Install bash 5 or newer (`brew install bash`) and invoke that one.
 No other external commands: floats run on a pure-Bash IEEE-754 softfloat, so there is no dependency on `bc`, `awk`, `python`, etc.
 
 ```console

--- a/docs/backends/python.md
+++ b/docs/backends/python.md
@@ -16,8 +16,10 @@ In **standalone** mode the class is always `Program` and `--module-name` is reje
 `python3` **3.9 or newer** on `PATH`.
 No third-party packages: the output uses only the standard library.
 
-**Avoid CPython 3.12.0 through 3.12.3.**
-A static-block limit in those releases breaks large generated modules with deeply nested loops (issue #21); 3.12.4 and newer are unaffected.
+> [!WARNING]
+> Avoid CPython 3.12.0 through 3.12.3.
+> A static-block limit in those releases breaks large generated modules with deeply nested loops (issue #21).
+> 3.12.4 and newer are unaffected.
 
 ## Running it
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -4,8 +4,11 @@ What the tests need and how to run them.
 
 ## Required environment
 
-A test whose required tool or setup step is missing **fails**; it never silently skips.
-Therefore, the following tools and setup steps are required to run all tests correctly:
+> [!IMPORTANT]
+> A test whose required tool or setup step is missing **fails**; it never silently skips.
+> Run `git submodule update --init` and `examples/apps/setup.sh` before the first `cargo test`, or a fresh checkout reports failures that look like broken code.
+
+The following tools and setup steps are required to run all tests correctly:
 
 - **Rust toolchain**: `rustup` applies the pin in `rust-toolchain.toml` automatically; a non-rustup `cargo` ignores the pin.
 - **Each backend's interpreter or toolchain**, at the version its page under [`docs/backends/`](backends/) states; a full `cargo test` needs all of them.


### PR DESCRIPTION
Promotes three existing caveats to GitHub Markdown alerts, chosen from a review of every user-facing page against one bar: overlooking the sentence must produce a failure that does not name its cause.

- `docs/backends/python.md`: the CPython 3.12.0 to 3.12.3 load failure becomes a warning (the interpreter error names nothing about the version).
- `docs/backends/bash.md`: the macOS `/bin/bash` 3.2 fact becomes its own alert under Requirements (the default shell on the most common developer platform fails with bare syntax errors), leaving the requirement line to state the version and the features it rests on.
- `docs/testing.md`: the fail-not-skip policy opens Required environment as an alert and now names the two setup commands, since a fresh checkout without them reports failures that look like broken code.

Reviewed and deliberately left as prose, so these three keep their weight: the standalone exit-code table, the benchmark measuring pitfalls (already under a heading that does the same work), the per-backend caveat bullets, and the `--module-name Ruby` collision note.