### PR TITLE
Introduce the downstream projects page

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ $ dewasm input.<wasm|wat>
 
 Please see `dewasm --help` for the full list of options.
 
-Next: [getting started](docs/getting-started.md), the [per-target reference](docs/backends/), and [what each backend supports](docs/support.md).
+Next: [getting started](docs/getting-started.md), the [per-target reference](docs/backends/), [what each backend supports](docs/support.md), and [projects built on dewasm](docs/users.md).
 
 ## Copyright
 

--- a/agents/docs-policy.md
+++ b/agents/docs-policy.md
@@ -30,6 +30,7 @@ A document a user would never open, but an agent must consult before changing so
 | [docs/benchmarks/results.md](../docs/benchmarks/results.md) | Measured performance, with figures under `figs/` | Evaluators | **Generated: never hand-edit** |
 | [docs/sizes/](../docs/sizes/README.md) | How to run the size record and read its numbers | Contributors | By hand |
 | [docs/sizes/results.md](../docs/sizes/results.md) | Measured distribution sizes (wasm binary, converted source, runtimes) with figures under `figs/` | Evaluators | **Generated: never hand-edit** |
+| [docs/users.md](../docs/users.md) | Downstream projects that ship dewasm-converted code | Users, evaluators | By hand |
 | [records/README.md](../records/README.md) | When, on what host, and on what occasion each stored measurement record was taken | Contributors, evaluators | By hand (`cargo xtask record-speed` and `cargo xtask record-size` append a placeholder line per record they write) |
 
 ## Rules
@@ -59,6 +60,7 @@ A document a user would never open, but an agent must consult before changing so
 - An experiment's outcome with no decision attached → its Issue/PR, plus an entry in `agents/experiments.md` when it changes what a future agent would do.
 - A rule that binds every change → a line in `AGENTS.md`, citing the record that holds its rationale.
 - A new real-world app target → an audited row in `agents/apps-audit.md`.
+- A downstream project shipping dewasm output → an entry in [docs/users.md](../docs/users.md).
 - A performance number → a workload under `benchmarks/`, measured by `cargo xtask record-speed`.
   Never a hand-written figure in prose: numbers drift silently, and the ratio a benchmark reports depends on the workload.
 - A size number → the record `cargo xtask record-size` writes to `records/`, rendered into `docs/sizes/results.md`, for the same reason: a generated artifact's size changes with every codegen change.

--- a/docs/users.md
+++ b/docs/users.md
@@ -1,15 +1,24 @@
-# Projects built on dewasm
+# Projects built on `dewasm`
 
-Downstream projects that ship dewasm-converted code.
-Each one is working evidence of the pipeline: a real library compiled to WebAssembly, converted to source, and packaged for a language's own ecosystem.
+A curated list of projects built on `dewasm`.
 
-## dewasm-merman
+## Official
 
-[dewasm-merman](https://github.com/dewasm/ruby-merman) ([RubyGems](https://rubygems.org/gems/dewasm-merman)) renders Mermaid diagrams in pure Ruby.
+Projects hosted by the `dewasm` team.
+
+### `dewasm-merman` (Ruby)
+
+[`dewasm-merman`](https://github.com/dewasm/ruby-merman) ([RubyGems](https://rubygems.org/gems/dewasm-merman)) renders Mermaid diagrams in pure Ruby.
 It wraps [merman](https://github.com/Latias94/merman), a Rust implementation of Mermaid, compiled to `wasm32-wasip1` and converted with the Ruby backend.
-It renders SVG and terminal text across merman's full diagram coverage, and ships a snapshot of the module state taken after initialization, so every render starts from initialized tables at a fraction of the cold cost.
+It renders SVG and terminal text across merman's full diagram coverage.
 
-## dewasm-pozeiden
+### `dewasm-pozeiden` (Ruby)
 
-[dewasm-pozeiden](https://github.com/dewasm/ruby-pozeiden) ([RubyGems](https://rubygems.org/gems/dewasm-pozeiden)) also renders Mermaid diagrams in pure Ruby, from [pozeiden](https://github.com/sc2in/pozeiden), a Zig implementation compiled to `wasm32-wasi`.
+[`dewasm-pozeiden`](https://github.com/dewasm/ruby-pozeiden) ([RubyGems](https://rubygems.org/gems/dewasm-pozeiden)) also renders Mermaid diagrams in pure Ruby, from [pozeiden](https://github.com/sc2in/pozeiden), a Zig implementation compiled to `wasm32-wasi`.
 It is far smaller than dewasm-merman, but covers fewer diagram types, and its license (PolyForm Noncommercial 1.0.0) does not permit commercial use.
+
+## Unofficial
+
+Unfortunately, there is no such project for now.
+
+If you create or find one, please update this file and open a pull request.

--- a/docs/users.md
+++ b/docs/users.md
@@ -1,0 +1,15 @@
+# Projects built on dewasm
+
+Downstream projects that ship dewasm-converted code.
+Each one is working evidence of the pipeline: a real library compiled to WebAssembly, converted to source, and packaged for a language's own ecosystem.
+
+## dewasm-merman
+
+[dewasm-merman](https://github.com/dewasm/ruby-merman) ([RubyGems](https://rubygems.org/gems/dewasm-merman)) renders Mermaid diagrams in pure Ruby.
+It wraps [merman](https://github.com/Latias94/merman), a Rust implementation of Mermaid, compiled to `wasm32-wasip1` and converted with the Ruby backend.
+It renders SVG and terminal text across merman's full diagram coverage, and ships a snapshot of the module state taken after initialization, so every render starts from initialized tables at a fraction of the cold cost.
+
+## dewasm-pozeiden
+
+[dewasm-pozeiden](https://github.com/dewasm/ruby-pozeiden) ([RubyGems](https://rubygems.org/gems/dewasm-pozeiden)) also renders Mermaid diagrams in pure Ruby, from [pozeiden](https://github.com/sc2in/pozeiden), a Zig implementation compiled to `wasm32-wasi`.
+It is far smaller than dewasm-merman, but covers fewer diagram types, and its license (PolyForm Noncommercial 1.0.0) does not permit commercial use.


### PR DESCRIPTION
Adds docs/users.md, introducing the two gems now published on RubyGems: dewasm-merman (merman, Rust, compiled to wasm32-wasip1, converted with the Ruby backend, SVG and terminal text, shipped state snapshot) and dewasm-pozeiden (pozeiden, Zig, far smaller, fewer diagram types, PolyForm Noncommercial). Each entry is two or three sentences with the repository and RubyGems links; sizes and timings stay in the gems' own READMEs so this page cannot go stale with their releases.

The documentation policy table gains the docs/users.md row plus a "where new content goes" line for future downstream projects, and the README's closing pointer line links the page.