### PR TITLE
Relocate the app audit record to agents/ and feature-audit to xtask

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ When support declarations or WASI units change, regenerate `docs/support.md` wit
 
 Significant decisions, anything with real alternatives, are recorded in [`agents/decisions/`](agents/decisions/README.md): its README holds the index, the authoring procedure, and the quality bar.
 An entry is `agents/decisions/<N>-<slug>.md`, cited as "decision N".
-Nothing outside `agents/` references anything under it (no decision citation, no link); this file, `CLAUDE.md`, and `.claude/` are the exceptions.
+Nothing outside `agents/` references anything under it (no decision citation, no link); this file, `CLAUDE.md`, `.claude/`, and the app audit tooling's citations of `agents/apps-audit.md` (the record its verdicts land in) are the exceptions.
 Code and user-facing docs state their constraints in place, and the decision links out to the code it governs, never the reverse.
 `agents/` is for documents an agent reads while working; `docs/` is for documents a human reads ([`agents/docs-policy.md`](agents/docs-policy.md)).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2425,6 +2425,7 @@ dependencies = [
  "png",
  "serde",
  "serde_json",
+ "wasmparser 0.254.0",
  "wasmtime",
  "wasmtime-wasi",
 ]

--- a/agents/apps-audit.md
+++ b/agents/apps-audit.md
@@ -3,7 +3,7 @@
 The scope test: before an app binary becomes a conversion target, run
 
 ```sh
-cargo run -p dewasm-core --bin feature-audit -- examples/apps/cache/*.wasm
+cargo xtask feature-audit examples/apps/cache/*.wasm
 ```
 
 and record the verdict here.

--- a/agents/decisions/24-01-scope-reset.md
+++ b/agents/decisions/24-01-scope-reset.md
@@ -17,7 +17,7 @@ For the 0.1 release, the accepted input is **wasm 1.0 + WASI preview 1**, where 
 Everything else (reference types, tail calls, exception handling, the component model, WASI preview 2, and all unimplemented proposals) is **removed from the code**, not frozen: IR variants, lowering, feature tests, runtime units, harness support, and docs rows all go.
 Unsupported input keeps failing at conversion time with a clear error (decision 0).
 
-One validator-level nuance, found by the app audit (`docs/apps-audit.md`): LLVM-based toolchains encode `call_indirect` immediates as overlong LEBs when the reference-types *target feature* is on (their default), so real wasip1 binaries (including the already shipping qjs and sqlite3) only validate with the reference-types feature bit enabled.
+One validator-level nuance, found by the app audit (`agents/apps-audit.md`): LLVM-based toolchains encode `call_indirect` immediates as overlong LEBs when the reference-types *target feature* is on (their default), so real wasip1 binaries (including the already shipping qjs and sqlite3) only validate with the reference-types feature bit enabled.
 The bit therefore stays on in `dewasm-core::module::features()` as a pure **encoding relaxation**; every actual reference-types construct (externref, table instructions, `ref.*`, non-zero table indices) is rejected during IR building with the usual attributed error.
 
 The discriminating criterion: **a feature stays only if a pinned target app needs it or every 0.1 backend is expected to implement it.**
@@ -25,7 +25,7 @@ Code kept "just in case" is code paid for in every exhaustive match, every new b
 
 Goals are stated app-first; the spec testsuite remains the correctness test (decision 3), not the goal.
 0.1 targets: cowsay (backend bring-up), quickjs-ng (one-shot, script with file I/O, REPL), sqlite3 (shell and C-API library, DB files on disk, callback binding), ripgrep, a CPython or CRuby runtime binary, and a compression CLI.
-A **feature audit** (conversion-time feature report over each pinned binary) runs before the excision; an app that needs a dropped feature is deferred with a written note in `docs/apps-audit.md`: it does not block the excision.
+A **feature audit** (conversion-time feature report over each pinned binary) runs before the excision; an app that needs a dropped feature is deferred with a written note in `agents/apps-audit.md`: it does not block the excision.
 pandoc.wasm is the expected first deferral (GHC's wasm backend is believed to emit tail calls; to be confirmed by the audit).
 
 0.1 backends: Ruby and Bash (existing) plus **Python, Go, Java**.

--- a/agents/decisions/27-test-helper-crate.md
+++ b/agents/decisions/27-test-helper-crate.md
@@ -28,7 +28,7 @@ With three more backends planned, the shape had to be fixed first.
   Aggregate macros survive only where there is no per-case glue to show (`spec_suite!`, `wasi_suite!`, `gzip_e2e!`, `apps_convert_suite!`, `wasi_testsuite_suite!`).
 - **A backend's `tests/e2e.rs` holds only the impl, the glue constants, and macro invocations.**
   No backend-specific `#[test]` exists, so a scenario written for one backend is by construction offered to every backend.
-  **Capability is declared by which macros a backend invokes**; a case it cannot run is simply not invoked, with the reason as a comment at the absent callsite and the measurements behind it in `docs/apps-audit.md`.
+  **Capability is declared by which macros a backend invokes**; a case it cannot run is simply not invoked, with the reason as a comment at the absent callsite and the measurements behind it in `agents/apps-audit.md`.
   This replaces the retired support-level conditioning ([decision 25](25-retire-support-levels.md)).
 - **The spec harness is one [libtest-mimic](https://crates.io/crates/libtest-mimic) trial per `.wast` file**, so selection is cargo's own UX: the file stem names the trial (`cargo test --test spec i32`), and files outside `SpecBackend::curated_files` are `#[ignore]`d, so `cargo test` runs the curated set and `--include-ignored` the whole testsuite.
   Trials run in parallel, so per-file state belongs to the trial, not to the shared backend object.

--- a/agents/decisions/37-data-segment-externalization.md
+++ b/agents/decisions/37-data-segment-externalization.md
@@ -69,7 +69,7 @@ Measured (release CLI; `ruby.wasm` = CRuby, 35 MB wasm; `qjs.wasm`, 1.5 MB):
 The Python and Java `qjs.wasm` deltas (measured after this revision, release CLI) match the Ruby/Go pattern exactly: the source shrinks by roughly the eliminated inline encoding (`bytes.fromhex` / chunked Base64) minus the shared 0.13 MB sidecar, a ~2-3 % code-dominated reduction, confirming the win is a source-size one, not a parse-time one.
 
 Ruby `compile_file` parse of `ruby.wasm`: 6.15 s → 5.97 s.
-Go `build` of `qjs.wasm`: 10.8 s → 11.1 s (within noise; `ruby.wasm`/Go build is impractical at either setting: CRuby exceeds the practicality bar, see docs/apps-audit.md).
+Go `build` of `qjs.wasm`: 10.8 s → 11.1 s (within noise; `ruby.wasm`/Go build is impractical at either setting: CRuby exceeds the practicality bar, see agents/apps-audit.md).
 
 Honest finding: these interpreters are **code-dominated**, so the source shrinks by roughly `2 × data_bytes − blob` (the eliminated hex), which is ~8 MB / 5 % for `ruby.wasm`, not the "dominated by data" the motivating framing assumed.
 Parse and build time are governed by the code, so they barely move.

--- a/agents/docs-policy.md
+++ b/agents/docs-policy.md
@@ -19,11 +19,11 @@ A document a user would never open, but an agent must consult before changing so
 | [agents/experiments.md](experiments.md) | Past experiments: the conclusion and its re-test condition, over the Issue/PR that holds the record | Agents | By hand |
 | [agents/docs-policy.md](docs-policy.md) | This file: which document each kind of content belongs in | Agents writing documents | By hand |
 | [agents/test-authoring.md](test-authoring.md) | How the test suites are structured and what a new case must look like | Agents and contributors writing tests | By hand |
+| [agents/apps-audit.md](apps-audit.md) | The real-world app test record and feature verdicts | Agents and contributors adding an app target | By hand |
 | [docs/getting-started.md](../docs/getting-started.md) | Tutorial: a verified end-to-end walkthrough | New users | By hand (verify every command) |
 | [docs/backends/](../docs/backends/) | Per-target reference: output shape, requirements, caveats, provider usage | Users of a specific target | By hand |
 | [docs/standalone-interface.md](../docs/standalone-interface.md) | The standalone runtime interface (argv, `--dir`, env, exit/trap), uniform across backends | Users running standalone output | By hand |
 | [docs/support.md](../docs/support.md) | The feature / WASI matrix per backend | Everyone | **Generated: never hand-edit** |
-| [docs/apps-audit.md](../docs/apps-audit.md) | The real-world app test record and feature verdicts | Contributors, evaluators | By hand |
 | [docs/testing.md](../docs/testing.md) | How to run the test suites: what each one needs installed, and why it fails loud | Contributors | By hand |
 | [docs/related-work.md](../docs/related-work.md) | Comparison with prior art | Evaluators | By hand |
 | [docs/benchmarks/](../docs/benchmarks/README.md) | How to run the benchmark suite and read its numbers | Contributors | By hand |
@@ -42,6 +42,7 @@ A document a user would never open, but an agent must consult before changing so
 - **Nothing outside `agents/` references anything under it.**
   `AGENTS.md`, `CLAUDE.md`, and `.claude/` are the exceptions.
   Code and user-facing docs state their constraint in place; an `agents/` document links outward to the code and docs it concerns, never the reverse.
+  The app audit tooling (the `feature-audit` xtask command and the `examples/apps` fetch scripts) is a further exception: it cites `agents/apps-audit.md` because that record is where its verdicts land.
 - **A skill under `.claude/skills/` is a router, not a store.**
   Claude Code auto-invokes a skill by its description, which is what a skill is for; the substance it routes to belongs under `agents/`.
   The test: if deleting `.claude/` would lose information rather than convenience, the file is holding content it should be pointing at.
@@ -57,7 +58,7 @@ A document a user would never open, but an agent must consult before changing so
 - A design decision → a new record (see [agents/decisions/README.md](decisions/README.md)).
 - An experiment's outcome with no decision attached → its Issue/PR, plus an entry in `agents/experiments.md` when it changes what a future agent would do.
 - A rule that binds every change → a line in `AGENTS.md`, citing the record that holds its rationale.
-- A new real-world app target → an audited row in `docs/apps-audit.md`.
+- A new real-world app target → an audited row in `agents/apps-audit.md`.
 - A performance number → a workload under `benchmarks/`, measured by `cargo xtask record-speed`.
   Never a hand-written figure in prose: numbers drift silently, and the ratio a benchmark reports depends on the workload.
 - A size number → the record `cargo xtask record-size` writes to `records/`, rendered into `docs/sizes/results.md`, for the same reason: a generated artifact's size changes with every codegen change.

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -35,6 +35,8 @@ dewasm-backend-java.workspace = true
 # Timings are not reproducible byte-for-byte, so this is a data drop, not a compared snapshot.
 serde.workspace = true
 serde_json.workspace = true
+# `feature-audit` validates candidate app binaries against raw feature bits, so it can name proposals the converter itself no longer models.
+wasmparser.workspace = true
 # Encodes the human-facing PNG sidecar of the DOOM frame snapshot; default settings kept fixed so regeneration is byte-stable.
 png = "0.18.1"
 # std makes `wasmtime::Error` an `anyhow::Error` (so `?` composes with our anyhow flow); cranelift+runtime is the embedder.

--- a/crates/xtask/src/feature_audit.rs
+++ b/crates/xtask/src/feature_audit.rs
@@ -1,14 +1,12 @@
 //! Report, per wasm binary, the minimal set of post-baseline proposals it needs to validate, plus its WASI preview 1 import surface.
 //!
-//! This is the app audit test: before an app is pinned as a conversion target, run this tool on its binary; an app that needs a proposal outside the 0.1 scope (wasm 1.0 + the universally-emitted baseline) is deferred and documented in `docs/apps-audit.md`.
+//! This is the app audit test: before an app is pinned as a conversion target, run this command on its binary; an app that needs a proposal outside the 0.1 scope (wasm 1.0 + the universally-emitted baseline) is deferred and documented in `agents/apps-audit.md`.
 //!
-//! Deliberately built on raw `wasmparser::WasmFeatures` bits rather than the crate's `Feature` enum, so it keeps naming proposals the converter itself no longer models.
-//!
-//! Usage: cargo run -p dewasm-core --bin feature-audit -- <file.wasm>...
+//! Deliberately built on raw `wasmparser::WasmFeatures` bits rather than `dewasm-core`'s `Feature` enum, so it keeps naming proposals the converter itself no longer models.
 
 use std::collections::BTreeMap;
-use std::process::ExitCode;
 
+use anyhow::{bail, Context, Result};
 use wasmparser::{Parser, Payload, TypeRef, Validator, WasmFeatures};
 
 /// The 0.1 input scope: wasm 1.0 plus the baseline extensions every current toolchain emits.
@@ -49,7 +47,7 @@ fn validates(bytes: &[u8], extra: &[(&str, WasmFeatures)]) -> bool {
         .is_ok()
 }
 
-/// Greedy minimization, same shape as `classify_validation_failure` in `module.rs`: start from all known proposals, drop any whose absence still validates.
+/// Greedy minimization, same shape as `classify_validation_failure` in `dewasm-core`'s `module.rs`: start from all known proposals, drop any whose absence still validates.
 fn minimal_proposals(bytes: &[u8]) -> Option<Vec<&'static str>> {
     let mut active = proposals();
     if !validates(bytes, &active) {
@@ -168,8 +166,8 @@ fn is_component(bytes: &[u8]) -> bool {
     bytes.len() >= 8 && bytes[0..4] == *b"\0asm" && bytes[6..8] == [0x01, 0x00]
 }
 
-fn audit(path: &str) -> Result<bool, String> {
-    let bytes = std::fs::read(path).map_err(|e| format!("{path}: {e}"))?;
+fn audit(path: &str) -> Result<bool> {
+    let bytes = std::fs::read(path).with_context(|| path.to_string())?;
     let name = std::path::Path::new(path)
         .file_name()
         .map(|n| n.to_string_lossy().into_owned())
@@ -227,26 +225,19 @@ fn audit(path: &str) -> Result<bool, String> {
     Ok(clean)
 }
 
-fn main() -> ExitCode {
-    let paths: Vec<String> = std::env::args().skip(1).collect();
+pub fn main(argv: impl Iterator<Item = String>) -> Result<()> {
+    let paths: Vec<String> = argv.collect();
     if paths.is_empty() {
-        eprintln!("usage: feature-audit <file.wasm>...");
-        return ExitCode::from(2);
+        bail!("usage: cargo xtask feature-audit <file.wasm>...");
     }
     let mut all_clean = true;
     for path in &paths {
-        match audit(path) {
-            Ok(clean) => all_clean &= clean,
-            Err(err) => {
-                eprintln!("{err}");
-                return ExitCode::from(2);
-            }
-        }
+        all_clean &= audit(path)?;
     }
-    // Nonzero when any binary needs out-of-scope features, so scripts can branch on the verdict; the human decision (defer vs. rethink) is recorded in docs/apps-audit.md.
+    // Failing when any binary needs out-of-scope features lets scripts branch on the verdict; the human decision (defer vs. rethink) is recorded in agents/apps-audit.md.
     if all_clean {
-        ExitCode::SUCCESS
+        Ok(())
     } else {
-        ExitCode::FAILURE
+        bail!("a binary needs features outside the 0.1 scope");
     }
 }

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -11,10 +11,13 @@
 //! Each writes a dated record under `records/` and renders nothing; `render-speed` and `render-size` turn a record into `docs/benchmarks/results.md` and `docs/sizes/results.md`.
 //! Unlike the commands above, none of those outputs is a compared snapshot: neither a timing nor an installed size is reproducible byte-for-byte, so no freshness test guards them.
 //!
+//! `feature-audit` is the app audit test: it reports each candidate app binary's post-baseline feature needs and WASI p1 import surface, with the verdicts recorded in `agents/apps-audit.md`.
+//!
 //! No `clap` dependency: a couple of subcommands and a help message do not need one.
 
 mod bench;
 mod doom_snapshot;
+mod feature_audit;
 mod nes_snapshot;
 mod size;
 mod snapshot_engine;
@@ -52,6 +55,8 @@ Commands:
         Regenerate docs/benchmarks/results.md and its charts from the named speed record, or from the newest one.
     render-size [record]
         Regenerate docs/sizes/results.md and its figures from the named size record, or from the newest one.
+    feature-audit <file.wasm>...
+        Report each binary's post-baseline feature needs and WASI p1 import surface; fails when one needs a proposal outside the 0.1 scope (verdicts are recorded in agents/apps-audit.md).
 ";
 
 fn main() -> Result<()> {
@@ -66,6 +71,7 @@ fn main() -> Result<()> {
         Some("record-size") => size::record(args),
         Some("render-speed") => bench::render(args),
         Some("render-size") => size::render(args),
+        Some("feature-audit") => feature_audit::main(args),
         Some("-h") | Some("--help") | Some("help") => {
             print!("{USAGE}");
             Ok(())

--- a/examples/apps/scripts/cpython.sh
+++ b/examples/apps/scripts/cpython.sh
@@ -6,8 +6,7 @@
 # (brettcannon/cpython-wasi-build: the PSF distributes no WASI binaries; this is a CPython core dev's build).
 # Beyond python.wasm we also extract the stdlib tree (lib/python3.14) the interpreter reads at startup from a preopened directory: the e2e case preopens cache/cpython-lib/lib at guest
 # /lib (PYTHONHOME=/, PYTHONPATH=/lib/python3.14).
-# Ruby-only, heavy:
-# execution behind the `heavy_test` cargo feature (docs/apps-audit.md).
+# Every backend converts and runs it, behind the `slow_test`/`ultra_slow_test` cargo features (the speed category varies by backend); the audit record is agents/apps-audit.md.
 
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 

--- a/examples/apps/scripts/cruby.sh
+++ b/examples/apps/scripts/cruby.sh
@@ -5,10 +5,7 @@
 # CRuby 3.4 (ruby.wasm 2.9.4): the official ruby.wasm wasm32-wasip1 full build.
 # Beyond ruby.wasm we extract the stdlib tree (usr/local/lib/ruby) the interpreter reads at startup; the multi-hundred-MB libruby-static.a and the rest of the tree are not needed at run time and are left out (the extract helpers unpack only the two named members).
 # The e2e case preopens cache/ruby-lib/usr at guest /usr.
-# Ruby-only, heavy: execution behind the
-# `heavy_test` cargo feature.
-# The "Ruby on Ruby" goal demo
-# (docs/apps-audit.md).
+# The "Ruby on Ruby" goal demo: every backend converts and runs it, behind the `slow_test`/`ultra_slow_test` cargo features (the speed category varies by backend); the audit record is agents/apps-audit.md.
 #
 # A second artifact, cache/ruby-packed.wasm, covers ruby.wasm's intended deployment shape: the same module with the stdlib embedded by
 # `wasi-vfs pack` (wizer pre-initialization), self-contained: no preopens.


### PR DESCRIPTION
Closes #210.

**`docs/apps-audit.md` → `agents/apps-audit.md`.**
The document is the record an agent consults and appends to before an app binary becomes a conversion target, plus per-app e2e engineering notes; by the docs-policy split that is `agents/` material, and no user-facing document links to it.
The audit tooling (the `feature-audit` command and the CPython/CRuby fetch scripts) keeps citing the record its verdicts land in; that citation is now a named exception to the "nothing outside `agents/` references anything under it" rule, in both `AGENTS.md` and `agents/docs-policy.md`.

**`cargo run -p dewasm-core --bin feature-audit` → `cargo xtask feature-audit`.**
The binary imports nothing from `dewasm-core` (it deliberately uses raw `wasmparser::WasmFeatures` so it can name proposals the converter no longer models), so it sat in the published crate without using it.
As an xtask subcommand it keeps its behavior: per-binary verdict lines plus the WASI p1 import surface, and a nonzero exit when any binary needs an out-of-scope proposal.
Verified over the full app cache: all 17 binaries report the same verdicts as recorded.

**Stale fetch-script comments, fixed in passing.**
`cpython.sh` and `cruby.sh` still said "Ruby-only, heavy: execution behind the `heavy_test` cargo feature"; the cases run on every backend behind `slow_test`/`ultra_slow_test` since decision 48.

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` all pass.