### PR TITLE
Elide i32/i64 masks inside expression trees when the consumer is modular

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ Each rule is stated here in full; the cited decision holds its rationale and rej
 - The spec testsuite binds (decision 3). Correctness of generated code outranks its readability; readability improvements go into optional passes, never into semantics-relevant lowering.
 - Where the WASI spec is silent, copy wasmtime's behavior as measured on both CI hosts (decision 49).
 - Numeric representation conventions (masked-unsigned integers, f32 re-rounding, NaN bit paths) are shared across backends (decision 2).
+  A backend skips a result mask only inside one expression tree, through the shared consumption-context and bound analysis in `dewasm_backend::masking`, never by its own reasoning (decision 71).
 - Each backend's lowering shapes are fixed; follow them rather than restructuring in passing. They are recorded per backend: Ruby decisions 4/42-44/58/60/65/72, Bash decisions 5/11-13/34/35/51/52, Python decision 28, Go decision 29, Java decision 30, Perl decision 55.
 - Runtime code lives as per-method units under `runtime/<lang>/units/` with `# requires:` headers, referenced as `Rt` (decision 6); keep the headers in sync when editing a unit (the units lint enforces most of it).
 - `Embedded` linkage isolates the runtime per artifact so two artifacts coexist in one namespace (decision 62); `embedded_coexist_e2e!` is the check, and a backend that does not invoke it is unfinished, not incapable.

--- a/agents/decisions/2-numeric-semantics.md
+++ b/agents/decisions/2-numeric-semantics.md
@@ -3,6 +3,7 @@
 Status: **Accepted, 2026-07-23.**
 Backfilled; implemented for Ruby in `runtime/ruby/runtime.rb`.
 The conventions below bind every backend whose language lacks fixed-width/unsigned integers or 32-bit floats (Ruby, Python, PHP, Bash); Java/Go map to native types instead.
+[Decision 71](71-mask-elision-modular-consumers.md) loosens the always-masked convention to masked at observation points: inside one expression tree, a value whose consumer restores the mask may stay unmasked; the storage representation itself is unchanged.
 
 ## Context
 

--- a/agents/decisions/43-ruby-i64-mask-fast-path.md
+++ b/agents/decisions/43-ruby-i64-mask-fast-path.md
@@ -3,6 +3,7 @@
 Status: **Accepted, 2026-07-28.**
 Implemented in `crates/dewasm-backend-ruby/src/lib.rs` and `runtime/ruby/units/rt/m64.rb`.
 Refines the masked-unsigned i64 lowering; the numeric conventions of [decision 2](2-numeric-semantics.md) are unchanged.
+Under [decision 71](71-mask-elision-modular-consumers.md), an `m64` site whose consumer is modular and whose bound guard holds is skipped entirely.
 
 ## Context
 

--- a/agents/decisions/71-mask-elision-modular-consumers.md
+++ b/agents/decisions/71-mask-elision-modular-consumers.md
@@ -1,0 +1,58 @@
+# Decision 71: Mask Elision Inside One Expression Tree Under a Modular Consumer
+
+Status: **Accepted, 2026-08-15.**
+Landed as the shared analysis in `crates/dewasm-backend/src/masking.rs` and its application in the Ruby backend's expression rendering (`crates/dewasm-backend-ruby/src/lib.rs`).
+The other masked-unsigned backends (Python, Perl, Bash) still mask every site; each can adopt the same analysis against its own unboxed-integer limit.
+This is stage 1 of issue #164: elision within one expression tree only, no cross-statement analysis.
+
+## Context
+
+[Decision 2](2-numeric-semantics.md) stores integers as masked unsigned values, and every wrapping operation re-masks its result (`& 0xffffffff` inline for i32, `Rt.m64` for i64 per [decision 43](43-ruby-i64-mask-fast-path.md)).
+Since [decision 32](32-expression-folding.md) folded single-use values into their consumers, many masked results feed directly into an operation that immediately re-masks: in `(a + b & 0xffffffff) + c & 0xffffffff` the inner mask buys nothing, because the outer one reduces the whole sum anyway.
+The converted `sqlite3-shell` carries 36.6k `& 0xffffffff` sites and 2.4k `m64` calls; each is parse work, ISeq instructions, and a runtime operation.
+
+## Decision
+
+**The invariant loosens from "every value is masked" to "every value is masked at its observation points."**
+An observation point is storage (local, temp, global, memory), a function boundary, or a non-modular consumer: a comparison, a division or remainder, a signed or unsigned view, a right shift's shifted operand, an address computation, a helper call.
+Inside one expression tree, a value whose consumer reads only its congruence class modulo 2^w (a wrapping add/sub/mul operand, a bitwise operand, `shl`'s shifted operand, any shift's count, the wrap's operand, the operand under a site's own kept mask) may stay unmasked: the consumer's own mask restores the invariant before the value is observed.
+
+**Soundness.**
+The targets this convention covers have arbitrary-precision two's-complement integers, so an unmasked intermediate is congruent to the masked value modulo 2^w, and every modular consumer preserves that congruence: `(x - y) & 0xffffffff` is the correct wrap of a negative difference, and `&`/`|`/`^` read a negative operand as its infinite two's-complement form, leaving the low w bits right.
+The first non-modular consumer sits behind a kept mask, which reduces the value back to the stored representation.
+
+**The consumption table and the bound analysis are shared**, in `crates/dewasm-backend/src/masking.rs`: which operand each `BinOp`/`UnOp` reads modularly (`bin_operand_context`/`un_operand_context`, with the maskless bitwise operators passing the consumer's context through), and a bottom-up interval bound over `ir::Expr` (`elides_mask`) that treats locals, temps, globals, and calls as their full masked width, constants and zero-extending loads exactly, and shift counts by constant where known.
+Only the emission and the limit are per backend.
+
+**The guard: a mask is skipped only when the exposed intermediate provably stays within the backend's unboxed-integer range.**
+For Ruby that is Fixnum, `-2**62 .. 2**62 - 1` on 64-bit MRI.
+Elision under this guard is strictly profitable: it removes a mask and can never introduce an integer allocation, because every exposed value is a provable Fixnum.
+Consequences of the bound: i32 add and sub always elide under a modular consumer (raw magnitude at most 2^33), while a full-range i32 mul (up to 2^64), `shl` by an unknown count (up to 2^63), and the wrap of a full-range i64 keep their masks unless the interval analysis narrows the operands.
+
+**i64 uses the same Fixnum limit, not a wider one.**
+A wider allowance (say 2^64, "no wider than the masked value") looks harmless because masked i64 values already reach 2^64, but it cuts both ways: an elided raw sum can be a guaranteed bignum where the masked value would have wrapped back into Fixnum range, and each unmasked mul doubles the width, so a chain grows without bound.
+Under the uniform limit an elided i64 site is provably allocation-free, the same claim as i32; the cost is that full-range i64 add/sub and `shr_s` keep `Rt.m64` even under a modular consumer, so i64 elision fires mainly on chains the analysis can narrow (zero-extending loads, constants, values shifted down).
+`i64.shr_s` is the known near-miss: its raw signed value (within 2^63) would often be cheaper elided than masked, since a negative result masks into a guaranteed bignum; loosening that one site is left for a later stage, with measurement.
+
+**Operand context is independent of the elision outcome.**
+Operands of a site that keeps its own mask are still rendered in modular context: the kept mask restores the invariant, so the guard failing at a node never forces masks back into its subtree.
+
+## Rejected alternatives
+
+- **Keep every mask (status quo).**
+  Simplest, but the inner masks a modular consumer restores are pure overhead at every stage: file size, parse, ISeq, runtime.
+- **Elide without the bound guard.**
+  Congruence still holds, so it is correct, but a mul chain's intermediates grow past Fixnum (two full i32 products already reach 2^128 multiplied together) and every operation on them becomes multi-word bignum arithmetic: a cheap mask traded for unpredictable slowdowns.
+- **A per-backend analysis.**
+  The consumption table and the interval logic follow from the shared masked-unsigned convention (decision 2), not from any one language; duplicating them per backend invites divergence for no flexibility gained, since only the limit and the emission differ.
+- **Cross-statement elision (unmasked locals or temps).**
+  Storage is where every consumer, including future ones, reads the value; proving all of them modular needs a dataflow analysis over the whole function.
+  Out of scope for stage 1, which establishes the invariant and the mechanism; issue #164 tracks the rest.
+
+## Consequences
+
+- On the converted `sqlite3-shell` (standalone Ruby): file size 7,937,554 to 7,868,630 bytes (0.87% smaller), ISeq instructions 1,370,047 to 1,360,259 (0.71% fewer), ISeq memsize 47,605,992 to 47,212,640 bytes (0.83% smaller; `RubyVM::InstructionSequence.compile_file` on MRI 4.0.4, children included).
+  4,822 of 36,622 `& 0xffffffff` sites (13.2%) and 72 of 2,443 `m64` calls (2.9%) are elided: above the rough 4% ceiling issue #219 estimated for this stage, and small in absolute terms as expected.
+- The spec harness (decision 3) binds as always and passes for the Ruby backend under this lowering; codegen-shape tests (`mod masks` in the Ruby backend, plus unit tests in `masking.rs`) pin both directions: an elided site, a site kept by a non-modular consumer, and a site kept by the bound guard.
+- Decision 2's storage representation is unchanged; only the point at which the mask is applied moved from every producer to every observation point.
+- A module whose only `m64` references were elided arithmetic sites no longer bundles the `rt/m64` unit (other runtime units can still require it).

--- a/agents/decisions/README.md
+++ b/agents/decisions/README.md
@@ -90,6 +90,7 @@ An entry is numbered: `<N>-<slug>.md`, cited as "decision N".
 | 68 | [Measurement Records at the Top Level, Written and Rendered by Symmetric Commands](68-records-directory.md) | Accepted |
 | 69 | [Exception Handling Joins the Accepted Input, Declared Per Backend](69-exception-handling-accepted-input.md) | Accepted |
 | 70 | [Shared Statement Traversal for IR Analyses](70-shared-statement-traversal.md) | Accepted |
+| 71 | [Mask Elision Inside One Expression Tree Under a Modular Consumer](71-mask-elision-modular-consumers.md) | Accepted |
 | 72 | [Ruby Backend Omits Dead Method-Level `__br` Clears](72-ruby-dead-br-clear-elision.md) | Accepted |
 
 ## Adding a new decision

--- a/crates/dewasm-backend-ruby/src/lib.rs
+++ b/crates/dewasm-backend-ruby/src/lib.rs
@@ -24,6 +24,7 @@ use std::collections::{BTreeSet, HashSet};
 use std::sync::OnceLock;
 
 use anyhow::Result;
+use dewasm_backend::masking::{bin_operand_context, elides_mask, un_operand_context, MaskContext};
 use dewasm_backend::{
     check_module_support, hex_string, is_boolean, is_ident, is_wasi_module, load_method,
     local_runs, module_name_error, signed_view_rel_op, store_method, terminates, type_key,
@@ -1451,10 +1452,10 @@ impl<'a> Gen<'a> {
 
     fn addr(&self, addr: &Expr, offset: u64) -> Rendered {
         if offset == 0 {
-            self.expr(addr)
+            self.masked(addr)
         } else {
             infix(
-                self.expr(addr),
+                self.masked(addr),
                 "+",
                 Rendered::atom(offset.to_string()),
                 ADD,
@@ -1464,10 +1465,16 @@ impl<'a> Gen<'a> {
 
     /// An expression in a position that constrains nothing, ready to be pasted into a statement.
     fn expr_text(&self, expr: &Expr) -> String {
-        self.expr(expr).free()
+        self.masked(expr).free()
     }
 
-    fn expr(&self, expr: &Expr) -> Rendered {
+    /// An expression whose exact stored value is observed (a store, an argument, an address, a comparison operand): every result mask is kept.
+    fn masked(&self, expr: &Expr) -> Rendered {
+        self.expr(expr, MaskContext::Masked)
+    }
+
+    /// `ctx` is the consumer's view of the value: under a `Modular` consumer a site's own result mask is skipped when the shared bound guard allows it (see [`FIXNUM_LIMIT`]).
+    fn expr(&self, expr: &Expr, ctx: MaskContext) -> Rendered {
         match expr {
             Expr::I32Const(v) => number(v.to_string()),
             Expr::I64Const(v) => number(v.to_string()),
@@ -1496,15 +1503,22 @@ impl<'a> Gen<'a> {
                 Rendered::atom("0".to_string()),
                 Rendered::atom("1".to_string()),
             ),
-            Expr::Un(op, a) => self.un(*op, self.expr(a)),
-            Expr::Bin(op, a, b) => self.bin(*op, self.expr(a), self.expr(b)),
+            Expr::Un(op, a) => {
+                let a = self.expr(a, un_operand_context(*op));
+                self.un(*op, a, elide(ctx, expr))
+            }
+            Expr::Bin(op, a, b) => {
+                let ra = self.expr(a, bin_operand_context(*op, 0, ctx));
+                let rb = self.expr(b, bin_operand_context(*op, 1, ctx));
+                self.bin(*op, ra, rb, elide(ctx, expr))
+            }
             Expr::Load { op, addr, offset } => Rendered::atom(format!(
                 "@m.{}({})",
                 self.mem(load_method(*op)),
                 self.addr(addr, *offset).free()
             )),
             Expr::Select { cond, then, els } => {
-                ternary(self.cond(cond), self.expr(then), self.expr(els))
+                ternary(self.cond(cond), self.masked(then), self.masked(els))
             }
             Expr::MemorySize => {
                 self.use_unit("memory/size");
@@ -1523,7 +1537,7 @@ impl<'a> Gen<'a> {
             // `eqz` in boolean context is the negation of its operand's own test.
             Expr::Un(UnOp::I32Eqz | UnOp::I64Eqz, a) => self.not_cond(a),
             Expr::Bin(op, a, b) => match signed_view_rel_op(*op) {
-                Some(rel) => self.rel(rel, self.expr(a), self.expr(b)),
+                Some(rel) => self.rel(rel, self.masked(a), self.masked(b)),
                 None => self.zero_test("!=", e),
             },
             _ => self.zero_test("!=", e),
@@ -1543,7 +1557,7 @@ impl<'a> Gen<'a> {
 
     /// `e == 0` / `e != 0`: the fallback test for a value that is not already a Ruby boolean.
     fn zero_test(&self, op: &'static str, e: &Expr) -> Rendered {
-        compare(self.expr(e), op, Rendered::atom("0".to_string()), EQ)
+        compare(self.masked(e), op, Rendered::atom("0".to_string()), EQ)
     }
 
     /// A one-argument call to a runtime helper, recording its unit.
@@ -1555,7 +1569,16 @@ impl<'a> Gen<'a> {
         Rendered::atom(format!("{}({}, {})", self.rt(name), a.free(), b.free()))
     }
 
-    fn un(&self, op: UnOp, a: Rendered) -> Rendered {
+    /// The i64 result mask (`Rt.m64`), skipped when the consumer restores it; an elided site also keeps the `rt/m64` unit out of the bundle.
+    fn m64_unless(&self, elide: bool, a: Rendered) -> Rendered {
+        if elide {
+            a
+        } else {
+            self.call1("m64", a)
+        }
+    }
+
+    fn un(&self, op: UnOp, a: Rendered, elide_mask: bool) -> Rendered {
         use UnOp::*;
         match op {
             I32Eqz | I64Eqz => ternary(
@@ -1581,7 +1604,7 @@ impl<'a> Gen<'a> {
                 self.call1("f32", r)
             }
             F64Sqrt => self.call1("fsqrt", a),
-            I32WrapI64 => mask32(a),
+            I32WrapI64 => mask32_unless(elide_mask, a),
             I32TruncF32S | I32TruncF64S => self.call1("i32_trunc_s", a),
             I32TruncF32U | I32TruncF64U => self.call1("i32_trunc_u", a),
             I64TruncF32S | I64TruncF64S => self.call1("i64_trunc_s", a),
@@ -1623,7 +1646,7 @@ impl<'a> Gen<'a> {
         }
     }
 
-    fn bin(&self, op: BinOp, a: Rendered, b: Rendered) -> Rendered {
+    fn bin(&self, op: BinOp, a: Rendered, b: Rendered, elide_mask: bool) -> Rendered {
         use BinOp::*;
         // A comparison is a Ruby boolean; outside condition position it needs the ternary back to the i32 0 or 1 wasm expects (see `cond`).
         if let Some(rel) = signed_view_rel_op(op) {
@@ -1634,12 +1657,12 @@ impl<'a> Gen<'a> {
             );
         }
         match op {
-            I32Add => mask32(infix(a, "+", b, ADD)),
-            I32Sub => mask32(infix(a, "-", b, ADD)),
-            I32Mul => mask32(infix(a, "*", b, MUL)),
-            I64Add => self.call1("m64", infix(a, "+", b, ADD)),
-            I64Sub => self.call1("m64", infix(a, "-", b, ADD)),
-            I64Mul => self.call1("m64", infix(a, "*", b, MUL)),
+            I32Add => mask32_unless(elide_mask, infix(a, "+", b, ADD)),
+            I32Sub => mask32_unless(elide_mask, infix(a, "-", b, ADD)),
+            I32Mul => mask32_unless(elide_mask, infix(a, "*", b, MUL)),
+            I64Add => self.m64_unless(elide_mask, infix(a, "+", b, ADD)),
+            I64Sub => self.m64_unless(elide_mask, infix(a, "-", b, ADD)),
+            I64Mul => self.m64_unless(elide_mask, infix(a, "*", b, MUL)),
             I32DivS => self.call2("i32_div_s", a, b),
             I32DivU => self.call2("i32_div_u", a, b),
             I32RemS => self.call2("i32_rem_s", a, b),
@@ -1651,14 +1674,17 @@ impl<'a> Gen<'a> {
             I32And | I64And => infix(a, "&", b, BIT_AND),
             I32Or | I64Or => infix(a, "|", b, BIT_OR),
             I32Xor | I64Xor => infix(a, "^", b, BIT_OR),
-            I32Shl => mask32(infix(a, "<<", shift_count(b, 31), SHIFT)),
+            I32Shl => mask32_unless(elide_mask, infix(a, "<<", shift_count(b, 31), SHIFT)),
             I32ShrU => infix(a, ">>", shift_count(b, 31), SHIFT),
-            I32ShrS => mask32(infix(self.call1("s32", a), ">>", shift_count(b, 31), SHIFT)),
-            I64Shl => self.call1("m64", infix(a, "<<", shift_count(b, 63), SHIFT)),
+            I32ShrS => mask32_unless(
+                elide_mask,
+                infix(self.call1("s32", a), ">>", shift_count(b, 31), SHIFT),
+            ),
+            I64Shl => self.m64_unless(elide_mask, infix(a, "<<", shift_count(b, 63), SHIFT)),
             I64ShrU => infix(a, ">>", shift_count(b, 63), SHIFT),
             I64ShrS => {
                 let s = self.call1("s64", a);
-                self.call1("m64", infix(s, ">>", shift_count(b, 63), SHIFT))
+                self.m64_unless(elide_mask, infix(s, ">>", shift_count(b, 63), SHIFT))
             }
             I32Rotl => self.call2("i32_rotl", a, b),
             I32Rotr => self.call2("i32_rotr", a, b),
@@ -1844,6 +1870,23 @@ fn not(a: Rendered) -> Rendered {
 
 fn mask32(a: Rendered) -> Rendered {
     infix(a, "&", Rendered::atom("0xffffffff".to_string()), BIT_AND)
+}
+
+/// The i32 result mask, skipped when the consumer restores it.
+fn mask32_unless(elide: bool, a: Rendered) -> Rendered {
+    if elide {
+        a
+    } else {
+        mask32(a)
+    }
+}
+
+/// 64-bit MRI keeps integers in `-2**62 .. 2**62 - 1` unboxed; a skipped mask must never expose an intermediate outside that range, or the elision would trade a cheap mask for bignum arithmetic.
+const FIXNUM_LIMIT: i128 = 1 << 62;
+
+/// Whether `e`'s own result mask may be skipped here: the consumer must be modular and the shared bound guard must hold.
+fn elide(ctx: MaskContext, e: &Expr) -> bool {
+    ctx == MaskContext::Modular && elides_mask(e, FIXNUM_LIMIT)
 }
 
 /// A shift count, masked to the width wasm defines it modulo.
@@ -2050,6 +2093,128 @@ mod parens {
             )
             .contains("if !(l0 < l1)"),
             "the negated comparison lost its group"
+        );
+    }
+}
+
+/// Codegen-shape checks for mask elision.
+/// The spec harness proves the generated code computes the right values; these pin the shapes it cannot distinguish: a mask restored by a modular consumer is gone, and a mask a non-modular consumer or the Fixnum bound guard requires is still there.
+#[cfg(test)]
+mod masks {
+    use super::*;
+
+    fn body(wat: &str) -> String {
+        let bytes = wat::parse_str(wat).expect("parse wat");
+        let module = dewasm_core::build_module(&bytes).expect("build module");
+        let (src, _) =
+            generate_class_with_units(&module, "M", &RuntimeLinkage::Embedded, false).unwrap();
+        src
+    }
+
+    /// One function of two i32 params whose body is `expr`, stored into a local so folding cannot drop it.
+    fn i32_expr(expr: &str) -> String {
+        body(&format!(
+            "(module (func (export \"f\") (param i32 i32) (result i32) (local.set 0 {expr}) (local.get 0)))"
+        ))
+    }
+
+    /// The i64 counterpart of [`i32_expr`].
+    fn i64_expr(expr: &str) -> String {
+        body(&format!(
+            "(module (func (export \"f\") (param i64 i64) (result i64) (local.set 0 {expr}) (local.get 0)))"
+        ))
+    }
+
+    fn assert_line(src: &str, want: &str) {
+        assert!(
+            src.lines().any(|l| l.trim() == want),
+            "expected line `{want}` in:\n{src}"
+        );
+    }
+
+    #[test]
+    fn modular_consumer_drops_the_operand_mask() {
+        // The outer add's mask reduces the whole sum; the inner add needs none.
+        assert_line(
+            &i32_expr("(i32.add (i32.add (local.get 0) (local.get 1)) (local.get 1))"),
+            "l0 = l0 + l1 + l1 & 0xffffffff",
+        );
+        // `shr_s` exposes at most the signed 32-bit range, so its own mask goes too.
+        assert_line(
+            &i32_expr("(i32.add (i32.shr_s (local.get 0) (local.get 1)) (local.get 1))"),
+            "l0 = (s32(l0) >> (l1 & 31)) + l1 & 0xffffffff",
+        );
+        // A shift count is read through `& 31`, so the subtraction feeding it needs no mask.
+        assert_line(
+            &i32_expr("(i32.shl (local.get 0) (i32.sub (local.get 1) (i32.const 1)))"),
+            "l0 = l0 << (l1 - 1 & 31) & 0xffffffff",
+        );
+        // The wrap disappears when the exposed i64 is provably narrow (here at most 2^32).
+        assert_line(
+            &body(
+                "(module (func (export \"f\") (param i64) (result i32) (local i32) \
+                 (local.set 1 (i32.add (i32.wrap_i64 (i64.shr_u (local.get 0) (i64.const 32))) (i32.const 7))) (local.get 1)))",
+            ),
+            "l1 = (l0 >> (32 & 63)) + 7 & 0xffffffff",
+        );
+    }
+
+    #[test]
+    fn non_modular_consumer_keeps_the_operand_mask() {
+        // A division observes the exact value.
+        assert_line(
+            &i32_expr("(i32.div_u (i32.add (local.get 0) (local.get 1)) (local.get 1))"),
+            "l0 = i32_div_u(l0 + l1 & 0xffffffff, l1)",
+        );
+        // So does a comparison.
+        assert_line(
+            &i32_expr("(i32.lt_u (i32.add (local.get 0) (local.get 1)) (local.get 1))"),
+            "l0 = l0 + l1 & 0xffffffff < l1 ? 1 : 0",
+        );
+        // And storage: the statement position itself is an observation point, so the outer mask always stays.
+        assert_line(
+            &i32_expr("(i32.add (local.get 0) (local.get 1))"),
+            "l0 = l0 + l1 & 0xffffffff",
+        );
+    }
+
+    #[test]
+    fn bound_guard_keeps_the_mask_on_wide_intermediates() {
+        // A full-range i32 product reaches 2^64, past the Fixnum limit: the mul stays masked under a modular consumer.
+        assert_line(
+            &i32_expr("(i32.add (i32.mul (local.get 0) (local.get 1)) (local.get 1))"),
+            "l0 = (l0 * l1 & 0xffffffff) + l1 & 0xffffffff",
+        );
+        // Narrowed to bytes, the product is provably small and the mask goes.
+        assert_line(
+            &i32_expr(
+                "(i32.add (i32.mul (i32.and (local.get 0) (i32.const 255)) (i32.and (local.get 1) (i32.const 255))) (local.get 1))",
+            ),
+            "l0 = (l0 & 255) * (l1 & 255) + l1 & 0xffffffff",
+        );
+        // A full-range i64 wraps past the limit too: the wrap keeps its mask.
+        assert_line(
+            &body(
+                "(module (func (export \"f\") (param i64) (result i32) (local i32) \
+                 (local.set 1 (i32.add (i32.wrap_i64 (local.get 0)) (i32.const 7))) (local.get 1)))",
+            ),
+            "l1 = (l0 & 0xffffffff) + 7 & 0xffffffff",
+        );
+    }
+
+    #[test]
+    fn i64_elides_only_under_the_same_fixnum_bound() {
+        // Two full-range i64 values sum past the Fixnum limit: `Rt.m64` stays even under the modular sub.
+        assert_line(
+            &i64_expr("(i64.sub (i64.add (local.get 0) (local.get 1)) (local.get 1))"),
+            "l0 = m64(m64(l0 + l1) - l1)",
+        );
+        // Provably narrow (the high half plus a constant), the inner `Rt.m64` goes.
+        assert_line(
+            &i64_expr(
+                "(i64.sub (local.get 1) (i64.add (i64.shr_u (local.get 0) (i64.const 32)) (i64.const 5)))",
+            ),
+            "l0 = m64(l1 - ((l0 >> (32 & 63)) + 5))",
         );
     }
 }

--- a/crates/dewasm-backend/src/lib.rs
+++ b/crates/dewasm-backend/src/lib.rs
@@ -1,6 +1,7 @@
 //! Backend trait and code emission utilities shared by all language backends.
 
 pub mod flat;
+pub mod masking;
 
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 

--- a/crates/dewasm-backend/src/masking.rs
+++ b/crates/dewasm-backend/src/masking.rs
@@ -1,0 +1,406 @@
+//! Mask elision inside one expression tree, for the backends that store integers masked-unsigned.
+//!
+//! The stored representation masks every integer to its width, and each wrapping operation re-masks its result.
+//! Inside a single [`Expr`] tree that is often double work: a consumer that reads its operand only modulo 2^32 or 2^64 (a wrapping add's operand, a shift count) cannot observe the high bits its own mask throws away.
+//! [`MaskContext`] names the two consumption contexts, [`bin_operand_context`] and [`un_operand_context`] are the table of which operands an operation reads modularly, and [`elides_mask`] is the guard: a backend may skip a site's own result mask exactly when the consumer is modular and the interval bound proves the exposed value stays within the backend's unboxed-integer range.
+//!
+//! Soundness rests on the targets' integers being arbitrary-precision two's complement (Ruby, Python, Perl): an unmasked intermediate is congruent to the masked value modulo 2^w, every modular consumer preserves that congruence (a bitwise operator reads a negative operand as its infinite two's-complement form, so `(x - y) & 0xffffffff` is the correct wrap of a negative difference), and the first non-modular consumer sits behind a kept mask, which reduces the value back to the stored representation.
+
+use dewasm_core::ir::{BinOp, Expr, LoadOp, UnOp};
+
+/// How a consumer reads an integer operand: `Masked` when it observes the exact stored value, `Modular` when it reads only the value's congruence class modulo the type width, so an unmasked operand serves.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum MaskContext {
+    Masked,
+    Modular,
+}
+
+/// The context in which `op` consumes its operand `k` (0-based), given that `op`'s own result is consumed in `ctx`.
+///
+/// An operation with its own result mask (wrapping add/sub/mul, `shl`, the wrap) reads its operands modularly regardless of `ctx`: the site's mask restores the invariant even when its own elision guard fails.
+/// A shift count is read through the semantic `& (w - 1)`, so it is modular for every shift.
+/// The maskless bitwise operators pass `ctx` through: their result is exact only when their operands are.
+/// Everything else (comparisons, division, signed and unsigned views, addresses, helper calls) observes the exact value.
+pub fn bin_operand_context(op: BinOp, k: usize, ctx: MaskContext) -> MaskContext {
+    use BinOp::*;
+    match op {
+        I32Add | I32Sub | I32Mul | I64Add | I64Sub | I64Mul | I32Shl | I64Shl => {
+            MaskContext::Modular
+        }
+        // The shifted value's high bits are observed exactly; the count is not.
+        I32ShrU | I32ShrS | I64ShrU | I64ShrS => {
+            if k == 1 {
+                MaskContext::Modular
+            } else {
+                MaskContext::Masked
+            }
+        }
+        I32And | I32Or | I32Xor | I64And | I64Or | I64Xor => ctx,
+        _ => MaskContext::Masked,
+    }
+}
+
+/// The [`bin_operand_context`] counterpart for unary operations: only the wrap consumes modularly (its result mask keeps the low 32 bits either way).
+pub fn un_operand_context(op: UnOp) -> MaskContext {
+    match op {
+        UnOp::I32WrapI64 => MaskContext::Modular,
+        _ => MaskContext::Masked,
+    }
+}
+
+/// Whether `e`'s own result mask may be skipped when its consumer is modular: `e` must carry a mask of its own, and the value it exposes unmasked must provably stay in `[-limit, limit)`.
+/// `limit` is the backend's unboxed-integer bound (Ruby: `1 << 62`); the guard keeps elision strictly profitable by never exposing an intermediate the mask would have kept out of bignum arithmetic.
+pub fn elides_mask(e: &Expr, limit: i128) -> bool {
+    match raw_bound(e, limit) {
+        Some(raw) => raw.within(limit),
+        None => false,
+    }
+}
+
+/// Everything the interval analysis tracks is clamped to this magnitude: far beyond any elision limit, and small enough that saturating i128 arithmetic on two clamped bounds cannot wrap.
+const CEILING: i128 = 1 << 100;
+
+#[derive(Clone, Copy, Debug)]
+struct Bound {
+    lo: i128,
+    hi: i128,
+}
+
+impl Bound {
+    fn new(lo: i128, hi: i128) -> Bound {
+        Bound {
+            lo: lo.clamp(-CEILING, CEILING),
+            hi: hi.clamp(-CEILING, CEILING),
+        }
+    }
+
+    fn exact(v: i128) -> Bound {
+        Bound::new(v, v)
+    }
+
+    /// The full masked range of a `bits`-wide value: `[0, 2^bits)`.
+    fn masked(bits: u32) -> Bound {
+        Bound {
+            lo: 0,
+            hi: (1i128 << bits) - 1,
+        }
+    }
+
+    fn union(self, o: Bound) -> Bound {
+        Bound {
+            lo: self.lo.min(o.lo),
+            hi: self.hi.max(o.hi),
+        }
+    }
+
+    fn within(self, limit: i128) -> bool {
+        self.lo >= -limit && self.hi < limit
+    }
+
+    fn is_masked_range(self, bits: u32) -> bool {
+        self.lo >= 0 && self.hi < (1i128 << bits)
+    }
+}
+
+/// The interval of the value `e`'s rendering takes when consumed in `ctx`, under the elision policy of [`elides_mask`] with the same `limit`.
+/// `bits` is the width of `e`'s integer type, which the caller knows from the operation consuming it.
+fn bound(e: &Expr, bits: u32, ctx: MaskContext, limit: i128) -> Bound {
+    if let Some(raw) = raw_bound(e, limit) {
+        if ctx == MaskContext::Modular && raw.within(limit) {
+            return raw;
+        }
+        // The kept mask reduces modulo 2^bits: exactly `raw` when no value in it wraps.
+        return if raw.is_masked_range(bits) {
+            raw
+        } else {
+            Bound::masked(bits)
+        };
+    }
+    use MaskContext::Masked;
+    match e {
+        Expr::I32Const(v) => Bound::exact(i128::from(*v)),
+        Expr::I64Const(v) => Bound::exact(i128::from(*v)),
+        Expr::Temp(_) | Expr::LocalGet(_) | Expr::GlobalGet(_) => Bound::masked(bits),
+        // wasm's memory is capped at 65536 pages.
+        Expr::MemorySize => Bound::new(0, 1 << 16),
+        Expr::Load { op, .. } => load_bound(*op, bits),
+        Expr::Select { then, els, .. } => {
+            bound(then, bits, Masked, limit).union(bound(els, bits, Masked, limit))
+        }
+        Expr::Un(op, a) => match op {
+            UnOp::I32Eqz | UnOp::I64Eqz => Bound::new(0, 1),
+            UnOp::I32Clz | UnOp::I32Ctz | UnOp::I32Popcnt => Bound::new(0, 32),
+            UnOp::I64Clz | UnOp::I64Ctz | UnOp::I64Popcnt => Bound::new(0, 64),
+            UnOp::I64ExtendI32U => bound(a, 32, Masked, limit),
+            _ => Bound::masked(bits),
+        },
+        Expr::Bin(op, a, b) => {
+            use BinOp::*;
+            if crate::comparison(*op).is_some() {
+                return Bound::new(0, 1);
+            }
+            match op {
+                I32And | I64And | I32Or | I64Or | I32Xor | I64Xor => bitwise_bound(
+                    matches!(op, I32And | I64And),
+                    bound(a, bits, ctx, limit),
+                    bound(b, bits, ctx, limit),
+                ),
+                I32ShrU | I64ShrU => {
+                    let ba = bound(a, bits, Masked, limit);
+                    let (cmin, cmax) = count_bound(b, bits);
+                    Bound::new(
+                        (ba.lo >> cmin).min(ba.lo >> cmax),
+                        (ba.hi >> cmin).max(ba.hi >> cmax),
+                    )
+                }
+                _ => Bound::masked(bits),
+            }
+        }
+        Expr::F32Const(_) | Expr::F64Const(_) => Bound::masked(bits),
+    }
+}
+
+/// The interval of `e`'s value rendered without its own result mask, or `None` when `e` carries no mask of its own.
+fn raw_bound(e: &Expr, limit: i128) -> Option<Bound> {
+    use BinOp::*;
+    use MaskContext::Modular;
+    match e {
+        Expr::Un(UnOp::I32WrapI64, a) => Some(bound(a, 64, Modular, limit)),
+        Expr::Bin(op, a, b) => {
+            let bits = match op {
+                I32Add | I32Sub | I32Mul | I32Shl | I32ShrS => 32,
+                I64Add | I64Sub | I64Mul | I64Shl | I64ShrS => 64,
+                _ => return None,
+            };
+            let ba = bound(a, bits, bin_operand_context(*op, 0, Modular), limit);
+            let bb = |b: &Expr| bound(b, bits, Modular, limit);
+            Some(match op {
+                I32Add | I64Add => {
+                    let bb = bb(b);
+                    Bound::new(ba.lo.saturating_add(bb.lo), ba.hi.saturating_add(bb.hi))
+                }
+                I32Sub | I64Sub => {
+                    let bb = bb(b);
+                    Bound::new(ba.lo.saturating_sub(bb.hi), ba.hi.saturating_sub(bb.lo))
+                }
+                I32Mul | I64Mul => {
+                    let bb = bb(b);
+                    let c = [
+                        ba.lo.saturating_mul(bb.lo),
+                        ba.lo.saturating_mul(bb.hi),
+                        ba.hi.saturating_mul(bb.lo),
+                        ba.hi.saturating_mul(bb.hi),
+                    ];
+                    Bound::new(*c.iter().min().unwrap(), *c.iter().max().unwrap())
+                }
+                I32Shl | I64Shl => {
+                    let (cmin, cmax) = count_bound(b, bits);
+                    let shl = |v: i128, c: u32| v.saturating_mul(1i128 << c);
+                    let c = [
+                        shl(ba.lo, cmin),
+                        shl(ba.lo, cmax),
+                        shl(ba.hi, cmin),
+                        shl(ba.hi, cmax),
+                    ];
+                    Bound::new(*c.iter().min().unwrap(), *c.iter().max().unwrap())
+                }
+                I32ShrS | I64ShrS => {
+                    let s = signed_view(ba, bits);
+                    let (cmin, cmax) = count_bound(b, bits);
+                    let c = [s.lo >> cmin, s.lo >> cmax, s.hi >> cmin, s.hi >> cmax];
+                    Bound::new(*c.iter().min().unwrap(), *c.iter().max().unwrap())
+                }
+                _ => unreachable!("filtered by the bits match above"),
+            })
+        }
+        _ => None,
+    }
+}
+
+/// The values a shift count takes after its semantic `& (bits - 1)`: exact for a constant, the full `0..bits` otherwise.
+fn count_bound(b: &Expr, bits: u32) -> (u32, u32) {
+    match b {
+        Expr::I32Const(v) => {
+            let c = v & (bits - 1);
+            (c, c)
+        }
+        Expr::I64Const(v) => {
+            let c = (*v & u64::from(bits - 1)) as u32;
+            (c, c)
+        }
+        _ => (0, bits - 1),
+    }
+}
+
+/// The interval of the signed view (`s32`/`s64`) of a masked interval: the identity below the sign bit, the full signed range once the interval reaches it.
+fn signed_view(a: Bound, bits: u32) -> Bound {
+    let half = 1i128 << (bits - 1);
+    if a.lo >= 0 && a.hi < half {
+        a
+    } else {
+        Bound::new(-half, half - 1)
+    }
+}
+
+/// Bitwise `&`, `|`, `^` on two's-complement integers.
+/// `x & y` with a non-negative `y` never sets a bit `y` lacks, whatever `x`'s sign: `0 <= x & y <= y`.
+/// `|` and `^` of non-negative operands stay inside the operands' bit envelope; with a possibly negative operand, anything representable in the covering two's-complement width can come out.
+fn bitwise_bound(is_and: bool, a: Bound, b: Bound) -> Bound {
+    if is_and {
+        match (a.lo >= 0, b.lo >= 0) {
+            (true, true) => return Bound::new(0, a.hi.min(b.hi)),
+            (true, false) => return Bound::new(0, a.hi),
+            (false, true) => return Bound::new(0, b.hi),
+            (false, false) => {}
+        }
+    } else if a.lo >= 0 && b.lo >= 0 {
+        let h = a.hi.max(b.hi);
+        let bits = 128 - (h as u128).leading_zeros();
+        return if bits >= 100 {
+            Bound::new(0, CEILING)
+        } else {
+            Bound::new(0, (1i128 << bits) - 1)
+        };
+    }
+    let mut p = 1i128;
+    while p < CEILING && (a.lo < -p || a.hi >= p || b.lo < -p || b.hi >= p) {
+        p <<= 1;
+    }
+    Bound::new(-p, p - 1)
+}
+
+/// The masked range a load produces, exact for the zero-extending narrow loads; a sign-extending load is stored re-masked, so it spans the full destination width.
+fn load_bound(op: LoadOp, bits: u32) -> Bound {
+    use LoadOp::*;
+    match op {
+        I32Load8U | I64Load8U => Bound::new(0, 0xff),
+        I32Load16U | I64Load16U => Bound::new(0, 0xffff),
+        I64Load32U => Bound::new(0, 0xffff_ffff),
+        I32Load => Bound::masked(32),
+        I64Load => Bound::masked(64),
+        _ => Bound::masked(bits),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const LIMIT: i128 = 1 << 62;
+
+    fn local(idx: u32) -> Expr {
+        Expr::LocalGet(idx)
+    }
+
+    fn bin(op: BinOp, a: Expr, b: Expr) -> Expr {
+        Expr::Bin(op, Box::new(a), Box::new(b))
+    }
+
+    fn load8u() -> Expr {
+        Expr::Load {
+            op: LoadOp::I64Load8U,
+            addr: Box::new(local(0)),
+            offset: 0,
+        }
+    }
+
+    #[test]
+    fn i32_add_and_sub_of_full_range_operands_elide() {
+        assert!(elides_mask(&bin(BinOp::I32Add, local(0), local(1)), LIMIT));
+        assert!(elides_mask(&bin(BinOp::I32Sub, local(0), local(1)), LIMIT));
+    }
+
+    #[test]
+    fn i32_mul_of_full_range_operands_keeps_its_mask() {
+        // (2^32 - 1)^2 exceeds the Fixnum limit.
+        assert!(!elides_mask(&bin(BinOp::I32Mul, local(0), local(1)), LIMIT));
+    }
+
+    #[test]
+    fn i32_mul_of_narrowed_operands_elides() {
+        let byte = |idx| bin(BinOp::I32And, local(idx), Expr::I32Const(0xff));
+        assert!(elides_mask(&bin(BinOp::I32Mul, byte(0), byte(1)), LIMIT));
+    }
+
+    #[test]
+    fn and_bounds_by_a_non_negative_operand_alone() {
+        // The unmasked difference can be negative, but `& 0xff` still lands in 0..255, so the product elides.
+        let byte_of_diff = |i, j| {
+            bin(
+                BinOp::I32And,
+                bin(BinOp::I32Sub, local(i), local(j)),
+                Expr::I32Const(0xff),
+            )
+        };
+        assert!(elides_mask(
+            &bin(BinOp::I32Mul, byte_of_diff(0, 1), byte_of_diff(2, 3)),
+            LIMIT
+        ));
+    }
+
+    #[test]
+    fn i32_shr_s_always_elides() {
+        // The raw signed value is within [-2^31, 2^31), well inside the limit.
+        assert!(elides_mask(&bin(BinOp::I32ShrS, local(0), local(1)), LIMIT));
+    }
+
+    #[test]
+    fn shl_elides_only_under_a_small_count_or_operand() {
+        // Full range shifted by an unknown count reaches 2^63.
+        assert!(!elides_mask(&bin(BinOp::I32Shl, local(0), local(1)), LIMIT));
+        // An exact small count keeps the raw value within the limit.
+        assert!(elides_mask(
+            &bin(BinOp::I32Shl, local(0), Expr::I32Const(4)),
+            LIMIT
+        ));
+    }
+
+    #[test]
+    fn wrap_elides_only_for_a_narrow_i64() {
+        let wrap = |e: Expr| Expr::Un(UnOp::I32WrapI64, Box::new(e));
+        // A full-range i64 exceeds the limit, so the wrap's mask stays.
+        assert!(!elides_mask(&wrap(local(0)), LIMIT));
+        assert!(elides_mask(&wrap(load8u()), LIMIT));
+        // The high half extracted by `>> 32` is bounded by 2^32.
+        assert!(elides_mask(
+            &wrap(bin(BinOp::I64ShrU, local(0), Expr::I64Const(32))),
+            LIMIT
+        ));
+    }
+
+    #[test]
+    fn i64_arithmetic_elides_only_with_provably_narrow_operands() {
+        assert!(!elides_mask(&bin(BinOp::I64Add, local(0), local(1)), LIMIT));
+        assert!(!elides_mask(
+            &bin(BinOp::I64ShrS, local(0), local(1)),
+            LIMIT
+        ));
+        assert!(elides_mask(
+            &bin(BinOp::I64Add, load8u(), Expr::I64Const(1)),
+            LIMIT
+        ));
+    }
+
+    #[test]
+    fn nested_elision_bounds_compose() {
+        // (l0 + l1) + l2 unmasked is below 3 * 2^32.
+        let inner = bin(BinOp::I32Add, local(0), local(1));
+        assert!(elides_mask(&bin(BinOp::I32Add, inner, local(2)), LIMIT));
+        // ((l0 + l1) * l2) unmasked reaches 2^65: the mul keeps its mask even though its operand elides.
+        let inner = bin(BinOp::I32Add, local(0), local(1));
+        assert!(!elides_mask(&bin(BinOp::I32Mul, inner, local(2)), LIMIT));
+    }
+
+    #[test]
+    fn operand_contexts_follow_the_table() {
+        use MaskContext::*;
+        assert_eq!(bin_operand_context(BinOp::I32Add, 0, Masked), Modular);
+        assert_eq!(bin_operand_context(BinOp::I32ShrU, 0, Modular), Masked);
+        assert_eq!(bin_operand_context(BinOp::I32ShrU, 1, Masked), Modular);
+        assert_eq!(bin_operand_context(BinOp::I32And, 0, Modular), Modular);
+        assert_eq!(bin_operand_context(BinOp::I32And, 0, Masked), Masked);
+        assert_eq!(bin_operand_context(BinOp::I32DivU, 0, Modular), Masked);
+        assert_eq!(un_operand_context(UnOp::I32WrapI64), Modular);
+        assert_eq!(un_operand_context(UnOp::I64ExtendI32U), Masked);
+    }
+}


### PR DESCRIPTION
Closes #219, stage 1 of #164.

A masked value feeding a wrapping add/sub/mul, a bitwise operator, a shift count, or the wrap is reduced again by the consumer's own mask, so its own mask buys nothing.
This threads a consumption context (masked or modular) through the Ruby backend's expression rendering, following the boolean-context precedent, and skips `& 0xffffffff` / `Rt.m64` where the consumer is modular.
Elision is guarded by a bottom-up interval bound over the IR expression so no exposed intermediate can leave the Fixnum range: elision never introduces an integer allocation, only removes work.
The consumption table and the bound analysis live in `dewasm_backend::masking` so the other masked-unsigned backends can adopt them against their own limits; the invariant change (masked at observation points instead of always masked) and the i64 bound judgement are recorded in decision 71.

Measured on sqlite3-shell (standalone Ruby, MRI 4.0.4):

| metric | before | after | delta |
| --- | --- | --- | --- |
| file size | 7,937,554 B | 7,868,630 B | −0.87% |
| ISeq instructions | 1,370,047 | 1,360,259 | −0.71% |
| ISeq memsize | 47,605,992 B | 47,212,640 B | −0.83% |
| `& 0xffffffff` sites | 36,622 | 31,800 | −13.2% |
| `m64(` sites | 2,443 | 2,371 | −2.9% |

Verified with `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, and `cargo test -p dewasm-backend-ruby --features slow_test` (spec 257/257, wasi 72/72, slow app cases included).
Codegen-shape tests pin an elided site, a site kept by a non-modular consumer, and a site kept by the bound guard.