### PR TITLE
Elide masks on local and temp stores via a per-function dataflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ Each rule is stated here in full; the cited decision holds its rationale and rej
 - The spec testsuite binds (decision 3). Correctness of generated code outranks its readability; readability improvements go into optional passes, never into semantics-relevant lowering.
 - Where the WASI spec is silent, copy wasmtime's behavior as measured on both CI hosts (decision 49).
 - Numeric representation conventions (masked-unsigned integers, f32 re-rounding, NaN bit paths) are shared across backends (decision 2).
-  A backend skips a result mask only inside one expression tree, through the shared consumption-context and bound analysis in `dewasm_backend::masking`, never by its own reasoning (decision 71).
+  A backend skips a result mask only through the shared analyses in `dewasm_backend::masking`, never by its own reasoning: the consumption-context and bound analysis inside one expression tree (decision 71), and the per-function variable dataflow for unmasked local and temp stores (decision 73).
 - Each backend's lowering shapes are fixed; follow them rather than restructuring in passing. They are recorded per backend: Ruby decisions 4/42-44/58/60/65/72, Bash decisions 5/11-13/34/35/51/52, Python decision 28, Go decision 29, Java decision 30, Perl decision 55.
 - Runtime code lives as per-method units under `runtime/<lang>/units/` with `# requires:` headers, referenced as `Rt` (decision 6); keep the headers in sync when editing a unit (the units lint enforces most of it).
 - `Embedded` linkage isolates the runtime per artifact so two artifacts coexist in one namespace (decision 62); `embedded_coexist_e2e!` is the check, and a backend that does not invoke it is unfinished, not incapable.

--- a/agents/decisions/71-mask-elision-modular-consumers.md
+++ b/agents/decisions/71-mask-elision-modular-consumers.md
@@ -3,7 +3,8 @@
 Status: **Accepted, 2026-08-15.**
 Landed as the shared analysis in `crates/dewasm-backend/src/masking.rs` and its application in the Ruby backend's expression rendering (`crates/dewasm-backend-ruby/src/lib.rs`).
 The other masked-unsigned backends (Python, Perl, Bash) still mask every site; each can adopt the same analysis against its own unboxed-integer limit.
-This is stage 1 of issue #164: elision within one expression tree only, no cross-statement analysis.
+This is stage 1 of issue #164: elision within one expression tree only.
+[Decision 73](73-mask-elision-variable-dataflow.md) extends it across statements, letting a local or temp store unmasked when a per-function dataflow proves every read modular.
 
 ## Context
 

--- a/agents/decisions/73-mask-elision-variable-dataflow.md
+++ b/agents/decisions/73-mask-elision-variable-dataflow.md
@@ -1,0 +1,58 @@
+# Decision 73: Mask Elision Across Statements via a Per-Function Variable Dataflow
+
+Status: **Accepted, 2026-08-15.**
+Landed as `Elision` in `crates/dewasm-backend/src/masking.rs` and its application to local and temp stores in the Ruby backend (`crates/dewasm-backend-ruby/src/lib.rs`).
+Refines [decision 71](71-mask-elision-modular-consumers.md), whose within-tree elision this extends across statements; the other masked-unsigned backends can adopt it the same way they can adopt decision 71.
+This is stage 2 of issue #164.
+
+## Context
+
+Decision 71 loosened the storage invariant to "masked at its observation points" but kept every store an observation point: a local or temp assignment always masks, because proving that every future read tolerates an unmasked value needs a whole-function analysis.
+Store masks are the largest group of what remains (a folded expression tree carries one final mask at its store; a hot loop re-masks its counter every iteration), so the within-tree stage left them all in place: 31.8k of the original 36.6k mask sites in the converted `sqlite3-shell`.
+
+## Decision
+
+**A local or temp may store an unmasked value when a per-function dataflow proves every read of it modular and its value interval convergent within the backend's unboxed-integer limit.**
+The analysis lives beside the consumption table in `dewasm_backend::masking` because it follows from the shared masked-unsigned convention (decision 2), not from any one language; only the limit and the emission are per backend.
+
+**Qualification: every read must be modular.**
+Reads are classified by the same consumption table emission threads through expression trees, from a `Masked` root at every observation statement (a comparison or condition, a division, a signed or unsigned view, an address, a call argument, a return, a memory store, a global set, a `Select` arm) and from a `Modular` root at a store whose destination itself qualifies.
+One refinement goes beyond the table: `&` with a constant operand observes only the bits that constant keeps, all inside the width because constants are stored masked, so its other operand is a modular read in any position (`x & 1` in a condition does not disqualify `x`); only the read classification uses this, emission contexts are unchanged.
+Any read the model does not cover disqualifies.
+This preserves decision 2's ABI by construction: function boundaries, helper calls, and globals only ever see masked values, and a parameter is defined by its caller at full masked width.
+The scan starts from every integer local and temp and only removes, so copies between variables (`BrTarget::Label`'s branch-result moves, a bare `local.get` on a store's right-hand side) resolve co-inductively: a copy is a modular read exactly while its destination still qualifies, and a copy cycle among survivors is sound because no survivor is ever observed exactly.
+
+**Intervals: a Kleene fixpoint with widening enforces the Fixnum guard of decision 71 across statements.**
+Each qualifying variable's interval is the join of its definitions' bounds: the decision 71 expression bound with qualifying variables read at their current intervals instead of full masked width, external definitions (call results, `memory.grow`, exception payloads) at full masked width, and the implicit definitions (a parameter at masked width, a declared local at its zero initializer).
+Iteration runs until a pass changes nothing, which certifies that every recorded interval contains all of its definitions' bounds; after three passes a still-growing interval is widened, first to its masked width and then past the limit.
+A variable whose interval ends outside `[-limit, limit)` is demoted to must-mask, and demotion reruns qualification, since the demoted variable's stores become masked observation roots again.
+The widening ladder is what decides loop-carried definitions: `l = l + 1` compounds, gets widened past the limit, and keeps its masks, while `l = (l + 1) & 255` re-narrows each iteration, settles, and elides both the store mask and the add's own mask.
+The masked-width rung exists so a definition whose bound is narrow on its own is widened to where a masked variable would live instead of being demoted outright.
+
+**Emission: only stores change.**
+A qualifying variable's assignments render their value in `Modular` context, so the root mask disappears under the decision 71 guard; every read is unchanged text, and the recorded intervals feed the same guard inside expression trees (a variable proven byte-narrow lets a product elide that masked-width operands would not).
+Under the uniform limit an i64 variable qualifies only if every definition is provably narrow, because full masked i64 width already exceeds the limit: the same conservatism decision 71 chose for i64, applied per variable.
+
+## Rejected alternatives
+
+- **Keep stores as observation points (decision 71 status quo).**
+  Store masks are the largest group of remaining sites (14.7k of the 31.8k on `sqlite3-shell` end a local or temp assignment) and include every loop-carried re-mask; the within-tree stage cannot reach them by design.
+- **A per-backend dataflow.**
+  Same reasoning as decision 71: qualification and intervals follow from the shared convention, only the limit and the emission differ, and duplication invites divergence.
+- **Pessimistic copy handling (a copy always disqualifies its source).**
+  Simpler than the optimistic removal fixpoint, but branch-result moves are exactly copies between temps, so block and loop results would almost never qualify.
+- **Qualification without the interval fixpoint.**
+  Congruence alone keeps it correct, but a loop-carried unmasked counter grows into guaranteed bignums: the same trade decision 71 rejected for expression trees, worse here because the value persists across iterations.
+- **Widening straight past the limit.**
+  Terminates just as fast but demotes every definition that converges slower than the pass budget, including the common `& mask` loop-carried shape the masked-width rung keeps.
+- **Extending the model to globals.**
+  A global is read by other functions and by the host boundary; proving all of those modular needs whole-module analysis for little gain, so globals stay observation points.
+
+## Consequences
+
+- On the converted `sqlite3-shell` (standalone Ruby), against the stage 1 tree: `& 0xffffffff` sites 31,800 to 31,603 (197 elided, 0.6%), `m64` calls 2,371 to 2,363, file size 7,868,630 to 7,866,029 bytes, ISeq instructions 1,360,259 to 1,359,849, ISeq memsize 47,212,640 to 47,196,232 bytes (same methodology as decision 71).
+- Coverage is small by design: in C-derived code most integers are eventually compared, used as an address, or passed across a boundary, and one such read disqualifies the whole variable.
+  What does clear are variables read purely as arithmetic and bitwise operands; wider coverage needs a finer-grained model (per definition-use region instead of per variable), left to a later stage with measurement.
+- The spec harness (decision 3) binds as always and passes for the Ruby backend under this lowering; `mod dataflow` in `masking.rs` pins qualification, disqualification, the `&`-constant refinement, and both loop-carried outcomes, and `mod masks` in the Ruby backend pins the emitted shapes.
+- The invariant of decision 71 tightens per variable: a qualifying variable is masked at none of its stores, and the soundness argument extends because all of its reads are modular consumers.
+- The analysis reruns per function at conversion time; its passes are bounded (qualification removes a variable per changing pass, widening caps interval changes), and converting `sqlite3-shell` measures 1.12 s to 1.25 s (debug build).

--- a/agents/decisions/README.md
+++ b/agents/decisions/README.md
@@ -92,6 +92,7 @@ An entry is numbered: `<N>-<slug>.md`, cited as "decision N".
 | 70 | [Shared Statement Traversal for IR Analyses](70-shared-statement-traversal.md) | Accepted |
 | 71 | [Mask Elision Inside One Expression Tree Under a Modular Consumer](71-mask-elision-modular-consumers.md) | Accepted |
 | 72 | [Ruby Backend Omits Dead Method-Level `__br` Clears](72-ruby-dead-br-clear-elision.md) | Accepted |
+| 73 | [Mask Elision Across Statements via a Per-Function Variable Dataflow](73-mask-elision-variable-dataflow.md) | Accepted |
 
 ## Adding a new decision
 

--- a/crates/dewasm-backend-ruby/src/lib.rs
+++ b/crates/dewasm-backend-ruby/src/lib.rs
@@ -24,7 +24,7 @@ use std::collections::{BTreeSet, HashSet};
 use std::sync::OnceLock;
 
 use anyhow::Result;
-use dewasm_backend::masking::{bin_operand_context, elides_mask, un_operand_context, MaskContext};
+use dewasm_backend::masking::{bin_operand_context, un_operand_context, Elision, MaskContext};
 use dewasm_backend::{
     check_module_support, hex_string, is_boolean, is_ident, is_wasi_module, load_method,
     local_runs, module_name_error, signed_view_rel_op, store_method, terminates, type_key,
@@ -180,6 +180,7 @@ fn generate_class_inner(
         frame_stack: RefCell::new(Vec::new()),
         flat: RefCell::new(None),
         dead_clears: RefCell::new(HashSet::new()),
+        elision: RefCell::new(Elision::none(FIXNUM_LIMIT)),
         boxed_globals,
         data_file: data_file.map(str::to_string),
         data_offsets,
@@ -514,6 +515,8 @@ struct Gen<'a> {
     flat: RefCell<Option<flat::Plan>>,
     /// Per-function labels whose method-body-level clear is dead, set by `function()`; see [`dead_clears`].
     dead_clears: RefCell<HashSet<u32>>,
+    /// Mask-elision dataflow for the function being emitted, set by `function()`: which locals and temps store unmasked, and the variable intervals the elision guard reads.
+    elision: RefCell<Elision>,
     /// Global indices that need the `Rt::Global` box: imported globals (index space `0..imported_globals.len()`) and every `ExportKind:: Global` target.
     /// Computed once in `generate_class_inner`.
     /// See the boundary criterion in the comment there.
@@ -927,6 +930,7 @@ impl<'a> Gen<'a> {
         *self.frames.borrow_mut() = flat::frames(&func.body, flat::BreakToBlockEnd::Available);
         self.frame_stack.borrow_mut().clear();
         let ty = &self.module.types[func.type_idx as usize];
+        *self.elision.borrow_mut() = Elision::analyze(&ty.params, func, FIXNUM_LIMIT);
         let params = (0..ty.params.len())
             .map(|i| format!("l{i}"))
             .collect::<Vec<_>>()
@@ -1004,6 +1008,7 @@ impl<'a> Gen<'a> {
                 }
             }
         });
+        *self.elision.borrow_mut() = Elision::none(FIXNUM_LIMIT);
     }
 
     /// Emit `stmts` into a state machine, splitting at each dissolved frame.
@@ -1090,10 +1095,16 @@ impl<'a> Gen<'a> {
     fn stmt(&self, w: &mut CodeWriter, stmt: &Stmt) {
         match stmt {
             Stmt::Assign { dst, expr } => {
-                w.line(format!("{} = {}", temp(*dst), self.expr_text(expr)));
+                let unmasked = self.elision.borrow().unmasked_temp(*dst);
+                w.line(format!(
+                    "{} = {}",
+                    temp(*dst),
+                    self.store_text(unmasked, expr)
+                ));
             }
             Stmt::LocalSet { idx, expr } => {
-                w.line(format!("l{idx} = {}", self.expr_text(expr)));
+                let unmasked = self.elision.borrow().unmasked_local(*idx);
+                w.line(format!("l{idx} = {}", self.store_text(unmasked, expr)));
             }
             Stmt::GlobalSet { idx, expr } => {
                 w.line(format!(
@@ -1468,9 +1479,24 @@ impl<'a> Gen<'a> {
         self.masked(expr).free()
     }
 
-    /// An expression whose exact stored value is observed (a store, an argument, an address, a comparison operand): every result mask is kept.
+    /// The right-hand side of a store: rendered modular when the dataflow proved every read of the destination modular, so the store needs no mask of its own.
+    fn store_text(&self, unmasked: bool, expr: &Expr) -> String {
+        let ctx = if unmasked {
+            MaskContext::Modular
+        } else {
+            MaskContext::Masked
+        };
+        self.expr(expr, ctx).free()
+    }
+
+    /// An expression whose exact stored value is observed (a store the dataflow did not clear, an argument, an address, a comparison operand): every result mask is kept.
     fn masked(&self, expr: &Expr) -> Rendered {
         self.expr(expr, MaskContext::Masked)
+    }
+
+    /// Whether `e`'s own result mask may be skipped here: the consumer must be modular and the shared bound guard must hold, with the current function's variable intervals supplied (see [`FIXNUM_LIMIT`]).
+    fn elide(&self, ctx: MaskContext, e: &Expr) -> bool {
+        ctx == MaskContext::Modular && self.elision.borrow().elides_mask(e)
     }
 
     /// `ctx` is the consumer's view of the value: under a `Modular` consumer a site's own result mask is skipped when the shared bound guard allows it (see [`FIXNUM_LIMIT`]).
@@ -1505,12 +1531,12 @@ impl<'a> Gen<'a> {
             ),
             Expr::Un(op, a) => {
                 let a = self.expr(a, un_operand_context(*op));
-                self.un(*op, a, elide(ctx, expr))
+                self.un(*op, a, self.elide(ctx, expr))
             }
             Expr::Bin(op, a, b) => {
                 let ra = self.expr(a, bin_operand_context(*op, 0, ctx));
                 let rb = self.expr(b, bin_operand_context(*op, 1, ctx));
-                self.bin(*op, ra, rb, elide(ctx, expr))
+                self.bin(*op, ra, rb, self.elide(ctx, expr))
             }
             Expr::Load { op, addr, offset } => Rendered::atom(format!(
                 "@m.{}({})",
@@ -1884,11 +1910,6 @@ fn mask32_unless(elide: bool, a: Rendered) -> Rendered {
 /// 64-bit MRI keeps integers in `-2**62 .. 2**62 - 1` unboxed; a skipped mask must never expose an intermediate outside that range, or the elision would trade a cheap mask for bignum arithmetic.
 const FIXNUM_LIMIT: i128 = 1 << 62;
 
-/// Whether `e`'s own result mask may be skipped here: the consumer must be modular and the shared bound guard must hold.
-fn elide(ctx: MaskContext, e: &Expr) -> bool {
-    ctx == MaskContext::Modular && elides_mask(e, FIXNUM_LIMIT)
-}
-
 /// A shift count, masked to the width wasm defines it modulo.
 fn shift_count(b: Rendered, mask: u32) -> Rendered {
     infix(b, "&", Rendered::atom(mask.to_string()), BIT_AND)
@@ -2171,7 +2192,7 @@ mod masks {
             &i32_expr("(i32.lt_u (i32.add (local.get 0) (local.get 1)) (local.get 1))"),
             "l0 = l0 + l1 & 0xffffffff < l1 ? 1 : 0",
         );
-        // And storage: the statement position itself is an observation point, so the outer mask always stays.
+        // And a store to a local the dataflow cannot clear (the helper returns it directly): the outer mask stays.
         assert_line(
             &i32_expr("(i32.add (local.get 0) (local.get 1))"),
             "l0 = l0 + l1 & 0xffffffff",
@@ -2200,6 +2221,55 @@ mod masks {
             ),
             "l1 = (l0 & 0xffffffff) + 7 & 0xffffffff",
         );
+    }
+
+    #[test]
+    fn dataflow_cleared_local_stores_unmasked() {
+        // Every read of l2 is a modular operand, so its store renders in modular context and the store mask disappears; the read sites are unchanged text.
+        let src = body(
+            "(module (func (export \"f\") (param i32 i32) (result i32) (local i32) \
+             (local.set 2 (i32.add (local.get 0) (i32.const 5))) \
+             (i32.add (local.get 2) (local.get 1))))",
+        );
+        assert_line(&src, "l2 = l0 + 5");
+        assert_line(&src, "return l2 + l1 & 0xffffffff");
+    }
+
+    #[test]
+    fn observed_local_keeps_the_store_mask() {
+        // l2 is returned directly, an exact observation, so its store keeps the mask.
+        let src = body(
+            "(module (func (export \"f\") (param i32) (result i32) (local i32) \
+             (local.set 1 (i32.add (local.get 0) (i32.const 5))) \
+             (local.get 1)))",
+        );
+        assert_line(&src, "l1 = l0 + 5 & 0xffffffff");
+    }
+
+    #[test]
+    fn compounding_loop_carried_local_keeps_the_store_mask() {
+        // l1 = l1 + 1 every iteration: unmasked, the interval would grow past the Fixnum limit, so the dataflow demotes it.
+        let src = body(
+            "(module (func (export \"f\") (param i32) (result i32) (local i32) \
+             (loop $l \
+               (local.set 1 (i32.add (local.get 1) (i32.const 1))) \
+               (br_if $l (local.get 0))) \
+             (i32.add (local.get 1) (local.get 0))))",
+        );
+        assert_line(&src, "l1 = l1 + 1 & 0xffffffff");
+    }
+
+    #[test]
+    fn converging_loop_carried_local_stores_unmasked() {
+        // The `& 255` re-narrows every iteration, so the interval settles and both the store mask and the add's own mask go.
+        let src = body(
+            "(module (func (export \"f\") (param i32) (result i32) (local i32) \
+             (loop $l \
+               (local.set 1 (i32.and (i32.add (local.get 1) (i32.const 1)) (i32.const 255))) \
+               (br_if $l (local.get 0))) \
+             (i32.add (local.get 1) (local.get 0))))",
+        );
+        assert_line(&src, "l1 = l1 + 1 & 255");
     }
 
     #[test]

--- a/crates/dewasm-backend/src/masking.rs
+++ b/crates/dewasm-backend/src/masking.rs
@@ -1,12 +1,15 @@
-//! Mask elision inside one expression tree, for the backends that store integers masked-unsigned.
+//! Mask elision for the backends that store integers masked-unsigned.
 //!
 //! The stored representation masks every integer to its width, and each wrapping operation re-masks its result.
-//! Inside a single [`Expr`] tree that is often double work: a consumer that reads its operand only modulo 2^32 or 2^64 (a wrapping add's operand, a shift count) cannot observe the high bits its own mask throws away.
-//! [`MaskContext`] names the two consumption contexts, [`bin_operand_context`] and [`un_operand_context`] are the table of which operands an operation reads modularly, and [`elides_mask`] is the guard: a backend may skip a site's own result mask exactly when the consumer is modular and the interval bound proves the exposed value stays within the backend's unboxed-integer range.
+//! That is often double work: a consumer that reads its operand only modulo 2^32 or 2^64 (a wrapping add's operand, a shift count) cannot observe the high bits its own mask throws away.
+//! [`MaskContext`] names the two consumption contexts, [`bin_operand_context`] and [`un_operand_context`] are the table of which operands an operation reads modularly, and the guard is an interval bound: a mask is skipped only when the value it would expose provably stays within the backend's unboxed-integer range.
+//! [`elides_mask`] applies this inside one expression tree; [`Elision`] extends it across statements with a per-function dataflow that lets a local or temp store an unmasked value when every read of it is modular.
 //!
-//! Soundness rests on the targets' integers being arbitrary-precision two's complement (Ruby, Python, Perl): an unmasked intermediate is congruent to the masked value modulo 2^w, every modular consumer preserves that congruence (a bitwise operator reads a negative operand as its infinite two's-complement form, so `(x - y) & 0xffffffff` is the correct wrap of a negative difference), and the first non-modular consumer sits behind a kept mask, which reduces the value back to the stored representation.
+//! Soundness rests on the targets' integers being arbitrary-precision two's complement (Ruby, Python, Perl): an unmasked value is congruent to the masked value modulo 2^w, every modular consumer preserves that congruence (a bitwise operator reads a negative operand as its infinite two's-complement form, so `(x - y) & 0xffffffff` is the correct wrap of a negative difference), and every non-modular consumer either sits behind a kept mask or reads a variable all of whose stores are masked.
 
-use dewasm_core::ir::{BinOp, Expr, LoadOp, UnOp};
+use std::collections::BTreeMap;
+
+use dewasm_core::ir::{BinOp, BrTarget, Expr, Func, LoadOp, Stmt, Temp, UnOp, ValType};
 
 /// How a consumer reads an integer operand: `Masked` when it observes the exact stored value, `Modular` when it reads only the value's congruence class modulo the type width, so an unmasked operand serves.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -48,19 +51,15 @@ pub fn un_operand_context(op: UnOp) -> MaskContext {
     }
 }
 
-/// Whether `e`'s own result mask may be skipped when its consumer is modular: `e` must carry a mask of its own, and the value it exposes unmasked must provably stay in `[-limit, limit)`.
-/// `limit` is the backend's unboxed-integer bound (Ruby: `1 << 62`); the guard keeps elision strictly profitable by never exposing an intermediate the mask would have kept out of bignum arithmetic.
+/// [`Elision::elides_mask`] with no variables tracked: every local and temp read counts as its full masked width, so the guard holds only from the expression tree itself.
 pub fn elides_mask(e: &Expr, limit: i128) -> bool {
-    match raw_bound(e, limit) {
-        Some(raw) => raw.within(limit),
-        None => false,
-    }
+    Elision::none(limit).elides_mask(e)
 }
 
 /// Everything the interval analysis tracks is clamped to this magnitude: far beyond any elision limit, and small enough that saturating i128 arithmetic on two clamped bounds cannot wrap.
 const CEILING: i128 = 1 << 100;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 struct Bound {
     lo: i128,
     hi: i128,
@@ -102,118 +101,532 @@ impl Bound {
     }
 }
 
-/// The interval of the value `e`'s rendering takes when consumed in `ctx`, under the elision policy of [`elides_mask`] with the same `limit`.
-/// `bits` is the width of `e`'s integer type, which the caller knows from the operation consuming it.
-fn bound(e: &Expr, bits: u32, ctx: MaskContext, limit: i128) -> Bound {
-    if let Some(raw) = raw_bound(e, limit) {
-        if ctx == MaskContext::Modular && raw.within(limit) {
-            return raw;
+/// Which of one function's locals and temps may store an unmasked value, each with the interval its stored values stay in.
+///
+/// A variable qualifies when the analysis proves two things.
+/// Every read of it is modular: an operand position the consumption table clears, or a copy into another qualifying variable.
+/// A comparison, a division, a signed or unsigned view, an address, a call argument, a return, a store, a global set, or any position the model does not cover disqualifies, which keeps the function boundary (decision 2's ABI) and every helper call fully masked; a function parameter is defined by the caller at full masked width.
+/// And its interval converges within `limit`: each definition's bound (the expression bound with qualifying variables read at their current intervals, an external definition such as a call result at full masked width) is joined to a fixpoint, so a loop-carried definition whose unmasked updates compound past the limit is demoted and keeps its masks.
+pub struct Elision {
+    limit: i128,
+    locals: BTreeMap<u32, Bound>,
+    temps: BTreeMap<Temp, Bound>,
+}
+
+impl Elision {
+    /// The empty analysis: no variable is tracked, so only within-tree elision applies.
+    pub fn none(limit: i128) -> Elision {
+        Elision {
+            limit,
+            locals: BTreeMap::new(),
+            temps: BTreeMap::new(),
         }
-        // The kept mask reduces modulo 2^bits: exactly `raw` when no value in it wraps.
-        return if raw.is_masked_range(bits) {
-            raw
-        } else {
-            Bound::masked(bits)
-        };
     }
-    use MaskContext::Masked;
-    match e {
-        Expr::I32Const(v) => Bound::exact(i128::from(*v)),
-        Expr::I64Const(v) => Bound::exact(i128::from(*v)),
-        Expr::Temp(_) | Expr::LocalGet(_) | Expr::GlobalGet(_) => Bound::masked(bits),
-        // wasm's memory is capped at 65536 pages.
-        Expr::MemorySize => Bound::new(0, 1 << 16),
-        Expr::Load { op, .. } => load_bound(*op, bits),
-        Expr::Select { then, els, .. } => {
-            bound(then, bits, Masked, limit).union(bound(els, bits, Masked, limit))
-        }
-        Expr::Un(op, a) => match op {
-            UnOp::I32Eqz | UnOp::I64Eqz => Bound::new(0, 1),
-            UnOp::I32Clz | UnOp::I32Ctz | UnOp::I32Popcnt => Bound::new(0, 32),
-            UnOp::I64Clz | UnOp::I64Ctz | UnOp::I64Popcnt => Bound::new(0, 64),
-            UnOp::I64ExtendI32U => bound(a, 32, Masked, limit),
-            _ => Bound::masked(bits),
-        },
-        Expr::Bin(op, a, b) => {
-            use BinOp::*;
-            if crate::comparison(*op).is_some() {
-                return Bound::new(0, 1);
+
+    /// Run the dataflow over `func` (`params` are the function's parameter types, indexed below its declared locals).
+    pub fn analyze(params: &[ValType], func: &Func, limit: i128) -> Elision {
+        let mut el = Elision::none(limit);
+        for (i, ty) in params.iter().chain(&func.locals).enumerate() {
+            if int_bits(*ty).is_some() {
+                el.locals.insert(i as u32, Bound::exact(0));
             }
-            match op {
-                I32And | I64And | I32Or | I64Or | I32Xor | I64Xor => bitwise_bound(
-                    matches!(op, I32And | I64And),
-                    bound(a, bits, ctx, limit),
-                    bound(b, bits, ctx, limit),
-                ),
-                I32ShrU | I64ShrU => {
-                    let ba = bound(a, bits, Masked, limit);
-                    let (cmin, cmax) = count_bound(b, bits);
-                    Bound::new(
-                        (ba.lo >> cmin).min(ba.lo >> cmax),
-                        (ba.hi >> cmin).max(ba.hi >> cmax),
-                    )
-                }
+        }
+        for t in &func.temps {
+            if int_bits(t.ty).is_some() {
+                el.temps.insert(*t, Bound::exact(0));
+            }
+        }
+        // A demotion turns a variable's stores back into masked observation roots, which can disqualify further variables, so both halves rerun until neither changes anything.
+        loop {
+            qualify(&mut el, func);
+            if solve(&mut el, params, func) == 0 {
+                break;
+            }
+        }
+        el
+    }
+
+    /// Whether stores to local `idx` may render their value in modular context, with no store mask of their own.
+    pub fn unmasked_local(&self, idx: u32) -> bool {
+        self.locals.contains_key(&idx)
+    }
+
+    /// The [`Elision::unmasked_local`] counterpart for temps.
+    pub fn unmasked_temp(&self, t: Temp) -> bool {
+        self.temps.contains_key(&t)
+    }
+
+    /// Whether `e`'s own result mask may be skipped when its consumer is modular: `e` must carry a mask of its own, and the value it exposes unmasked must provably stay in `[-limit, limit)`, with tracked variables read at their analyzed intervals.
+    /// `limit` is the backend's unboxed-integer bound (Ruby: `1 << 62`); the guard keeps elision strictly profitable by never exposing an intermediate the mask would have kept out of bignum arithmetic.
+    pub fn elides_mask(&self, e: &Expr) -> bool {
+        match self.raw_bound(e) {
+            Some(raw) => raw.within(self.limit),
+            None => false,
+        }
+    }
+
+    fn member(&self, var: Var) -> bool {
+        match var {
+            Var::Local(i) => self.locals.contains_key(&i),
+            Var::Temp(t) => self.temps.contains_key(&t),
+        }
+    }
+
+    /// Join a definition's bound into `var`'s interval, reporting whether it changed.
+    /// From pass [`WIDEN_AFTER`] on, a still-changing interval is widened, to its masked width first and past the limit after that: growth too slow to wait out (a loop counter gaining 1 per pass) ends in a bounded number of steps, while a definition whose bound is narrow on its own (a bitwise `&`) still settles at the masked width instead of being demoted.
+    fn join(&mut self, var: Var, b: Bound, bits: u32, pass: usize) -> bool {
+        let cur = match var {
+            Var::Local(i) => self.locals.get_mut(&i),
+            Var::Temp(t) => self.temps.get_mut(&t),
+        };
+        let Some(cur) = cur else { return false };
+        let mut next = cur.union(b);
+        if next == *cur {
+            return false;
+        }
+        if pass >= WIDEN_AFTER {
+            next = if cur.lo <= 0 && cur.hi >= (1i128 << bits) - 1 {
+                Bound::new(-CEILING, CEILING)
+            } else {
+                next.union(Bound::masked(bits))
+            };
+        }
+        *cur = next;
+        true
+    }
+
+    /// The interval of the value `e`'s rendering takes when consumed in `ctx`, under the elision policy of [`Elision::elides_mask`].
+    /// `bits` is the width of `e`'s integer type, which the caller knows from the operation consuming it.
+    fn bound(&self, e: &Expr, bits: u32, ctx: MaskContext) -> Bound {
+        if let Some(raw) = self.raw_bound(e) {
+            if ctx == MaskContext::Modular && raw.within(self.limit) {
+                return raw;
+            }
+            // The kept mask reduces modulo 2^bits: exactly `raw` when no value in it wraps.
+            return if raw.is_masked_range(bits) {
+                raw
+            } else {
+                Bound::masked(bits)
+            };
+        }
+        use MaskContext::Masked;
+        match e {
+            Expr::I32Const(v) => Bound::exact(i128::from(*v)),
+            Expr::I64Const(v) => Bound::exact(i128::from(*v)),
+            Expr::LocalGet(i) => self
+                .locals
+                .get(i)
+                .copied()
+                .unwrap_or_else(|| Bound::masked(bits)),
+            Expr::Temp(t) => self
+                .temps
+                .get(t)
+                .copied()
+                .unwrap_or_else(|| Bound::masked(bits)),
+            Expr::GlobalGet(_) => Bound::masked(bits),
+            // wasm's memory is capped at 65536 pages.
+            Expr::MemorySize => Bound::new(0, 1 << 16),
+            Expr::Load { op, .. } => load_bound(*op, bits),
+            Expr::Select { then, els, .. } => self
+                .bound(then, bits, Masked)
+                .union(self.bound(els, bits, Masked)),
+            Expr::Un(op, a) => match op {
+                UnOp::I32Eqz | UnOp::I64Eqz => Bound::new(0, 1),
+                UnOp::I32Clz | UnOp::I32Ctz | UnOp::I32Popcnt => Bound::new(0, 32),
+                UnOp::I64Clz | UnOp::I64Ctz | UnOp::I64Popcnt => Bound::new(0, 64),
+                UnOp::I64ExtendI32U => self.bound(a, 32, Masked),
                 _ => Bound::masked(bits),
+            },
+            Expr::Bin(op, a, b) => {
+                use BinOp::*;
+                if crate::comparison(*op).is_some() {
+                    return Bound::new(0, 1);
+                }
+                match op {
+                    I32And | I64And | I32Or | I64Or | I32Xor | I64Xor => bitwise_bound(
+                        matches!(op, I32And | I64And),
+                        self.bound(a, bits, ctx),
+                        self.bound(b, bits, ctx),
+                    ),
+                    I32ShrU | I64ShrU => {
+                        let ba = self.bound(a, bits, Masked);
+                        let (cmin, cmax) = count_bound(b, bits);
+                        Bound::new(
+                            (ba.lo >> cmin).min(ba.lo >> cmax),
+                            (ba.hi >> cmin).max(ba.hi >> cmax),
+                        )
+                    }
+                    _ => Bound::masked(bits),
+                }
             }
+            Expr::F32Const(_) | Expr::F64Const(_) => Bound::masked(bits),
         }
-        Expr::F32Const(_) | Expr::F64Const(_) => Bound::masked(bits),
+    }
+
+    /// The interval of `e`'s value rendered without its own result mask, or `None` when `e` carries no mask of its own.
+    fn raw_bound(&self, e: &Expr) -> Option<Bound> {
+        use BinOp::*;
+        use MaskContext::Modular;
+        match e {
+            Expr::Un(UnOp::I32WrapI64, a) => Some(self.bound(a, 64, Modular)),
+            Expr::Bin(op, a, b) => {
+                let bits = match op {
+                    I32Add | I32Sub | I32Mul | I32Shl | I32ShrS => 32,
+                    I64Add | I64Sub | I64Mul | I64Shl | I64ShrS => 64,
+                    _ => return None,
+                };
+                let ba = self.bound(a, bits, bin_operand_context(*op, 0, Modular));
+                let bb = |b: &Expr| self.bound(b, bits, Modular);
+                Some(match op {
+                    I32Add | I64Add => {
+                        let bb = bb(b);
+                        Bound::new(ba.lo.saturating_add(bb.lo), ba.hi.saturating_add(bb.hi))
+                    }
+                    I32Sub | I64Sub => {
+                        let bb = bb(b);
+                        Bound::new(ba.lo.saturating_sub(bb.hi), ba.hi.saturating_sub(bb.lo))
+                    }
+                    I32Mul | I64Mul => {
+                        let bb = bb(b);
+                        let c = [
+                            ba.lo.saturating_mul(bb.lo),
+                            ba.lo.saturating_mul(bb.hi),
+                            ba.hi.saturating_mul(bb.lo),
+                            ba.hi.saturating_mul(bb.hi),
+                        ];
+                        Bound::new(*c.iter().min().unwrap(), *c.iter().max().unwrap())
+                    }
+                    I32Shl | I64Shl => {
+                        let (cmin, cmax) = count_bound(b, bits);
+                        let shl = |v: i128, c: u32| v.saturating_mul(1i128 << c);
+                        let c = [
+                            shl(ba.lo, cmin),
+                            shl(ba.lo, cmax),
+                            shl(ba.hi, cmin),
+                            shl(ba.hi, cmax),
+                        ];
+                        Bound::new(*c.iter().min().unwrap(), *c.iter().max().unwrap())
+                    }
+                    I32ShrS | I64ShrS => {
+                        let s = signed_view(ba, bits);
+                        let (cmin, cmax) = count_bound(b, bits);
+                        let c = [s.lo >> cmin, s.lo >> cmax, s.hi >> cmin, s.hi >> cmax];
+                        Bound::new(*c.iter().min().unwrap(), *c.iter().max().unwrap())
+                    }
+                    _ => unreachable!("filtered by the bits match above"),
+                })
+            }
+            _ => None,
+        }
     }
 }
 
-/// The interval of `e`'s value rendered without its own result mask, or `None` when `e` carries no mask of its own.
-fn raw_bound(e: &Expr, limit: i128) -> Option<Bound> {
-    use BinOp::*;
-    use MaskContext::Modular;
-    match e {
-        Expr::Un(UnOp::I32WrapI64, a) => Some(bound(a, 64, Modular, limit)),
-        Expr::Bin(op, a, b) => {
-            let bits = match op {
-                I32Add | I32Sub | I32Mul | I32Shl | I32ShrS => 32,
-                I64Add | I64Sub | I64Mul | I64Shl | I64ShrS => 64,
-                _ => return None,
-            };
-            let ba = bound(a, bits, bin_operand_context(*op, 0, Modular), limit);
-            let bb = |b: &Expr| bound(b, bits, Modular, limit);
-            Some(match op {
-                I32Add | I64Add => {
-                    let bb = bb(b);
-                    Bound::new(ba.lo.saturating_add(bb.lo), ba.hi.saturating_add(bb.hi))
-                }
-                I32Sub | I64Sub => {
-                    let bb = bb(b);
-                    Bound::new(ba.lo.saturating_sub(bb.hi), ba.hi.saturating_sub(bb.lo))
-                }
-                I32Mul | I64Mul => {
-                    let bb = bb(b);
-                    let c = [
-                        ba.lo.saturating_mul(bb.lo),
-                        ba.lo.saturating_mul(bb.hi),
-                        ba.hi.saturating_mul(bb.lo),
-                        ba.hi.saturating_mul(bb.hi),
-                    ];
-                    Bound::new(*c.iter().min().unwrap(), *c.iter().max().unwrap())
-                }
-                I32Shl | I64Shl => {
-                    let (cmin, cmax) = count_bound(b, bits);
-                    let shl = |v: i128, c: u32| v.saturating_mul(1i128 << c);
-                    let c = [
-                        shl(ba.lo, cmin),
-                        shl(ba.lo, cmax),
-                        shl(ba.hi, cmin),
-                        shl(ba.hi, cmax),
-                    ];
-                    Bound::new(*c.iter().min().unwrap(), *c.iter().max().unwrap())
-                }
-                I32ShrS | I64ShrS => {
-                    let s = signed_view(ba, bits);
-                    let (cmin, cmax) = count_bound(b, bits);
-                    let c = [s.lo >> cmin, s.lo >> cmax, s.hi >> cmin, s.hi >> cmax];
-                    Bound::new(*c.iter().min().unwrap(), *c.iter().max().unwrap())
-                }
-                _ => unreachable!("filtered by the bits match above"),
-            })
-        }
+/// The integer width the masking convention covers; floats and references are never mask candidates.
+fn int_bits(ty: ValType) -> Option<u32> {
+    match ty {
+        ValType::I32 => Some(32),
+        ValType::I64 => Some(64),
         _ => None,
+    }
+}
+
+/// A store's destination: the two variable kinds the dataflow tracks.
+#[derive(Clone, Copy)]
+enum Var {
+    Local(u32),
+    Temp(Temp),
+}
+
+/// One dataflow-relevant position directly in a statement.
+enum Site<'a> {
+    /// `var = expr` (`Stmt::LocalSet` / `Stmt::Assign`): rendered in modular context when `var` stores unmasked.
+    Assign(Var, &'a Expr),
+    /// `dst = src`, a branch-result copy between temps (`BrTarget::Label`'s `assigns`).
+    Copy(Temp, Temp),
+    /// `temp` receives an externally produced value of full masked width: a call result, `memory.grow`, an exception payload.
+    External(Temp),
+    /// `expr` is a statement root whose exact value is observed; reads inside it follow the consumption table from `Masked` down.
+    Observe(&'a Expr),
+}
+
+/// Every dataflow-relevant position directly in `stmt`; nested statement sequences are reached by [`Stmt::any`].
+/// A condition is an observation root: boolean lowering tests the exact value (comparison operands, zero tests), and the table takes over below it.
+fn sites<'a>(stmt: &'a Stmt, f: &mut impl FnMut(Site<'a>)) {
+    fn target<'a>(t: &'a BrTarget, f: &mut dyn FnMut(Site<'a>)) {
+        match t {
+            BrTarget::Return { values } => {
+                for v in values {
+                    f(Site::Observe(v));
+                }
+            }
+            BrTarget::Label { assigns, .. } => {
+                for (dst, src) in assigns {
+                    f(Site::Copy(*dst, *src));
+                }
+            }
+        }
+    }
+    match stmt {
+        Stmt::Assign { dst, expr } => f(Site::Assign(Var::Temp(*dst), expr)),
+        Stmt::LocalSet { idx, expr } => f(Site::Assign(Var::Local(*idx), expr)),
+        Stmt::GlobalSet { expr, .. } => f(Site::Observe(expr)),
+        Stmt::Store { addr, value, .. } => {
+            f(Site::Observe(addr));
+            f(Site::Observe(value));
+        }
+        Stmt::If { cond, .. } => f(Site::Observe(cond)),
+        Stmt::Br(t) => target(t, f),
+        Stmt::BrIf { cond, target: t } => {
+            f(Site::Observe(cond));
+            target(t, f);
+        }
+        Stmt::BrTable {
+            index,
+            targets,
+            default,
+        } => {
+            f(Site::Observe(index));
+            for t in targets {
+                target(t, f);
+            }
+            target(default, f);
+        }
+        Stmt::Return { values } => {
+            for v in values {
+                f(Site::Observe(v));
+            }
+        }
+        Stmt::Call { args, results, .. } => {
+            for a in args {
+                f(Site::Observe(a));
+            }
+            for r in results {
+                f(Site::External(*r));
+            }
+        }
+        Stmt::CallIndirect {
+            index,
+            args,
+            results,
+            ..
+        } => {
+            f(Site::Observe(index));
+            for a in args {
+                f(Site::Observe(a));
+            }
+            for r in results {
+                f(Site::External(*r));
+            }
+        }
+        Stmt::MemoryGrow { dst, delta } => {
+            f(Site::Observe(delta));
+            f(Site::External(*dst));
+        }
+        Stmt::MemoryCopy { dst, src, len }
+        | Stmt::MemoryInit { dst, src, len, .. }
+        | Stmt::TableInit { dst, src, len, .. }
+        | Stmt::TableCopy { dst, src, len, .. } => {
+            f(Site::Observe(dst));
+            f(Site::Observe(src));
+            f(Site::Observe(len));
+        }
+        Stmt::MemoryFill { dst, val, len } => {
+            f(Site::Observe(dst));
+            f(Site::Observe(val));
+            f(Site::Observe(len));
+        }
+        Stmt::TryTable { catches, .. } => {
+            for c in catches {
+                for t in &c.value_temps {
+                    f(Site::External(*t));
+                }
+                target(&c.target, f);
+            }
+        }
+        Stmt::Throw { args, .. } => {
+            for a in args {
+                f(Site::Observe(a));
+            }
+        }
+        Stmt::ThrowRef { exn } => f(Site::Observe(exn)),
+        Stmt::SourceLine(_)
+        | Stmt::Block { .. }
+        | Stmt::Loop { .. }
+        | Stmt::DataDrop { .. }
+        | Stmt::ElemDrop { .. }
+        | Stmt::Unreachable => {}
+    }
+}
+
+/// The reads of locals and temps inside `e` that observe the exact value, mirroring the contexts emission threads through the tree: operands per the consumption table, a load address, `Select`'s condition and arms.
+/// One refinement beyond the table: `&` with a constant operand observes only the bits that constant keeps, all within the width (constants are stored masked), so the other operand is modular whatever the consumer; only the read classification uses this, emission contexts are unchanged.
+fn scan_reads(e: &Expr, ctx: MaskContext, on_masked_read: &mut impl FnMut(&Expr)) {
+    match e {
+        Expr::LocalGet(_) | Expr::Temp(_) => {
+            if ctx == MaskContext::Masked {
+                on_masked_read(e);
+            }
+        }
+        Expr::Un(op, a) => scan_reads(a, un_operand_context(*op), on_masked_read),
+        Expr::Bin(op, a, b) => {
+            let is_const = |e: &Expr| matches!(e, Expr::I32Const(_) | Expr::I64Const(_));
+            let refine = |sibling: &Expr, table: MaskContext| {
+                if matches!(op, BinOp::I32And | BinOp::I64And) && is_const(sibling) {
+                    MaskContext::Modular
+                } else {
+                    table
+                }
+            };
+            scan_reads(
+                a,
+                refine(b, bin_operand_context(*op, 0, ctx)),
+                on_masked_read,
+            );
+            scan_reads(
+                b,
+                refine(a, bin_operand_context(*op, 1, ctx)),
+                on_masked_read,
+            );
+        }
+        Expr::Load { addr, .. } => scan_reads(addr, MaskContext::Masked, on_masked_read),
+        Expr::Select { cond, then, els } => {
+            scan_reads(cond, MaskContext::Masked, on_masked_read);
+            scan_reads(then, MaskContext::Masked, on_masked_read);
+            scan_reads(els, MaskContext::Masked, on_masked_read);
+        }
+        Expr::I32Const(_)
+        | Expr::I64Const(_)
+        | Expr::F32Const(_)
+        | Expr::F64Const(_)
+        | Expr::GlobalGet(_)
+        | Expr::MemorySize => {}
+    }
+}
+
+fn remove_read(el: &mut Elision, read: &Expr) -> bool {
+    match read {
+        Expr::LocalGet(i) => el.locals.remove(i).is_some(),
+        Expr::Temp(t) => el.temps.remove(t).is_some(),
+        _ => false,
+    }
+}
+
+/// The qualification half: remove every variable one of whose reads observes the exact value.
+/// It starts from everything tracked and only removes; a store root or a copy counts as modular exactly while its destination is still tracked, so removals cascade, and each changing pass removes at least one variable, which bounds the passes.
+/// The surviving set is consistent as a whole: copy cycles among survivors are sound because no survivor is ever observed exactly.
+fn qualify(el: &mut Elision, func: &Func) {
+    loop {
+        let mut changed = false;
+        Stmt::any(&func.body, &mut |stmt| {
+            sites(stmt, &mut |site| match site {
+                Site::Assign(var, e) => {
+                    let ctx = if el.member(var) {
+                        MaskContext::Modular
+                    } else {
+                        MaskContext::Masked
+                    };
+                    scan_reads(e, ctx, &mut |read| changed |= remove_read(el, read));
+                }
+                Site::Copy(dst, src) => {
+                    if !el.member(Var::Temp(dst)) {
+                        changed |= el.temps.remove(&src).is_some();
+                    }
+                }
+                Site::External(_) => {}
+                Site::Observe(e) => {
+                    scan_reads(e, MaskContext::Masked, &mut |read| {
+                        changed |= remove_read(el, read)
+                    });
+                }
+            });
+            false
+        });
+        if !changed {
+            break;
+        }
+    }
+}
+
+/// Kleene passes before [`Elision::join`] starts widening: enough for chains of narrow definitions to settle without it.
+const WIDEN_AFTER: usize = 3;
+
+/// The interval half: Kleene iteration from the seeds (a parameter at full masked width, a declared local at its zero initializer, a temp at zero), joining every definition's bound until a pass changes nothing.
+/// Joins only grow and widening caps how often each variable can change, so the iteration ends; the unchanged pass certifies that every tracked interval contains all of its definitions' bounds, which is what makes the recorded intervals hold at runtime.
+/// Variables whose interval breached the limit are then demoted to must-mask; the count of demotions is returned.
+fn solve(el: &mut Elision, params: &[ValType], func: &Func) -> usize {
+    for (i, b) in el.locals.iter_mut() {
+        let i = *i as usize;
+        *b = if i < params.len() {
+            Bound::masked(int_bits(params[i]).expect("tracked locals are integers"))
+        } else {
+            Bound::exact(0)
+        };
+    }
+    for b in el.temps.values_mut() {
+        *b = Bound::exact(0);
+    }
+    let mut pass = 0;
+    loop {
+        let mut changed = false;
+        Stmt::any(&func.body, &mut |stmt| {
+            sites(stmt, &mut |site| match site {
+                Site::Assign(var, e) => {
+                    if el.member(var) {
+                        let bits = var_bits(var, params, func).expect("tracked vars are integers");
+                        let b = el.bound(e, bits, MaskContext::Modular);
+                        changed |= el.join(var, b, bits, pass);
+                    }
+                }
+                Site::Copy(dst, src) => {
+                    if let Some(bits) = int_bits(src.ty) {
+                        let b = el
+                            .temps
+                            .get(&src)
+                            .copied()
+                            .unwrap_or_else(|| Bound::masked(bits));
+                        changed |= el.join(Var::Temp(dst), b, bits, pass);
+                    }
+                }
+                Site::External(t) => {
+                    if let Some(bits) = int_bits(t.ty) {
+                        changed |= el.join(Var::Temp(t), Bound::masked(bits), bits, pass);
+                    }
+                }
+                Site::Observe(_) => {}
+            });
+            false
+        });
+        if !changed {
+            break;
+        }
+        pass += 1;
+    }
+    let limit = el.limit;
+    let mut demoted = 0;
+    let mut keep = |b: &Bound| {
+        let keep = b.within(limit);
+        if !keep {
+            demoted += 1;
+        }
+        keep
+    };
+    el.locals.retain(|_, b| keep(b));
+    el.temps.retain(|_, b| keep(b));
+    demoted
+}
+
+fn var_bits(var: Var, params: &[ValType], func: &Func) -> Option<u32> {
+    match var {
+        Var::Local(i) => {
+            let i = i as usize;
+            let ty = if i < params.len() {
+                params[i]
+            } else {
+                func.locals[i - params.len()]
+            };
+            int_bits(ty)
+        }
+        Var::Temp(t) => int_bits(t.ty),
     }
 }
 
@@ -402,5 +815,252 @@ mod tests {
         assert_eq!(bin_operand_context(BinOp::I32DivU, 0, Modular), Masked);
         assert_eq!(un_operand_context(UnOp::I32WrapI64), Modular);
         assert_eq!(un_operand_context(UnOp::I64ExtendI32U), Masked);
+    }
+}
+
+#[cfg(test)]
+mod dataflow {
+    use super::*;
+    use dewasm_core::ir::Label;
+
+    const LIMIT: i128 = 1 << 62;
+
+    fn local(idx: u32) -> Expr {
+        Expr::LocalGet(idx)
+    }
+
+    fn c32(v: u32) -> Expr {
+        Expr::I32Const(v)
+    }
+
+    fn bin(op: BinOp, a: Expr, b: Expr) -> Expr {
+        Expr::Bin(op, Box::new(a), Box::new(b))
+    }
+
+    fn func(locals: Vec<ValType>, temps: Vec<Temp>, body: Vec<Stmt>) -> Func {
+        Func {
+            type_idx: 0,
+            locals,
+            temps,
+            body,
+        }
+    }
+
+    fn t32(depth: u32) -> Temp {
+        Temp {
+            depth,
+            ty: ValType::I32,
+        }
+    }
+
+    #[test]
+    fn a_local_with_only_modular_reads_stores_unmasked() {
+        let f = func(
+            vec![ValType::I32],
+            vec![],
+            vec![
+                Stmt::LocalSet {
+                    idx: 1,
+                    expr: bin(BinOp::I32Add, local(0), c32(5)),
+                },
+                Stmt::Return {
+                    values: vec![bin(BinOp::I32Add, local(1), c32(1))],
+                },
+            ],
+        );
+        let el = Elision::analyze(&[ValType::I32], &f, LIMIT);
+        assert!(el.unmasked_local(1));
+    }
+
+    #[test]
+    fn an_exactly_observed_read_disqualifies_the_local() {
+        // Returning the local directly observes its exact stored value: the ABI needs the mask.
+        let f = func(
+            vec![ValType::I32],
+            vec![],
+            vec![
+                Stmt::LocalSet {
+                    idx: 1,
+                    expr: bin(BinOp::I32Add, local(0), c32(5)),
+                },
+                Stmt::Return {
+                    values: vec![local(1)],
+                },
+            ],
+        );
+        let el = Elision::analyze(&[ValType::I32], &f, LIMIT);
+        assert!(!el.unmasked_local(1));
+    }
+
+    fn counting_loop(update: Expr) -> Func {
+        func(
+            vec![ValType::I32],
+            vec![],
+            vec![
+                Stmt::Loop {
+                    label: Label {
+                        id: 0,
+                        referenced: true,
+                    },
+                    body: vec![
+                        Stmt::LocalSet {
+                            idx: 1,
+                            expr: update,
+                        },
+                        Stmt::BrIf {
+                            cond: local(0),
+                            target: BrTarget::Label {
+                                label: 0,
+                                is_loop: true,
+                                assigns: vec![],
+                            },
+                        },
+                    ],
+                },
+                Stmt::Return {
+                    values: vec![bin(BinOp::I32Add, local(1), local(0))],
+                },
+            ],
+        )
+    }
+
+    #[test]
+    fn a_loop_carried_definition_narrowed_by_and_converges() {
+        // l1 = (l1 + 1) & 255 in a loop: the `&` re-narrows every iteration, so the interval settles and the store elides.
+        let update = bin(
+            BinOp::I32And,
+            bin(BinOp::I32Add, local(1), c32(1)),
+            c32(255),
+        );
+        let el = Elision::analyze(&[ValType::I32], &counting_loop(update), LIMIT);
+        assert!(el.unmasked_local(1));
+    }
+
+    #[test]
+    fn a_compounding_loop_carried_definition_is_demoted() {
+        // l1 = l1 + 1 in a loop: the unmasked interval grows without bound, so widening pushes it past the limit and the store keeps its mask.
+        let update = bin(BinOp::I32Add, local(1), c32(1));
+        let el = Elision::analyze(&[ValType::I32], &counting_loop(update), LIMIT);
+        assert!(!el.unmasked_local(1));
+    }
+
+    fn copy_pair(read_of_dst: Expr) -> Func {
+        func(
+            vec![],
+            vec![t32(0), t32(1)],
+            vec![
+                Stmt::Assign {
+                    dst: t32(0),
+                    expr: bin(BinOp::I32Add, local(0), c32(1)),
+                },
+                Stmt::Br(BrTarget::Label {
+                    label: 0,
+                    is_loop: false,
+                    assigns: vec![(t32(1), t32(0))],
+                }),
+                Stmt::Return {
+                    values: vec![read_of_dst],
+                },
+            ],
+        )
+    }
+
+    #[test]
+    fn a_bit_test_under_a_constant_mask_reads_modularly() {
+        // `l1 & 1` in a condition observes only bit 0, which congruence preserves, so it does not disqualify l1.
+        let f = func(
+            vec![ValType::I32],
+            vec![],
+            vec![
+                Stmt::LocalSet {
+                    idx: 1,
+                    expr: bin(BinOp::I32Add, local(0), c32(5)),
+                },
+                Stmt::If {
+                    label: Label {
+                        id: 0,
+                        referenced: false,
+                    },
+                    cond: bin(BinOp::I32And, local(1), c32(1)),
+                    then: vec![Stmt::Return {
+                        values: vec![c32(0)],
+                    }],
+                    els: vec![],
+                },
+                Stmt::Return {
+                    values: vec![bin(BinOp::I32Add, local(1), c32(1))],
+                },
+            ],
+        );
+        let el = Elision::analyze(&[ValType::I32], &f, LIMIT);
+        assert!(el.unmasked_local(1));
+    }
+
+    #[test]
+    fn a_copy_into_an_observed_temp_disqualifies_the_source() {
+        let f = copy_pair(Expr::Temp(t32(1)));
+        let el = Elision::analyze(&[ValType::I32], &f, LIMIT);
+        assert!(!el.unmasked_temp(t32(1)));
+        assert!(!el.unmasked_temp(t32(0)));
+    }
+
+    #[test]
+    fn a_copy_between_qualifying_temps_stays_unmasked() {
+        let f = copy_pair(bin(BinOp::I32Add, Expr::Temp(t32(1)), c32(1)));
+        let el = Elision::analyze(&[ValType::I32], &f, LIMIT);
+        assert!(el.unmasked_temp(t32(0)));
+        assert!(el.unmasked_temp(t32(1)));
+    }
+
+    #[test]
+    fn an_i64_call_result_breaches_the_limit_and_keeps_masks() {
+        let t64 = Temp {
+            depth: 0,
+            ty: ValType::I64,
+        };
+        let f = func(
+            vec![],
+            vec![t64],
+            vec![
+                Stmt::Call {
+                    func: 0,
+                    args: vec![],
+                    results: vec![t64],
+                },
+                Stmt::Return {
+                    values: vec![bin(BinOp::I64Add, Expr::Temp(t64), Expr::I64Const(1))],
+                },
+            ],
+        );
+        let el = Elision::analyze(&[], &f, LIMIT);
+        // The full masked i64 width reaches 2^64, past the Fixnum limit, so even a purely modular consumer set cannot clear it.
+        assert!(!el.unmasked_temp(t64));
+    }
+
+    #[test]
+    fn a_tracked_interval_refines_the_expression_guard() {
+        // l1 is confined to a byte by its only definition, so a product of two reads elides where masked-width operands would not.
+        let f = func(
+            vec![ValType::I32],
+            vec![],
+            vec![
+                Stmt::LocalSet {
+                    idx: 1,
+                    expr: bin(BinOp::I32And, local(0), c32(255)),
+                },
+                Stmt::Return {
+                    values: vec![bin(
+                        BinOp::I32Add,
+                        bin(BinOp::I32Mul, local(1), local(1)),
+                        c32(1),
+                    )],
+                },
+            ],
+        );
+        let el = Elision::analyze(&[ValType::I32], &f, LIMIT);
+        assert!(el.unmasked_local(1));
+        let product = bin(BinOp::I32Mul, local(1), local(1));
+        assert!(el.elides_mask(&product));
+        assert!(!Elision::none(LIMIT).elides_mask(&product));
     }
 }


### PR DESCRIPTION
Closes #220, stage 2 of #164. Stacked on #225 (stage 1); merge that first, then retarget this to main.

A local or temp may store an unmasked value when every read of it sits in a modular-consumer position and a per-function interval fixpoint proves the stored values stay within the unboxed-integer limit.
The analysis (`masking::Elision`, backend-independent) runs two interleaved fixpoints: qualification only removes variables (a read at a comparison, division, signed/unsigned view, address, call argument, return, memory store, or global set disqualifies; copies resolve co-inductively), and the interval pass widens loop-carried definitions first to their masked width (so `l = (l + 1) & 255` settles and elides) and then past the limit (so `l = l + 1` keeps its masks).
The ABI stays masked by construction; parameters are seeded at full masked width.
Design, widening ladder, and rejected alternatives are in decision 73 (refines 71).

Measured on sqlite3-shell (standalone Ruby, before = stage 1 tree):

| metric | before | after |
| --- | --- | --- |
| `& 0xffffffff` sites | 31,800 | 31,603 (−197) |
| `m64(` sites | 2,371 | 2,363 |
| ISeq instructions | 1,360,259 | 1,359,849 |
| ISeq memsize | 47,212,640 B | 47,196,232 B |

Coverage is honestly small: in C-derived code one comparison or address read disqualifies a variable.
Decision 73 records this and names per definition-use regions as the finer-grained follow-up.
Verified with `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, and `cargo test -p dewasm-backend-ruby --features slow_test` (spec 257/257, wasi 72/72, slow app cases included).
New dataflow unit tests cover qualification, loop-carried convergence and divergence, copy cycles, and the interval-refined guard; codegen-shape tests pin elided and kept stores on both loop-carried sides.