### PR TITLE
Fold constant shift counts and elide provably in-range count reductions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ Each rule is stated here in full; the cited decision holds its rationale and rej
 - The spec testsuite binds (decision 3). Correctness of generated code outranks its readability; readability improvements go into optional passes, never into semantics-relevant lowering.
 - Where the WASI spec is silent, copy wasmtime's behavior as measured on both CI hosts (decision 49).
 - Numeric representation conventions (masked-unsigned integers, f32 re-rounding, NaN bit paths) are shared across backends (decision 2).
-  A backend skips a result mask only inside one expression tree, through the shared consumption-context and bound analysis in `dewasm_backend::masking`, never by its own reasoning (decision 71).
+  A backend skips a result mask only inside one expression tree, through the shared consumption-context and bound analysis in `dewasm_backend::masking`, never by its own reasoning (decision 71); a shift-count reduction folds or drops only through the same module's `shift_count_mode` (decision 74).
 - Each backend's lowering shapes are fixed; follow them rather than restructuring in passing. They are recorded per backend: Ruby decisions 4/42-44/58/60/65/72, Bash decisions 5/11-13/34/35/51/52, Python decision 28, Go decision 29, Java decision 30, Perl decision 55.
 - Runtime code lives as per-method units under `runtime/<lang>/units/` with `# requires:` headers, referenced as `Rt` (decision 6); keep the headers in sync when editing a unit (the units lint enforces most of it).
 - `Embedded` linkage isolates the runtime per artifact so two artifacts coexist in one namespace (decision 62); `embedded_coexist_e2e!` is the check, and a backend that does not invoke it is unfinished, not incapable.

--- a/agents/decisions/71-mask-elision-modular-consumers.md
+++ b/agents/decisions/71-mask-elision-modular-consumers.md
@@ -2,7 +2,8 @@
 
 Status: **Accepted, 2026-08-15.**
 Landed as the shared analysis in `crates/dewasm-backend/src/masking.rs` and its application in the Ruby backend's expression rendering (`crates/dewasm-backend-ruby/src/lib.rs`).
-The other masked-unsigned backends (Python, Perl, Bash) still mask every site; each can adopt the same analysis against its own unboxed-integer limit.
+The other masked-unsigned backends (Perl, Bash) still mask every site; each can adopt the same analysis against its own unboxed-integer limit.
+The Python backend adopted the analysis with the same 2^62 limit, 2026-08-15 (issue #221); the limit judgement and the measurements are in the consequences below.
 This is stage 1 of issue #164: elision within one expression tree only, no cross-statement analysis.
 
 ## Context
@@ -53,6 +54,9 @@ Operands of a site that keeps its own mask are still rendered in modular context
 
 - On the converted `sqlite3-shell` (standalone Ruby): file size 7,937,554 to 7,868,630 bytes (0.87% smaller), ISeq instructions 1,370,047 to 1,360,259 (0.71% fewer), ISeq memsize 47,605,992 to 47,212,640 bytes (0.83% smaller; `RubyVM::InstructionSequence.compile_file` on MRI 4.0.4, children included).
   4,822 of 36,622 `& 0xffffffff` sites (13.2%) and 72 of 2,443 `m64` calls (2.9%) are elided: above the rough 4% ceiling issue #219 estimated for this stage, and small in absolute terms as expected.
+- The Python backend (issue #221) uses the same 2^62 limit.
+  CPython integers are heap-allocated 30-bit-digit bignums at every size, so no unboxed range makes elision allocation-free as Fixnum does for Ruby; under the shared limit every exposed intermediate still fits in three digits, at most one more than the masked value it replaces, and the guard states the same claim on every backend.
+  On the converted `sqlite3-shell` (standalone Python): file size 8,403,153 to 8,329,167 bytes (0.88% smaller), 4,822 of 36,624 i32 and 72 of 2,440 i64 inline mask sites elided (the same sites as Ruby, analysis and limit being shared); a sqlite workload timing measured no change, and the Python backend's `mod masks` tests pin the same three shape directions.
 - The spec harness (decision 3) binds as always and passes for the Ruby backend under this lowering; codegen-shape tests (`mod masks` in the Ruby backend, plus unit tests in `masking.rs`) pin both directions: an elided site, a site kept by a non-modular consumer, and a site kept by the bound guard.
 - Decision 2's storage representation is unchanged; only the point at which the mask is applied moved from every producer to every observation point.
 - A module whose only `m64` references were elided arithmetic sites no longer bundles the `rt/m64` unit (other runtime units can still require it).

--- a/agents/decisions/74-shift-count-reduction-elision.md
+++ b/agents/decisions/74-shift-count-reduction-elision.md
@@ -1,0 +1,49 @@
+# Decision 74: Shift-Count Reduction Folded for Constants, Dropped Only on an Exact-Value Proof
+
+Status: **Accepted, 2026-08-15.**
+Landed as `shift_count_mode` in `crates/dewasm-backend/src/masking.rs` and its use in the Ruby and Python backends (`fn shift_count` in each backend's `lib.rs`).
+Perl and Bash still emit the reduction at every shift site; each can adopt `shift_count_mode` the same way.
+
+## Context
+
+wasm defines every shift to reduce its count modulo the width, and the backends implement that per site: `x << (c & 31)` for i32, `& 63` for i64 ([decision 2](2-numeric-semantics.md)).
+On the converted `sqlite3-shell` (Ruby, standalone) that is 3,672 `& 31` and 942 `& 63` occurrences (count reductions plus the module's own and-operations), the count reductions overwhelmingly constant, and wasm code that already reduced the count itself produces doubled forms like `x << (l6 & 63 & 63)` (13 such sites).
+[Decision 71](71-mask-elision-modular-consumers.md) elides representation masks under modular consumers, and its machinery renders a shift count in the `Modular` context because the emitted reduction is congruence-preserving.
+
+## Decision
+
+**A semantic mask is dropped only when it is provably the identity on the exact rendered value; congruence is not enough.**
+The count reduction is not a representation mask restoring decision 2's invariant: its result feeds the target's shift operator, which observes the exact count (a negative count shifts the other way, an oversized one shifts too far).
+So the decision 71 rule (elide under a modular consumer) does not apply, and `shift_count_mode` implements the exact-value rule with three outcomes:
+
+- **Constant count**: fold at conversion time and emit the reduced value bare (`x << 2`; the width itself folds to 0 and still shifts, `x << 0`).
+- **Provably in-range count**: when the interval bound proves the count's rendering sits in `0..width`, emit it bare; this removes the doubled reduction above.
+- **Anything else**: emit the reduction as before.
+
+**A dropped reduction switches the count to the `Masked` rendering context.**
+Under a kept reduction the count may render in the `Modular` context, exposing unmasked intermediates, because the emitted `& (width - 1)` reduces them.
+With no reduction emitted, the count must be the exact stored value, so the count renders in the `Masked` context and the in-range interval is judged on that rendering.
+This is the soundness point: an interval judged on the `Modular` rendering would accept a count expression whose unmasked value is negative.
+
+`rotl`/`rotr` are unaffected: their runtime helpers reduce the count internally, so no per-site reduction exists to fold.
+
+## Rejected alternatives
+
+- **Keep every count reduction (status quo).**
+  Constant counts dominate and their reduction is pure parse, size, and runtime overhead; folding them is free and loses nothing.
+- **Fold constants only.**
+  Simpler, but leaves the doubled reduction on wasm code that already masked its count, which the interval machinery of decision 71 detects with no extra analysis.
+- **Judge the interval on the `Modular` rendering.**
+  Unsound: a count like `l1 - 1` renders unmasked under decision 71 and can be negative, which the target's shift operator observes.
+  The `Masked`-context switch is what makes the elision exact.
+- **Elide a count-0 shift entirely (`x` instead of `x << 0`).**
+  A separate identity rewrite with its own operand-context questions, for a case wasm-opt already removes from optimized modules; not worth coupling to this change.
+
+## Consequences
+
+- On the converted `sqlite3-shell` (standalone Ruby, base = the decision 71 + Python-port state): file size 7,868,630 to 7,839,479 bytes (0.37% smaller), ISeq instructions 1,360,259 to 1,351,909 (0.61% fewer), ISeq memsize 47,212,640 to 46,876,408 bytes (0.71% smaller; `RubyVM::InstructionSequence.compile_file` on MRI 4.0.4, children included).
+  `& 31` occurrences drop from 3,672 to 150 and `& 63` from 942 to 289; the survivors are variable counts the interval cannot bound, plus the module's own and-operations.
+- The spec harness (decision 3) binds as always and passes for both backends.
+  The i32/i64 shift trials drive counts of 32, 33, 64, and wrapped negatives through function parameters, pinning the kept reduction at its boundaries; folded constant counts run for real in the app suites and the converted `sqlite3-shell` (984 bare `<< 2` sites alone), whose output matches its snapshot.
+- Codegen-shape tests (`shift_count_reductions_fold_and_elide` in each backend's `mod masks`, plus `shift_count_*` unit tests in `masking.rs`) pin all three outcomes and the boundary fold.
+- The consumption table in `bin_operand_context` still calls a shift count modular; backends that render counts through `shift_count_mode` consult it instead, and a backend that adopts elision without the `Masked`-context switch reintroduces the unsoundness above.

--- a/agents/decisions/README.md
+++ b/agents/decisions/README.md
@@ -92,6 +92,7 @@ An entry is numbered: `<N>-<slug>.md`, cited as "decision N".
 | 70 | [Shared Statement Traversal for IR Analyses](70-shared-statement-traversal.md) | Accepted |
 | 71 | [Mask Elision Inside One Expression Tree Under a Modular Consumer](71-mask-elision-modular-consumers.md) | Accepted |
 | 72 | [Ruby Backend Omits Dead Method-Level `__br` Clears](72-ruby-dead-br-clear-elision.md) | Accepted |
+| 74 | [Shift-Count Reduction Folded for Constants, Dropped Only on an Exact-Value Proof](74-shift-count-reduction-elision.md) | Accepted |
 
 ## Adding a new decision
 

--- a/crates/dewasm-backend-python/src/lib.rs
+++ b/crates/dewasm-backend-python/src/lib.rs
@@ -28,7 +28,10 @@ use std::collections::BTreeSet;
 use std::sync::OnceLock;
 
 use anyhow::Result;
-use dewasm_backend::masking::{bin_operand_context, elides_mask, un_operand_context, MaskContext};
+use dewasm_backend::masking::{
+    bin_operand_context, elides_mask, shift_count_mode, shift_width, un_operand_context,
+    MaskContext, ShiftCountMode,
+};
 use dewasm_backend::{
     check_module_support, hex_string, is_boolean, is_ident, is_wasi_module, load_method,
     local_runs, module_name_error, signed_view_rel_op, store_method, terminates, type_key,
@@ -1686,7 +1689,10 @@ impl<'a> Gen<'a> {
             }
             Expr::Bin(op, a, b) => {
                 let ra = self.expr(a, bin_operand_context(*op, 0, ctx));
-                let rb = self.expr(b, bin_operand_context(*op, 1, ctx));
+                let rb = match shift_width(*op) {
+                    Some(bits) => self.shift_count(b, bits),
+                    None => self.expr(b, bin_operand_context(*op, 1, ctx)),
+                };
                 self.bin(*op, &ra, &rb, elide(ctx, expr))
             }
             Expr::Load { op, addr, offset } => {
@@ -1707,6 +1713,17 @@ impl<'a> Gen<'a> {
             Expr::MemorySize => {
                 self.use_unit("memory/size");
                 "self.m.size()".to_string()
+            }
+        }
+    }
+
+    /// A shift count, reduced modulo the width as wasm requires ([`shift_count_mode`]): a constant folds at conversion time, a provably in-range count is emitted bare from its `Masked` rendering, anything else under `& (bits - 1)`.
+    fn shift_count(&self, b: &Expr, bits: u32) -> String {
+        match shift_count_mode(b, bits, ELISION_LIMIT) {
+            ShiftCountMode::Constant(c) => c.to_string(),
+            ShiftCountMode::InRange => self.expr(b, MaskContext::Masked),
+            ShiftCountMode::Masked => {
+                format!("({} & {})", self.expr(b, MaskContext::Modular), bits - 1)
             }
         }
     }
@@ -1834,12 +1851,13 @@ impl<'a> Gen<'a> {
             I32And | I64And => format!("({a} & {b})"),
             I32Or | I64Or => format!("({a} | {b})"),
             I32Xor | I64Xor => format!("({a} ^ {b})"),
-            I32Shl => mask32_unless(elide_mask, format!("{a} << ({b} & 31)")),
-            I32ShrU => format!("({a} >> ({b} & 31))"),
-            I32ShrS => mask32_unless(elide_mask, format!("{}({a}) >> ({b} & 31)", self.rt("s32"))),
-            I64Shl => mask64_unless(elide_mask, format!("{a} << ({b} & 63)")),
-            I64ShrU => format!("({a} >> ({b} & 63))"),
-            I64ShrS => mask64_unless(elide_mask, format!("{}({a}) >> ({b} & 63)", self.rt("s64"))),
+            // A shift's `b` arrives from `shift_count`, already reduced modulo the width.
+            I32Shl => mask32_unless(elide_mask, format!("{a} << {b}")),
+            I32ShrU => format!("({a} >> {b})"),
+            I32ShrS => mask32_unless(elide_mask, format!("{}({a}) >> {b}", self.rt("s32"))),
+            I64Shl => mask64_unless(elide_mask, format!("{a} << {b}")),
+            I64ShrU => format!("({a} >> {b})"),
+            I64ShrS => mask64_unless(elide_mask, format!("{}({a}) >> {b}", self.rt("s64"))),
             I32Rotl => format!("{}({a}, {b})", self.rt("i32_rotl")),
             I32Rotr => format!("{}({a}, {b})", self.rt("i32_rotr")),
             I64Rotl => format!("{}({a}, {b})", self.rt("i64_rotl")),
@@ -2005,7 +2023,7 @@ mod masks {
                 "(module (func (export \"f\") (param i64) (result i32) (local i32) \
                  (local.set 1 (i32.add (i32.wrap_i64 (i64.shr_u (local.get 0) (i64.const 32))) (i32.const 7))) (local.get 1)))",
             ),
-            "l1 = (((l0 >> (32 & 63)) + 7) & 0xFFFFFFFF)",
+            "l1 = (((l0 >> 32) + 7) & 0xFFFFFFFF)",
         );
     }
 
@@ -2053,6 +2071,30 @@ mod masks {
     }
 
     #[test]
+    fn shift_count_reductions_fold_and_elide() {
+        // A constant count folds at conversion time.
+        assert_line(
+            &i32_expr("(i32.shl (local.get 0) (i32.const 2))"),
+            "l0 = ((l0 << 2) & 0xFFFFFFFF)",
+        );
+        // The width reduces to 0; the shift stays.
+        assert_line(
+            &i32_expr("(i32.shl (local.get 0) (i32.const 32))"),
+            "l0 = ((l0 << 0) & 0xFFFFFFFF)",
+        );
+        // A variable count keeps the reduction.
+        assert_line(
+            &i32_expr("(i32.shl (local.get 0) (local.get 1))"),
+            "l0 = ((l0 << (l1 & 31)) & 0xFFFFFFFF)",
+        );
+        // A count wasm code already reduced is provably in range: no second `& 63`.
+        assert_line(
+            &i64_expr("(i64.shl (local.get 0) (i64.and (local.get 1) (i64.const 63)))"),
+            "l0 = ((l0 << (l1 & 63)) & 0xFFFFFFFFFFFFFFFF)",
+        );
+    }
+
+    #[test]
     fn i64_elides_only_under_the_shared_bound() {
         // Two full-range i64 values sum past the limit: the inline mask stays even under the modular sub.
         assert_line(
@@ -2064,7 +2106,7 @@ mod masks {
             &i64_expr(
                 "(i64.sub (local.get 1) (i64.add (i64.shr_u (local.get 0) (i64.const 32)) (i64.const 5)))",
             ),
-            "l0 = ((l1 - ((l0 >> (32 & 63)) + 5)) & 0xFFFFFFFFFFFFFFFF)",
+            "l0 = ((l1 - ((l0 >> 32) + 5)) & 0xFFFFFFFFFFFFFFFF)",
         );
     }
 }

--- a/crates/dewasm-backend-python/src/lib.rs
+++ b/crates/dewasm-backend-python/src/lib.rs
@@ -28,6 +28,7 @@ use std::collections::BTreeSet;
 use std::sync::OnceLock;
 
 use anyhow::Result;
+use dewasm_backend::masking::{bin_operand_context, elides_mask, un_operand_context, MaskContext};
 use dewasm_backend::{
     check_module_support, hex_string, is_boolean, is_ident, is_wasi_module, load_method,
     local_runs, module_name_error, signed_view_rel_op, store_method, terminates, type_key,
@@ -697,7 +698,7 @@ impl<'a> Gen<'a> {
             w.line(format!(
                 "self.g{idx} = {}.Global({})",
                 self.rt_name,
-                self.expr(&global.init)
+                self.masked(&global.init)
             ));
         }
 
@@ -739,7 +740,7 @@ impl<'a> Gen<'a> {
                 } => {
                     self.use_unit("table/init");
                     w.line(format!("self.elem{i} = [{}]", items()));
-                    let offset = self.expr(offset);
+                    let offset = self.masked(offset);
                     w.line(format!(
                         "self.t{table_index}.init({offset}, self.elem{i}, 0, {})",
                         elem.items.len()
@@ -755,7 +756,7 @@ impl<'a> Gen<'a> {
                     self.use_unit("memory/init");
                     w.line(format!(
                         "self.m.init({}, {}, 0, {})",
-                        self.expr(offset),
+                        self.masked(offset),
                         self.data_expr(i, &data.data),
                         data.data.len()
                     ));
@@ -1255,7 +1256,7 @@ impl<'a> Gen<'a> {
                 results,
             } => {
                 let &[t] = &results[..] else { return None };
-                let args: Vec<String> = args.iter().map(|a| self.expr(a)).collect();
+                let args: Vec<String> = args.iter().map(|a| self.masked(a)).collect();
                 (t, self.call_string(*func, &args))
             }
             Stmt::CallIndirect {
@@ -1267,8 +1268,8 @@ impl<'a> Gen<'a> {
             } => {
                 let &[t] = &results[..] else { return None };
                 self.use_unit("table/call");
-                let mut call_args = vec![self.expr(index), self.type_symbol(*type_idx)];
-                call_args.extend(args.iter().map(|a| self.expr(a)));
+                let mut call_args = vec![self.masked(index), self.type_symbol(*type_idx)];
+                call_args.extend(args.iter().map(|a| self.masked(a)));
                 (
                     t,
                     format!("self.t{table_index}.call({})", call_args.join(", ")),
@@ -1276,7 +1277,7 @@ impl<'a> Gen<'a> {
             }
             Stmt::MemoryGrow { dst, delta } => {
                 self.use_unit("memory/grow");
-                (*dst, format!("self.m.grow({})", self.expr(delta)))
+                (*dst, format!("self.m.grow({})", self.masked(delta)))
             }
             _ => return None,
         };
@@ -1345,13 +1346,13 @@ impl<'a> Gen<'a> {
     fn simple_stmt(&self, w: &mut CodeWriter, stmt: &Stmt) {
         match stmt {
             Stmt::Assign { dst, expr } => {
-                w.line(format!("{} = {}", temp(*dst), self.expr(expr)));
+                w.line(format!("{} = {}", temp(*dst), self.masked(expr)));
             }
             Stmt::LocalSet { idx, expr } => {
-                w.line(format!("l{idx} = {}", self.expr(expr)));
+                w.line(format!("l{idx} = {}", self.masked(expr)));
             }
             Stmt::GlobalSet { idx, expr } => {
-                w.line(format!("self.g{idx}.value = {}", self.expr(expr)));
+                w.line(format!("self.g{idx}.value = {}", self.masked(expr)));
             }
             Stmt::Store {
                 op,
@@ -1363,7 +1364,7 @@ impl<'a> Gen<'a> {
                     "self.m.{}({}, {})",
                     self.mem(store_method(*op)),
                     self.addr(addr, *offset),
-                    self.expr(value)
+                    self.masked(value)
                 ));
             }
             Stmt::Br(target) => self.branch(w, target),
@@ -1382,7 +1383,7 @@ impl<'a> Gen<'a> {
                     self.branch(w, default);
                     return;
                 }
-                w.line(format!("_i = {}", self.expr(index)));
+                w.line(format!("_i = {}", self.masked(index)));
                 for (n, target) in targets.iter().enumerate() {
                     let kw = if n == 0 { "if" } else { "elif" };
                     w.line(format!("{kw} _i == {n}:"));
@@ -1401,7 +1402,7 @@ impl<'a> Gen<'a> {
                 args,
                 results,
             } => {
-                let args: Vec<String> = args.iter().map(|a| self.expr(a)).collect();
+                let args: Vec<String> = args.iter().map(|a| self.masked(a)).collect();
                 let call = self.call_string(*func, &args);
                 w.line(assign_results(results, call));
             }
@@ -1413,8 +1414,8 @@ impl<'a> Gen<'a> {
                 results,
             } => {
                 self.use_unit("table/call");
-                let mut call_args = vec![self.expr(index), self.type_symbol(*type_idx)];
-                call_args.extend(args.iter().map(|a| self.expr(a)));
+                let mut call_args = vec![self.masked(index), self.type_symbol(*type_idx)];
+                call_args.extend(args.iter().map(|a| self.masked(a)));
                 let call = format!("self.t{table_index}.call({})", call_args.join(", "));
                 w.line(assign_results(results, call));
             }
@@ -1423,34 +1424,34 @@ impl<'a> Gen<'a> {
                 w.line(format!(
                     "{} = self.m.grow({})",
                     temp(*dst),
-                    self.expr(delta)
+                    self.masked(delta)
                 ));
             }
             Stmt::MemoryCopy { dst, src, len } => {
                 self.use_unit("memory/copy");
                 w.line(format!(
                     "self.m.copy({}, {}, {})",
-                    self.expr(dst),
-                    self.expr(src),
-                    self.expr(len)
+                    self.masked(dst),
+                    self.masked(src),
+                    self.masked(len)
                 ));
             }
             Stmt::MemoryFill { dst, val, len } => {
                 self.use_unit("memory/fill");
                 w.line(format!(
                     "self.m.fill({}, {}, {})",
-                    self.expr(dst),
-                    self.expr(val),
-                    self.expr(len)
+                    self.masked(dst),
+                    self.masked(val),
+                    self.masked(len)
                 ));
             }
             Stmt::MemoryInit { seg, dst, src, len } => {
                 self.use_unit("memory/init");
                 w.line(format!(
                     "self.m.init({}, self.data{seg}, {}, {})",
-                    self.expr(dst),
-                    self.expr(src),
-                    self.expr(len)
+                    self.masked(dst),
+                    self.masked(src),
+                    self.masked(len)
                 ));
             }
             Stmt::DataDrop { seg } => {
@@ -1461,7 +1462,7 @@ impl<'a> Gen<'a> {
             }
             Stmt::Throw { tag, args } => {
                 self.use_unit("rt/wasm_exception");
-                let args: Vec<String> = args.iter().map(|a| self.expr(a)).collect();
+                let args: Vec<String> = args.iter().map(|a| self.masked(a)).collect();
                 w.line(format!(
                     "raise {}.WasmException(self.tag{tag}, [{}])",
                     self.rt_name,
@@ -1469,7 +1470,7 @@ impl<'a> Gen<'a> {
                 ));
             }
             Stmt::ThrowRef { exn } => {
-                w.line(format!("{}({})", self.rt("throw_ref"), self.expr(exn)));
+                w.line(format!("{}({})", self.rt("throw_ref"), self.masked(exn)));
             }
             Stmt::SourceLine(pos) => {
                 let file = &self.module.debug_files[pos.file as usize];
@@ -1485,9 +1486,9 @@ impl<'a> Gen<'a> {
                 self.use_unit("table/init");
                 w.line(format!(
                     "self.t{table_index}.init({}, self.elem{seg}, {}, {})",
-                    self.expr(dst),
-                    self.expr(src),
-                    self.expr(len)
+                    self.masked(dst),
+                    self.masked(src),
+                    self.masked(len)
                 ));
             }
             Stmt::TableCopy {
@@ -1500,9 +1501,9 @@ impl<'a> Gen<'a> {
                 self.use_unit("table/copy");
                 w.line(format!(
                     "self.t{dst_table}.copy({}, self.t{src_table}, {}, {})",
-                    self.expr(dst),
-                    self.expr(src),
-                    self.expr(len)
+                    self.masked(dst),
+                    self.masked(src),
+                    self.masked(len)
                 ));
             }
             Stmt::ElemDrop { seg } => {
@@ -1543,11 +1544,11 @@ impl<'a> Gen<'a> {
     fn return_stmt(&self, w: &mut CodeWriter, values: &[Expr]) {
         match values {
             [] => w.line("return"),
-            [v] => w.line(format!("return {}", self.expr(v))),
+            [v] => w.line(format!("return {}", self.masked(v))),
             vs => {
                 let vs = vs
                     .iter()
-                    .map(|v| self.expr(v))
+                    .map(|v| self.masked(v))
                     .collect::<Vec<_>>()
                     .join(", ");
                 w.line(format!("return ({vs})"));
@@ -1640,13 +1641,19 @@ impl<'a> Gen<'a> {
 
     fn addr(&self, addr: &Expr, offset: u64) -> String {
         if offset == 0 {
-            self.expr(addr)
+            self.masked(addr)
         } else {
-            format!("{} + {offset}", self.expr(addr))
+            format!("{} + {offset}", self.masked(addr))
         }
     }
 
-    fn expr(&self, expr: &Expr) -> String {
+    /// An expression whose exact stored value is observed (a store, an argument, an address, a comparison operand): every result mask is kept.
+    fn masked(&self, expr: &Expr) -> String {
+        self.expr(expr, MaskContext::Masked)
+    }
+
+    /// `ctx` is the consumer's view of the value: under a `Modular` consumer a site's own result mask is skipped when the shared bound guard allows it (see [`ELISION_LIMIT`]).
+    fn expr(&self, expr: &Expr, ctx: MaskContext) -> String {
         match expr {
             Expr::I32Const(v) => v.to_string(),
             Expr::I64Const(v) => v.to_string(),
@@ -1673,8 +1680,15 @@ impl<'a> Gen<'a> {
             Expr::Un(UnOp::I32Eqz | UnOp::I64Eqz, a) if is_boolean(a) => {
                 format!("(0 if {} else 1)", self.cond(a))
             }
-            Expr::Un(op, a) => self.un(*op, &self.expr(a)),
-            Expr::Bin(op, a, b) => self.bin(*op, &self.expr(a), &self.expr(b)),
+            Expr::Un(op, a) => {
+                let a = self.expr(a, un_operand_context(*op));
+                self.un(*op, &a, elide(ctx, expr))
+            }
+            Expr::Bin(op, a, b) => {
+                let ra = self.expr(a, bin_operand_context(*op, 0, ctx));
+                let rb = self.expr(b, bin_operand_context(*op, 1, ctx));
+                self.bin(*op, &ra, &rb, elide(ctx, expr))
+            }
             Expr::Load { op, addr, offset } => {
                 format!(
                     "self.m.{}({})",
@@ -1685,9 +1699,9 @@ impl<'a> Gen<'a> {
             Expr::Select { cond, then, els } => {
                 format!(
                     "({} if {} else {})",
-                    self.expr(then),
+                    self.masked(then),
                     self.cond(cond),
-                    self.expr(els)
+                    self.masked(els)
                 )
             }
             Expr::MemorySize => {
@@ -1707,10 +1721,10 @@ impl<'a> Gen<'a> {
             // `eqz` in boolean context is the negation of its operand's own test.
             Expr::Un(UnOp::I32Eqz | UnOp::I64Eqz, a) => self.not_cond(a),
             Expr::Bin(op, a, b) => match signed_view_rel_op(*op) {
-                Some(rel) => self.rel(rel, &self.expr(a), &self.expr(b)),
-                None => format!("({}) != 0", self.expr(e)),
+                Some(rel) => self.rel(rel, &self.masked(a), &self.masked(b)),
+                None => format!("({}) != 0", self.masked(e)),
             },
-            _ => format!("({}) != 0", self.expr(e)),
+            _ => format!("({}) != 0", self.masked(e)),
         }
     }
 
@@ -1723,7 +1737,7 @@ impl<'a> Gen<'a> {
             Expr::Bin(op, ..) if signed_view_rel_op(*op).is_some() => {
                 format!("not ({})", self.cond(e))
             }
-            _ => format!("{} == 0", self.expr(e)),
+            _ => format!("{} == 0", self.masked(e)),
         }
     }
 
@@ -1738,7 +1752,7 @@ impl<'a> Gen<'a> {
         }
     }
 
-    fn un(&self, op: UnOp, a: &str) -> String {
+    fn un(&self, op: UnOp, a: &str, elide_mask: bool) -> String {
         use UnOp::*;
         match op {
             I32Eqz | I64Eqz => format!("(1 if {a} == 0 else 0)"),
@@ -1757,7 +1771,13 @@ impl<'a> Gen<'a> {
             F32Nearest | F64Nearest => format!("{}({a})", self.rt("fnearest")),
             F32Sqrt => format!("{}({}({a}))", self.rt("f32"), self.rt("fsqrt")),
             F64Sqrt => format!("{}({a})", self.rt("fsqrt")),
-            I32WrapI64 => format!("({a} & 0xFFFFFFFF)"),
+            I32WrapI64 => {
+                if elide_mask {
+                    a.to_string()
+                } else {
+                    format!("({a} & 0xFFFFFFFF)")
+                }
+            }
             I32TruncF32S | I32TruncF64S => format!("{}({a})", self.rt("i32_trunc_s")),
             I32TruncF32U | I32TruncF64U => format!("{}({a})", self.rt("i32_trunc_u")),
             I64TruncF32S | I64TruncF64S => format!("{}({a})", self.rt("i64_trunc_s")),
@@ -1790,19 +1810,19 @@ impl<'a> Gen<'a> {
         }
     }
 
-    fn bin(&self, op: BinOp, a: &str, b: &str) -> String {
+    fn bin(&self, op: BinOp, a: &str, b: &str, elide_mask: bool) -> String {
         use BinOp::*;
         // A comparison is a Python boolean; outside condition position it needs the conditional back to the i32 0 or 1 wasm expects (see `cond`).
         if let Some(rel) = signed_view_rel_op(op) {
             return format!("(1 if {} else 0)", self.rel(rel, a, b));
         }
         match op {
-            I32Add => format!("(({a} + {b}) & 0xFFFFFFFF)"),
-            I32Sub => format!("(({a} - {b}) & 0xFFFFFFFF)"),
-            I32Mul => format!("(({a} * {b}) & 0xFFFFFFFF)"),
-            I64Add => format!("(({a} + {b}) & 0xFFFFFFFFFFFFFFFF)"),
-            I64Sub => format!("(({a} - {b}) & 0xFFFFFFFFFFFFFFFF)"),
-            I64Mul => format!("(({a} * {b}) & 0xFFFFFFFFFFFFFFFF)"),
+            I32Add => mask32_unless(elide_mask, format!("{a} + {b}")),
+            I32Sub => mask32_unless(elide_mask, format!("{a} - {b}")),
+            I32Mul => mask32_unless(elide_mask, format!("{a} * {b}")),
+            I64Add => mask64_unless(elide_mask, format!("{a} + {b}")),
+            I64Sub => mask64_unless(elide_mask, format!("{a} - {b}")),
+            I64Mul => mask64_unless(elide_mask, format!("{a} * {b}")),
             I32DivS => format!("{}({a}, {b})", self.rt("i32_div_s")),
             I32DivU => format!("{}({a}, {b})", self.rt("i32_div_u")),
             I32RemS => format!("{}({a}, {b})", self.rt("i32_rem_s")),
@@ -1814,15 +1834,12 @@ impl<'a> Gen<'a> {
             I32And | I64And => format!("({a} & {b})"),
             I32Or | I64Or => format!("({a} | {b})"),
             I32Xor | I64Xor => format!("({a} ^ {b})"),
-            I32Shl => format!("(({a} << ({b} & 31)) & 0xFFFFFFFF)"),
+            I32Shl => mask32_unless(elide_mask, format!("{a} << ({b} & 31)")),
             I32ShrU => format!("({a} >> ({b} & 31))"),
-            I32ShrS => format!("(({}({a}) >> ({b} & 31)) & 0xFFFFFFFF)", self.rt("s32")),
-            I64Shl => format!("(({a} << ({b} & 63)) & 0xFFFFFFFFFFFFFFFF)"),
+            I32ShrS => mask32_unless(elide_mask, format!("{}({a}) >> ({b} & 31)", self.rt("s32"))),
+            I64Shl => mask64_unless(elide_mask, format!("{a} << ({b} & 63)")),
             I64ShrU => format!("({a} >> ({b} & 63))"),
-            I64ShrS => format!(
-                "(({}({a}) >> ({b} & 63)) & 0xFFFFFFFFFFFFFFFF)",
-                self.rt("s64")
-            ),
+            I64ShrS => mask64_unless(elide_mask, format!("{}({a}) >> ({b} & 63)", self.rt("s64"))),
             I32Rotl => format!("{}({a}, {b})", self.rt("i32_rotl")),
             I32Rotr => format!("{}({a}, {b})", self.rt("i32_rotr")),
             I64Rotl => format!("{}({a}, {b})", self.rt("i64_rotl")),
@@ -1842,6 +1859,33 @@ impl<'a> Gen<'a> {
             _ => unreachable!("op {op:?} is a comparison, rendered by `rel`"),
         }
     }
+}
+
+/// The i32 result mask, skipped when the consumer restores it; the grouping parentheses stay.
+fn mask32_unless(elide: bool, e: String) -> String {
+    if elide {
+        format!("({e})")
+    } else {
+        format!("(({e}) & 0xFFFFFFFF)")
+    }
+}
+
+/// The i64 counterpart of [`mask32_unless`].
+fn mask64_unless(elide: bool, e: String) -> String {
+    if elide {
+        format!("({e})")
+    } else {
+        format!("(({e}) & 0xFFFFFFFFFFFFFFFF)")
+    }
+}
+
+/// CPython integers are heap-allocated 30-bit-digit bignums at every size, so no unboxed range bounds an exposed intermediate the way Ruby's Fixnum does.
+/// The Ruby limit is kept anyway: under it every exposed intermediate fits in three digits, at most one more than the masked value it replaces, and the guard makes the same claim on every backend that uses it.
+const ELISION_LIMIT: i128 = 1 << 62;
+
+/// Whether `e`'s own result mask may be skipped here: the consumer must be modular and the shared bound guard must hold.
+fn elide(ctx: MaskContext, e: &Expr) -> bool {
+    ctx == MaskContext::Modular && elides_mask(e, ELISION_LIMIT)
 }
 
 /// A Python float literal that round-trips to the same double.
@@ -1900,6 +1944,128 @@ fn stmt_emits(stmt: &Stmt) -> bool {
         }
         // Everything else emits unconditionally (an `if` emits its header, with an empty `then` arm becoming `pass`), so only a construct that can lower to nothing needs an arm above.
         _ => true,
+    }
+}
+
+/// Codegen-shape checks for mask elision.
+/// The spec harness proves the generated code computes the right values; these pin the shapes it cannot distinguish: a mask restored by a modular consumer is gone, and a mask a non-modular consumer or the bound guard requires is still there.
+#[cfg(test)]
+mod masks {
+    use super::*;
+
+    fn body(wat: &str) -> String {
+        let bytes = wat::parse_str(wat).expect("parse wat");
+        let module = dewasm_core::build_module(&bytes).expect("build module");
+        let (src, _) =
+            generate_class_with_units(&module, "M", &RuntimeLinkage::Embedded, false).unwrap();
+        src
+    }
+
+    /// One function of two i32 params whose body is `expr`, stored into a local so folding cannot drop it.
+    fn i32_expr(expr: &str) -> String {
+        body(&format!(
+            "(module (func (export \"f\") (param i32 i32) (result i32) (local.set 0 {expr}) (local.get 0)))"
+        ))
+    }
+
+    /// The i64 counterpart of [`i32_expr`].
+    fn i64_expr(expr: &str) -> String {
+        body(&format!(
+            "(module (func (export \"f\") (param i64 i64) (result i64) (local.set 0 {expr}) (local.get 0)))"
+        ))
+    }
+
+    fn assert_line(src: &str, want: &str) {
+        assert!(
+            src.lines().any(|l| l.trim() == want),
+            "expected line `{want}` in:\n{src}"
+        );
+    }
+
+    #[test]
+    fn modular_consumer_drops_the_operand_mask() {
+        // The outer add's mask reduces the whole sum; the inner add needs none.
+        assert_line(
+            &i32_expr("(i32.add (i32.add (local.get 0) (local.get 1)) (local.get 1))"),
+            "l0 = (((l0 + l1) + l1) & 0xFFFFFFFF)",
+        );
+        // `shr_s` exposes at most the signed 32-bit range, so its own mask goes too.
+        assert_line(
+            &i32_expr("(i32.add (i32.shr_s (local.get 0) (local.get 1)) (local.get 1))"),
+            "l0 = (((MRt.s32(l0) >> (l1 & 31)) + l1) & 0xFFFFFFFF)",
+        );
+        // A shift count is read through `& 31`, so the subtraction feeding it needs no mask.
+        assert_line(
+            &i32_expr("(i32.shl (local.get 0) (i32.sub (local.get 1) (i32.const 1)))"),
+            "l0 = ((l0 << ((l1 - 1) & 31)) & 0xFFFFFFFF)",
+        );
+        // The wrap disappears when the exposed i64 is provably narrow (here at most 2^32).
+        assert_line(
+            &body(
+                "(module (func (export \"f\") (param i64) (result i32) (local i32) \
+                 (local.set 1 (i32.add (i32.wrap_i64 (i64.shr_u (local.get 0) (i64.const 32))) (i32.const 7))) (local.get 1)))",
+            ),
+            "l1 = (((l0 >> (32 & 63)) + 7) & 0xFFFFFFFF)",
+        );
+    }
+
+    #[test]
+    fn non_modular_consumer_keeps_the_operand_mask() {
+        // A division observes the exact value.
+        assert_line(
+            &i32_expr("(i32.div_u (i32.add (local.get 0) (local.get 1)) (local.get 1))"),
+            "l0 = MRt.i32_div_u(((l0 + l1) & 0xFFFFFFFF), l1)",
+        );
+        // So does a comparison.
+        assert_line(
+            &i32_expr("(i32.lt_u (i32.add (local.get 0) (local.get 1)) (local.get 1))"),
+            "l0 = (1 if ((l0 + l1) & 0xFFFFFFFF) < l1 else 0)",
+        );
+        // And storage: the statement position itself is an observation point, so the outer mask always stays.
+        assert_line(
+            &i32_expr("(i32.add (local.get 0) (local.get 1))"),
+            "l0 = ((l0 + l1) & 0xFFFFFFFF)",
+        );
+    }
+
+    #[test]
+    fn bound_guard_keeps_the_mask_on_wide_intermediates() {
+        // A full-range i32 product reaches 2^64, past the elision limit: the mul stays masked under a modular consumer.
+        assert_line(
+            &i32_expr("(i32.add (i32.mul (local.get 0) (local.get 1)) (local.get 1))"),
+            "l0 = ((((l0 * l1) & 0xFFFFFFFF) + l1) & 0xFFFFFFFF)",
+        );
+        // Narrowed to bytes, the product is provably small and the mask goes.
+        assert_line(
+            &i32_expr(
+                "(i32.add (i32.mul (i32.and (local.get 0) (i32.const 255)) (i32.and (local.get 1) (i32.const 255))) (local.get 1))",
+            ),
+            "l0 = ((((l0 & 255) * (l1 & 255)) + l1) & 0xFFFFFFFF)",
+        );
+        // A full-range i64 wraps past the limit too: the wrap keeps its mask.
+        assert_line(
+            &body(
+                "(module (func (export \"f\") (param i64) (result i32) (local i32) \
+                 (local.set 1 (i32.add (i32.wrap_i64 (local.get 0)) (i32.const 7))) (local.get 1)))",
+            ),
+            "l1 = (((l0 & 0xFFFFFFFF) + 7) & 0xFFFFFFFF)",
+        );
+    }
+
+    #[test]
+    fn i64_elides_only_under_the_shared_bound() {
+        // Two full-range i64 values sum past the limit: the inline mask stays even under the modular sub.
+        assert_line(
+            &i64_expr("(i64.sub (i64.add (local.get 0) (local.get 1)) (local.get 1))"),
+            "l0 = ((((l0 + l1) & 0xFFFFFFFFFFFFFFFF) - l1) & 0xFFFFFFFFFFFFFFFF)",
+        );
+        // Provably narrow (the high half plus a constant), the inner mask goes.
+        assert_line(
+            &i64_expr(
+                "(i64.sub (local.get 1) (i64.add (i64.shr_u (local.get 0) (i64.const 32)) (i64.const 5)))",
+            ),
+            "l0 = ((l1 - ((l0 >> (32 & 63)) + 5)) & 0xFFFFFFFFFFFFFFFF)",
+        );
     }
 }
 

--- a/crates/dewasm-backend-ruby/src/lib.rs
+++ b/crates/dewasm-backend-ruby/src/lib.rs
@@ -24,7 +24,10 @@ use std::collections::{BTreeSet, HashSet};
 use std::sync::OnceLock;
 
 use anyhow::Result;
-use dewasm_backend::masking::{bin_operand_context, elides_mask, un_operand_context, MaskContext};
+use dewasm_backend::masking::{
+    bin_operand_context, elides_mask, shift_count_mode, shift_width, un_operand_context,
+    MaskContext, ShiftCountMode,
+};
 use dewasm_backend::{
     check_module_support, hex_string, is_boolean, is_ident, is_wasi_module, load_method,
     local_runs, module_name_error, signed_view_rel_op, store_method, terminates, type_key,
@@ -1509,7 +1512,10 @@ impl<'a> Gen<'a> {
             }
             Expr::Bin(op, a, b) => {
                 let ra = self.expr(a, bin_operand_context(*op, 0, ctx));
-                let rb = self.expr(b, bin_operand_context(*op, 1, ctx));
+                let rb = match shift_width(*op) {
+                    Some(bits) => self.shift_count(b, bits),
+                    None => self.expr(b, bin_operand_context(*op, 1, ctx)),
+                };
                 self.bin(*op, ra, rb, elide(ctx, expr))
             }
             Expr::Load { op, addr, offset } => Rendered::atom(format!(
@@ -1524,6 +1530,20 @@ impl<'a> Gen<'a> {
                 self.use_unit("memory/size");
                 Rendered::atom("@m.size".to_string())
             }
+        }
+    }
+
+    /// A shift count, reduced modulo the width as wasm requires ([`shift_count_mode`]): a constant folds at conversion time, a provably in-range count is emitted bare from its `Masked` rendering, anything else under `& (bits - 1)`.
+    fn shift_count(&self, b: &Expr, bits: u32) -> Rendered {
+        match shift_count_mode(b, bits, FIXNUM_LIMIT) {
+            ShiftCountMode::Constant(c) => Rendered::atom(c.to_string()),
+            ShiftCountMode::InRange => self.expr(b, MaskContext::Masked),
+            ShiftCountMode::Masked => infix(
+                self.expr(b, MaskContext::Modular),
+                "&",
+                Rendered::atom((bits - 1).to_string()),
+                BIT_AND,
+            ),
         }
     }
 
@@ -1674,17 +1694,15 @@ impl<'a> Gen<'a> {
             I32And | I64And => infix(a, "&", b, BIT_AND),
             I32Or | I64Or => infix(a, "|", b, BIT_OR),
             I32Xor | I64Xor => infix(a, "^", b, BIT_OR),
-            I32Shl => mask32_unless(elide_mask, infix(a, "<<", shift_count(b, 31), SHIFT)),
-            I32ShrU => infix(a, ">>", shift_count(b, 31), SHIFT),
-            I32ShrS => mask32_unless(
-                elide_mask,
-                infix(self.call1("s32", a), ">>", shift_count(b, 31), SHIFT),
-            ),
-            I64Shl => self.m64_unless(elide_mask, infix(a, "<<", shift_count(b, 63), SHIFT)),
-            I64ShrU => infix(a, ">>", shift_count(b, 63), SHIFT),
+            // A shift's `b` arrives from `shift_count`, already reduced modulo the width.
+            I32Shl => mask32_unless(elide_mask, infix(a, "<<", b, SHIFT)),
+            I32ShrU => infix(a, ">>", b, SHIFT),
+            I32ShrS => mask32_unless(elide_mask, infix(self.call1("s32", a), ">>", b, SHIFT)),
+            I64Shl => self.m64_unless(elide_mask, infix(a, "<<", b, SHIFT)),
+            I64ShrU => infix(a, ">>", b, SHIFT),
             I64ShrS => {
                 let s = self.call1("s64", a);
-                self.m64_unless(elide_mask, infix(s, ">>", shift_count(b, 63), SHIFT))
+                self.m64_unless(elide_mask, infix(s, ">>", b, SHIFT))
             }
             I32Rotl => self.call2("i32_rotl", a, b),
             I32Rotr => self.call2("i32_rotr", a, b),
@@ -1887,11 +1905,6 @@ const FIXNUM_LIMIT: i128 = 1 << 62;
 /// Whether `e`'s own result mask may be skipped here: the consumer must be modular and the shared bound guard must hold.
 fn elide(ctx: MaskContext, e: &Expr) -> bool {
     ctx == MaskContext::Modular && elides_mask(e, FIXNUM_LIMIT)
-}
-
-/// A shift count, masked to the width wasm defines it modulo.
-fn shift_count(b: Rendered, mask: u32) -> Rendered {
-    infix(b, "&", Rendered::atom(mask.to_string()), BIT_AND)
 }
 
 /// A receiver binds as tightly as a call, so anything looser is parenthesized.
@@ -2155,7 +2168,7 @@ mod masks {
                 "(module (func (export \"f\") (param i64) (result i32) (local i32) \
                  (local.set 1 (i32.add (i32.wrap_i64 (i64.shr_u (local.get 0) (i64.const 32))) (i32.const 7))) (local.get 1)))",
             ),
-            "l1 = (l0 >> (32 & 63)) + 7 & 0xffffffff",
+            "l1 = (l0 >> 32) + 7 & 0xffffffff",
         );
     }
 
@@ -2203,6 +2216,30 @@ mod masks {
     }
 
     #[test]
+    fn shift_count_reductions_fold_and_elide() {
+        // A constant count folds at conversion time.
+        assert_line(
+            &i32_expr("(i32.shl (local.get 0) (i32.const 2))"),
+            "l0 = l0 << 2 & 0xffffffff",
+        );
+        // The width reduces to 0; the shift stays.
+        assert_line(
+            &i32_expr("(i32.shl (local.get 0) (i32.const 32))"),
+            "l0 = l0 << 0 & 0xffffffff",
+        );
+        // A variable count keeps the reduction.
+        assert_line(
+            &i32_expr("(i32.shl (local.get 0) (local.get 1))"),
+            "l0 = l0 << (l1 & 31) & 0xffffffff",
+        );
+        // A count wasm code already reduced is provably in range: no second `& 63`.
+        assert_line(
+            &i64_expr("(i64.shl (local.get 0) (i64.and (local.get 1) (i64.const 63)))"),
+            "l0 = m64(l0 << (l1 & 63))",
+        );
+    }
+
+    #[test]
     fn i64_elides_only_under_the_same_fixnum_bound() {
         // Two full-range i64 values sum past the Fixnum limit: `Rt.m64` stays even under the modular sub.
         assert_line(
@@ -2214,7 +2251,7 @@ mod masks {
             &i64_expr(
                 "(i64.sub (local.get 1) (i64.add (i64.shr_u (local.get 0) (i64.const 32)) (i64.const 5)))",
             ),
-            "l0 = m64(l1 - ((l0 >> (32 & 63)) + 5))",
+            "l0 = m64(l1 - ((l0 >> 32) + 5))",
         );
     }
 }

--- a/crates/dewasm-backend/src/masking.rs
+++ b/crates/dewasm-backend/src/masking.rs
@@ -3,6 +3,7 @@
 //! The stored representation masks every integer to its width, and each wrapping operation re-masks its result.
 //! Inside a single [`Expr`] tree that is often double work: a consumer that reads its operand only modulo 2^32 or 2^64 (a wrapping add's operand, a shift count) cannot observe the high bits its own mask throws away.
 //! [`MaskContext`] names the two consumption contexts, [`bin_operand_context`] and [`un_operand_context`] are the table of which operands an operation reads modularly, and [`elides_mask`] is the guard: a backend may skip a site's own result mask exactly when the consumer is modular and the interval bound proves the exposed value stays within the backend's unboxed-integer range.
+//! [`shift_count_mode`] is the count-position counterpart: the `& (width - 1)` a backend emits on a shift count implements wasm's semantic reduction, and it folds for a constant count and drops when the count's exact rendering provably sits in range.
 //!
 //! Soundness rests on the targets' integers being arbitrary-precision two's complement (Ruby, Python, Perl): an unmasked intermediate is congruent to the masked value modulo 2^w, every modular consumer preserves that congruence (a bitwise operator reads a negative operand as its infinite two's-complement form, so `(x - y) & 0xffffffff` is the correct wrap of a negative difference), and the first non-modular consumer sits behind a kept mask, which reduces the value back to the stored representation.
 
@@ -18,7 +19,7 @@ pub enum MaskContext {
 /// The context in which `op` consumes its operand `k` (0-based), given that `op`'s own result is consumed in `ctx`.
 ///
 /// An operation with its own result mask (wrapping add/sub/mul, `shl`, the wrap) reads its operands modularly regardless of `ctx`: the site's mask restores the invariant even when its own elision guard fails.
-/// A shift count is read through the semantic `& (w - 1)`, so it is modular for every shift.
+/// A shift count is read through the semantic `& (w - 1)`, so it is modular for every shift; a backend that renders counts through [`shift_count_mode`] consults that instead, because a skipped count reduction demands the `Masked` context.
 /// The maskless bitwise operators pass `ctx` through: their result is exact only when their operands are.
 /// Everything else (comparisons, division, signed and unsigned views, addresses, helper calls) observes the exact value.
 pub fn bin_operand_context(op: BinOp, k: usize, ctx: MaskContext) -> MaskContext {
@@ -54,6 +55,44 @@ pub fn elides_mask(e: &Expr, limit: i128) -> bool {
     match raw_bound(e, limit) {
         Some(raw) => raw.within(limit),
         None => false,
+    }
+}
+
+/// How a backend renders a shift count.
+/// wasm reduces the count modulo the shift width; the `& (bits - 1)` a backend emits implements that reduction and is dropped exactly when the reduction is provably the identity on the rendered value.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ShiftCountMode {
+    /// A constant count, already reduced modulo the width: emit the value bare.
+    Constant(u32),
+    /// The count's `Masked` rendering provably sits in `0..bits`: emit that rendering bare.
+    InRange,
+    /// Emit the count's `Modular` rendering under `& (bits - 1)`.
+    Masked,
+}
+
+/// [`ShiftCountMode`] for the count `e` of a `bits`-wide shift, under the elision policy of [`elides_mask`] with the same `limit`.
+///
+/// The emitted `& (bits - 1)` is congruence-preserving, so a kept reduction takes the count's `Modular` rendering.
+/// Skipping it hands the rendered value straight to the target's shift operator, which observes the exact count (a negative or oversized count would shift the wrong way or too far), so the in-range proof is judged on the `Masked` rendering, and an `InRange` site must emit that rendering.
+pub fn shift_count_mode(e: &Expr, bits: u32, limit: i128) -> ShiftCountMode {
+    if matches!(e, Expr::I32Const(_) | Expr::I64Const(_)) {
+        return ShiftCountMode::Constant(count_bound(e, bits).0);
+    }
+    let b = bound(e, bits, MaskContext::Masked, limit);
+    if b.lo >= 0 && b.hi < i128::from(bits) {
+        ShiftCountMode::InRange
+    } else {
+        ShiftCountMode::Masked
+    }
+}
+
+/// The width `op` reduces its shift count modulo, for the shifts whose count reduction sits at the call site (`rotl`/`rotr` reduce inside their runtime helpers).
+pub fn shift_width(op: BinOp) -> Option<u32> {
+    use BinOp::*;
+    match op {
+        I32Shl | I32ShrS | I32ShrU => Some(32),
+        I64Shl | I64ShrS | I64ShrU => Some(64),
+        _ => None,
     }
 }
 
@@ -389,6 +428,53 @@ mod tests {
         // ((l0 + l1) * l2) unmasked reaches 2^65: the mul keeps its mask even though its operand elides.
         let inner = bin(BinOp::I32Add, local(0), local(1));
         assert!(!elides_mask(&bin(BinOp::I32Mul, inner, local(2)), LIMIT));
+    }
+
+    #[test]
+    fn shift_count_folds_a_constant_reduced_modulo_the_width() {
+        use ShiftCountMode::Constant;
+        assert_eq!(shift_count_mode(&Expr::I32Const(2), 32, LIMIT), Constant(2));
+        // The width itself reduces to 0; the shift still happens, by nothing.
+        assert_eq!(
+            shift_count_mode(&Expr::I32Const(32), 32, LIMIT),
+            Constant(0)
+        );
+        // 32 and 63 are valid i64 counts and stay themselves.
+        assert_eq!(
+            shift_count_mode(&Expr::I64Const(32), 64, LIMIT),
+            Constant(32)
+        );
+        assert_eq!(
+            shift_count_mode(&Expr::I64Const(63), 64, LIMIT),
+            Constant(63)
+        );
+        // A wrapped negative reduces like any other bit pattern.
+        assert_eq!(
+            shift_count_mode(&Expr::I32Const(-3i32 as u32), 32, LIMIT),
+            Constant(29)
+        );
+    }
+
+    #[test]
+    fn shift_count_drops_the_reduction_only_for_a_provably_in_range_count() {
+        use ShiftCountMode::{InRange, Masked};
+        // The doubled reduction wasm code produces: the count `l0 & 63` already sits in 0..64.
+        assert_eq!(
+            shift_count_mode(&bin(BinOp::I64And, local(0), Expr::I64Const(63)), 64, LIMIT),
+            InRange
+        );
+        // A full-range count keeps the reduction.
+        assert_eq!(shift_count_mode(&local(0), 64, LIMIT), Masked);
+        // `clz` reaches the width itself (32 on an i32 zero), one past the last valid count.
+        assert_eq!(
+            shift_count_mode(&Expr::Un(UnOp::I32Clz, Box::new(local(0))), 32, LIMIT),
+            Masked
+        );
+        // A sub elides its mask under a modular consumer, but its exact rendering can be negative: the in-range proof binds the Masked rendering, so the reduction stays.
+        assert_eq!(
+            shift_count_mode(&bin(BinOp::I32Sub, local(0), local(1)), 32, LIMIT),
+            Masked
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #229, part of #164. Stacked on #227; merge #225 and #227 first, then retarget this to main.

The shift-count reduction (`& 31` / `& 63`) is semantic, wasm reduces the count modulo the width, so it drops only when it is provably the identity on the exact rendered value; congruence is not enough.
A constant count folds at conversion time and is emitted bare and reduced (`x << 2`; `32 & 63` stays `32`; the width itself folds to 0 and still shifts).
A non-constant count whose interval provably sits in `0..width` is emitted bare, which removes the doubled `(l6 & 63) & 63` shapes wasm code produces; everything else keeps the reduction.
An eliding site renders the count in masked context, because the target's shift operator observes the exact count; a kept reduction keeps the modular rendering.
The shared policy (`shift_count_mode` in `dewasm_backend::masking`) is used by Ruby and Python; `rotl`/`rotr` are untouched because their runtime helpers reduce the count internally.
The rule is recorded in decision 74.

Measured on sqlite3-shell (standalone Ruby, before = base of this stack):

| metric | before | after | delta |
| --- | --- | --- | --- |
| `& 31` occurrences | 3,672 | 150 | −96% |
| `& 63` occurrences | 942 | 289 | −69% |
| ISeq instructions | 1,360,259 | 1,351,909 | −0.61% |
| ISeq memsize | 47,212,640 B | 46,876,408 B | −0.71% |
| file size | 7,868,630 B | 7,839,479 B | −0.37% |

The smoke run's output is byte-identical to the sqlite3-shell snapshot.
Verified with `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, and `--features slow_test` for both backends (Ruby and Python each: spec 257/257, wasi 72/72).
The spec shift trials pin the kept-reduction boundary path (counts 31/32/33/-1 via parameters); folded constants are executed by the app suites and the smoke run.