### PR TITLE
Fold and elide masks around constant bitwise operations and comparisons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ Each rule is stated here in full; the cited decision holds its rationale and rej
 - The spec testsuite binds (decision 3). Correctness of generated code outranks its readability; readability improvements go into optional passes, never into semantics-relevant lowering.
 - Where the WASI spec is silent, copy wasmtime's behavior as measured on both CI hosts (decision 49).
 - Numeric representation conventions (masked-unsigned integers, f32 re-rounding, NaN bit paths) are shared across backends (decision 2).
-  A backend skips a result mask only inside one expression tree, through the shared consumption-context and bound analysis in `dewasm_backend::masking`, never by its own reasoning (decision 71).
+  A backend skips a result mask only inside one expression tree, through the shared consumption-context and bound analysis in `dewasm_backend::masking`, never by its own reasoning (decision 71); constant AND operands, identity masks, and constant equalities go through the same machinery (decision 77).
 - Each backend's lowering shapes are fixed; follow them rather than restructuring in passing. They are recorded per backend: Ruby decisions 4/42-44/58/60/65/72/75/76, Bash decisions 5/11-13/34/35/51/52, Python decisions 28/75/76, Go decision 29, Java decision 30, Perl decision 55.
 - Runtime code lives as per-method units under `runtime/<lang>/units/` with `# requires:` headers, referenced as `Rt` (decision 6); keep the headers in sync when editing a unit (the units lint enforces most of it).
 - `Embedded` linkage isolates the runtime per artifact so two artifacts coexist in one namespace (decision 62); `embedded_coexist_e2e!` is the check, and a backend that does not invoke it is unfinished, not incapable.

--- a/agents/decisions/71-mask-elision-modular-consumers.md
+++ b/agents/decisions/71-mask-elision-modular-consumers.md
@@ -4,6 +4,7 @@ Status: **Accepted, 2026-08-15.**
 Landed as the shared analysis in `crates/dewasm-backend/src/masking.rs` and its application in the Ruby backend's expression rendering (`crates/dewasm-backend-ruby/src/lib.rs`).
 The other masked-unsigned backends (Perl, Bash) still mask every site; each can adopt the same analysis against its own unboxed-integer limit.
 The Python backend adopted the analysis with the same 2^62 limit, 2026-08-15 (issue #221); the limit judgement and the measurements are in the consequences below.
+[Decision 77](77-mask-constant-folds.md) extends the same machinery with constant AND folding, the `Reducing` context, identity-mask elision, and the pinned constant-equality rewrite.
 This is stage 1 of issue #164: elision within one expression tree only, no cross-statement analysis.
 
 ## Context

--- a/agents/decisions/77-mask-constant-folds.md
+++ b/agents/decisions/77-mask-constant-folds.md
@@ -1,0 +1,65 @@
+# Decision 77: Constant AND Operands, Identity Masks, and Pinned Constant Equalities Extend Mask Elision
+
+Status: **Accepted, 2026-08-16.** Landed in the shared analysis (`crates/dewasm-backend/src/masking.rs`) and the Ruby and Python emitters. Perl and Bash still mask every site, as under [decision 71](71-mask-elision-modular-consumers.md), and can adopt the same machinery.
+
+## Context
+
+[Decision 71](71-mask-elision-modular-consumers.md) skips a site's result mask only under a modular consumer, guarded by the interval bound against the backend's unboxed-integer limit.
+Three shapes it leaves masked are common in real conversions (counted on the converted merman, Ruby library mode): a masked value feeding a bitwise AND (1,985 `& 0xffffffff & ` renderings, most with a constant on the other side), AND chains carrying two constants, and a masked value compared for equality against a constant (572 `& 0xffffffff ==`/`!=` sites plus 188 through `m64`).
+In all three the consumer either redoes the mask's reduction or pins the value so tightly that the mask decides nothing.
+
+## Decision
+
+Four rules, all in the shared analysis per decision 71's discipline (the table and the bound decide; a backend never reasons on its own):
+
+1. **Constant AND chains fold at conversion time** (`fold_and_chain`): `x & c1 & c2` emits `x & (c1 & c2)`, the constant computed during conversion.
+   Sound by associativity of `&`; fires only when at least two constants fold.
+2. **An AND with a constant operand consumes its other operand in a new `Reducing` context, in any position, with no bound guard.**
+   Every IR constant sits inside its type's width, so `v & c` reduces `v` at least as strongly as `v`'s own mask would; by congruence the results agree, even at an observation point.
+   The bound guard of decision 71 is not needed for profitability: the raw value feeds nothing but that one reduction, which the kept mask would have performed anyway (and once more).
+   Through the other maskless bitwise operators a `Reducing` consumer weakens to `Modular`: they preserve congruence, but the raw operands feed the operator itself, so the guard binds again.
+   This is what folds a kept representation mask into a constant AND: `(x * y & 0xffffffff) & 255` becomes `x * y & 255`.
+3. **A mask whose raw interval already sits inside `[0, 2^w)` is the identity on the exact value and drops in every context** (`may_skip_mask`), including observation points: storage, comparisons, call arguments.
+   The exposed value equals the masked value, so decision 71's allocation claim holds trivially.
+4. **A masked equality against a constant drops the mask when the interval pins a unique preimage** (`eq_const_rewrite`): `wrap(v) == c` holds exactly when raw `v` lands on `c + k * 2^w`, so when the raw interval of `v` contains exactly one such candidate, the comparison reads raw `v` against that candidate.
+   The constant then migrates across the raw add/sub-by-constant layers the rendering exposes, stopping at the first kept mask: `x - c1 & 0xffffffff == c` becomes `x == c1 + c`.
+   `eqz` is the same rewrite with `c = 0`.
+   With several candidates the mask stays; with none, see below.
+
+Evaluation order is untouched: every rule reshapes a pure integer expression tree in place, and the one operand-order change (a constant moving to the other side of `==`) commutes with anything because a constant has no effects.
+
+**A zero-candidate equality keeps its mask.**
+The interval proves the comparison statically false, but replacing it with its constant result would delete the operand, and the operand can hold a trapping load or division.
+The site keeps its mask and the comparison runs; rule 3 may still drop the mask when it is the identity.
+This is the conservative branch of the "emit the boolean or keep the mask" choice; the aggressive branch needs a trap-freedom analysis over the operand, disproportionate for a comparison real code rarely writes.
+
+## Rejected alternatives
+
+- **Rewrite the unsigned range-check idiom `wrap(x - c1) < c2` to `Range#===`.**
+  Measured 3.6x slower interpreted and 3.7 to 3.9x slower under YJIT for roughly 70KB of source saved on merman: `Range#===` is a method call where the mask is one instruction.
+- **Rewrite the same idiom to two comparisons (`x >= c1 && x < c1 + c2`).**
+  More ISeq than the mask it removes.
+- **Constant-fold the zero-candidate equality to its boolean.**
+  Smallest output, but it erases a trap the operand may carry; rejected above.
+- **Extend `Reducing` through OR and XOR operands.**
+  `v | c` and `v ^ c` pass `v`'s high bits through, so they do not reduce; only AND qualifies.
+
+## Consequences
+
+- Measured on the converted sqlite3-shell (standalone Ruby) and merman (`--target ruby --mode library --no-default-wasi`), before (decision 76's state) to after; ISeq via `RubyVM::InstructionSequence.compile_file` on ruby 4.0.4 arm64-darwin, children included:
+
+  | Metric | sqlite3-shell before | after | merman before | after |
+  | --- | --- | --- | --- | --- |
+  | `& 0xffffffff` sites | 22,055 | 21,218 | 193,525 | 189,380 |
+  | `Rt.m64` calls | 2,367 | 2,105 | 5,483 | 4,673 |
+  | `& 0xffffffff & ` renderings | 449 | 18 | 1,985 | 550 |
+  | `& 0xffffffff ==`/`!=` sites | 60 | 53 | 572 | 343 |
+  | Source bytes | 7,744,041 | 7,731,846 | 47,771,297 | 47,712,065 |
+  | ISeq instructions | 1,290,623 | 1,288,425 | 6,860,215 | 6,850,285 |
+  | ISeq memsize (bytes) | 44,013,944 | 43,927,584 | 240,008,120 | 239,615,184 |
+
+  The remaining mask-into-AND renderings have a non-constant other operand, or feed the semantic shift-count mask, which the table still reads as `Modular`; merman's 188 `m64(...) ==`/`!=` sites all compare `m64(x * y)` whose interval genuinely admits several candidates, and none dropped.
+- Rule 1's literal chain is rare in wasm-opt-processed input (a handful of sites on sqlite3-shell, none on merman): the fold is kept because it is a few lines, sound unconditionally, and completes rule 2 (without it the folded-away mask would simply reappear as a second constant AND).
+- The spec harness (decision 3) binds and passes for Ruby and Python; `masking.rs` unit tests cover each rule's firing and non-firing intervals, and each backend's `mod masks` pins the emitted shapes both ways.
+- The `MaskContext` table gained sibling-operand visibility (`bin_operand_context` takes the other operand) and the `Reducing` variant; the interval analysis is otherwise decision 71's, and the limit judgement there is unchanged.
+- Rule 4's constant migration can emit a comparison constant outside `[0, 2^w)` (a negative preimage of a wrapped subtraction); that is the exact raw value, not a masked one, and correct by construction.

--- a/agents/decisions/README.md
+++ b/agents/decisions/README.md
@@ -94,6 +94,7 @@ An entry is numbered: `<N>-<slug>.md`, cited as "decision N".
 | 72 | [Ruby Backend Omits Dead Method-Level `__br` Clears](72-ruby-dead-br-clear-elision.md) | Accepted |
 | 75 | [Pass the Static Load/Store Offset as a Second Argument](75-memory-offset-argument.md) | Accepted |
 | 76 | [Memory Units Reduce Their Address and Stored-Value Operands](76-memory-unit-operand-reduction.md) | Accepted |
+| 77 | [Constant AND Operands, Identity Masks, and Pinned Constant Equalities Extend Mask Elision](77-mask-constant-folds.md) | Accepted |
 
 ## Adding a new decision
 

--- a/crates/dewasm-backend-python/src/lib.rs
+++ b/crates/dewasm-backend-python/src/lib.rs
@@ -28,7 +28,10 @@ use std::collections::BTreeSet;
 use std::sync::OnceLock;
 
 use anyhow::Result;
-use dewasm_backend::masking::{bin_operand_context, elides_mask, un_operand_context, MaskContext};
+use dewasm_backend::masking::{
+    bin_operand_context, elides_mask, eq_const_rewrite, fold_and_chain, un_operand_context,
+    MaskContext,
+};
 use dewasm_backend::{
     check_module_support, hex_string, is_boolean, is_ident, is_wasi_module, load_method,
     local_runs, module_name_error, signed_view_rel_op, store_method, terminates, type_key,
@@ -1658,7 +1661,7 @@ impl<'a> Gen<'a> {
         (method, args)
     }
 
-    /// An expression whose exact stored value is observed (an argument, a comparison operand): every result mask is kept.
+    /// An expression whose exact stored value is observed (an argument, a comparison operand): a result mask stays unless it is provably the identity on the exact value.
     fn masked(&self, expr: &Expr) -> String {
         self.expr(expr, MaskContext::Masked)
     }
@@ -1701,8 +1704,16 @@ impl<'a> Gen<'a> {
                 self.un(*op, &a, elide(ctx, expr))
             }
             Expr::Bin(op, a, b) => {
-                let ra = self.expr(a, bin_operand_context(*op, 0, ctx));
-                let rb = self.expr(b, bin_operand_context(*op, 1, ctx));
+                if matches!(op, BinOp::I32And | BinOp::I64And) {
+                    if let Some((e, c)) = fold_and_chain(a, b) {
+                        return format!("({} & {c})", self.expr(e, MaskContext::Reducing));
+                    }
+                }
+                if let Some((ra, rb)) = self.eq_rewrite_operands(*op, a, b) {
+                    return self.bin(*op, &ra, &rb, false);
+                }
+                let ra = self.expr(a, bin_operand_context(*op, 0, b, ctx));
+                let rb = self.expr(b, bin_operand_context(*op, 1, a, ctx));
                 self.bin(*op, &ra, &rb, elide(ctx, expr))
             }
             Expr::Load { op, addr, offset } => {
@@ -1734,11 +1745,41 @@ impl<'a> Gen<'a> {
             // `eqz` in boolean context is the negation of its operand's own test.
             Expr::Un(UnOp::I32Eqz | UnOp::I64Eqz, a) => self.not_cond(a),
             Expr::Bin(op, a, b) => match signed_view_rel_op(*op) {
-                Some(rel) => self.rel(rel, &self.masked(a), &self.masked(b)),
-                None => format!("({}) != 0", self.masked(e)),
+                Some(rel) => {
+                    let (ra, rb) = match self.eq_rewrite_operands(*op, a, b) {
+                        Some(pair) => pair,
+                        None => (self.masked(a), self.masked(b)),
+                    };
+                    self.rel(rel, &ra, &rb)
+                }
+                None => self.nonzero_test(e),
             },
-            _ => format!("({}) != 0", self.masked(e)),
+            _ => self.nonzero_test(e),
         }
+    }
+
+    /// `e != 0`: the fallback test for a value that is not already a Python boolean.
+    /// A mask site whose raw interval pins a unique preimage of 0 compares unmasked against it (see [`eq_const_rewrite`]).
+    fn nonzero_test(&self, e: &Expr) -> String {
+        match eq_const_rewrite(e, 0, ELISION_LIMIT) {
+            Some((x, ctx, t)) => format!("{} != {t}", self.expr(x, ctx)),
+            None => format!("({}) != 0", self.masked(e)),
+        }
+    }
+
+    /// The rendered operands of an integer equality whose one side is a constant, when the shared analysis pins the other side's mask to a unique raw preimage (see [`eq_const_rewrite`]); `None` renders both sides exact.
+    fn eq_rewrite_operands(&self, op: BinOp, a: &Expr, b: &Expr) -> Option<(String, String)> {
+        use BinOp::*;
+        if !matches!(op, I32Eq | I32Ne | I64Eq | I64Ne) {
+            return None;
+        }
+        let (e, c) = match (a, b) {
+            (Expr::I32Const(c), e) | (e, Expr::I32Const(c)) => (e, u64::from(*c)),
+            (Expr::I64Const(c), e) | (e, Expr::I64Const(c)) => (e, *c),
+            _ => return None,
+        };
+        let (x, ctx, t) = eq_const_rewrite(e, c, ELISION_LIMIT)?;
+        Some((self.expr(x, ctx), t.to_string()))
     }
 
     /// The negation of [`cond`]: `e` is zero.
@@ -1750,7 +1791,10 @@ impl<'a> Gen<'a> {
             Expr::Bin(op, ..) if signed_view_rel_op(*op).is_some() => {
                 format!("not ({})", self.cond(e))
             }
-            _ => format!("{} == 0", self.masked(e)),
+            _ => match eq_const_rewrite(e, 0, ELISION_LIMIT) {
+                Some((x, ctx, t)) => format!("{} == {t}", self.expr(x, ctx)),
+                None => format!("{} == 0", self.masked(e)),
+            },
         }
     }
 
@@ -1896,9 +1940,9 @@ fn mask64_unless(elide: bool, e: String) -> String {
 /// The Ruby limit is kept anyway: under it every exposed intermediate fits in three digits, at most one more than the masked value it replaces, and the guard makes the same claim on every backend that uses it.
 const ELISION_LIMIT: i128 = 1 << 62;
 
-/// Whether `e`'s own result mask may be skipped here: the consumer must be modular and the shared bound guard must hold.
+/// Whether `e`'s own result mask may be skipped here, per the shared context and bound analysis.
 fn elide(ctx: MaskContext, e: &Expr) -> bool {
-    ctx == MaskContext::Modular && elides_mask(e, ELISION_LIMIT)
+    elides_mask(e, ctx, ELISION_LIMIT)
 }
 
 /// A Python float literal that round-trips to the same double.
@@ -2078,6 +2122,93 @@ mod masks {
                 "(i64.sub (local.get 1) (i64.add (i64.shr_u (local.get 0) (i64.const 32)) (i64.const 5)))",
             ),
             "l0 = ((l1 - ((l0 >> (32 & 63)) + 5)) & 0xFFFFFFFFFFFFFFFF)",
+        );
+    }
+
+    #[test]
+    fn and_chain_constants_fold_at_conversion_time() {
+        assert_line(
+            &i32_expr("(i32.and (i32.and (local.get 0) (i32.const 65280)) (i32.const 4080))"),
+            "l0 = (l0 & 3840)",
+        );
+        // A single constant is the plain AND shape: nothing folds.
+        assert_line(
+            &i32_expr("(i32.and (i32.and (local.get 0) (local.get 1)) (i32.const 15))"),
+            "l0 = ((l0 & l1) & 15)",
+        );
+    }
+
+    #[test]
+    fn a_constant_and_drops_the_operand_mask_unguarded() {
+        // The raw product exceeds the bound guard, but `& 255` reduces at least as strongly as the mask it replaces.
+        assert_line(
+            &i32_expr("(i32.and (i32.mul (local.get 0) (local.get 1)) (i32.const 255))"),
+            "l0 = ((l0 * l1) & 255)",
+        );
+        // The i64 mask disappears the same way.
+        assert_line(
+            &i64_expr("(i64.and (i64.add (local.get 0) (local.get 1)) (i64.const 255))"),
+            "l0 = ((l0 + l1) & 255)",
+        );
+        // The reduction covers only the AND's own operand: under the XOR the bound guard still binds.
+        assert_line(
+            &i32_expr(
+                "(i32.and (i32.xor (i32.mul (local.get 0) (local.get 1)) (local.get 1)) (i32.const 255))",
+            ),
+            "l0 = ((((l0 * l1) & 0xFFFFFFFF) ^ l1) & 255)",
+        );
+    }
+
+    #[test]
+    fn an_identity_mask_drops_at_an_observation_point() {
+        // The high half extracted by `>> 32` sits in [0, 2^32): the wrap is the identity even in the stored position.
+        assert_line(
+            &body(
+                "(module (func (export \"f\") (param i64) (result i32) (local i32) \
+                 (local.set 1 (i32.wrap_i64 (i64.shr_u (local.get 0) (i64.const 32)))) (local.get 1)))",
+            ),
+            "l1 = (l0 >> (32 & 63))",
+        );
+    }
+
+    #[test]
+    fn a_pinned_constant_equality_drops_the_mask() {
+        // `((l0 - 5) & 0xFFFFFFFF) == 7` admits exactly one raw preimage, and the constant migrates across the sub.
+        assert_line(
+            &i32_expr("(i32.eq (i32.sub (local.get 0) (i32.const 5)) (i32.const 7))"),
+            "l0 = (1 if l0 == 12 else 0)",
+        );
+        // The same rewrite in boolean position.
+        assert_line(
+            &body(
+                "(module (func (export \"f\") (param i32) (result i32) (local i32) \
+                 (if (i32.eq (i32.sub (local.get 0) (i32.const 5)) (i32.const 7)) (then (local.set 1 (i32.const 1)))) (local.get 1)))",
+            ),
+            "if l0 == 12:",
+        );
+        // `eqz` is the equality against 0.
+        assert_line(
+            &body(
+                "(module (func (export \"f\") (param i32) (result i32) (local i32) \
+                 (if (i32.eqz (i32.sub (local.get 0) (i32.const 5))) (then (local.set 1 (i32.const 1)))) (local.get 1)))",
+            ),
+            "if l0 == 5:",
+        );
+    }
+
+    #[test]
+    fn an_unpinned_constant_equality_keeps_the_mask() {
+        // A two-sided sub spans almost 2^33: two candidates fit, so the mask stays.
+        assert_line(
+            &i32_expr("(i32.eq (i32.sub (local.get 0) (local.get 1)) (i32.const 7))"),
+            "l0 = (1 if ((l0 - l1) & 0xFFFFFFFF) == 7 else 0)",
+        );
+        // No candidate fits: statically false, but the comparison still runs (the operand could trap), only the identity mask goes.
+        assert_line(
+            &i32_expr(
+                "(i32.eq (i32.add (i32.and (local.get 0) (i32.const 3)) (i32.const 1)) (i32.const 9))",
+            ),
+            "l0 = (1 if ((l0 & 3) + 1) == 9 else 0)",
         );
     }
 }

--- a/crates/dewasm-backend-ruby/src/lib.rs
+++ b/crates/dewasm-backend-ruby/src/lib.rs
@@ -24,7 +24,10 @@ use std::collections::{BTreeSet, HashSet};
 use std::sync::OnceLock;
 
 use anyhow::Result;
-use dewasm_backend::masking::{bin_operand_context, elides_mask, un_operand_context, MaskContext};
+use dewasm_backend::masking::{
+    bin_operand_context, elides_mask, eq_const_rewrite, fold_and_chain, un_operand_context,
+    MaskContext,
+};
 use dewasm_backend::{
     check_module_support, hex_string, is_boolean, is_ident, is_wasi_module, load_method,
     local_runs, module_name_error, signed_view_rel_op, store_method, terminates, type_key,
@@ -1474,7 +1477,7 @@ impl<'a> Gen<'a> {
         self.masked(expr).free()
     }
 
-    /// An expression whose exact stored value is observed (an argument, a comparison operand): every result mask is kept.
+    /// An expression whose exact stored value is observed (an argument, a comparison operand): a result mask stays unless it is provably the identity on the exact value.
     fn masked(&self, expr: &Expr) -> Rendered {
         self.expr(expr, MaskContext::Masked)
     }
@@ -1519,8 +1522,17 @@ impl<'a> Gen<'a> {
                 self.un(*op, a, elide(ctx, expr))
             }
             Expr::Bin(op, a, b) => {
-                let ra = self.expr(a, bin_operand_context(*op, 0, ctx));
-                let rb = self.expr(b, bin_operand_context(*op, 1, ctx));
+                if matches!(op, BinOp::I32And | BinOp::I64And) {
+                    if let Some((e, c)) = fold_and_chain(a, b) {
+                        let re = self.expr(e, MaskContext::Reducing);
+                        return infix(re, "&", number(c.to_string()), BIT_AND);
+                    }
+                }
+                if let Some((ra, rb)) = self.eq_rewrite_operands(*op, a, b) {
+                    return self.bin(*op, ra, rb, false);
+                }
+                let ra = self.expr(a, bin_operand_context(*op, 0, b, ctx));
+                let rb = self.expr(b, bin_operand_context(*op, 1, a, ctx));
                 self.bin(*op, ra, rb, elide(ctx, expr))
             }
             Expr::Load { op, addr, offset } => {
@@ -1547,7 +1559,12 @@ impl<'a> Gen<'a> {
             // `eqz` in boolean context is the negation of its operand's own test.
             Expr::Un(UnOp::I32Eqz | UnOp::I64Eqz, a) => self.not_cond(a),
             Expr::Bin(op, a, b) => match signed_view_rel_op(*op) {
-                Some(rel) => self.rel(rel, self.masked(a), self.masked(b)),
+                Some(rel) => {
+                    let (ra, rb) = self
+                        .eq_rewrite_operands(*op, a, b)
+                        .unwrap_or_else(|| (self.masked(a), self.masked(b)));
+                    self.rel(rel, ra, rb)
+                }
                 None => self.zero_test("!=", e),
             },
             _ => self.zero_test("!=", e),
@@ -1566,8 +1583,28 @@ impl<'a> Gen<'a> {
     }
 
     /// `e == 0` / `e != 0`: the fallback test for a value that is not already a Ruby boolean.
+    /// A mask site whose raw interval pins a unique preimage of 0 compares unmasked against it (see [`eq_const_rewrite`]).
     fn zero_test(&self, op: &'static str, e: &Expr) -> Rendered {
-        compare(self.masked(e), op, Rendered::atom("0".to_string()), EQ)
+        let (lhs, rhs) = match eq_const_rewrite(e, 0, FIXNUM_LIMIT) {
+            Some((x, ctx, t)) => (self.expr(x, ctx), number(t.to_string())),
+            None => (self.masked(e), Rendered::atom("0".to_string())),
+        };
+        compare(lhs, op, rhs, EQ)
+    }
+
+    /// The rendered operands of an integer equality whose one side is a constant, when the shared analysis pins the other side's mask to a unique raw preimage (see [`eq_const_rewrite`]); `None` renders both sides exact.
+    fn eq_rewrite_operands(&self, op: BinOp, a: &Expr, b: &Expr) -> Option<(Rendered, Rendered)> {
+        use BinOp::*;
+        if !matches!(op, I32Eq | I32Ne | I64Eq | I64Ne) {
+            return None;
+        }
+        let (e, c) = match (a, b) {
+            (Expr::I32Const(c), e) | (e, Expr::I32Const(c)) => (e, u64::from(*c)),
+            (Expr::I64Const(c), e) | (e, Expr::I64Const(c)) => (e, *c),
+            _ => return None,
+        };
+        let (x, ctx, t) = eq_const_rewrite(e, c, FIXNUM_LIMIT)?;
+        Some((self.expr(x, ctx), number(t.to_string())))
     }
 
     /// A one-argument call to a runtime helper, recording its unit.
@@ -1894,9 +1931,9 @@ fn mask32_unless(elide: bool, a: Rendered) -> Rendered {
 /// 64-bit MRI keeps integers in `-2**62 .. 2**62 - 1` unboxed; a skipped mask must never expose an intermediate outside that range, or the elision would trade a cheap mask for bignum arithmetic.
 const FIXNUM_LIMIT: i128 = 1 << 62;
 
-/// Whether `e`'s own result mask may be skipped here: the consumer must be modular and the shared bound guard must hold.
+/// Whether `e`'s own result mask may be skipped here, per the shared context and bound analysis.
 fn elide(ctx: MaskContext, e: &Expr) -> bool {
-    ctx == MaskContext::Modular && elides_mask(e, FIXNUM_LIMIT)
+    elides_mask(e, ctx, FIXNUM_LIMIT)
 }
 
 /// A shift count, masked to the width wasm defines it modulo.
@@ -2225,6 +2262,93 @@ mod masks {
                 "(i64.sub (local.get 1) (i64.add (i64.shr_u (local.get 0) (i64.const 32)) (i64.const 5)))",
             ),
             "l0 = m64(l1 - ((l0 >> (32 & 63)) + 5))",
+        );
+    }
+
+    #[test]
+    fn and_chain_constants_fold_at_conversion_time() {
+        assert_line(
+            &i32_expr("(i32.and (i32.and (local.get 0) (i32.const 65280)) (i32.const 4080))"),
+            "l0 = l0 & 3840",
+        );
+        // A single constant is the plain AND shape: nothing folds.
+        assert_line(
+            &i32_expr("(i32.and (i32.and (local.get 0) (local.get 1)) (i32.const 15))"),
+            "l0 = l0 & l1 & 15",
+        );
+    }
+
+    #[test]
+    fn a_constant_and_drops_the_operand_mask_unguarded() {
+        // The raw product exceeds the Fixnum guard, but `& 255` reduces at least as strongly as the mask it replaces.
+        assert_line(
+            &i32_expr("(i32.and (i32.mul (local.get 0) (local.get 1)) (i32.const 255))"),
+            "l0 = l0 * l1 & 255",
+        );
+        // The i64 `Rt.m64` disappears the same way.
+        assert_line(
+            &i64_expr("(i64.and (i64.add (local.get 0) (local.get 1)) (i64.const 255))"),
+            "l0 = l0 + l1 & 255",
+        );
+        // The reduction covers only the AND's own operand: under the XOR the bound guard still binds.
+        assert_line(
+            &i32_expr(
+                "(i32.and (i32.xor (i32.mul (local.get 0) (local.get 1)) (local.get 1)) (i32.const 255))",
+            ),
+            "l0 = (l0 * l1 & 0xffffffff ^ l1) & 255",
+        );
+    }
+
+    #[test]
+    fn an_identity_mask_drops_at_an_observation_point() {
+        // The high half extracted by `>> 32` sits in [0, 2^32): the wrap is the identity even in the stored position.
+        assert_line(
+            &body(
+                "(module (func (export \"f\") (param i64) (result i32) (local i32) \
+                 (local.set 1 (i32.wrap_i64 (i64.shr_u (local.get 0) (i64.const 32)))) (local.get 1)))",
+            ),
+            "l1 = l0 >> (32 & 63)",
+        );
+    }
+
+    #[test]
+    fn a_pinned_constant_equality_drops_the_mask() {
+        // `(l0 - 5) & 0xffffffff == 7` admits exactly one raw preimage, and the constant migrates across the sub.
+        assert_line(
+            &i32_expr("(i32.eq (i32.sub (local.get 0) (i32.const 5)) (i32.const 7))"),
+            "l0 = l0 == 12 ? 1 : 0",
+        );
+        // The same rewrite in boolean position.
+        assert_line(
+            &body(
+                "(module (func (export \"f\") (param i32) (result i32) (local i32) \
+                 (if (i32.eq (i32.sub (local.get 0) (i32.const 5)) (i32.const 7)) (then (local.set 1 (i32.const 1)))) (local.get 1)))",
+            ),
+            "if l0 == 12",
+        );
+        // `eqz` is the equality against 0.
+        assert_line(
+            &body(
+                "(module (func (export \"f\") (param i32) (result i32) (local i32) \
+                 (if (i32.eqz (i32.sub (local.get 0) (i32.const 5))) (then (local.set 1 (i32.const 1)))) (local.get 1)))",
+            ),
+            "if l0 == 5",
+        );
+    }
+
+    #[test]
+    fn an_unpinned_constant_equality_keeps_the_mask() {
+        // A two-sided sub spans almost 2^33: two candidates fit, so the mask stays.
+        assert_line(
+            &i32_expr("(i32.eq (i32.sub (local.get 0) (local.get 1)) (i32.const 7))"),
+            "l0 = l0 - l1 & 0xffffffff == 7 ? 1 : 0",
+        );
+        // No candidate fits: statically false, but the comparison still runs (the operand could trap), only the identity mask goes.
+        assert_line(
+            &i32_expr(
+                "(i32.eq (i32.add (i32.and (local.get 0) (i32.const 3)) (i32.const 1)) (i32.const 9))",
+            ),
+            "l0 = (l0 & 3) + 1 == 9 ? 1 : 0",
         );
     }
 }

--- a/crates/dewasm-backend/src/masking.rs
+++ b/crates/dewasm-backend/src/masking.rs
@@ -2,26 +2,30 @@
 //!
 //! The stored representation masks every integer to its width, and each wrapping operation re-masks its result.
 //! Inside a single [`Expr`] tree that is often double work: a consumer that reads its operand only modulo 2^32 or 2^64 (a wrapping add's operand, a shift count) cannot observe the high bits its own mask throws away.
-//! [`MaskContext`] names the two consumption contexts, [`bin_operand_context`] and [`un_operand_context`] are the table of which operands an operation reads modularly, and [`elides_mask`] is the guard: a backend may skip a site's own result mask exactly when the consumer is modular and the interval bound proves the exposed value stays within the backend's unboxed-integer range.
+//! [`MaskContext`] names the consumption contexts, [`bin_operand_context`] and [`un_operand_context`] are the table of which operands an operation reads modularly, and [`elides_mask`] is the guard: a backend may skip a site's own result mask exactly when the consumer's context and the interval bound allow it.
+//! [`fold_and_chain`] folds the constants of an AND chain at conversion time, and [`eq_const_rewrite`] drops the mask of a site compared for equality against a constant when the interval pins a unique raw preimage.
 //!
 //! Soundness rests on the targets' integers being arbitrary-precision two's complement (Ruby, Python, Perl): an unmasked intermediate is congruent to the masked value modulo 2^w, every modular consumer preserves that congruence (a bitwise operator reads a negative operand as its infinite two's-complement form, so `(x - y) & 0xffffffff` is the correct wrap of a negative difference), and the first non-modular consumer sits behind a kept mask, which reduces the value back to the stored representation.
+//! A mask whose raw interval already sits inside `[0, 2^w)` is the identity on the exact value, so it drops in every context.
 
 use dewasm_core::ir::{BinOp, Expr, LoadOp, UnOp};
 
-/// How a consumer reads an integer operand: `Masked` when it observes the exact stored value, `Modular` when it reads only the value's congruence class modulo the type width, so an unmasked operand serves.
+/// How a consumer reads an integer operand: `Masked` when it observes the exact stored value, `Modular` when it reads only the value's congruence class modulo the type width, so an unmasked operand serves, and `Reducing` when it additionally reduces what it is handed at least as strongly as the operand's own mask would (a bitwise AND with a constant operand, or the pinned equality of [`eq_const_rewrite`]), so the operand's mask drops with no bound guard.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum MaskContext {
     Masked,
     Modular,
+    Reducing,
 }
 
-/// The context in which `op` consumes its operand `k` (0-based), given that `op`'s own result is consumed in `ctx`.
+/// The context in which `op` consumes its operand `k` (0-based), whose sibling operand is `sibling`, given that `op`'s own result is consumed in `ctx`.
 ///
 /// An operation with its own result mask (wrapping add/sub/mul, `shl`, the wrap) reads its operands modularly regardless of `ctx`: the site's mask restores the invariant even when its own elision guard fails.
 /// A shift count is read through the semantic `& (w - 1)`, so it is modular for every shift.
-/// The maskless bitwise operators pass `ctx` through: their result is exact only when their operands are.
+/// An AND with a constant sibling reduces its other operand into `[0, constant]` itself (every IR constant sits inside its width), at least as strong a reduction as the operand's own mask, in every `ctx`.
+/// The other maskless bitwise operators pass `ctx` through, except that a reducing consumer weakens to `Modular`: it reduces the operator's result, which needs only congruent operands, and the raw operands feed the operator itself, so the bound guard must still hold for them.
 /// Everything else (comparisons, division, signed and unsigned views, addresses, helper calls) observes the exact value.
-pub fn bin_operand_context(op: BinOp, k: usize, ctx: MaskContext) -> MaskContext {
+pub fn bin_operand_context(op: BinOp, k: usize, sibling: &Expr, ctx: MaskContext) -> MaskContext {
     use BinOp::*;
     match op {
         I32Add | I32Sub | I32Mul | I64Add | I64Sub | I64Mul | I32Shl | I64Shl => {
@@ -35,7 +39,11 @@ pub fn bin_operand_context(op: BinOp, k: usize, ctx: MaskContext) -> MaskContext
                 MaskContext::Masked
             }
         }
-        I32And | I32Or | I32Xor | I64And | I64Or | I64Xor => ctx,
+        I32And | I64And if int_const(sibling).is_some() => MaskContext::Reducing,
+        I32And | I32Or | I32Xor | I64And | I64Or | I64Xor => match ctx {
+            MaskContext::Reducing => MaskContext::Modular,
+            _ => ctx,
+        },
         _ => MaskContext::Masked,
     }
 }
@@ -48,13 +56,26 @@ pub fn un_operand_context(op: UnOp) -> MaskContext {
     }
 }
 
-/// Whether `e`'s own result mask may be skipped when its consumer is modular: `e` must carry a mask of its own, and the value it exposes unmasked must provably stay in `[-limit, limit)`.
-/// `limit` is the backend's unboxed-integer bound (Ruby: `1 << 62`); the guard keeps elision strictly profitable by never exposing an intermediate the mask would have kept out of bignum arithmetic.
-pub fn elides_mask(e: &Expr, limit: i128) -> bool {
+/// Whether `e`'s own result mask may be skipped when its consumer reads it in `ctx`: `e` must carry a mask of its own, and the interval of the value it exposes unmasked decides per [`may_skip_mask`].
+/// `limit` is the backend's unboxed-integer bound (Ruby: `1 << 62`).
+pub fn elides_mask(e: &Expr, ctx: MaskContext, limit: i128) -> bool {
     match raw_bound(e, limit) {
-        Some(raw) => raw.within(limit),
+        Some((raw, bits)) => may_skip_mask(raw, bits, ctx, limit),
         None => false,
     }
+}
+
+/// Whether a site with raw interval `raw` under a `bits`-wide mask may render unmasked when consumed in `ctx`.
+/// An interval inside `[0, 2^bits)` makes the mask the identity on the exact value: it drops in every context.
+/// A modular consumer needs only congruence, but elision must stay strictly profitable: the exposed value must provably stay in `[-limit, limit)`, never trading a cheap mask for bignum arithmetic.
+/// A reducing consumer hands the raw value to nothing but its own reduction, which the mask's presence would not weaken, so no guard applies.
+fn may_skip_mask(raw: Bound, bits: u32, ctx: MaskContext, limit: i128) -> bool {
+    raw.is_masked_range(bits)
+        || match ctx {
+            MaskContext::Masked => false,
+            MaskContext::Modular => raw.within(limit),
+            MaskContext::Reducing => true,
+        }
 }
 
 /// Everything the interval analysis tracks is clamped to this magnitude: far beyond any elision limit, and small enough that saturating i128 arithmetic on two clamped bounds cannot wrap.
@@ -105,14 +126,11 @@ impl Bound {
 /// The interval of the value `e`'s rendering takes when consumed in `ctx`, under the elision policy of [`elides_mask`] with the same `limit`.
 /// `bits` is the width of `e`'s integer type, which the caller knows from the operation consuming it.
 fn bound(e: &Expr, bits: u32, ctx: MaskContext, limit: i128) -> Bound {
-    if let Some(raw) = raw_bound(e, limit) {
-        if ctx == MaskContext::Modular && raw.within(limit) {
-            return raw;
-        }
-        // The kept mask reduces modulo 2^bits: exactly `raw` when no value in it wraps.
-        return if raw.is_masked_range(bits) {
+    if let Some((raw, _)) = raw_bound(e, limit) {
+        return if may_skip_mask(raw, bits, ctx, limit) {
             raw
         } else {
+            // The kept mask reduces modulo 2^bits.
             Bound::masked(bits)
         };
     }
@@ -142,8 +160,8 @@ fn bound(e: &Expr, bits: u32, ctx: MaskContext, limit: i128) -> Bound {
             match op {
                 I32And | I64And | I32Or | I64Or | I32Xor | I64Xor => bitwise_bound(
                     matches!(op, I32And | I64And),
-                    bound(a, bits, ctx, limit),
-                    bound(b, bits, ctx, limit),
+                    bound(a, bits, bin_operand_context(*op, 0, b, ctx), limit),
+                    bound(b, bits, bin_operand_context(*op, 1, a, ctx), limit),
                 ),
                 I32ShrU | I64ShrU => {
                     let ba = bound(a, bits, Masked, limit);
@@ -160,21 +178,21 @@ fn bound(e: &Expr, bits: u32, ctx: MaskContext, limit: i128) -> Bound {
     }
 }
 
-/// The interval of `e`'s value rendered without its own result mask, or `None` when `e` carries no mask of its own.
-fn raw_bound(e: &Expr, limit: i128) -> Option<Bound> {
+/// The interval of `e`'s value rendered without its own result mask and the width of that mask, or `None` when `e` carries no mask of its own.
+fn raw_bound(e: &Expr, limit: i128) -> Option<(Bound, u32)> {
     use BinOp::*;
     use MaskContext::Modular;
     match e {
-        Expr::Un(UnOp::I32WrapI64, a) => Some(bound(a, 64, Modular, limit)),
+        Expr::Un(UnOp::I32WrapI64, a) => Some((bound(a, 64, Modular, limit), 32)),
         Expr::Bin(op, a, b) => {
             let bits = match op {
                 I32Add | I32Sub | I32Mul | I32Shl | I32ShrS => 32,
                 I64Add | I64Sub | I64Mul | I64Shl | I64ShrS => 64,
                 _ => return None,
             };
-            let ba = bound(a, bits, bin_operand_context(*op, 0, Modular), limit);
+            let ba = bound(a, bits, bin_operand_context(*op, 0, b, Modular), limit);
             let bb = |b: &Expr| bound(b, bits, Modular, limit);
-            Some(match op {
+            let raw = match op {
                 I32Add | I64Add => {
                     let bb = bb(b);
                     Bound::new(ba.lo.saturating_add(bb.lo), ba.hi.saturating_add(bb.hi))
@@ -211,10 +229,97 @@ fn raw_bound(e: &Expr, limit: i128) -> Option<Bound> {
                     Bound::new(*c.iter().min().unwrap(), *c.iter().max().unwrap())
                 }
                 _ => unreachable!("filtered by the bits match above"),
-            })
+            };
+            Some((raw, bits))
         }
         _ => None,
     }
+}
+
+/// The value of an integer constant, in its stored masked-unsigned form.
+fn int_const(e: &Expr) -> Option<u64> {
+    match e {
+        Expr::I32Const(v) => Some(u64::from(*v)),
+        Expr::I64Const(v) => Some(*v),
+        _ => None,
+    }
+}
+
+/// The conversion-time fold of a constant AND chain: in `x & c1 & c2` the two constants meet in one `c1 & c2`, by associativity.
+/// `a` and `b` are the operands of the outermost AND; `Some` only when at least two constants fold.
+/// The residual expression is consumed in [`MaskContext::Reducing`], like the non-constant operand of any AND with a constant.
+pub fn fold_and_chain<'a>(a: &'a Expr, b: &'a Expr) -> Option<(&'a Expr, u64)> {
+    let (mut e, mut c) = and_const_split(a, b)?;
+    let mut folded = false;
+    while let Expr::Bin(BinOp::I32And | BinOp::I64And, x, y) = e {
+        match and_const_split(x, y) {
+            Some((inner, c2)) => {
+                e = inner;
+                c &= c2;
+                folded = true;
+            }
+            None => break,
+        }
+    }
+    folded.then_some((e, c))
+}
+
+/// The non-constant operand of an AND and its constant sibling, when exactly one operand is an integer constant.
+fn and_const_split<'a>(a: &'a Expr, b: &'a Expr) -> Option<(&'a Expr, u64)> {
+    match (int_const(a), int_const(b)) {
+        (Some(c), None) => Some((b, c)),
+        (None, Some(c)) => Some((a, c)),
+        _ => None,
+    }
+}
+
+/// The unmasked form of an integer equality between a mask site `e` and the constant `c` (given in its stored masked form): `wrap(v) == c` holds exactly when raw `v` lands on `c + k * 2^bits`, so when the raw interval of `v` meets exactly one such candidate, the mask drops and `v` compares against that candidate directly.
+/// The constant then migrates across the raw add/sub-by-constant layers the rendering exposes (`x - c1 == c'` is `x == c' + c1`), stopping at the first layer whose own mask stays.
+/// The result is the expression to render, the context to render it in, and the exact comparison constant.
+/// `None` keeps the mask: when `e` carries none, when several candidates fit the interval, and also when none does; the comparison is then statically false, but the operand can hold a trapping load or division, so it must still run.
+pub fn eq_const_rewrite(e: &Expr, c: u64, limit: i128) -> Option<(&Expr, MaskContext, i128)> {
+    let (raw, bits) = raw_bound(e, limit)?;
+    // An interval touching the analysis ceiling may have been clamped, hiding candidates beyond it.
+    if raw.lo <= -CEILING || raw.hi >= CEILING {
+        return None;
+    }
+    let module = 1i128 << bits;
+    let c = i128::from(c);
+    let k_min = (raw.lo - c + module - 1).div_euclid(module);
+    let k_max = (raw.hi - c).div_euclid(module);
+    if k_min != k_max {
+        return None;
+    }
+    let mut e = e;
+    let mut target = c + k_min * module;
+    let mut ctx = MaskContext::Reducing;
+    // Invariant: `e` rendered in `ctx` is the raw arithmetic form the algebra below rewrites (at the top the rewrite itself replaces the mask; deeper, elision is checked before descending).
+    loop {
+        use BinOp::*;
+        let peeled = match e {
+            Expr::Un(UnOp::I32WrapI64, x) => Some((&**x, target)),
+            Expr::Bin(I32Add | I64Add, x, y) => match (int_const(x), int_const(y)) {
+                (Some(c1), None) => Some((&**y, target - i128::from(c1))),
+                (None, Some(c1)) => Some((&**x, target - i128::from(c1))),
+                _ => None,
+            },
+            Expr::Bin(I32Sub | I64Sub, x, y) => match (int_const(x), int_const(y)) {
+                // `c1 - v == t` pins `v == c1 - t`.
+                (Some(c1), None) => Some((&**y, i128::from(c1) - target)),
+                (None, Some(c1)) => Some((&**x, target + i128::from(c1))),
+                _ => None,
+            },
+            _ => None,
+        };
+        let Some((inner, t)) = peeled else { break };
+        e = inner;
+        target = t;
+        ctx = MaskContext::Modular;
+        if !elides_mask(e, MaskContext::Modular, limit) {
+            break;
+        }
+    }
+    Some((e, ctx, target))
 }
 
 /// The values a shift count takes after its semantic `& (bits - 1)`: exact for a constant, the full `0..bits` otherwise.
@@ -285,6 +390,7 @@ fn load_bound(op: LoadOp, bits: u32) -> Bound {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use MaskContext::{Masked, Modular, Reducing};
 
     const LIMIT: i128 = 1 << 62;
 
@@ -304,22 +410,26 @@ mod tests {
         }
     }
 
+    fn elides_modular(e: &Expr) -> bool {
+        elides_mask(e, Modular, LIMIT)
+    }
+
     #[test]
     fn i32_add_and_sub_of_full_range_operands_elide() {
-        assert!(elides_mask(&bin(BinOp::I32Add, local(0), local(1)), LIMIT));
-        assert!(elides_mask(&bin(BinOp::I32Sub, local(0), local(1)), LIMIT));
+        assert!(elides_modular(&bin(BinOp::I32Add, local(0), local(1))));
+        assert!(elides_modular(&bin(BinOp::I32Sub, local(0), local(1))));
     }
 
     #[test]
     fn i32_mul_of_full_range_operands_keeps_its_mask() {
         // (2^32 - 1)^2 exceeds the Fixnum limit.
-        assert!(!elides_mask(&bin(BinOp::I32Mul, local(0), local(1)), LIMIT));
+        assert!(!elides_modular(&bin(BinOp::I32Mul, local(0), local(1))));
     }
 
     #[test]
     fn i32_mul_of_narrowed_operands_elides() {
         let byte = |idx| bin(BinOp::I32And, local(idx), Expr::I32Const(0xff));
-        assert!(elides_mask(&bin(BinOp::I32Mul, byte(0), byte(1)), LIMIT));
+        assert!(elides_modular(&bin(BinOp::I32Mul, byte(0), byte(1))));
     }
 
     #[test]
@@ -332,75 +442,219 @@ mod tests {
                 Expr::I32Const(0xff),
             )
         };
-        assert!(elides_mask(
-            &bin(BinOp::I32Mul, byte_of_diff(0, 1), byte_of_diff(2, 3)),
-            LIMIT
-        ));
+        assert!(elides_modular(&bin(
+            BinOp::I32Mul,
+            byte_of_diff(0, 1),
+            byte_of_diff(2, 3)
+        )));
     }
 
     #[test]
     fn i32_shr_s_always_elides() {
         // The raw signed value is within [-2^31, 2^31), well inside the limit.
-        assert!(elides_mask(&bin(BinOp::I32ShrS, local(0), local(1)), LIMIT));
+        assert!(elides_modular(&bin(BinOp::I32ShrS, local(0), local(1))));
     }
 
     #[test]
     fn shl_elides_only_under_a_small_count_or_operand() {
         // Full range shifted by an unknown count reaches 2^63.
-        assert!(!elides_mask(&bin(BinOp::I32Shl, local(0), local(1)), LIMIT));
+        assert!(!elides_modular(&bin(BinOp::I32Shl, local(0), local(1))));
         // An exact small count keeps the raw value within the limit.
-        assert!(elides_mask(
-            &bin(BinOp::I32Shl, local(0), Expr::I32Const(4)),
-            LIMIT
-        ));
+        assert!(elides_modular(&bin(
+            BinOp::I32Shl,
+            local(0),
+            Expr::I32Const(4)
+        )));
     }
 
     #[test]
     fn wrap_elides_only_for_a_narrow_i64() {
         let wrap = |e: Expr| Expr::Un(UnOp::I32WrapI64, Box::new(e));
         // A full-range i64 exceeds the limit, so the wrap's mask stays.
-        assert!(!elides_mask(&wrap(local(0)), LIMIT));
-        assert!(elides_mask(&wrap(load8u()), LIMIT));
+        assert!(!elides_modular(&wrap(local(0))));
+        assert!(elides_modular(&wrap(load8u())));
         // The high half extracted by `>> 32` is bounded by 2^32.
-        assert!(elides_mask(
-            &wrap(bin(BinOp::I64ShrU, local(0), Expr::I64Const(32))),
-            LIMIT
-        ));
+        assert!(elides_modular(&wrap(bin(
+            BinOp::I64ShrU,
+            local(0),
+            Expr::I64Const(32)
+        ))));
     }
 
     #[test]
     fn i64_arithmetic_elides_only_with_provably_narrow_operands() {
-        assert!(!elides_mask(&bin(BinOp::I64Add, local(0), local(1)), LIMIT));
-        assert!(!elides_mask(
-            &bin(BinOp::I64ShrS, local(0), local(1)),
-            LIMIT
-        ));
-        assert!(elides_mask(
-            &bin(BinOp::I64Add, load8u(), Expr::I64Const(1)),
-            LIMIT
-        ));
+        assert!(!elides_modular(&bin(BinOp::I64Add, local(0), local(1))));
+        assert!(!elides_modular(&bin(BinOp::I64ShrS, local(0), local(1))));
+        assert!(elides_modular(&bin(
+            BinOp::I64Add,
+            load8u(),
+            Expr::I64Const(1)
+        )));
     }
 
     #[test]
     fn nested_elision_bounds_compose() {
         // (l0 + l1) + l2 unmasked is below 3 * 2^32.
         let inner = bin(BinOp::I32Add, local(0), local(1));
-        assert!(elides_mask(&bin(BinOp::I32Add, inner, local(2)), LIMIT));
+        assert!(elides_modular(&bin(BinOp::I32Add, inner, local(2))));
         // ((l0 + l1) * l2) unmasked reaches 2^65: the mul keeps its mask even though its operand elides.
         let inner = bin(BinOp::I32Add, local(0), local(1));
-        assert!(!elides_mask(&bin(BinOp::I32Mul, inner, local(2)), LIMIT));
+        assert!(!elides_modular(&bin(BinOp::I32Mul, inner, local(2))));
     }
 
     #[test]
     fn operand_contexts_follow_the_table() {
-        use MaskContext::*;
-        assert_eq!(bin_operand_context(BinOp::I32Add, 0, Masked), Modular);
-        assert_eq!(bin_operand_context(BinOp::I32ShrU, 0, Modular), Masked);
-        assert_eq!(bin_operand_context(BinOp::I32ShrU, 1, Masked), Modular);
-        assert_eq!(bin_operand_context(BinOp::I32And, 0, Modular), Modular);
-        assert_eq!(bin_operand_context(BinOp::I32And, 0, Masked), Masked);
-        assert_eq!(bin_operand_context(BinOp::I32DivU, 0, Modular), Masked);
+        let l = local(1);
+        assert_eq!(bin_operand_context(BinOp::I32Add, 0, &l, Masked), Modular);
+        assert_eq!(bin_operand_context(BinOp::I32ShrU, 0, &l, Modular), Masked);
+        assert_eq!(bin_operand_context(BinOp::I32ShrU, 1, &l, Masked), Modular);
+        assert_eq!(bin_operand_context(BinOp::I32And, 0, &l, Modular), Modular);
+        assert_eq!(bin_operand_context(BinOp::I32And, 0, &l, Masked), Masked);
+        assert_eq!(bin_operand_context(BinOp::I32DivU, 0, &l, Modular), Masked);
         assert_eq!(un_operand_context(UnOp::I32WrapI64), Modular);
         assert_eq!(un_operand_context(UnOp::I64ExtendI32U), Masked);
+    }
+
+    #[test]
+    fn a_constant_and_sibling_makes_the_operand_context_reducing() {
+        let c = Expr::I32Const(0xff);
+        let c64 = Expr::I64Const(0xff);
+        let l = local(1);
+        assert_eq!(bin_operand_context(BinOp::I32And, 0, &c, Masked), Reducing);
+        assert_eq!(
+            bin_operand_context(BinOp::I64And, 0, &c64, Masked),
+            Reducing
+        );
+        // Only AND reduces its other operand; OR and XOR pass the high bits through.
+        assert_eq!(bin_operand_context(BinOp::I32Or, 0, &c, Masked), Masked);
+        assert_eq!(bin_operand_context(BinOp::I32Xor, 0, &c, Masked), Masked);
+        // A reducing consumer weakens to modular through a maskless bitwise operator.
+        assert_eq!(bin_operand_context(BinOp::I32Xor, 0, &l, Reducing), Modular);
+        assert_eq!(bin_operand_context(BinOp::I32And, 0, &l, Reducing), Modular);
+    }
+
+    #[test]
+    fn a_reducing_consumer_drops_the_mask_with_no_bound_guard() {
+        // A full-range product exceeds the limit, so a modular consumer keeps its mask; a reducing one drops it.
+        let mul = bin(BinOp::I32Mul, local(0), local(1));
+        assert!(!elides_mask(&mul, Modular, LIMIT));
+        assert!(elides_mask(&mul, Reducing, LIMIT));
+        let wrap = Expr::Un(UnOp::I32WrapI64, Box::new(local(0)));
+        assert!(!elides_mask(&wrap, Modular, LIMIT));
+        assert!(elides_mask(&wrap, Reducing, LIMIT));
+        // A maskless site has nothing to drop in any context.
+        assert!(!elides_mask(&local(0), Reducing, LIMIT));
+    }
+
+    #[test]
+    fn an_identity_mask_drops_in_every_context() {
+        // The high half extracted by `>> 32` sits in [0, 2^32): the wrap is the identity even at an observation point.
+        let wrap = Expr::Un(
+            UnOp::I32WrapI64,
+            Box::new(bin(BinOp::I64ShrU, local(0), Expr::I64Const(32))),
+        );
+        assert!(elides_mask(&wrap, Masked, LIMIT));
+        // A raw interval reaching outside [0, 2^32) is not the identity: the mask stays under a masked consumer.
+        let add = bin(BinOp::I32Add, local(0), local(1));
+        assert!(!elides_mask(&add, Masked, LIMIT));
+        let sub = bin(BinOp::I32Sub, local(0), Expr::I32Const(1));
+        assert!(!elides_mask(&sub, Masked, LIMIT));
+        // A sum of narrowed operands stays inside the width: identity again.
+        let narrow_add = bin(BinOp::I32Add, load8u(), Expr::I32Const(1));
+        assert!(elides_mask(&narrow_add, Masked, LIMIT));
+    }
+
+    #[test]
+    fn and_chains_fold_their_constants() {
+        let chain = bin(
+            BinOp::I32And,
+            bin(BinOp::I32And, local(0), Expr::I32Const(0xff00)),
+            Expr::I32Const(0x0ff0),
+        );
+        let Expr::Bin(_, a, b) = &chain else {
+            unreachable!()
+        };
+        let (e, c) = fold_and_chain(a, b).expect("two constants fold");
+        assert!(matches!(e, Expr::LocalGet(0)));
+        assert_eq!(c, 0x0f00);
+        // Constants on either side of either AND fold the same.
+        let chain = bin(
+            BinOp::I64And,
+            Expr::I64Const(0xff),
+            bin(BinOp::I64And, Expr::I64Const(0x0f), local(0)),
+        );
+        let Expr::Bin(_, a, b) = &chain else {
+            unreachable!()
+        };
+        let (e, c) = fold_and_chain(a, b).expect("two constants fold");
+        assert!(matches!(e, Expr::LocalGet(0)));
+        assert_eq!(c, 0x0f);
+    }
+
+    #[test]
+    fn and_chain_folding_needs_two_constants() {
+        // A single constant is the plain AND shape, not a chain.
+        assert!(fold_and_chain(&local(0), &Expr::I32Const(0xff)).is_none());
+        // No constant at the outer AND leaves nothing to fold into.
+        let inner = bin(BinOp::I32And, local(0), Expr::I32Const(0xff));
+        assert!(fold_and_chain(&inner, &local(1)).is_none());
+    }
+
+    #[test]
+    fn eq_rewrite_pins_a_unique_preimage_and_migrates_the_constant() {
+        // `(l0 - 5) & 0xffffffff == 7` has raw interval [-5, 2^32 - 6]: only 7 fits, and the constant migrates to `l0 == 12`.
+        let sub = bin(BinOp::I32Sub, local(0), Expr::I32Const(5));
+        let (e, ctx, t) = eq_const_rewrite(&sub, 7, LIMIT).expect("unique preimage");
+        assert!(matches!(e, Expr::LocalGet(0)));
+        assert_eq!(ctx, Modular);
+        assert_eq!(t, 12);
+        // `5 - l0` flips the migration: `l0 == 5 - 7` lands on the wrapped candidate 7 - 2^32.
+        let rsub = bin(BinOp::I32Sub, Expr::I32Const(5), local(0));
+        let (e, _, t) = eq_const_rewrite(&rsub, 7, LIMIT).expect("unique preimage");
+        assert!(matches!(e, Expr::LocalGet(0)));
+        assert_eq!(t, 5 - (7 - (1i128 << 32)));
+        // Migration walks through nested elided layers: `(l0 + 3) - 5 == 7` pins `l0 == 9`.
+        let nested = bin(
+            BinOp::I32Sub,
+            bin(BinOp::I32Add, local(0), Expr::I32Const(3)),
+            Expr::I32Const(5),
+        );
+        let (e, _, t) = eq_const_rewrite(&nested, 7, LIMIT).expect("unique preimage");
+        assert!(matches!(e, Expr::LocalGet(0)));
+        assert_eq!(t, 9);
+        // The wrap peels away like an add/sub layer, leaving its operand in modular context.
+        let wrap = Expr::Un(UnOp::I32WrapI64, Box::new(load8u()));
+        let (e, ctx, t) = eq_const_rewrite(&wrap, 7, LIMIT).expect("unique preimage");
+        assert!(matches!(e, Expr::Load { .. }));
+        assert_eq!(ctx, Modular);
+        assert_eq!(t, 7);
+        // A site with no peelable layer compares its whole raw form in reducing context: `i64.shr_s` raw is within [-2^63, 2^63), so only the candidate 7 fits.
+        let shr = bin(BinOp::I64ShrS, local(0), local(1));
+        let (e, ctx, t) = eq_const_rewrite(&shr, 7, LIMIT).expect("unique preimage");
+        assert!(matches!(e, Expr::Bin(BinOp::I64ShrS, ..)));
+        assert_eq!(ctx, Reducing);
+        assert_eq!(t, 7);
+    }
+
+    #[test]
+    fn eq_rewrite_against_zero_pins_a_two_sided_sub() {
+        // The sub's open interval (-2^32, 2^32) holds exactly one multiple of 2^32: zero itself, so `eqz(x - y)` reads the raw difference.
+        let sub = bin(BinOp::I32Sub, local(0), local(1));
+        let (e, ctx, t) = eq_const_rewrite(&sub, 0, LIMIT).expect("unique preimage");
+        assert!(matches!(e, Expr::Bin(BinOp::I32Sub, ..)));
+        assert_eq!(ctx, Reducing);
+        assert_eq!(t, 0);
+    }
+
+    #[test]
+    fn eq_rewrite_keeps_the_mask_without_a_unique_preimage() {
+        // A two-sided sub spans almost 2^33: both 7 and 7 - 2^32 fit.
+        let sub = bin(BinOp::I32Sub, local(0), local(1));
+        assert!(eq_const_rewrite(&sub, 7, LIMIT).is_none());
+        // A narrow interval missing the constant fits no candidate: statically false, but the operand must still run, so the mask stays.
+        let narrow = bin(BinOp::I32Add, load8u(), Expr::I32Const(1));
+        assert!(eq_const_rewrite(&narrow, 500, LIMIT).is_none());
+        // A maskless expression is no rewrite site.
+        assert!(eq_const_rewrite(&local(0), 7, LIMIT).is_none());
     }
 }


### PR DESCRIPTION
Closes #235, part of #164. Stacked on #234; merge the stack in order, then retarget to main.

Four rules, all in the shared analysis and applied by Ruby and Python identically:
1. `x & c1 & c2` folds the constants at conversion time.
2. An AND with a constant sibling reads its other operand in a new `Reducing` context in any position, dropping that operand's mask with no bound guard (the constant AND reduces at least as strongly), so `(x * y & 0xffffffff) & 255` becomes `x * y & 255`.
3. A mask whose raw interval already sits inside the type's range is the identity and drops in every context, including observation points.
4. `wrap(e) == c` pins the preimage: when exactly one candidate `c + k * 2^w` intersects the raw interval, the mask drops and the constant migrates across constant add/sub layers (`x - c1 & 0xffffffff == c` becomes `x == c1 + c`); `eqz` rides as `c = 0`. With zero candidates the mask stays (folding to a constant boolean could delete a trapping operand).

Rejected with measurements in decision 77: `Range#===` for the unsigned range-check idiom (3.6x slower interpreted, 3.7-3.9x under YJIT) and the two-comparison form (more ISeq than the mask).

Measured (standalone Ruby sqlite3-shell / library merman, before = #234):

| metric | sqlite3-shell | merman |
| --- | --- | --- |
| mask feeding an AND | 449 → 18 | 1,985 → 550 |
| masked `==`/`!=` | 60 → 53 | 572 → 343 |
| `Rt.m64` calls | 2,367 → 2,105 | 5,483 → 4,673 |
| `& 0xffffffff` sites | 22,055 → 21,218 | 193,525 → 189,380 |
| ISeq memsize | 44,013,944 → 43,927,584 B | 240,008,120 → 239,615,184 B |

Verified with `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, and `--features slow_test` for both backends (each: spec 257/257, wasi 72/72).
Unit tests cover both fold orders, the `Reducing` table, identity elision in masked context, and equality with one, zero, and two candidates; codegen-shape tests pin each rule firing and not firing.