### PR TITLE
Add the post-#164 speed and size records

### DIFF
--- a/docs/benchmarks/figs/app-cowsay-dark.svg
+++ b/docs/benchmarks/figs/app-cowsay-dark.svg
@@ -1,75 +1,87 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="464" viewBox="0 0 820 464" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/cowsay: seconds per run for 15 runners on a log scale, fastest first. dewasm-go is fastest at 4.54 ms, then wasm3 at 11.8 ms; dewasm-bash is slowest at 1.34 s, a span of 296x. The table below carries every number.">
-<title>app/cowsay: seconds per run for 15 runners on a log scale, fastest first. dewasm-go is fastest at 4.54 ms, then wasm3 at 11.8 ms; dewasm-bash is slowest at 1.34 s, a span of 296x. The table below carries every number.</title>
-<rect width="820" height="464" fill="#1a1a19"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ms</text>
-<line x1="343.8" y1="68.0" x2="343.8" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="343.8" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
-<line x1="519.7" y1="68.0" x2="519.7" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="519.7" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
-<line x1="695.5" y1="68.0" x2="695.5" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="695.5" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
-<line x1="168.0" y1="434.0" x2="726.0" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/cowsay: seconds per run for 18 runners on a log scale, fastest first. dewasm-go is fastest at 6.01 ms, then wasm3 at 8.04 ms; dewasm-bash is slowest at 1.11 s, a span of 185x. The table below carries every number.">
+<title>app/cowsay: seconds per run for 18 runners on a log scale, fastest first. dewasm-go is fastest at 6.01 ms, then wasm3 at 8.04 ms; dewasm-bash is slowest at 1.11 s, a span of 185x. The table below carries every number.</title>
+<rect width="820" height="536" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ms</text>
+<line x1="348.5" y1="68.0" x2="348.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="348.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
+<line x1="529.0" y1="68.0" x2="529.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="529.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
+<line x1="709.5" y1="68.0" x2="709.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="709.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
+<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="86.0" x2="283.5" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="283.5" cy="86.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.54 ms</text>
+<line x1="168.0" y1="86.0" x2="308.6" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="308.6" cy="86.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.01 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="110.0" x2="356.8" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="356.8" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">11.8 ms</text>
+<line x1="168.0" y1="110.0" x2="331.4" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="331.4" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.04 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="134.0" x2="376.0" y2="134.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="376.0" cy="134.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.2 ms</text>
+<line x1="168.0" y1="134.0" x2="354.3" y2="134.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="354.3" cy="134.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.8 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="158.0" x2="391.3" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="391.3" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">18.6 ms</text>
+<line x1="168.0" y1="158.0" x2="381.5" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="381.5" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.2 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="182.0" x2="431.6" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="431.6" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">31.6 ms</text>
+<line x1="168.0" y1="182.0" x2="428.1" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="428.1" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">27.6 ms</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="206.0" x2="526.1" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="526.1" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">109 ms</text>
+<line x1="168.0" y1="206.0" x2="532.7" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="532.7" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">105 ms</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="230.0" x2="528.6" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="528.6" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">112 ms</text>
+<line x1="168.0" y1="230.0" x2="533.9" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="533.9" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">106 ms</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="254.0" x2="541.2" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="541.2" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">133 ms</text>
+<line x1="168.0" y1="254.0" x2="546.1" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="546.1" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">124 ms</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="278.0" x2="553.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="553.5" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">156 ms</text>
+<line x1="168.0" y1="278.0" x2="553.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="553.6" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">137 ms</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="302.0" x2="574.4" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="574.4" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">205 ms</text>
-<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="326.0" x2="597.1" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="597.1" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">276 ms</text>
-<text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="632.5" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="632.5" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">438 ms</text>
-<text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="374.0" x2="656.9" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="656.9" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">603 ms</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="398.0" x2="689.1" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="689.1" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">919 ms</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="422.0" x2="718.0" y2="422.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="422.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.34 s</text>
+<line x1="168.0" y1="302.0" x2="576.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="576.2" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">182 ms</text>
+<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
+<line x1="168.0" y1="326.0" x2="593.9" y2="326.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="593.9" cy="326.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">229 ms</text>
+<text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
+<line x1="168.0" y1="350.0" x2="597.3" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="597.3" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">239 ms</text>
+<text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
+<line x1="168.0" y1="374.0" x2="601.8" y2="374.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="601.8" cy="374.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">253 ms</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
+<line x1="168.0" y1="398.0" x2="639.5" y2="398.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="639.5" cy="398.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">409 ms</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="422.0" x2="652.8" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="652.8" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">485 ms</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
+<line x1="168.0" y1="446.0" x2="670.1" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="670.1" cy="446.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">605 ms</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="470.0" x2="694.8" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="694.8" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">829 ms</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.11 s</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">app/cowsay: seconds per run, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/app-cowsay.svg
+++ b/docs/benchmarks/figs/app-cowsay.svg
@@ -1,75 +1,87 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="464" viewBox="0 0 820 464" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/cowsay: seconds per run for 15 runners on a log scale, fastest first. dewasm-go is fastest at 4.54 ms, then wasm3 at 11.8 ms; dewasm-bash is slowest at 1.34 s, a span of 296x. The table below carries every number.">
-<title>app/cowsay: seconds per run for 15 runners on a log scale, fastest first. dewasm-go is fastest at 4.54 ms, then wasm3 at 11.8 ms; dewasm-bash is slowest at 1.34 s, a span of 296x. The table below carries every number.</title>
-<rect width="820" height="464" fill="#fcfcfb"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">1 ms</text>
-<line x1="343.8" y1="68.0" x2="343.8" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="343.8" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
-<line x1="519.7" y1="68.0" x2="519.7" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="519.7" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
-<line x1="695.5" y1="68.0" x2="695.5" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="695.5" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
-<line x1="168.0" y1="434.0" x2="726.0" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/cowsay: seconds per run for 18 runners on a log scale, fastest first. dewasm-go is fastest at 6.01 ms, then wasm3 at 8.04 ms; dewasm-bash is slowest at 1.11 s, a span of 185x. The table below carries every number.">
+<title>app/cowsay: seconds per run for 18 runners on a log scale, fastest first. dewasm-go is fastest at 6.01 ms, then wasm3 at 8.04 ms; dewasm-bash is slowest at 1.11 s, a span of 185x. The table below carries every number.</title>
+<rect width="820" height="536" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ms</text>
+<line x1="348.5" y1="68.0" x2="348.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="348.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
+<line x1="529.0" y1="68.0" x2="529.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="529.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
+<line x1="709.5" y1="68.0" x2="709.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="709.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
+<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="86.0" x2="283.5" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="283.5" cy="86.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.54 ms</text>
+<line x1="168.0" y1="86.0" x2="308.6" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="308.6" cy="86.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.01 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="110.0" x2="356.8" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="356.8" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">11.8 ms</text>
+<line x1="168.0" y1="110.0" x2="331.4" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="331.4" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.04 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="134.0" x2="376.0" y2="134.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="376.0" cy="134.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.2 ms</text>
+<line x1="168.0" y1="134.0" x2="354.3" y2="134.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="354.3" cy="134.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.8 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="158.0" x2="391.3" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="391.3" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">18.6 ms</text>
+<line x1="168.0" y1="158.0" x2="381.5" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="381.5" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.2 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="182.0" x2="431.6" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="431.6" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">31.6 ms</text>
+<line x1="168.0" y1="182.0" x2="428.1" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="428.1" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">27.6 ms</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="206.0" x2="526.1" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="526.1" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">109 ms</text>
+<line x1="168.0" y1="206.0" x2="532.7" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="532.7" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">105 ms</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="230.0" x2="528.6" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="528.6" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">112 ms</text>
+<line x1="168.0" y1="230.0" x2="533.9" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="533.9" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">106 ms</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="254.0" x2="541.2" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="541.2" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">133 ms</text>
+<line x1="168.0" y1="254.0" x2="546.1" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="546.1" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">124 ms</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="278.0" x2="553.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="553.5" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">156 ms</text>
+<line x1="168.0" y1="278.0" x2="553.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="553.6" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">137 ms</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="302.0" x2="574.4" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="574.4" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">205 ms</text>
-<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="326.0" x2="597.1" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="597.1" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">276 ms</text>
-<text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="632.5" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="632.5" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">438 ms</text>
-<text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="374.0" x2="656.9" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="656.9" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">603 ms</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="398.0" x2="689.1" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="689.1" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">919 ms</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="422.0" x2="718.0" y2="422.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="422.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.34 s</text>
+<line x1="168.0" y1="302.0" x2="576.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="576.2" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">182 ms</text>
+<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
+<line x1="168.0" y1="326.0" x2="593.9" y2="326.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="593.9" cy="326.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">229 ms</text>
+<text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
+<line x1="168.0" y1="350.0" x2="597.3" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="597.3" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">239 ms</text>
+<text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
+<line x1="168.0" y1="374.0" x2="601.8" y2="374.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="601.8" cy="374.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">253 ms</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
+<line x1="168.0" y1="398.0" x2="639.5" y2="398.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="639.5" cy="398.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">409 ms</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="422.0" x2="652.8" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="652.8" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">485 ms</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
+<line x1="168.0" y1="446.0" x2="670.1" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="670.1" cy="446.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">605 ms</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="470.0" x2="694.8" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="694.8" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">829 ms</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.11 s</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">app/cowsay: seconds per run, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/app-sqlite3-query-dark.svg
+++ b/docs/benchmarks/figs/app-sqlite3-query-dark.svg
@@ -1,69 +1,69 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="416" viewBox="0 0 820 416" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_query: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 78.9 ms, then wasmer at 89.8 ms; dewasm-perl is slowest at 114 s, a span of 1450x. The table below carries every number.">
-<title>app/sqlite3_query: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 78.9 ms, then wasmer at 89.8 ms; dewasm-perl is slowest at 114 s, a span of 1450x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="416" viewBox="0 0 820 416" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_query: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 75.5 ms, then wasmer at 85.1 ms; dewasm-perl is slowest at 108 s, a span of 1440x. The table below carries every number.">
+<title>app/sqlite3_query: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 75.5 ms, then wasmer at 85.1 ms; dewasm-perl is slowest at 108 s, a span of 1440x. The table below carries every number.</title>
 <rect width="820" height="416" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
-<line x1="303.5" y1="68.0" x2="303.5" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="303.5" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
-<line x1="439.0" y1="68.0" x2="439.0" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="439.0" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
-<line x1="574.5" y1="68.0" x2="574.5" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="574.5" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 s</text>
-<line x1="710.0" y1="68.0" x2="710.0" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="710.0" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 s</text>
+<line x1="304.3" y1="68.0" x2="304.3" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="304.3" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
+<line x1="440.6" y1="68.0" x2="440.6" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="440.6" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
+<line x1="576.9" y1="68.0" x2="576.9" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="576.9" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 s</text>
+<line x1="713.2" y1="68.0" x2="713.2" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="713.2" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 s</text>
 <line x1="168.0" y1="386.0" x2="726.0" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="289.6" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="289.6" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">78.9 ms</text>
+<line x1="168.0" y1="86.0" x2="287.7" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="287.7" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">75.5 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="297.2" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="297.2" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">89.8 ms</text>
+<line x1="168.0" y1="110.0" x2="294.7" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="294.7" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">85.1 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="336.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="336.6" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">176 ms</text>
+<line x1="168.0" y1="134.0" x2="335.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="335.6" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">170 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="413.5" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="413.5" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">648 ms</text>
+<line x1="168.0" y1="158.0" x2="412.4" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="412.4" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">621 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="182.0" x2="445.4" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="445.4" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.12 s</text>
+<line x1="168.0" y1="182.0" x2="444.7" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="444.7" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.07 s</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="206.0" x2="491.3" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="491.3" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.43 s</text>
+<line x1="168.0" y1="206.0" x2="490.3" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="490.3" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.31 s</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="230.0" x2="570.6" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="570.6" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.36 s</text>
+<line x1="168.0" y1="230.0" x2="569.9" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="569.9" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.88 s</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
 <line x1="168.0" y1="254.0" x2="574.2" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="574.2" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.95 s</text>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.55 s</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="278.0" x2="587.7" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="587.7" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.5 s</text>
+<line x1="168.0" y1="278.0" x2="585.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="585.1" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">11.5 s</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="597.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="597.8" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.9 s</text>
+<line x1="168.0" y1="302.0" x2="594.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="594.8" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.5 s</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="608.8" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="608.8" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">17.9 s</text>
+<line x1="168.0" y1="326.0" x2="614.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="614.0" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">18.7 s</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="673.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="673.7" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">53.9 s</text>
+<line x1="168.0" y1="350.0" x2="676.4" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="676.4" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">53.7 s</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
 <line x1="168.0" y1="374.0" x2="718.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">114 s</text>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">108 s</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">app/sqlite3_query: seconds per run, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/app-sqlite3-query.svg
+++ b/docs/benchmarks/figs/app-sqlite3-query.svg
@@ -1,69 +1,69 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="416" viewBox="0 0 820 416" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_query: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 78.9 ms, then wasmer at 89.8 ms; dewasm-perl is slowest at 114 s, a span of 1450x. The table below carries every number.">
-<title>app/sqlite3_query: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 78.9 ms, then wasmer at 89.8 ms; dewasm-perl is slowest at 114 s, a span of 1450x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="416" viewBox="0 0 820 416" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_query: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 75.5 ms, then wasmer at 85.1 ms; dewasm-perl is slowest at 108 s, a span of 1440x. The table below carries every number.">
+<title>app/sqlite3_query: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 75.5 ms, then wasmer at 85.1 ms; dewasm-perl is slowest at 108 s, a span of 1440x. The table below carries every number.</title>
 <rect width="820" height="416" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
-<line x1="303.5" y1="68.0" x2="303.5" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="303.5" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
-<line x1="439.0" y1="68.0" x2="439.0" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="439.0" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
-<line x1="574.5" y1="68.0" x2="574.5" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="574.5" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">10 s</text>
-<line x1="710.0" y1="68.0" x2="710.0" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="710.0" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">100 s</text>
+<line x1="304.3" y1="68.0" x2="304.3" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="304.3" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
+<line x1="440.6" y1="68.0" x2="440.6" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="440.6" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
+<line x1="576.9" y1="68.0" x2="576.9" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="576.9" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">10 s</text>
+<line x1="713.2" y1="68.0" x2="713.2" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="713.2" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">100 s</text>
 <line x1="168.0" y1="386.0" x2="726.0" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="289.6" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="289.6" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">78.9 ms</text>
+<line x1="168.0" y1="86.0" x2="287.7" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="287.7" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">75.5 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="297.2" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="297.2" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">89.8 ms</text>
+<line x1="168.0" y1="110.0" x2="294.7" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="294.7" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">85.1 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="336.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="336.6" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">176 ms</text>
+<line x1="168.0" y1="134.0" x2="335.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="335.6" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">170 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="413.5" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="413.5" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">648 ms</text>
+<line x1="168.0" y1="158.0" x2="412.4" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="412.4" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">621 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="182.0" x2="445.4" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="445.4" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.12 s</text>
+<line x1="168.0" y1="182.0" x2="444.7" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="444.7" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.07 s</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="206.0" x2="491.3" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="491.3" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.43 s</text>
+<line x1="168.0" y1="206.0" x2="490.3" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="490.3" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.31 s</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="230.0" x2="570.6" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="570.6" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.36 s</text>
+<line x1="168.0" y1="230.0" x2="569.9" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="569.9" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.88 s</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
 <line x1="168.0" y1="254.0" x2="574.2" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="574.2" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.95 s</text>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.55 s</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="278.0" x2="587.7" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="587.7" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.5 s</text>
+<line x1="168.0" y1="278.0" x2="585.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="585.1" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">11.5 s</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="597.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="597.8" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.9 s</text>
+<line x1="168.0" y1="302.0" x2="594.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="594.8" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.5 s</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="608.8" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="608.8" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">17.9 s</text>
+<line x1="168.0" y1="326.0" x2="614.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="614.0" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">18.7 s</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="673.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="673.7" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">53.9 s</text>
+<line x1="168.0" y1="350.0" x2="676.4" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="676.4" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">53.7 s</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
 <line x1="168.0" y1="374.0" x2="718.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">114 s</text>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">108 s</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">app/sqlite3_query: seconds per run, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/c-mandelbrot-dark.svg
+++ b/docs/benchmarks/figs/c-mandelbrot-dark.svg
@@ -1,81 +1,93 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="464" viewBox="0 0 820 464" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/mandelbrot: seconds per iteration for 15 runners on a log scale, fastest first. wasmer is fastest at 98.0 ns, then wasmtime at 98.8 ns; dewasm-bash is slowest at 20.5 ms, a span of 209000x. The table below carries every number.">
-<title>c/mandelbrot: seconds per iteration for 15 runners on a log scale, fastest first. wasmer is fastest at 98.0 ns, then wasmtime at 98.8 ns; dewasm-bash is slowest at 20.5 ms, a span of 209000x. The table below carries every number.</title>
-<rect width="820" height="464" fill="#1a1a19"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="255.1" y1="68.0" x2="255.1" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="255.1" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="342.3" y1="68.0" x2="342.3" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="342.3" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="429.4" y1="68.0" x2="429.4" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="429.4" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="516.5" y1="68.0" x2="516.5" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="516.5" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
-<line x1="603.6" y1="68.0" x2="603.6" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="603.6" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ms</text>
-<line x1="690.8" y1="68.0" x2="690.8" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="690.8" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
-<line x1="168.0" y1="434.0" x2="726.0" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/mandelbrot: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 94.4 ns, then wasmtime at 94.7 ns; dewasm-bash is slowest at 17.0 ms, a span of 180000x. The table below carries every number.">
+<title>c/mandelbrot: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 94.4 ns, then wasmtime at 94.7 ns; dewasm-bash is slowest at 17.0 ms, a span of 180000x. The table below carries every number.</title>
+<rect width="820" height="536" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="256.3" y1="68.0" x2="256.3" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="256.3" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="344.5" y1="68.0" x2="344.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="344.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="432.8" y1="68.0" x2="432.8" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="432.8" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="521.1" y1="68.0" x2="521.1" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="521.1" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="609.3" y1="68.0" x2="609.3" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="609.3" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ms</text>
+<line x1="697.6" y1="68.0" x2="697.6" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="697.6" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
+<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="86.0" x2="254.4" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="254.4" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">98.0 ns</text>
+<line x1="168.0" y1="86.0" x2="254.1" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="254.1" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">94.4 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="254.7" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="254.7" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">98.8 ns</text>
+<line x1="168.0" y1="110.0" x2="254.2" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="254.2" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">94.7 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="256.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="256.1" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">102 ns</text>
+<line x1="168.0" y1="134.0" x2="254.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="254.6" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">95.8 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="258.9" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="258.9" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">111 ns</text>
+<line x1="168.0" y1="158.0" x2="258.6" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="258.6" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">106 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="182.0" x2="269.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="269.7" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">147 ns</text>
+<line x1="168.0" y1="182.0" x2="269.2" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="269.2" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">140 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="206.0" x2="288.8" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="288.8" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">243 ns</text>
+<line x1="168.0" y1="206.0" x2="288.7" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="288.7" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">233 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="230.0" x2="313.6" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="313.6" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">470 ns</text>
+<line x1="168.0" y1="230.0" x2="313.9" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="313.9" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">450 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="254.0" x2="391.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="391.8" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.70 µs</text>
+<line x1="168.0" y1="254.0" x2="393.1" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="393.1" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.55 µs</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="278.0" x2="393.9" y2="278.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="393.9" cy="278.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.91 µs</text>
+<line x1="168.0" y1="278.0" x2="395.5" y2="278.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="395.5" cy="278.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.78 µs</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="302.0" x2="400.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="400.2" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.62 µs</text>
+<line x1="168.0" y1="302.0" x2="401.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="401.5" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.42 µs</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="326.0" x2="400.3" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="400.3" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.63 µs</text>
+<line x1="168.0" y1="326.0" x2="401.6" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="401.6" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.43 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="350.0" x2="401.0" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="401.0" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.72 µs</text>
+<line x1="168.0" y1="350.0" x2="401.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="401.7" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.44 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="495.4" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="495.4" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">57.3 µs</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="398.0" x2="629.7" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="629.7" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.99 ms</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="422.0" x2="718.0" y2="422.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="422.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.5 ms</text>
+<line x1="168.0" y1="374.0" x2="498.4" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="498.4" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">55.3 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
+<line x1="168.0" y1="398.0" x2="543.3" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="543.3" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">179 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
+<line x1="168.0" y1="422.0" x2="571.5" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="571.5" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">373 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="446.0" x2="623.7" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="623.7" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.45 ms</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="470.0" x2="632.8" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="632.8" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.85 ms</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">17.0 ms</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">c/mandelbrot: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/c-mandelbrot.svg
+++ b/docs/benchmarks/figs/c-mandelbrot.svg
@@ -1,81 +1,93 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="464" viewBox="0 0 820 464" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/mandelbrot: seconds per iteration for 15 runners on a log scale, fastest first. wasmer is fastest at 98.0 ns, then wasmtime at 98.8 ns; dewasm-bash is slowest at 20.5 ms, a span of 209000x. The table below carries every number.">
-<title>c/mandelbrot: seconds per iteration for 15 runners on a log scale, fastest first. wasmer is fastest at 98.0 ns, then wasmtime at 98.8 ns; dewasm-bash is slowest at 20.5 ms, a span of 209000x. The table below carries every number.</title>
-<rect width="820" height="464" fill="#fcfcfb"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="255.1" y1="68.0" x2="255.1" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="255.1" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="342.3" y1="68.0" x2="342.3" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="342.3" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="429.4" y1="68.0" x2="429.4" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="429.4" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="516.5" y1="68.0" x2="516.5" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="516.5" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
-<line x1="603.6" y1="68.0" x2="603.6" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="603.6" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">1 ms</text>
-<line x1="690.8" y1="68.0" x2="690.8" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="690.8" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
-<line x1="168.0" y1="434.0" x2="726.0" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/mandelbrot: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 94.4 ns, then wasmtime at 94.7 ns; dewasm-bash is slowest at 17.0 ms, a span of 180000x. The table below carries every number.">
+<title>c/mandelbrot: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 94.4 ns, then wasmtime at 94.7 ns; dewasm-bash is slowest at 17.0 ms, a span of 180000x. The table below carries every number.</title>
+<rect width="820" height="536" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="256.3" y1="68.0" x2="256.3" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="256.3" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="344.5" y1="68.0" x2="344.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="344.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="432.8" y1="68.0" x2="432.8" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="432.8" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="521.1" y1="68.0" x2="521.1" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="521.1" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="609.3" y1="68.0" x2="609.3" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="609.3" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ms</text>
+<line x1="697.6" y1="68.0" x2="697.6" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="697.6" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
+<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="86.0" x2="254.4" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="254.4" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">98.0 ns</text>
+<line x1="168.0" y1="86.0" x2="254.1" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="254.1" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">94.4 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="254.7" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="254.7" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">98.8 ns</text>
+<line x1="168.0" y1="110.0" x2="254.2" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="254.2" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">94.7 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="256.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="256.1" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">102 ns</text>
+<line x1="168.0" y1="134.0" x2="254.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="254.6" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">95.8 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="258.9" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="258.9" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">111 ns</text>
+<line x1="168.0" y1="158.0" x2="258.6" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="258.6" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">106 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="182.0" x2="269.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="269.7" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">147 ns</text>
+<line x1="168.0" y1="182.0" x2="269.2" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="269.2" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">140 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="206.0" x2="288.8" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="288.8" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">243 ns</text>
+<line x1="168.0" y1="206.0" x2="288.7" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="288.7" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">233 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="230.0" x2="313.6" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="313.6" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">470 ns</text>
+<line x1="168.0" y1="230.0" x2="313.9" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="313.9" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">450 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="254.0" x2="391.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="391.8" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.70 µs</text>
+<line x1="168.0" y1="254.0" x2="393.1" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="393.1" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.55 µs</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="278.0" x2="393.9" y2="278.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="393.9" cy="278.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.91 µs</text>
+<line x1="168.0" y1="278.0" x2="395.5" y2="278.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="395.5" cy="278.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.78 µs</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="302.0" x2="400.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="400.2" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.62 µs</text>
+<line x1="168.0" y1="302.0" x2="401.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="401.5" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.42 µs</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="326.0" x2="400.3" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="400.3" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.63 µs</text>
+<line x1="168.0" y1="326.0" x2="401.6" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="401.6" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.43 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="350.0" x2="401.0" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="401.0" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.72 µs</text>
+<line x1="168.0" y1="350.0" x2="401.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="401.7" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.44 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="495.4" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="495.4" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">57.3 µs</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="398.0" x2="629.7" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="629.7" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.99 ms</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="422.0" x2="718.0" y2="422.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="422.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.5 ms</text>
+<line x1="168.0" y1="374.0" x2="498.4" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="498.4" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">55.3 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
+<line x1="168.0" y1="398.0" x2="543.3" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="543.3" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">179 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
+<line x1="168.0" y1="422.0" x2="571.5" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="571.5" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">373 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="446.0" x2="623.7" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="623.7" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.45 ms</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="470.0" x2="632.8" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="632.8" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.85 ms</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">17.0 ms</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">c/mandelbrot: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/c-sha256-dark.svg
+++ b/docs/benchmarks/figs/c-sha256-dark.svg
@@ -1,79 +1,91 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="464" viewBox="0 0 820 464" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/sha256: seconds per iteration for 15 runners on a log scale, fastest first. wasmer is fastest at 303 ns, then wasmtime at 305 ns; dewasm-bash is slowest at 16.2 ms, a span of 53300x. The table below carries every number.">
-<title>c/sha256: seconds per iteration for 15 runners on a log scale, fastest first. wasmer is fastest at 303 ns, then wasmtime at 305 ns; dewasm-bash is slowest at 16.2 ms, a span of 53300x. The table below carries every number.</title>
-<rect width="820" height="464" fill="#1a1a19"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="273.6" y1="68.0" x2="273.6" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="273.6" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="379.2" y1="68.0" x2="379.2" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="379.2" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="484.8" y1="68.0" x2="484.8" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="484.8" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
-<line x1="590.4" y1="68.0" x2="590.4" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="590.4" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ms</text>
-<line x1="696.0" y1="68.0" x2="696.0" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="696.0" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
-<line x1="168.0" y1="434.0" x2="726.0" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="86.0" x2="218.9" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="218.9" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">303 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="219.1" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="219.1" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">305 ns</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/sha256: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 289 ns, then wasmer at 289 ns; pywasm-cpython is slowest at 14.3 ms, a span of 49300x. The table below carries every number.">
+<title>c/sha256: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 289 ns, then wasmer at 289 ns; pywasm-cpython is slowest at 14.3 ms, a span of 49300x. The table below carries every number.</title>
+<rect width="820" height="536" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="274.7" y1="68.0" x2="274.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="274.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="381.4" y1="68.0" x2="381.4" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="381.4" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="488.1" y1="68.0" x2="488.1" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="488.1" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="594.8" y1="68.0" x2="594.8" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="594.8" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ms</text>
+<line x1="701.5" y1="68.0" x2="701.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="701.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
+<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="217.2" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="217.2" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">289 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="110.0" x2="217.2" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="217.2" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">289 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="227.0" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="227.0" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">362 ns</text>
+<line x1="168.0" y1="134.0" x2="225.0" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="225.0" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">342 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="230.7" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="230.7" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">393 ns</text>
+<line x1="168.0" y1="158.0" x2="229.2" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="229.2" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">374 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="245.6" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="245.6" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">543 ns</text>
+<line x1="168.0" y1="182.0" x2="239.2" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="239.2" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">465 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="349.6" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="349.6" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.24 µs</text>
+<line x1="168.0" y1="206.0" x2="349.3" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="349.3" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.00 µs</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="398.0" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="398.0" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.1 µs</text>
+<line x1="168.0" y1="230.0" x2="397.8" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="397.8" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.2 µs</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="445.8" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="445.8" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">42.7 µs</text>
+<line x1="168.0" y1="254.0" x2="447.4" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="447.4" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">41.5 µs</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="454.9" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="454.9" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">52.1 µs</text>
+<line x1="168.0" y1="278.0" x2="454.4" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="454.4" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">48.3 µs</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="458.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="458.8" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">56.7 µs</text>
+<line x1="168.0" y1="302.0" x2="458.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="458.0" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">52.2 µs</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="474.8" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="474.8" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">80.5 µs</text>
+<line x1="168.0" y1="326.0" x2="476.8" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="476.8" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">78.3 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="533.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="533.1" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">287 µs</text>
+<line x1="168.0" y1="350.0" x2="533.6" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="533.6" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">267 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="539.5" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="539.5" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">330 µs</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="398.0" x2="682.0" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="682.0" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.37 ms</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="422.0" x2="718.0" y2="422.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="422.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">16.2 ms</text>
+<line x1="168.0" y1="374.0" x2="541.7" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="541.7" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">318 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
+<line x1="168.0" y1="398.0" x2="623.7" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="623.7" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.86 ms</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
+<line x1="168.0" y1="422.0" x2="660.1" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="660.1" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.09 ms</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="446.0" x2="684.7" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="684.7" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.95 ms</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="470.0" x2="715.4" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="715.4" cy="470.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.5 ms</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.3 ms</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">c/sha256: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/c-sha256.svg
+++ b/docs/benchmarks/figs/c-sha256.svg
@@ -1,79 +1,91 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="464" viewBox="0 0 820 464" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/sha256: seconds per iteration for 15 runners on a log scale, fastest first. wasmer is fastest at 303 ns, then wasmtime at 305 ns; dewasm-bash is slowest at 16.2 ms, a span of 53300x. The table below carries every number.">
-<title>c/sha256: seconds per iteration for 15 runners on a log scale, fastest first. wasmer is fastest at 303 ns, then wasmtime at 305 ns; dewasm-bash is slowest at 16.2 ms, a span of 53300x. The table below carries every number.</title>
-<rect width="820" height="464" fill="#fcfcfb"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="273.6" y1="68.0" x2="273.6" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="273.6" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="379.2" y1="68.0" x2="379.2" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="379.2" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="484.8" y1="68.0" x2="484.8" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="484.8" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
-<line x1="590.4" y1="68.0" x2="590.4" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="590.4" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">1 ms</text>
-<line x1="696.0" y1="68.0" x2="696.0" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="696.0" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
-<line x1="168.0" y1="434.0" x2="726.0" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="86.0" x2="218.9" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="218.9" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">303 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="219.1" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="219.1" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">305 ns</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/sha256: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 289 ns, then wasmer at 289 ns; pywasm-cpython is slowest at 14.3 ms, a span of 49300x. The table below carries every number.">
+<title>c/sha256: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 289 ns, then wasmer at 289 ns; pywasm-cpython is slowest at 14.3 ms, a span of 49300x. The table below carries every number.</title>
+<rect width="820" height="536" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="274.7" y1="68.0" x2="274.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="274.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="381.4" y1="68.0" x2="381.4" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="381.4" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="488.1" y1="68.0" x2="488.1" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="488.1" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="594.8" y1="68.0" x2="594.8" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="594.8" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ms</text>
+<line x1="701.5" y1="68.0" x2="701.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="701.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
+<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="217.2" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="217.2" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">289 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="110.0" x2="217.2" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="217.2" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">289 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="227.0" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="227.0" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">362 ns</text>
+<line x1="168.0" y1="134.0" x2="225.0" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="225.0" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">342 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="230.7" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="230.7" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">393 ns</text>
+<line x1="168.0" y1="158.0" x2="229.2" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="229.2" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">374 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="245.6" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="245.6" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">543 ns</text>
+<line x1="168.0" y1="182.0" x2="239.2" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="239.2" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">465 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="349.6" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="349.6" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.24 µs</text>
+<line x1="168.0" y1="206.0" x2="349.3" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="349.3" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.00 µs</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="398.0" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="398.0" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.1 µs</text>
+<line x1="168.0" y1="230.0" x2="397.8" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="397.8" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.2 µs</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="445.8" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="445.8" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">42.7 µs</text>
+<line x1="168.0" y1="254.0" x2="447.4" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="447.4" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">41.5 µs</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="454.9" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="454.9" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">52.1 µs</text>
+<line x1="168.0" y1="278.0" x2="454.4" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="454.4" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">48.3 µs</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="458.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="458.8" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">56.7 µs</text>
+<line x1="168.0" y1="302.0" x2="458.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="458.0" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">52.2 µs</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="474.8" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="474.8" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">80.5 µs</text>
+<line x1="168.0" y1="326.0" x2="476.8" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="476.8" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">78.3 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="533.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="533.1" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">287 µs</text>
+<line x1="168.0" y1="350.0" x2="533.6" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="533.6" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">267 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="539.5" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="539.5" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">330 µs</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="398.0" x2="682.0" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="682.0" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.37 ms</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="422.0" x2="718.0" y2="422.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="422.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">16.2 ms</text>
+<line x1="168.0" y1="374.0" x2="541.7" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="541.7" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">318 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
+<line x1="168.0" y1="398.0" x2="623.7" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="623.7" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.86 ms</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
+<line x1="168.0" y1="422.0" x2="660.1" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="660.1" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.09 ms</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="446.0" x2="684.7" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="684.7" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.95 ms</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="470.0" x2="715.4" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="715.4" cy="470.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.5 ms</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.3 ms</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">c/sha256: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/c-wordcount-dark.svg
+++ b/docs/benchmarks/figs/c-wordcount-dark.svg
@@ -1,77 +1,89 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="464" viewBox="0 0 820 464" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/wordcount: seconds per iteration for 15 runners on a log scale, fastest first. wasmer is fastest at 1.72 ns, then wasmtime at 1.82 ns; dewasm-bash is slowest at 43.8 µs, a span of 25500x. The table below carries every number.">
-<title>c/wordcount: seconds per iteration for 15 runners on a log scale, fastest first. wasmer is fastest at 1.72 ns, then wasmtime at 1.82 ns; dewasm-bash is slowest at 43.8 µs, a span of 25500x. The table below carries every number.</title>
-<rect width="820" height="464" fill="#1a1a19"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="286.5" y1="68.0" x2="286.5" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="286.5" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="405.0" y1="68.0" x2="405.0" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="405.0" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="523.5" y1="68.0" x2="523.5" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="523.5" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="642.0" y1="68.0" x2="642.0" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="642.0" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="168.0" y1="434.0" x2="726.0" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="86.0" x2="195.9" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="195.9" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.72 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="198.9" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="198.9" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.82 ns</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/wordcount: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.67 ns, then wasmer at 1.68 ns; pywasm-cpython is slowest at 58.9 µs, a span of 35300x. The table below carries every number.">
+<title>c/wordcount: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.67 ns, then wasmer at 1.68 ns; pywasm-cpython is slowest at 58.9 µs, a span of 35300x. The table below carries every number.</title>
+<rect width="820" height="536" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
+<line x1="283.3" y1="68.0" x2="283.3" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="283.3" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="398.6" y1="68.0" x2="398.6" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="398.6" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="513.9" y1="68.0" x2="513.9" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="513.9" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="629.2" y1="68.0" x2="629.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="629.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="193.7" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="193.7" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.67 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="110.0" x2="194.0" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="194.0" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.68 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="216.4" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="216.4" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.56 ns</text>
+<line x1="168.0" y1="134.0" x2="212.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="212.6" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.44 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="226.6" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="226.6" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.13 ns</text>
+<line x1="168.0" y1="158.0" x2="222.9" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="222.9" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.99 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="232.0" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="232.0" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.47 ns</text>
+<line x1="168.0" y1="182.0" x2="230.5" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="230.5" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.48 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="325.5" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="325.5" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">21.3 ns</text>
+<line x1="168.0" y1="206.0" x2="319.3" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="319.3" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.5 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="377.6" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="377.6" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">58.8 ns</text>
+<line x1="168.0" y1="230.0" x2="369.8" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="369.8" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">56.3 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="443.3" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="443.3" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">210 ns</text>
+<line x1="168.0" y1="254.0" x2="434.0" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="434.0" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">203 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="459.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="459.6" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">289 ns</text>
+<line x1="168.0" y1="278.0" x2="448.7" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="448.7" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">272 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="463.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="463.6" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">313 ns</text>
+<line x1="168.0" y1="302.0" x2="452.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="452.5" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">293 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="477.1" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="477.1" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">406 ns</text>
+<line x1="168.0" y1="326.0" x2="469.2" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="469.2" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">409 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="517.8" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="517.8" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">895 ns</text>
+<line x1="168.0" y1="350.0" x2="507.9" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="507.9" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">888 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="545.4" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="545.4" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.53 µs</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="398.0" x2="668.7" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="668.7" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">16.8 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="422.0" x2="718.0" y2="422.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="422.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">43.8 µs</text>
+<line x1="168.0" y1="374.0" x2="533.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="533.0" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.47 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
+<line x1="168.0" y1="398.0" x2="627.6" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="627.6" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.68 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="422.0" x2="650.5" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="650.5" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.3 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
+<line x1="168.0" y1="446.0" x2="665.2" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="665.2" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.5 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="470.0" x2="694.6" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="694.6" cy="470.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">36.9 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">58.9 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">c/wordcount: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/c-wordcount.svg
+++ b/docs/benchmarks/figs/c-wordcount.svg
@@ -1,77 +1,89 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="464" viewBox="0 0 820 464" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/wordcount: seconds per iteration for 15 runners on a log scale, fastest first. wasmer is fastest at 1.72 ns, then wasmtime at 1.82 ns; dewasm-bash is slowest at 43.8 µs, a span of 25500x. The table below carries every number.">
-<title>c/wordcount: seconds per iteration for 15 runners on a log scale, fastest first. wasmer is fastest at 1.72 ns, then wasmtime at 1.82 ns; dewasm-bash is slowest at 43.8 µs, a span of 25500x. The table below carries every number.</title>
-<rect width="820" height="464" fill="#fcfcfb"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="286.5" y1="68.0" x2="286.5" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="286.5" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="405.0" y1="68.0" x2="405.0" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="405.0" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="523.5" y1="68.0" x2="523.5" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="523.5" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="642.0" y1="68.0" x2="642.0" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="642.0" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="168.0" y1="434.0" x2="726.0" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="86.0" x2="195.9" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="195.9" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.72 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="198.9" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="198.9" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.82 ns</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/wordcount: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.67 ns, then wasmer at 1.68 ns; pywasm-cpython is slowest at 58.9 µs, a span of 35300x. The table below carries every number.">
+<title>c/wordcount: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.67 ns, then wasmer at 1.68 ns; pywasm-cpython is slowest at 58.9 µs, a span of 35300x. The table below carries every number.</title>
+<rect width="820" height="536" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
+<line x1="283.3" y1="68.0" x2="283.3" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="283.3" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="398.6" y1="68.0" x2="398.6" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="398.6" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="513.9" y1="68.0" x2="513.9" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="513.9" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="629.2" y1="68.0" x2="629.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="629.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="193.7" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="193.7" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.67 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="110.0" x2="194.0" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="194.0" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.68 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="216.4" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="216.4" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.56 ns</text>
+<line x1="168.0" y1="134.0" x2="212.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="212.6" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.44 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="226.6" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="226.6" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.13 ns</text>
+<line x1="168.0" y1="158.0" x2="222.9" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="222.9" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.99 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="232.0" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="232.0" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.47 ns</text>
+<line x1="168.0" y1="182.0" x2="230.5" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="230.5" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.48 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="325.5" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="325.5" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">21.3 ns</text>
+<line x1="168.0" y1="206.0" x2="319.3" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="319.3" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.5 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="377.6" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="377.6" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">58.8 ns</text>
+<line x1="168.0" y1="230.0" x2="369.8" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="369.8" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">56.3 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="443.3" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="443.3" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">210 ns</text>
+<line x1="168.0" y1="254.0" x2="434.0" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="434.0" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">203 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="459.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="459.6" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">289 ns</text>
+<line x1="168.0" y1="278.0" x2="448.7" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="448.7" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">272 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="463.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="463.6" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">313 ns</text>
+<line x1="168.0" y1="302.0" x2="452.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="452.5" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">293 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="477.1" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="477.1" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">406 ns</text>
+<line x1="168.0" y1="326.0" x2="469.2" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="469.2" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">409 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="517.8" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="517.8" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">895 ns</text>
+<line x1="168.0" y1="350.0" x2="507.9" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="507.9" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">888 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="545.4" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="545.4" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.53 µs</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="398.0" x2="668.7" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="668.7" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">16.8 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="422.0" x2="718.0" y2="422.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="422.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">43.8 µs</text>
+<line x1="168.0" y1="374.0" x2="533.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="533.0" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.47 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
+<line x1="168.0" y1="398.0" x2="627.6" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="627.6" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.68 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="422.0" x2="650.5" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="650.5" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.3 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
+<line x1="168.0" y1="446.0" x2="665.2" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="665.2" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.5 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="470.0" x2="694.6" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="694.6" cy="470.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">36.9 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">58.9 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">c/wordcount: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-call-direct-dark.svg
+++ b/docs/benchmarks/figs/wat-call-direct-dark.svg
@@ -1,77 +1,89 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="464" viewBox="0 0 820 464" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_direct: seconds per iteration for 15 runners on a log scale, fastest first. wasmer is fastest at 3.61 ns, then wasmtime at 3.62 ns; dewasm-bash is slowest at 57.3 µs, a span of 15900x. The table below carries every number.">
-<title>wat/call_direct: seconds per iteration for 15 runners on a log scale, fastest first. wasmer is fastest at 3.61 ns, then wasmtime at 3.62 ns; dewasm-bash is slowest at 57.3 µs, a span of 15900x. The table below carries every number.</title>
-<rect width="820" height="464" fill="#1a1a19"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="283.6" y1="68.0" x2="283.6" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="283.6" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="399.2" y1="68.0" x2="399.2" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="399.2" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="514.8" y1="68.0" x2="514.8" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="514.8" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="630.4" y1="68.0" x2="630.4" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="630.4" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="168.0" y1="434.0" x2="726.0" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_direct: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 3.47 ns, then wasmtime at 3.48 ns; pywasm-cpython is slowest at 49.0 µs, a span of 14100x. The table below carries every number.">
+<title>wat/call_direct: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 3.47 ns, then wasmtime at 3.48 ns; pywasm-cpython is slowest at 49.0 µs, a span of 14100x. The table below carries every number.</title>
+<rect width="820" height="536" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
+<line x1="285.3" y1="68.0" x2="285.3" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="285.3" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="402.5" y1="68.0" x2="402.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="402.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="519.8" y1="68.0" x2="519.8" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="519.8" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="637.0" y1="68.0" x2="637.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="637.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="86.0" x2="232.5" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="232.5" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.61 ns</text>
+<line x1="168.0" y1="86.0" x2="231.3" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="231.3" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.47 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="232.6" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="232.6" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.62 ns</text>
+<line x1="168.0" y1="110.0" x2="231.5" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="231.5" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.48 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="234.2" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="234.2" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.74 ns</text>
+<line x1="168.0" y1="134.0" x2="232.4" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="232.4" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.54 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="158.0" x2="240.8" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="240.8" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.26 ns</text>
+<line x1="168.0" y1="158.0" x2="239.5" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="239.5" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.07 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="182.0" x2="259.8" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="259.8" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.23 ns</text>
+<line x1="168.0" y1="182.0" x2="258.8" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="258.8" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.94 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="365.7" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="365.7" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">51.4 ns</text>
+<line x1="168.0" y1="206.0" x2="366.5" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="366.5" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">49.3 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="394.8" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="394.8" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">91.6 ns</text>
+<line x1="168.0" y1="230.0" x2="396.4" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="396.4" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">88.7 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="404.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="404.8" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">112 ns</text>
+<line x1="168.0" y1="254.0" x2="406.2" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="406.2" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">108 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="278.0" x2="415.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="415.8" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">139 ns</text>
-<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="302.0" x2="436.8" y2="302.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="436.8" cy="302.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">211 ns</text>
-<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="437.8" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="437.8" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">216 ns</text>
+<line x1="168.0" y1="278.0" x2="413.7" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="413.7" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">124 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
+<line x1="168.0" y1="302.0" x2="438.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="438.7" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">204 ns</text>
+<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
+<line x1="168.0" y1="326.0" x2="439.1" y2="326.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="439.1" cy="326.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">205 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="472.6" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="472.6" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">432 ns</text>
+<line x1="168.0" y1="350.0" x2="474.9" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="474.9" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">414 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="521.3" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="521.3" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.14 µs</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="398.0" x2="629.0" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="629.0" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.73 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="422.0" x2="718.0" y2="422.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="422.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">57.3 µs</text>
+<line x1="168.0" y1="374.0" x2="524.6" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="524.6" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.10 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
+<line x1="168.0" y1="398.0" x2="626.5" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="626.5" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.13 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="422.0" x2="630.9" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="630.9" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.87 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
+<line x1="168.0" y1="446.0" x2="666.7" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="666.7" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">17.9 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="470.0" x2="715.9" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="715.9" cy="470.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">47.1 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">49.0 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/call_direct: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-call-direct.svg
+++ b/docs/benchmarks/figs/wat-call-direct.svg
@@ -1,77 +1,89 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="464" viewBox="0 0 820 464" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_direct: seconds per iteration for 15 runners on a log scale, fastest first. wasmer is fastest at 3.61 ns, then wasmtime at 3.62 ns; dewasm-bash is slowest at 57.3 µs, a span of 15900x. The table below carries every number.">
-<title>wat/call_direct: seconds per iteration for 15 runners on a log scale, fastest first. wasmer is fastest at 3.61 ns, then wasmtime at 3.62 ns; dewasm-bash is slowest at 57.3 µs, a span of 15900x. The table below carries every number.</title>
-<rect width="820" height="464" fill="#fcfcfb"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="283.6" y1="68.0" x2="283.6" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="283.6" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="399.2" y1="68.0" x2="399.2" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="399.2" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="514.8" y1="68.0" x2="514.8" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="514.8" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="630.4" y1="68.0" x2="630.4" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="630.4" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="168.0" y1="434.0" x2="726.0" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_direct: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 3.47 ns, then wasmtime at 3.48 ns; pywasm-cpython is slowest at 49.0 µs, a span of 14100x. The table below carries every number.">
+<title>wat/call_direct: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 3.47 ns, then wasmtime at 3.48 ns; pywasm-cpython is slowest at 49.0 µs, a span of 14100x. The table below carries every number.</title>
+<rect width="820" height="536" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
+<line x1="285.3" y1="68.0" x2="285.3" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="285.3" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="402.5" y1="68.0" x2="402.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="402.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="519.8" y1="68.0" x2="519.8" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="519.8" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="637.0" y1="68.0" x2="637.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="637.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="86.0" x2="232.5" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="232.5" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.61 ns</text>
+<line x1="168.0" y1="86.0" x2="231.3" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="231.3" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.47 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="232.6" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="232.6" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.62 ns</text>
+<line x1="168.0" y1="110.0" x2="231.5" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="231.5" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.48 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="234.2" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="234.2" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.74 ns</text>
+<line x1="168.0" y1="134.0" x2="232.4" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="232.4" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.54 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="158.0" x2="240.8" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="240.8" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.26 ns</text>
+<line x1="168.0" y1="158.0" x2="239.5" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="239.5" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.07 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="182.0" x2="259.8" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="259.8" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.23 ns</text>
+<line x1="168.0" y1="182.0" x2="258.8" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="258.8" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.94 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="365.7" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="365.7" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">51.4 ns</text>
+<line x1="168.0" y1="206.0" x2="366.5" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="366.5" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">49.3 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="394.8" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="394.8" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">91.6 ns</text>
+<line x1="168.0" y1="230.0" x2="396.4" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="396.4" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">88.7 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="404.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="404.8" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">112 ns</text>
+<line x1="168.0" y1="254.0" x2="406.2" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="406.2" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">108 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="278.0" x2="415.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="415.8" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">139 ns</text>
-<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="302.0" x2="436.8" y2="302.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="436.8" cy="302.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">211 ns</text>
-<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="437.8" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="437.8" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">216 ns</text>
+<line x1="168.0" y1="278.0" x2="413.7" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="413.7" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">124 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
+<line x1="168.0" y1="302.0" x2="438.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="438.7" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">204 ns</text>
+<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
+<line x1="168.0" y1="326.0" x2="439.1" y2="326.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="439.1" cy="326.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">205 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="472.6" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="472.6" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">432 ns</text>
+<line x1="168.0" y1="350.0" x2="474.9" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="474.9" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">414 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="521.3" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="521.3" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.14 µs</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="398.0" x2="629.0" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="629.0" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.73 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="422.0" x2="718.0" y2="422.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="422.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">57.3 µs</text>
+<line x1="168.0" y1="374.0" x2="524.6" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="524.6" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.10 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
+<line x1="168.0" y1="398.0" x2="626.5" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="626.5" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.13 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="422.0" x2="630.9" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="630.9" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.87 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
+<line x1="168.0" y1="446.0" x2="666.7" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="666.7" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">17.9 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="470.0" x2="715.9" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="715.9" cy="470.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">47.1 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">49.0 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/call_direct: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-call-indirect-dark.svg
+++ b/docs/benchmarks/figs/wat-call-indirect-dark.svg
@@ -1,75 +1,87 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="464" viewBox="0 0 820 464" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_indirect: seconds per iteration for 15 runners on a log scale, fastest first. wasmtime is fastest at 10.9 ns, then wasmer at 10.9 ns; dewasm-bash is slowest at 77.3 µs, a span of 7120x. The table below carries every number.">
-<title>wat/call_indirect: seconds per iteration for 15 runners on a log scale, fastest first. wasmtime is fastest at 10.9 ns, then wasmer at 10.9 ns; dewasm-bash is slowest at 77.3 µs, a span of 7120x. The table below carries every number.</title>
-<rect width="820" height="464" fill="#1a1a19"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="309.5" y1="68.0" x2="309.5" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="309.5" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="450.9" y1="68.0" x2="450.9" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="450.9" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="592.4" y1="68.0" x2="592.4" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="592.4" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="168.0" y1="434.0" x2="726.0" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="173.0" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="173.0" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.9 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="173.0" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="173.0" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.9 ns</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_indirect: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 10.3 ns, then wasmtime at 10.4 ns; pywasm-cpython is slowest at 80.6 µs, a span of 7820x. The table below carries every number.">
+<title>wat/call_indirect: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 10.3 ns, then wasmtime at 10.4 ns; pywasm-cpython is slowest at 80.6 µs, a span of 7820x. The table below carries every number.</title>
+<rect width="820" height="536" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="308.8" y1="68.0" x2="308.8" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="308.8" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="449.6" y1="68.0" x2="449.6" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="449.6" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="590.4" y1="68.0" x2="590.4" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="590.4" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="86.0" x2="169.8" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="169.8" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.3 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="110.0" x2="170.4" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="170.4" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.4 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="174.7" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="174.7" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">11.1 ns</text>
+<line x1="168.0" y1="134.0" x2="172.3" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="172.3" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.7 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="179.1" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="179.1" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.0 ns</text>
+<line x1="168.0" y1="158.0" x2="178.1" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="178.1" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">11.8 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="273.0" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="273.0" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">55.2 ns</text>
+<line x1="168.0" y1="182.0" x2="273.8" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="273.8" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">56.4 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="288.7" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="288.7" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">71.3 ns</text>
+<line x1="168.0" y1="206.0" x2="286.4" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="286.4" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">69.4 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="331.7" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="331.7" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">144 ns</text>
+<line x1="168.0" y1="230.0" x2="327.7" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="327.7" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">136 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="397.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="397.8" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">421 ns</text>
+<line x1="168.0" y1="254.0" x2="394.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="394.6" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">407 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="278.0" x2="399.2" y2="278.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="399.2" cy="278.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">431 ns</text>
+<line x1="168.0" y1="278.0" x2="396.0" y2="278.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="396.0" cy="278.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">416 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="408.4" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="408.4" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">501 ns</text>
+<line x1="168.0" y1="302.0" x2="403.3" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="403.3" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">469 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="428.5" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="428.5" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">694 ns</text>
+<line x1="168.0" y1="326.0" x2="423.9" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="423.9" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">657 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="442.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="442.2" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">868 ns</text>
+<line x1="168.0" y1="350.0" x2="434.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="434.2" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">777 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="508.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="508.1" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.53 µs</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="398.0" x2="665.9" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="665.9" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">33.1 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="422.0" x2="718.0" y2="422.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="422.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">77.3 µs</text>
+<line x1="168.0" y1="374.0" x2="504.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="504.0" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.44 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
+<line x1="168.0" y1="398.0" x2="610.2" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="610.2" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.8 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="422.0" x2="643.4" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="643.4" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">23.8 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
+<line x1="168.0" y1="446.0" x2="652.0" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="652.0" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">27.4 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="470.0" x2="705.2" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="705.2" cy="470.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">65.4 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">80.6 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/call_indirect: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-call-indirect.svg
+++ b/docs/benchmarks/figs/wat-call-indirect.svg
@@ -1,75 +1,87 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="464" viewBox="0 0 820 464" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_indirect: seconds per iteration for 15 runners on a log scale, fastest first. wasmtime is fastest at 10.9 ns, then wasmer at 10.9 ns; dewasm-bash is slowest at 77.3 µs, a span of 7120x. The table below carries every number.">
-<title>wat/call_indirect: seconds per iteration for 15 runners on a log scale, fastest first. wasmtime is fastest at 10.9 ns, then wasmer at 10.9 ns; dewasm-bash is slowest at 77.3 µs, a span of 7120x. The table below carries every number.</title>
-<rect width="820" height="464" fill="#fcfcfb"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="309.5" y1="68.0" x2="309.5" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="309.5" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="450.9" y1="68.0" x2="450.9" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="450.9" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="592.4" y1="68.0" x2="592.4" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="592.4" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="168.0" y1="434.0" x2="726.0" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="173.0" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="173.0" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.9 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="173.0" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="173.0" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.9 ns</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_indirect: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 10.3 ns, then wasmtime at 10.4 ns; pywasm-cpython is slowest at 80.6 µs, a span of 7820x. The table below carries every number.">
+<title>wat/call_indirect: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 10.3 ns, then wasmtime at 10.4 ns; pywasm-cpython is slowest at 80.6 µs, a span of 7820x. The table below carries every number.</title>
+<rect width="820" height="536" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="308.8" y1="68.0" x2="308.8" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="308.8" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="449.6" y1="68.0" x2="449.6" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="449.6" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="590.4" y1="68.0" x2="590.4" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="590.4" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="86.0" x2="169.8" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="169.8" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.3 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="110.0" x2="170.4" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="170.4" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.4 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="174.7" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="174.7" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">11.1 ns</text>
+<line x1="168.0" y1="134.0" x2="172.3" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="172.3" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.7 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="179.1" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="179.1" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.0 ns</text>
+<line x1="168.0" y1="158.0" x2="178.1" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="178.1" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">11.8 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="273.0" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="273.0" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">55.2 ns</text>
+<line x1="168.0" y1="182.0" x2="273.8" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="273.8" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">56.4 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="288.7" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="288.7" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">71.3 ns</text>
+<line x1="168.0" y1="206.0" x2="286.4" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="286.4" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">69.4 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="331.7" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="331.7" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">144 ns</text>
+<line x1="168.0" y1="230.0" x2="327.7" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="327.7" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">136 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="397.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="397.8" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">421 ns</text>
+<line x1="168.0" y1="254.0" x2="394.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="394.6" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">407 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="278.0" x2="399.2" y2="278.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="399.2" cy="278.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">431 ns</text>
+<line x1="168.0" y1="278.0" x2="396.0" y2="278.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="396.0" cy="278.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">416 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="408.4" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="408.4" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">501 ns</text>
+<line x1="168.0" y1="302.0" x2="403.3" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="403.3" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">469 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="428.5" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="428.5" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">694 ns</text>
+<line x1="168.0" y1="326.0" x2="423.9" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="423.9" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">657 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="442.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="442.2" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">868 ns</text>
+<line x1="168.0" y1="350.0" x2="434.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="434.2" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">777 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="508.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="508.1" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.53 µs</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="398.0" x2="665.9" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="665.9" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">33.1 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="422.0" x2="718.0" y2="422.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="422.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">77.3 µs</text>
+<line x1="168.0" y1="374.0" x2="504.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="504.0" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.44 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
+<line x1="168.0" y1="398.0" x2="610.2" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="610.2" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.8 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="422.0" x2="643.4" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="643.4" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">23.8 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
+<line x1="168.0" y1="446.0" x2="652.0" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="652.0" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">27.4 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="470.0" x2="705.2" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="705.2" cy="470.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">65.4 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">80.6 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/call_indirect: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-f64-alu-dark.svg
+++ b/docs/benchmarks/figs/wat-f64-alu-dark.svg
@@ -1,76 +1,93 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="464" viewBox="0 0 820 464" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f64_alu: seconds per iteration for 15 runners on a log scale, fastest first. wazero is fastest at 1.00 ns, then wasmer at 1.01 ns; dewasm-bash is slowest at 593 µs, a span of 590000x. The table below carries every number.">
-<title>wat/f64_alu: seconds per iteration for 15 runners on a log scale, fastest first. wazero is fastest at 1.00 ns, then wasmer at 1.01 ns; dewasm-bash is slowest at 593 µs, a span of 590000x. The table below carries every number.</title>
-<rect width="820" height="464" fill="#1a1a19"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="263.3" y1="68.0" x2="263.3" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="263.3" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="358.5" y1="68.0" x2="358.5" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="358.5" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="453.8" y1="68.0" x2="453.8" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="453.8" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="549.1" y1="68.0" x2="549.1" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="549.1" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="644.4" y1="68.0" x2="644.4" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="644.4" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
-<line x1="168.0" y1="434.0" x2="726.0" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wazero is fastest at 0.96 ns, then wasmer at 0.97 ns; dewasm-bash is slowest at 498 µs, a span of 518000x. The table below carries every number.">
+<title>wat/f64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wazero is fastest at 0.96 ns, then wasmer at 0.97 ns; dewasm-bash is slowest at 498 µs, a span of 518000x. The table below carries every number.</title>
+<rect width="820" height="536" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">0 ns</text>
+<line x1="250.1" y1="68.0" x2="250.1" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="250.1" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
+<line x1="332.2" y1="68.0" x2="332.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="332.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="414.4" y1="68.0" x2="414.4" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="414.4" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="496.5" y1="68.0" x2="496.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="496.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="578.6" y1="68.0" x2="578.6" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="578.6" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="660.7" y1="68.0" x2="660.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="660.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<circle cx="168.2" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.00 ns</text>
+<line x1="168.0" y1="86.0" x2="248.7" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="248.7" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.96 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<circle cx="168.5" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.01 ns</text>
+<line x1="168.0" y1="110.0" x2="248.9" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="248.9" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.97 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<circle cx="168.6" cy="134.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.01 ns</text>
+<line x1="168.0" y1="134.0" x2="249.0" y2="134.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="249.0" cy="134.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.97 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="158.0" x2="190.3" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="190.3" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.71 ns</text>
+<line x1="168.0" y1="158.0" x2="267.2" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="267.2" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.61 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="182.0" x2="201.2" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="201.2" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.23 ns</text>
+<line x1="168.0" y1="182.0" x2="277.1" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="277.1" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.13 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="206.0" x2="221.4" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="221.4" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.64 ns</text>
+<line x1="168.0" y1="206.0" x2="294.3" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="294.3" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.45 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="230.0" x2="239.2" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="239.2" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.58 ns</text>
+<line x1="168.0" y1="230.0" x2="310.3" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="310.3" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.41 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="348.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="348.8" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">79.0 ns</text>
+<line x1="168.0" y1="254.0" x2="405.0" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="405.0" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">76.8 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="278.0" x2="351.6" y2="278.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="351.6" cy="278.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">84.6 ns</text>
+<line x1="168.0" y1="278.0" x2="407.1" y2="278.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="407.1" cy="278.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">81.7 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="352.4" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="352.4" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">86.1 ns</text>
+<line x1="168.0" y1="302.0" x2="407.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="407.5" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">82.4 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="360.9" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="360.9" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">106 ns</text>
+<line x1="168.0" y1="326.0" x2="415.1" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="415.1" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">102 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="377.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="377.2" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">157 ns</text>
+<line x1="168.0" y1="350.0" x2="429.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="429.1" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">151 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="447.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="447.8" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">865 ns</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="398.0" x2="534.8" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="534.8" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.08 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="422.0" x2="718.0" y2="422.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="422.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">593 µs</text>
+<line x1="168.0" y1="374.0" x2="489.6" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="489.6" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">824 ns</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
+<line x1="168.0" y1="398.0" x2="541.2" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="541.2" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.50 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="422.0" x2="564.2" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="564.2" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.69 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
+<line x1="168.0" y1="446.0" x2="568.2" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="568.2" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.47 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="470.0" x2="616.1" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="616.1" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">28.6 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">498 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/f64_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-f64-alu.svg
+++ b/docs/benchmarks/figs/wat-f64-alu.svg
@@ -1,76 +1,93 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="464" viewBox="0 0 820 464" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f64_alu: seconds per iteration for 15 runners on a log scale, fastest first. wazero is fastest at 1.00 ns, then wasmer at 1.01 ns; dewasm-bash is slowest at 593 µs, a span of 590000x. The table below carries every number.">
-<title>wat/f64_alu: seconds per iteration for 15 runners on a log scale, fastest first. wazero is fastest at 1.00 ns, then wasmer at 1.01 ns; dewasm-bash is slowest at 593 µs, a span of 590000x. The table below carries every number.</title>
-<rect width="820" height="464" fill="#fcfcfb"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="263.3" y1="68.0" x2="263.3" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="263.3" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="358.5" y1="68.0" x2="358.5" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="358.5" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="453.8" y1="68.0" x2="453.8" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="453.8" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="549.1" y1="68.0" x2="549.1" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="549.1" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="644.4" y1="68.0" x2="644.4" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="644.4" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
-<line x1="168.0" y1="434.0" x2="726.0" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wazero is fastest at 0.96 ns, then wasmer at 0.97 ns; dewasm-bash is slowest at 498 µs, a span of 518000x. The table below carries every number.">
+<title>wat/f64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wazero is fastest at 0.96 ns, then wasmer at 0.97 ns; dewasm-bash is slowest at 498 µs, a span of 518000x. The table below carries every number.</title>
+<rect width="820" height="536" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">0 ns</text>
+<line x1="250.1" y1="68.0" x2="250.1" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="250.1" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
+<line x1="332.2" y1="68.0" x2="332.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="332.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="414.4" y1="68.0" x2="414.4" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="414.4" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="496.5" y1="68.0" x2="496.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="496.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="578.6" y1="68.0" x2="578.6" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="578.6" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="660.7" y1="68.0" x2="660.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="660.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<circle cx="168.2" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.00 ns</text>
+<line x1="168.0" y1="86.0" x2="248.7" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="248.7" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.96 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<circle cx="168.5" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.01 ns</text>
+<line x1="168.0" y1="110.0" x2="248.9" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="248.9" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.97 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<circle cx="168.6" cy="134.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.01 ns</text>
+<line x1="168.0" y1="134.0" x2="249.0" y2="134.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="249.0" cy="134.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.97 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="158.0" x2="190.3" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="190.3" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.71 ns</text>
+<line x1="168.0" y1="158.0" x2="267.2" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="267.2" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.61 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="182.0" x2="201.2" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="201.2" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.23 ns</text>
+<line x1="168.0" y1="182.0" x2="277.1" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="277.1" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.13 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="206.0" x2="221.4" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="221.4" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.64 ns</text>
+<line x1="168.0" y1="206.0" x2="294.3" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="294.3" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.45 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="230.0" x2="239.2" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="239.2" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.58 ns</text>
+<line x1="168.0" y1="230.0" x2="310.3" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="310.3" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.41 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="348.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="348.8" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">79.0 ns</text>
+<line x1="168.0" y1="254.0" x2="405.0" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="405.0" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">76.8 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="278.0" x2="351.6" y2="278.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="351.6" cy="278.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">84.6 ns</text>
+<line x1="168.0" y1="278.0" x2="407.1" y2="278.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="407.1" cy="278.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">81.7 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="352.4" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="352.4" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">86.1 ns</text>
+<line x1="168.0" y1="302.0" x2="407.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="407.5" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">82.4 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="360.9" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="360.9" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">106 ns</text>
+<line x1="168.0" y1="326.0" x2="415.1" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="415.1" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">102 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="377.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="377.2" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">157 ns</text>
+<line x1="168.0" y1="350.0" x2="429.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="429.1" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">151 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="447.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="447.8" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">865 ns</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="398.0" x2="534.8" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="534.8" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.08 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="422.0" x2="718.0" y2="422.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="422.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">593 µs</text>
+<line x1="168.0" y1="374.0" x2="489.6" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="489.6" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">824 ns</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
+<line x1="168.0" y1="398.0" x2="541.2" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="541.2" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.50 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="422.0" x2="564.2" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="564.2" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.69 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
+<line x1="168.0" y1="446.0" x2="568.2" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="568.2" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.47 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="470.0" x2="616.1" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="616.1" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">28.6 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">498 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/f64_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i32-alu-dark.svg
+++ b/docs/benchmarks/figs/wat-i32-alu-dark.svg
@@ -1,77 +1,89 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="464" viewBox="0 0 820 464" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_alu: seconds per iteration for 15 runners on a log scale, fastest first. wasmtime is fastest at 2.40 ns, then wasmer at 2.40 ns; pywasm-pypy is slowest at 29.9 µs, a span of 12500x. The table below carries every number.">
-<title>wat/i32_alu: seconds per iteration for 15 runners on a log scale, fastest first. wasmtime is fastest at 2.40 ns, then wasmer at 2.40 ns; pywasm-pypy is slowest at 29.9 µs, a span of 12500x. The table below carries every number.</title>
-<rect width="820" height="464" fill="#1a1a19"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="290.9" y1="68.0" x2="290.9" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="290.9" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="413.8" y1="68.0" x2="413.8" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="413.8" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="536.7" y1="68.0" x2="536.7" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="536.7" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="659.5" y1="68.0" x2="659.5" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="659.5" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="168.0" y1="434.0" x2="726.0" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 2.30 ns, then dewasm-java at 2.33 ns; pywasm-cpython is slowest at 53.4 µs, a span of 23200x. The table below carries every number.">
+<title>wat/i32_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 2.30 ns, then dewasm-java at 2.33 ns; pywasm-cpython is slowest at 53.4 µs, a span of 23200x. The table below carries every number.</title>
+<rect width="820" height="536" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
+<line x1="284.3" y1="68.0" x2="284.3" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="284.3" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="400.7" y1="68.0" x2="400.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="400.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="517.0" y1="68.0" x2="517.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="517.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="633.4" y1="68.0" x2="633.4" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="633.4" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="214.7" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="214.7" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.40 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="214.8" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="214.8" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.40 ns</text>
-<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="215.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="215.6" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.44 ns</text>
+<line x1="168.0" y1="86.0" x2="210.1" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="210.1" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.30 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
+<line x1="168.0" y1="110.0" x2="210.7" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="210.7" cy="110.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.33 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="134.0" x2="211.3" y2="134.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="211.3" cy="134.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.36 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="221.9" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="221.9" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.75 ns</text>
+<line x1="168.0" y1="158.0" x2="217.7" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="217.7" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.68 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="182.0" x2="229.8" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="229.8" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.18 ns</text>
+<line x1="168.0" y1="182.0" x2="223.9" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="223.9" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.02 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="206.0" x2="294.4" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="294.4" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.7 ns</text>
+<line x1="168.0" y1="206.0" x2="281.3" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="281.3" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.42 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="230.0" x2="306.6" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="306.6" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.4 ns</text>
+<line x1="168.0" y1="230.0" x2="297.1" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="297.1" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.9 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="437.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="437.8" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">157 ns</text>
-<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="278.0" x2="439.3" y2="278.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="439.3" cy="278.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">161 ns</text>
-<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="441.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="441.6" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">168 ns</text>
+<line x1="168.0" y1="254.0" x2="417.3" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="417.3" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">139 ns</text>
+<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
+<line x1="168.0" y1="278.0" x2="421.0" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="421.0" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">149 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
+<line x1="168.0" y1="302.0" x2="423.8" y2="302.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="423.8" cy="302.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">158 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="452.3" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="452.3" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">206 ns</text>
+<line x1="168.0" y1="326.0" x2="431.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="431.0" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">182 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="514.3" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="514.3" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">658 ns</text>
+<line x1="168.0" y1="350.0" x2="487.5" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="487.5" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">558 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="518.5" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="518.5" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">712 ns</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="398.0" x2="709.9" y2="398.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="709.9" cy="398.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">25.7 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="422.0" x2="718.0" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">29.9 µs</text>
+<line x1="168.0" y1="374.0" x2="497.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="497.8" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">684 ns</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
+<line x1="168.0" y1="398.0" x2="614.4" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="614.4" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.87 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
+<line x1="168.0" y1="422.0" x2="654.0" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="654.0" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.1 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="446.0" x2="658.5" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="658.5" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">16.5 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="470.0" x2="673.4" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="673.4" cy="470.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">22.1 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">53.4 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/i32_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i32-alu.svg
+++ b/docs/benchmarks/figs/wat-i32-alu.svg
@@ -1,77 +1,89 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="464" viewBox="0 0 820 464" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_alu: seconds per iteration for 15 runners on a log scale, fastest first. wasmtime is fastest at 2.40 ns, then wasmer at 2.40 ns; pywasm-pypy is slowest at 29.9 µs, a span of 12500x. The table below carries every number.">
-<title>wat/i32_alu: seconds per iteration for 15 runners on a log scale, fastest first. wasmtime is fastest at 2.40 ns, then wasmer at 2.40 ns; pywasm-pypy is slowest at 29.9 µs, a span of 12500x. The table below carries every number.</title>
-<rect width="820" height="464" fill="#fcfcfb"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="290.9" y1="68.0" x2="290.9" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="290.9" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="413.8" y1="68.0" x2="413.8" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="413.8" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="536.7" y1="68.0" x2="536.7" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="536.7" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="659.5" y1="68.0" x2="659.5" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="659.5" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="168.0" y1="434.0" x2="726.0" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 2.30 ns, then dewasm-java at 2.33 ns; pywasm-cpython is slowest at 53.4 µs, a span of 23200x. The table below carries every number.">
+<title>wat/i32_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 2.30 ns, then dewasm-java at 2.33 ns; pywasm-cpython is slowest at 53.4 µs, a span of 23200x. The table below carries every number.</title>
+<rect width="820" height="536" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
+<line x1="284.3" y1="68.0" x2="284.3" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="284.3" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="400.7" y1="68.0" x2="400.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="400.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="517.0" y1="68.0" x2="517.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="517.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="633.4" y1="68.0" x2="633.4" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="633.4" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="214.7" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="214.7" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.40 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="214.8" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="214.8" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.40 ns</text>
-<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="215.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="215.6" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.44 ns</text>
+<line x1="168.0" y1="86.0" x2="210.1" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="210.1" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.30 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
+<line x1="168.0" y1="110.0" x2="210.7" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="210.7" cy="110.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.33 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="134.0" x2="211.3" y2="134.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="211.3" cy="134.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.36 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="221.9" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="221.9" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.75 ns</text>
+<line x1="168.0" y1="158.0" x2="217.7" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="217.7" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.68 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="182.0" x2="229.8" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="229.8" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.18 ns</text>
+<line x1="168.0" y1="182.0" x2="223.9" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="223.9" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.02 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="206.0" x2="294.4" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="294.4" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.7 ns</text>
+<line x1="168.0" y1="206.0" x2="281.3" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="281.3" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.42 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="230.0" x2="306.6" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="306.6" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.4 ns</text>
+<line x1="168.0" y1="230.0" x2="297.1" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="297.1" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.9 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="437.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="437.8" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">157 ns</text>
-<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="278.0" x2="439.3" y2="278.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="439.3" cy="278.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">161 ns</text>
-<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="441.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="441.6" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">168 ns</text>
+<line x1="168.0" y1="254.0" x2="417.3" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="417.3" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">139 ns</text>
+<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
+<line x1="168.0" y1="278.0" x2="421.0" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="421.0" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">149 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
+<line x1="168.0" y1="302.0" x2="423.8" y2="302.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="423.8" cy="302.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">158 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="452.3" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="452.3" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">206 ns</text>
+<line x1="168.0" y1="326.0" x2="431.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="431.0" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">182 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="514.3" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="514.3" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">658 ns</text>
+<line x1="168.0" y1="350.0" x2="487.5" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="487.5" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">558 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="518.5" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="518.5" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">712 ns</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="398.0" x2="709.9" y2="398.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="709.9" cy="398.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">25.7 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="422.0" x2="718.0" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">29.9 µs</text>
+<line x1="168.0" y1="374.0" x2="497.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="497.8" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">684 ns</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
+<line x1="168.0" y1="398.0" x2="614.4" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="614.4" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.87 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
+<line x1="168.0" y1="422.0" x2="654.0" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="654.0" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.1 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="446.0" x2="658.5" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="658.5" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">16.5 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="470.0" x2="673.4" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="673.4" cy="470.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">22.1 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">53.4 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/i32_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i64-alu-dark.svg
+++ b/docs/benchmarks/figs/wat-i64-alu-dark.svg
@@ -1,79 +1,91 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="464" viewBox="0 0 820 464" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_alu: seconds per iteration for 15 runners on a log scale, fastest first. wasmtime is fastest at 2.36 ns, then wasmer at 2.38 ns; pywasm-pypy is slowest at 390 µs, a span of 165000x. The table below carries every number.">
-<title>wat/i64_alu: seconds per iteration for 15 runners on a log scale, fastest first. wasmtime is fastest at 2.36 ns, then wasmer at 2.38 ns; pywasm-pypy is slowest at 390 µs, a span of 165000x. The table below carries every number.</title>
-<rect width="820" height="464" fill="#1a1a19"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="266.4" y1="68.0" x2="266.4" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="266.4" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="364.8" y1="68.0" x2="364.8" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="364.8" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="463.1" y1="68.0" x2="463.1" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="463.1" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="561.5" y1="68.0" x2="561.5" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="561.5" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="659.9" y1="68.0" x2="659.9" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="659.9" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
-<line x1="168.0" y1="434.0" x2="726.0" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 2.30 ns, then wasmer at 2.30 ns; pywasm-pypy is slowest at 359 µs, a span of 156000x. The table below carries every number.">
+<title>wat/i64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 2.30 ns, then wasmer at 2.30 ns; pywasm-pypy is slowest at 359 µs, a span of 156000x. The table below carries every number.</title>
+<rect width="820" height="536" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
+<line x1="267.0" y1="68.0" x2="267.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="267.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="366.0" y1="68.0" x2="366.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="366.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="465.0" y1="68.0" x2="465.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="465.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="564.1" y1="68.0" x2="564.1" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="564.1" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="663.1" y1="68.0" x2="663.1" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="663.1" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="204.7" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="204.7" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.36 ns</text>
+<line x1="168.0" y1="86.0" x2="203.8" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="203.8" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.30 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="205.0" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="205.0" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.38 ns</text>
+<line x1="168.0" y1="110.0" x2="203.9" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="203.9" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.30 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="205.9" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="205.9" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.43 ns</text>
+<line x1="168.0" y1="134.0" x2="204.4" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="204.4" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.33 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="158.0" x2="210.0" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="210.0" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.68 ns</text>
+<line x1="168.0" y1="158.0" x2="209.0" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="209.0" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.59 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="182.0" x2="210.7" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="210.7" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.71 ns</text>
+<line x1="168.0" y1="182.0" x2="210.0" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="210.0" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.66 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="277.3" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="277.3" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.9 ns</text>
+<line x1="168.0" y1="206.0" x2="275.3" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="275.3" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.1 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="230.0" x2="384.8" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="384.8" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="230.0" x2="386.2" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="386.2" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">160 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="254.0" x2="404.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="404.5" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">253 ns</text>
+<line x1="168.0" y1="254.0" x2="400.1" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="400.1" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">221 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="278.0" x2="445.9" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="445.9" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">667 ns</text>
-<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="302.0" x2="464.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="464.2" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.02 µs</text>
-<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="326.0" x2="467.2" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="467.2" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.10 µs</text>
+<line x1="168.0" y1="278.0" x2="445.3" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="445.3" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">631 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
+<line x1="168.0" y1="302.0" x2="463.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="463.0" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">954 ns</text>
+<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
+<line x1="168.0" y1="326.0" x2="464.9" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="464.9" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">996 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="350.0" x2="472.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="472.7" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.25 µs</text>
+<line x1="168.0" y1="350.0" x2="466.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="466.1" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.02 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="374.0" x2="480.7" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="480.7" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.51 µs</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="398.0" x2="606.0" y2="398.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="606.0" cy="398.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">28.3 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="422.0" x2="718.0" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">390 µs</text>
+<line x1="168.0" y1="374.0" x2="476.5" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="476.5" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.31 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
+<line x1="168.0" y1="398.0" x2="559.1" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="559.1" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.91 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
+<line x1="168.0" y1="422.0" x2="585.0" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="585.0" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">16.3 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="446.0" x2="602.3" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="602.3" cy="446.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">24.3 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="470.0" x2="638.6" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="638.6" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">56.6 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">359 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/i64_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i64-alu.svg
+++ b/docs/benchmarks/figs/wat-i64-alu.svg
@@ -1,79 +1,91 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="464" viewBox="0 0 820 464" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_alu: seconds per iteration for 15 runners on a log scale, fastest first. wasmtime is fastest at 2.36 ns, then wasmer at 2.38 ns; pywasm-pypy is slowest at 390 µs, a span of 165000x. The table below carries every number.">
-<title>wat/i64_alu: seconds per iteration for 15 runners on a log scale, fastest first. wasmtime is fastest at 2.36 ns, then wasmer at 2.38 ns; pywasm-pypy is slowest at 390 µs, a span of 165000x. The table below carries every number.</title>
-<rect width="820" height="464" fill="#fcfcfb"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="266.4" y1="68.0" x2="266.4" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="266.4" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="364.8" y1="68.0" x2="364.8" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="364.8" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="463.1" y1="68.0" x2="463.1" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="463.1" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="561.5" y1="68.0" x2="561.5" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="561.5" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="659.9" y1="68.0" x2="659.9" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="659.9" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
-<line x1="168.0" y1="434.0" x2="726.0" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 2.30 ns, then wasmer at 2.30 ns; pywasm-pypy is slowest at 359 µs, a span of 156000x. The table below carries every number.">
+<title>wat/i64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 2.30 ns, then wasmer at 2.30 ns; pywasm-pypy is slowest at 359 µs, a span of 156000x. The table below carries every number.</title>
+<rect width="820" height="536" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
+<line x1="267.0" y1="68.0" x2="267.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="267.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="366.0" y1="68.0" x2="366.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="366.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="465.0" y1="68.0" x2="465.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="465.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="564.1" y1="68.0" x2="564.1" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="564.1" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="663.1" y1="68.0" x2="663.1" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="663.1" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="204.7" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="204.7" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.36 ns</text>
+<line x1="168.0" y1="86.0" x2="203.8" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="203.8" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.30 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="205.0" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="205.0" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.38 ns</text>
+<line x1="168.0" y1="110.0" x2="203.9" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="203.9" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.30 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="205.9" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="205.9" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.43 ns</text>
+<line x1="168.0" y1="134.0" x2="204.4" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="204.4" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.33 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="158.0" x2="210.0" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="210.0" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.68 ns</text>
+<line x1="168.0" y1="158.0" x2="209.0" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="209.0" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.59 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="182.0" x2="210.7" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="210.7" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.71 ns</text>
+<line x1="168.0" y1="182.0" x2="210.0" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="210.0" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.66 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="277.3" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="277.3" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.9 ns</text>
+<line x1="168.0" y1="206.0" x2="275.3" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="275.3" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.1 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="230.0" x2="384.8" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="384.8" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="230.0" x2="386.2" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="386.2" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">160 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="254.0" x2="404.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="404.5" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">253 ns</text>
+<line x1="168.0" y1="254.0" x2="400.1" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="400.1" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">221 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="278.0" x2="445.9" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="445.9" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">667 ns</text>
-<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="302.0" x2="464.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="464.2" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.02 µs</text>
-<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="326.0" x2="467.2" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="467.2" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.10 µs</text>
+<line x1="168.0" y1="278.0" x2="445.3" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="445.3" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">631 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
+<line x1="168.0" y1="302.0" x2="463.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="463.0" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">954 ns</text>
+<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
+<line x1="168.0" y1="326.0" x2="464.9" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="464.9" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">996 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="350.0" x2="472.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="472.7" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.25 µs</text>
+<line x1="168.0" y1="350.0" x2="466.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="466.1" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.02 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="374.0" x2="480.7" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="480.7" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.51 µs</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="398.0" x2="606.0" y2="398.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="606.0" cy="398.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">28.3 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="422.0" x2="718.0" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">390 µs</text>
+<line x1="168.0" y1="374.0" x2="476.5" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="476.5" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.31 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
+<line x1="168.0" y1="398.0" x2="559.1" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="559.1" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.91 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
+<line x1="168.0" y1="422.0" x2="585.0" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="585.0" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">16.3 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="446.0" x2="602.3" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="602.3" cy="446.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">24.3 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="470.0" x2="638.6" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="638.6" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">56.6 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">359 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/i64_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-mem-rw-dark.svg
+++ b/docs/benchmarks/figs/wat-mem-rw-dark.svg
@@ -1,77 +1,91 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="464" viewBox="0 0 820 464" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_rw: seconds per iteration for 15 runners on a log scale, fastest first. wasmtime is fastest at 1.03 ns, then wasmer at 1.03 ns; dewasm-bash is slowest at 31.4 µs, a span of 30400x. The table below carries every number.">
-<title>wat/mem_rw: seconds per iteration for 15 runners on a log scale, fastest first. wasmtime is fastest at 1.03 ns, then wasmer at 1.03 ns; dewasm-bash is slowest at 31.4 µs, a span of 30400x. The table below carries every number.</title>
-<rect width="820" height="464" fill="#1a1a19"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="290.3" y1="68.0" x2="290.3" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="290.3" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="412.6" y1="68.0" x2="412.6" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="412.6" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="534.9" y1="68.0" x2="534.9" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="534.9" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="657.2" y1="68.0" x2="657.2" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="657.2" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="168.0" y1="434.0" x2="726.0" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_rw: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 0.98 ns, then wasmer at 0.99 ns; pywasm-cpython is slowest at 38.1 µs, a span of 38700x. The table below carries every number.">
+<title>wat/mem_rw: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 0.98 ns, then wasmer at 0.99 ns; pywasm-cpython is slowest at 38.1 µs, a span of 38700x. The table below carries every number.</title>
+<rect width="820" height="536" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">0 ns</text>
+<line x1="266.5" y1="68.0" x2="266.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="266.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
+<line x1="365.1" y1="68.0" x2="365.1" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="365.1" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="463.6" y1="68.0" x2="463.6" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="463.6" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="562.2" y1="68.0" x2="562.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="562.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="660.7" y1="68.0" x2="660.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="660.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="169.7" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="169.7" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.03 ns</text>
+<line x1="168.0" y1="86.0" x2="265.9" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="265.9" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.98 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="169.8" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="169.8" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.03 ns</text>
+<line x1="168.0" y1="110.0" x2="266.1" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="266.1" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.99 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="191.5" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="191.5" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.56 ns</text>
+<line x1="168.0" y1="134.0" x2="283.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="283.1" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.47 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="196.3" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="196.3" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.70 ns</text>
+<line x1="168.0" y1="158.0" x2="284.7" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="284.7" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.53 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="200.1" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="200.1" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.83 ns</text>
+<line x1="168.0" y1="182.0" x2="290.0" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="290.0" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.73 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="294.4" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="294.4" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.8 ns</text>
+<line x1="168.0" y1="206.0" x2="365.2" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="365.2" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.0 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="380.9" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="380.9" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">55.1 ns</text>
+<line x1="168.0" y1="230.0" x2="436.6" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="436.6" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">53.1 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="429.7" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="429.7" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">138 ns</text>
+<line x1="168.0" y1="254.0" x2="473.8" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="473.8" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">127 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="430.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="430.8" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">141 ns</text>
+<line x1="168.0" y1="278.0" x2="475.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="475.1" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">131 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="433.3" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="433.3" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">148 ns</text>
+<line x1="168.0" y1="302.0" x2="478.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="478.0" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">140 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="438.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="438.7" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">164 ns</text>
+<line x1="168.0" y1="326.0" x2="487.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="487.7" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">175 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="519.0" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="519.0" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">741 ns</text>
+<line x1="168.0" y1="350.0" x2="549.4" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="549.4" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">742 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="534.4" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="534.4" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">990 ns</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="398.0" x2="705.4" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="705.4" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">24.8 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="422.0" x2="718.0" y2="422.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="422.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">31.4 µs</text>
+<line x1="168.0" y1="374.0" x2="560.6" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="560.6" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">964 ns</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
+<line x1="168.0" y1="398.0" x2="638.4" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="638.4" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.94 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="422.0" x2="662.6" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="662.6" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.4 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
+<line x1="168.0" y1="446.0" x2="672.5" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="672.5" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.2 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="470.0" x2="702.6" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="702.6" cy="470.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">26.6 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">38.1 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/mem_rw: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-mem-rw.svg
+++ b/docs/benchmarks/figs/wat-mem-rw.svg
@@ -1,77 +1,91 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="464" viewBox="0 0 820 464" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_rw: seconds per iteration for 15 runners on a log scale, fastest first. wasmtime is fastest at 1.03 ns, then wasmer at 1.03 ns; dewasm-bash is slowest at 31.4 µs, a span of 30400x. The table below carries every number.">
-<title>wat/mem_rw: seconds per iteration for 15 runners on a log scale, fastest first. wasmtime is fastest at 1.03 ns, then wasmer at 1.03 ns; dewasm-bash is slowest at 31.4 µs, a span of 30400x. The table below carries every number.</title>
-<rect width="820" height="464" fill="#fcfcfb"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="290.3" y1="68.0" x2="290.3" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="290.3" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="412.6" y1="68.0" x2="412.6" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="412.6" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="534.9" y1="68.0" x2="534.9" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="534.9" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="657.2" y1="68.0" x2="657.2" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="657.2" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="168.0" y1="434.0" x2="726.0" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_rw: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 0.98 ns, then wasmer at 0.99 ns; pywasm-cpython is slowest at 38.1 µs, a span of 38700x. The table below carries every number.">
+<title>wat/mem_rw: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 0.98 ns, then wasmer at 0.99 ns; pywasm-cpython is slowest at 38.1 µs, a span of 38700x. The table below carries every number.</title>
+<rect width="820" height="536" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">0 ns</text>
+<line x1="266.5" y1="68.0" x2="266.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="266.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
+<line x1="365.1" y1="68.0" x2="365.1" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="365.1" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="463.6" y1="68.0" x2="463.6" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="463.6" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="562.2" y1="68.0" x2="562.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="562.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="660.7" y1="68.0" x2="660.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="660.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="169.7" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="169.7" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.03 ns</text>
+<line x1="168.0" y1="86.0" x2="265.9" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="265.9" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.98 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="169.8" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="169.8" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.03 ns</text>
+<line x1="168.0" y1="110.0" x2="266.1" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="266.1" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.99 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="191.5" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="191.5" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.56 ns</text>
+<line x1="168.0" y1="134.0" x2="283.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="283.1" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.47 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="196.3" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="196.3" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.70 ns</text>
+<line x1="168.0" y1="158.0" x2="284.7" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="284.7" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.53 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="200.1" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="200.1" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.83 ns</text>
+<line x1="168.0" y1="182.0" x2="290.0" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="290.0" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.73 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="294.4" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="294.4" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.8 ns</text>
+<line x1="168.0" y1="206.0" x2="365.2" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="365.2" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.0 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="380.9" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="380.9" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">55.1 ns</text>
+<line x1="168.0" y1="230.0" x2="436.6" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="436.6" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">53.1 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="429.7" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="429.7" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">138 ns</text>
+<line x1="168.0" y1="254.0" x2="473.8" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="473.8" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">127 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="430.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="430.8" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">141 ns</text>
+<line x1="168.0" y1="278.0" x2="475.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="475.1" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">131 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="433.3" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="433.3" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">148 ns</text>
+<line x1="168.0" y1="302.0" x2="478.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="478.0" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">140 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="438.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="438.7" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">164 ns</text>
+<line x1="168.0" y1="326.0" x2="487.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="487.7" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">175 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="519.0" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="519.0" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">741 ns</text>
+<line x1="168.0" y1="350.0" x2="549.4" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="549.4" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">742 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="534.4" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="534.4" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">990 ns</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="398.0" x2="705.4" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="705.4" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">24.8 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="422.0" x2="718.0" y2="422.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="422.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">31.4 µs</text>
+<line x1="168.0" y1="374.0" x2="560.6" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="560.6" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">964 ns</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
+<line x1="168.0" y1="398.0" x2="638.4" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="638.4" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.94 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="422.0" x2="662.6" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="662.6" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.4 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
+<line x1="168.0" y1="446.0" x2="672.5" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="672.5" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.2 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="470.0" x2="702.6" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="702.6" cy="470.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">26.6 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">38.1 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/mem_rw: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/results.md
+++ b/docs/benchmarks/results.md
@@ -7,7 +7,7 @@ How to run and read these measurements is [README.md](README.md).
 
 ## Environment
 
-Measured 2026-08-11T18:25:24Z.
+Measured 2026-08-16T09:22:02Z.
 
 | | |
 | --- | --- |
@@ -29,13 +29,16 @@ A runner missing from this table was unavailable on this host; its cells appear 
 | `dewasm-ruby` | ruby 4.0.4 (2026-05-12 revision b89eb1bcbf) +PRISM [arm64-darwin25] |
 | `dewasm-ruby-yjit` | ruby 4.0.4 (2026-05-12 revision b89eb1bcbf) +PRISM [arm64-darwin25] |
 | `dewasm-ruby-zjit` | ruby 4.0.4 (2026-05-12 revision b89eb1bcbf) +PRISM [arm64-darwin25] |
-| `dewasm-python` | Python 3.14.6 (main, Jun 10 2026, 10:03:53) [Clang 21.0.0 (clang-2100.0.123.102)] |
+| `dewasm-python` | Python 3.14.7 (main, Aug  5 2026, 10:29:49) [Clang 21.0.0 (clang-2100.1.1.101)] |
 | `dewasm-pypy` | Python 3.11.15 (194f9f44b505, Jul 15 2026, 12:14:56) |
 | `dewasm-perl` | v5.44.0 |
 | `dewasm-go` | go version go1.26.2 darwin/arm64 |
 | `dewasm-java` | java version "25.0.4" 2026-07-21 LTS |
 | `dewasm-bash` | 5.3.15(1)-release |
+| `pywasm-cpython` | pywasm 2.2.3 |
 | `pywasm-pypy` | pywasm 2.2.3 |
+| `wardite` | wardite 0.9.0 |
+| `wardite-yjit` | wardite 0.9.0 |
 
 ## Results
 
@@ -51,7 +54,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/c-mandelbrot-dark.svg">
-  <img alt="c/mandelbrot: seconds per iteration for 15 runners on a log scale, fastest first. wasmer is fastest at 98.0 ns, then wasmtime at 98.8 ns; dewasm-bash is slowest at 20.5 ms, a span of 209000x. The table below carries every number." src="figs/c-mandelbrot.svg">
+  <img alt="c/mandelbrot: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 94.4 ns, then wasmtime at 94.7 ns; dewasm-bash is slowest at 17.0 ms, a span of 180000x. The table below carries every number." src="figs/c-mandelbrot.svg">
 </picture>
 
 <details>
@@ -59,21 +62,24 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 3 052 504 | 98.8 | 98.8 | 5.4 ms | 306.8 ms | 1.00x | — |
-| `wasmer` | 3 105 706 | 97.9 | 98.0 | 8.7 ms | 312.8 ms | 0.99x | — |
-| `wasmedge` | 48 598 | 3911 | 3913 | 15.7 ms | 205.7 ms | 40x | — |
-| `wazero` | 2 779 517 | 110.4 | 110.6 | 4.9 ms | 311.7 ms | 1.12x | — |
-| `wasm3` | 630 165 | 467.2 | 469.5 | 4.1 ms | 298.5 ms | 4.73x | — |
-| `dewasm-ruby` | 63 908 | 4701 | 4716 | 37.0 ms | 337.5 ms | 48x | — |
-| `dewasm-ruby-yjit` | 54 016 | 4597 | 4622 | 38.8 ms | 287.1 ms | 47x | — |
-| `dewasm-ruby-zjit` | 65 055 | 4632 | 4633 | 38.2 ms | 339.5 ms | 47x | — |
-| `dewasm-python` | 81 036 | 3684 | 3705 | 27.5 ms | 326.0 ms | 37x | — |
-| `dewasm-pypy` | 1 883 967 | 145.0 | 146.9 | 38.9 ms | 312.2 ms | 1.47x | — |
-| `dewasm-perl` | 5 188 | 57263 | 57260 | 10.5 ms | 307.6 ms | 580x | — |
-| `dewasm-go` | 1 227 281 | 243.0 | 243.3 | 2.6 ms | 300.8 ms | 2.46x | — |
-| `dewasm-java` | 1 671 115 | 104.2 | 102.5 | 60.4 ms | 234.5 ms | 1.05x | — |
-| `dewasm-bash` | 132 | 20490808 | 20531967 | 12.4 ms | 2.72 s | 207500x | — |
-| `pywasm-pypy` | 103 | 2001748 | 1988706 | 76.5 ms | 282.7 ms | 20271x | 5.0 ms |
+| `wasmtime` | 2 296 534 | 94.8 | 94.7 | 7.6 ms | 225.3 ms | 1.00x | — |
+| `wasmer` | 3 189 797 | 94.3 | 94.4 | 9.5 ms | 310.4 ms | 1.00x | — |
+| `wasmedge` | 59 621 | 3761 | 3784 | 15.6 ms | 239.8 ms | 40x | — |
+| `wazero` | 2 788 930 | 105.8 | 106.3 | 5.5 ms | 300.7 ms | 1.12x | — |
+| `wasm3` | 673 890 | 448.4 | 450.0 | 4.9 ms | 307.1 ms | 4.73x | — |
+| `dewasm-ruby` | 41 827 | 4435 | 4442 | 37.2 ms | 222.7 ms | 47x | — |
+| `dewasm-ruby-yjit` | 45 698 | 4408 | 4420 | 37.4 ms | 238.9 ms | 47x | — |
+| `dewasm-ruby-zjit` | 48 422 | 4434 | 4429 | 37.4 ms | 252.1 ms | 47x | — |
+| `dewasm-python` | 65 536 | 3540 | 3549 | 28.6 ms | 260.6 ms | 37x | — |
+| `dewasm-pypy` | 2 072 024 | 139.7 | 140.2 | 37.6 ms | 327.1 ms | 1.47x | — |
+| `dewasm-perl` | 5 479 | 54913 | 55323 | 11.1 ms | 312.0 ms | 579x | — |
+| `dewasm-go` | 905 207 | 232.5 | 232.9 | 3.1 ms | 213.6 ms | 2.45x | — |
+| `dewasm-java` | 2 833 577 | 95.1 | 95.8 | 61.8 ms | 331.4 ms | 1.00x | — |
+| `dewasm-bash` | 208 | 16977683 | 17024387 | 12.5 ms | 3.54 s | 179113x | — |
+| `pywasm-cpython` | 256 | 1445249 | 1452877 | 44.5 ms | 414.5 ms | 15247x | 0.9 ms |
+| `pywasm-pypy` | 102 | 1846056 | 1845232 | 74.9 ms | 263.2 ms | 19476x | 4.9 ms |
+| `wardite` | 670 | 370178 | 372797 | 50.1 ms | 298.1 ms | 3905x | 3.6 ms |
+| `wardite-yjit` | 1 451 | 177756 | 178692 | 95.1 ms | 353.0 ms | 1875x | 9.1 ms |
 
 </details>
 
@@ -81,7 +87,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/c-sha256-dark.svg">
-  <img alt="c/sha256: seconds per iteration for 15 runners on a log scale, fastest first. wasmer is fastest at 303 ns, then wasmtime at 305 ns; dewasm-bash is slowest at 16.2 ms, a span of 53300x. The table below carries every number." src="figs/c-sha256.svg">
+  <img alt="c/sha256: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 289 ns, then wasmer at 289 ns; pywasm-cpython is slowest at 14.3 ms, a span of 49300x. The table below carries every number." src="figs/c-sha256.svg">
 </picture>
 
 <details>
@@ -89,21 +95,24 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 983 827 | 302.6 | 304.7 | 5.1 ms | 302.8 ms | 1.00x | — |
-| `wasmer` | 1 002 886 | 302.2 | 303.3 | 8.4 ms | 311.5 ms | 1.00x | — |
-| `wasmedge` | 6 673 | 42662 | 42716 | 15.2 ms | 299.9 ms | 141x | — |
-| `wazero` | 756 775 | 391.1 | 392.8 | 4.9 ms | 300.9 ms | 1.29x | — |
-| `wasm3` | 50 168 | 5207 | 5244 | 4.2 ms | 265.5 ms | 17x | — |
-| `dewasm-ruby` | 3 760 | 79865 | 80528 | 37.7 ms | 338.0 ms | 264x | — |
-| `dewasm-ruby-yjit` | 4 705 | 52330 | 52126 | 37.7 ms | 284.0 ms | 173x | — |
-| `dewasm-ruby-zjit` | 4 850 | 56443 | 56745 | 38.8 ms | 312.6 ms | 187x | — |
-| `dewasm-python` | 1 019 | 284085 | 286952 | 27.6 ms | 317.1 ms | 939x | — |
-| `dewasm-pypy` | 11 976 | 15016 | 15073 | 40.0 ms | 219.8 ms | 50x | — |
-| `dewasm-perl` | 913 | 328948 | 329560 | 10.6 ms | 311.0 ms | 1087x | — |
-| `dewasm-go` | 829 127 | 360.6 | 361.8 | 2.6 ms | 301.5 ms | 1.19x | — |
-| `dewasm-java` | 349 606 | 540.3 | 543.2 | 62.7 ms | 251.6 ms | 1.79x | — |
-| `dewasm-bash` | 17 | 16126172 | 16168578 | 14.2 ms | 288.4 ms | 53289x | — |
-| `pywasm-pypy` | 28 | 7363411 | 7370754 | 85.1 ms | 291.2 ms | 24333x | 7.8 ms |
+| `wasmtime` | 1 045 402 | 288.7 | 289.0 | 6.2 ms | 308.0 ms | 1.00x | — |
+| `wasmer` | 1 012 616 | 288.5 | 289.0 | 9.3 ms | 301.5 ms | 1.00x | — |
+| `wasmedge` | 7 200 | 41252 | 41510 | 15.5 ms | 312.5 ms | 143x | — |
+| `wazero` | 802 468 | 373.6 | 374.3 | 5.8 ms | 305.6 ms | 1.29x | — |
+| `wasm3` | 59 828 | 4969 | 4996 | 4.8 ms | 302.1 ms | 17x | — |
+| `dewasm-ruby` | 3 879 | 77951 | 78307 | 37.3 ms | 339.6 ms | 270x | — |
+| `dewasm-ruby-yjit` | 4 902 | 47868 | 48340 | 37.6 ms | 272.3 ms | 166x | — |
+| `dewasm-ruby-zjit` | 4 460 | 52258 | 52190 | 37.6 ms | 270.7 ms | 181x | — |
+| `dewasm-python` | 1 130 | 264716 | 266828 | 28.5 ms | 327.7 ms | 917x | — |
+| `dewasm-pypy` | 13 124 | 14150 | 14249 | 39.3 ms | 225.0 ms | 49x | — |
+| `dewasm-perl` | 913 | 316339 | 317578 | 11.5 ms | 300.3 ms | 1096x | — |
+| `dewasm-go` | 619 024 | 341.2 | 342.2 | 4.2 ms | 215.4 ms | 1.18x | — |
+| `dewasm-java` | 661 058 | 461.1 | 464.7 | 58.9 ms | 363.7 ms | 1.60x | — |
+| `dewasm-bash` | 21 | 13415361 | 13491083 | 14.4 ms | 296.1 ms | 46468x | — |
+| `pywasm-cpython` | 19 | 14237537 | 14261568 | 44.8 ms | 315.3 ms | 49316x | 1.3 ms |
+| `pywasm-pypy` | 28 | 6953801 | 6947685 | 82.0 ms | 276.7 ms | 24087x | 7.2 ms |
+| `wardite` | 62 | 4022305 | 4089675 | 50.6 ms | 299.9 ms | 13933x | 3.8 ms |
+| `wardite-yjit` | 136 | 1866015 | 1864172 | 96.0 ms | 349.7 ms | 6464x | 9.1 ms |
 
 </details>
 
@@ -111,7 +120,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/c-wordcount-dark.svg">
-  <img alt="c/wordcount: seconds per iteration for 15 runners on a log scale, fastest first. wasmer is fastest at 1.72 ns, then wasmtime at 1.82 ns; dewasm-bash is slowest at 43.8 µs, a span of 25500x. The table below carries every number." src="figs/c-wordcount.svg">
+  <img alt="c/wordcount: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.67 ns, then wasmer at 1.68 ns; pywasm-cpython is slowest at 58.9 µs, a span of 35300x. The table below carries every number." src="figs/c-wordcount.svg">
 </picture>
 
 <details>
@@ -119,21 +128,24 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 168 601 827 | 1.73 | 1.82 | 5.6 ms | 297.8 ms | 1.00x | — |
-| `wasmer` | 162 308 671 | 1.70 | 1.72 | 9.1 ms | 285.6 ms | 0.98x | — |
-| `wasmedge` | 1 381 539 | 209.7 | 210.5 | 15.9 ms | 305.7 ms | 121x | — |
-| `wazero` | 96 349 719 | 3.10 | 3.13 | 5.4 ms | 304.5 ms | 1.79x | — |
-| `wasm3` | 11 735 745 | 21.2 | 21.3 | 4.1 ms | 252.9 ms | 12x | — |
-| `dewasm-ruby` | 715 210 | 403.9 | 405.8 | 39.4 ms | 328.2 ms | 233x | — |
-| `dewasm-ruby-yjit` | 947 653 | 287.9 | 289.2 | 39.7 ms | 312.6 ms | 166x | — |
-| `dewasm-ruby-zjit` | 913 218 | 307.3 | 312.6 | 39.6 ms | 320.3 ms | 177x | — |
-| `dewasm-python` | 314 560 | 893.6 | 894.8 | 31.2 ms | 312.3 ms | 516x | — |
-| `dewasm-pypy` | 4 890 717 | 58.5 | 58.8 | 45.6 ms | 331.6 ms | 34x | — |
-| `dewasm-perl` | 198 078 | 1523 | 1530 | 18.2 ms | 319.8 ms | 879x | — |
-| `dewasm-go` | 110 039 483 | 2.52 | 2.56 | 2.5 ms | 279.9 ms | 1.45x | — |
-| `dewasm-java` | 90 534 162 | 3.38 | 3.47 | 63.9 ms | 369.6 ms | 1.95x | — |
-| `dewasm-bash` | 6 400 | 43730 | 43803 | 125.2 ms | 405.1 ms | 25240x | — |
-| `pywasm-pypy` | 11 392 | 16902 | 16797 | 191.9 ms | 384.5 ms | 9755x | 8.4 ms |
+| `wasmtime` | 157 637 187 | 1.65 | 1.67 | 6.4 ms | 266.8 ms | 1.00x | — |
+| `wasmer` | 179 760 700 | 1.63 | 1.68 | 9.3 ms | 303.1 ms | 0.99x | — |
+| `wasmedge` | 1 320 980 | 202.0 | 202.8 | 16.4 ms | 283.3 ms | 122x | — |
+| `wazero` | 100 143 883 | 2.99 | 2.99 | 6.2 ms | 305.5 ms | 1.81x | — |
+| `wasm3` | 16 777 216 | 20.4 | 20.5 | 5.0 ms | 347.6 ms | 12x | — |
+| `dewasm-ruby` | 762 010 | 404.2 | 409.3 | 38.6 ms | 346.7 ms | 245x | — |
+| `dewasm-ruby-yjit` | 1 046 821 | 270.8 | 272.1 | 39.1 ms | 322.6 ms | 164x | — |
+| `dewasm-ruby-zjit` | 958 667 | 292.7 | 293.5 | 39.5 ms | 320.1 ms | 177x | — |
+| `dewasm-python` | 344 306 | 875.9 | 887.5 | 32.5 ms | 334.0 ms | 530x | — |
+| `dewasm-pypy` | 4 966 832 | 55.9 | 56.3 | 43.0 ms | 320.8 ms | 34x | — |
+| `dewasm-perl` | 202 952 | 1461 | 1465 | 19.2 ms | 315.8 ms | 885x | — |
+| `dewasm-go` | 85 795 492 | 2.40 | 2.44 | 3.7 ms | 210.0 ms | 1.46x | — |
+| `dewasm-java` | 56 691 018 | 3.49 | 3.48 | 63.6 ms | 261.3 ms | 2.11x | — |
+| `dewasm-bash` | 5 647 | 36534 | 36882 | 109.3 ms | 315.6 ms | 22118x | — |
+| `pywasm-cpython` | 4 741 | 57794 | 58903 | 278.1 ms | 552.1 ms | 34989x | 1.3 ms |
+| `pywasm-pypy` | 12 594 | 15099 | 15299 | 184.6 ms | 374.7 ms | 9141x | 7.6 ms |
+| `wardite` | 15 874 | 20463 | 20510 | 117.2 ms | 442.0 ms | 12388x | 3.8 ms |
+| `wardite-yjit` | 25 217 | 9599 | 9682 | 134.0 ms | 376.1 ms | 5811x | 9.1 ms |
 
 </details>
 
@@ -141,7 +153,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-call-direct-dark.svg">
-  <img alt="wat/call_direct: seconds per iteration for 15 runners on a log scale, fastest first. wasmer is fastest at 3.61 ns, then wasmtime at 3.62 ns; dewasm-bash is slowest at 57.3 µs, a span of 15900x. The table below carries every number." src="figs/wat-call-direct.svg">
+  <img alt="wat/call_direct: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 3.47 ns, then wasmtime at 3.48 ns; pywasm-cpython is slowest at 49.0 µs, a span of 14100x. The table below carries every number." src="figs/wat-call-direct.svg">
 </picture>
 
 <details>
@@ -149,21 +161,24 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 83 089 858 | 3.61 | 3.62 | 5.3 ms | 304.9 ms | 1.00x | — |
-| `wasmer` | 83 527 434 | 3.60 | 3.61 | 8.4 ms | 308.9 ms | 1.00x | — |
-| `wasmedge` | 1 385 343 | 211.5 | 211.4 | 14.8 ms | 307.9 ms | 59x | — |
-| `wazero` | 48 432 372 | 6.15 | 6.23 | 4.5 ms | 302.3 ms | 1.70x | — |
-| `wasm3` | 4 716 942 | 51.2 | 51.4 | 4.1 ms | 245.4 ms | 14x | — |
-| `dewasm-ruby` | 1 057 726 | 216.1 | 215.8 | 36.9 ms | 265.4 ms | 60x | — |
-| `dewasm-ruby-yjit` | 2 706 988 | 111.3 | 111.9 | 37.2 ms | 338.5 ms | 31x | — |
-| `dewasm-ruby-zjit` | 1 510 875 | 139.1 | 139.1 | 37.8 ms | 247.9 ms | 39x | — |
-| `dewasm-python` | 694 646 | 428.1 | 431.6 | 27.0 ms | 324.4 ms | 119x | — |
-| `dewasm-pypy` | 2 142 973 | 91.2 | 91.6 | 38.8 ms | 234.2 ms | 25x | — |
-| `dewasm-perl` | 266 355 | 1129 | 1138 | 10.1 ms | 310.7 ms | 313x | — |
-| `dewasm-go` | 70 829 956 | 4.21 | 4.26 | 2.8 ms | 301.0 ms | 1.17x | — |
-| `dewasm-java` | 55 552 526 | 3.71 | 3.74 | 62.6 ms | 268.9 ms | 1.03x | — |
-| `dewasm-bash` | 4 645 | 57195 | 57301 | 11.8 ms | 277.5 ms | 15861x | — |
-| `pywasm-pypy` | 25 084 | 9661 | 9735 | 75.8 ms | 318.2 ms | 2679x | 3.5 ms |
+| `wasmtime` | 86 184 820 | 3.48 | 3.48 | 6.5 ms | 306.6 ms | 1.00x | — |
+| `wasmer` | 87 149 968 | 3.44 | 3.47 | 9.0 ms | 308.7 ms | 0.99x | — |
+| `wasmedge` | 1 483 241 | 204.3 | 205.1 | 16.8 ms | 319.8 ms | 59x | — |
+| `wazero` | 50 774 272 | 5.90 | 5.94 | 5.6 ms | 305.1 ms | 1.69x | — |
+| `wasm3` | 6 877 712 | 49.0 | 49.3 | 5.2 ms | 342.1 ms | 14x | — |
+| `dewasm-ruby` | 1 371 297 | 201.5 | 203.6 | 37.8 ms | 314.2 ms | 58x | — |
+| `dewasm-ruby-yjit` | 1 700 601 | 106.7 | 107.5 | 37.7 ms | 219.2 ms | 31x | — |
+| `dewasm-ruby-zjit` | 1 902 474 | 123.4 | 124.5 | 37.4 ms | 272.1 ms | 35x | — |
+| `dewasm-python` | 738 780 | 413.7 | 414.2 | 27.7 ms | 333.3 ms | 119x | — |
+| `dewasm-pypy` | 3 392 380 | 88.0 | 88.7 | 37.6 ms | 336.2 ms | 25x | — |
+| `dewasm-perl` | 276 263 | 1095 | 1098 | 11.1 ms | 313.5 ms | 314x | — |
+| `dewasm-go` | 55 884 932 | 4.05 | 4.07 | 3.7 ms | 230.2 ms | 1.16x | — |
+| `dewasm-java` | 57 779 650 | 3.55 | 3.54 | 62.3 ms | 267.5 ms | 1.02x | — |
+| `dewasm-bash` | 5 883 | 47041 | 47060 | 12.0 ms | 288.7 ms | 13508x | — |
+| `pywasm-cpython` | 5 242 | 48190 | 49017 | 43.9 ms | 296.5 ms | 13838x | 0.7 ms |
+| `pywasm-pypy` | 28 000 | 8716 | 8871 | 73.9 ms | 317.9 ms | 2503x | 3.4 ms |
+| `wardite` | 13 135 | 17580 | 17905 | 50.4 ms | 281.3 ms | 5048x | 3.5 ms |
+| `wardite-yjit` | 36 475 | 8076 | 8129 | 96.0 ms | 390.5 ms | 2319x | 8.9 ms |
 
 </details>
 
@@ -171,7 +186,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-call-indirect-dark.svg">
-  <img alt="wat/call_indirect: seconds per iteration for 15 runners on a log scale, fastest first. wasmtime is fastest at 10.9 ns, then wasmer at 10.9 ns; dewasm-bash is slowest at 77.3 µs, a span of 7120x. The table below carries every number." src="figs/wat-call-indirect.svg">
+  <img alt="wat/call_indirect: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 10.3 ns, then wasmtime at 10.4 ns; pywasm-cpython is slowest at 80.6 µs, a span of 7820x. The table below carries every number." src="figs/wat-call-indirect.svg">
 </picture>
 
 <details>
@@ -179,21 +194,24 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 16 777 216 | 10.8 | 10.9 | 5.2 ms | 187.0 ms | 1.00x | — |
-| `wasmer` | 33 554 432 | 10.8 | 10.9 | 8.4 ms | 370.7 ms | 1.00x | — |
-| `wasmedge` | 671 842 | 428.8 | 430.6 | 15.2 ms | 303.3 ms | 40x | — |
-| `wazero` | 15 408 657 | 12.0 | 12.0 | 4.7 ms | 189.2 ms | 1.11x | — |
-| `wasm3` | 4 277 456 | 70.9 | 71.3 | 4.2 ms | 307.4 ms | 6.54x | — |
-| `dewasm-ruby` | 425 461 | 690.2 | 694.4 | 38.1 ms | 331.8 ms | 64x | — |
-| `dewasm-ruby-yjit` | 649 365 | 421.4 | 421.5 | 38.0 ms | 311.6 ms | 39x | — |
-| `dewasm-ruby-zjit` | 543 081 | 498.3 | 500.6 | 38.7 ms | 309.4 ms | 46x | — |
-| `dewasm-python` | 336 585 | 865.2 | 867.7 | 26.8 ms | 318.0 ms | 80x | — |
-| `dewasm-pypy` | 1 790 750 | 143.4 | 143.6 | 38.7 ms | 295.5 ms | 13x | — |
-| `dewasm-perl` | 118 664 | 2523 | 2535 | 10.2 ms | 309.6 ms | 233x | — |
-| `dewasm-go` | 16 777 216 | 11.1 | 11.1 | 2.7 ms | 189.4 ms | 1.03x | — |
-| `dewasm-java` | 3 885 141 | 51.5 | 55.2 | 61.7 ms | 262.0 ms | 4.76x | — |
-| `dewasm-bash` | 3 651 | 76518 | 77278 | 11.8 ms | 291.2 ms | 7063x | — |
-| `pywasm-pypy` | 5 940 | 33066 | 33102 | 76.0 ms | 272.4 ms | 3052x | 4.6 ms |
+| `wasmtime` | 33 554 432 | 10.3 | 10.4 | 6.0 ms | 353.0 ms | 1.00x | — |
+| `wasmer` | 33 554 432 | 10.3 | 10.3 | 9.1 ms | 354.4 ms | 1.00x | — |
+| `wasmedge` | 730 531 | 414.4 | 416.4 | 16.3 ms | 319.0 ms | 40x | — |
+| `wazero` | 16 777 216 | 11.7 | 11.8 | 5.8 ms | 202.8 ms | 1.14x | — |
+| `wasm3` | 4 244 635 | 68.4 | 69.4 | 4.9 ms | 295.1 ms | 6.61x | — |
+| `dewasm-ruby` | 441 211 | 657.4 | 657.5 | 37.4 ms | 327.5 ms | 64x | — |
+| `dewasm-ruby-yjit` | 674 449 | 401.5 | 406.9 | 37.6 ms | 308.4 ms | 39x | — |
+| `dewasm-ruby-zjit` | 573 612 | 459.9 | 469.1 | 37.4 ms | 301.1 ms | 44x | — |
+| `dewasm-python` | 362 583 | 776.5 | 777.3 | 27.9 ms | 309.4 ms | 75x | — |
+| `dewasm-pypy` | 1 981 557 | 135.2 | 136.2 | 38.0 ms | 306.0 ms | 13x | — |
+| `dewasm-perl` | 131 072 | 2429 | 2436 | 11.4 ms | 329.7 ms | 235x | — |
+| `dewasm-go` | 16 777 216 | 10.6 | 10.7 | 4.6 ms | 182.3 ms | 1.02x | — |
+| `dewasm-java` | 3 700 208 | 54.5 | 56.4 | 62.4 ms | 263.9 ms | 5.27x | — |
+| `dewasm-bash` | 4 385 | 64496 | 65394 | 12.3 ms | 295.1 ms | 6238x | — |
+| `pywasm-cpython` | 2 427 | 80819 | 80602 | 43.0 ms | 239.2 ms | 7817x | 0.7 ms |
+| `pywasm-pypy` | 9 308 | 23642 | 23791 | 74.3 ms | 294.4 ms | 2287x | 4.1 ms |
+| `wardite` | 8 108 | 27262 | 27382 | 50.9 ms | 271.9 ms | 2637x | 3.6 ms |
+| `wardite-yjit` | 16 995 | 13553 | 13829 | 95.6 ms | 325.9 ms | 1311x | 8.3 ms |
 
 </details>
 
@@ -201,7 +219,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-f64-alu-dark.svg">
-  <img alt="wat/f64_alu: seconds per iteration for 15 runners on a log scale, fastest first. wazero is fastest at 1.00 ns, then wasmer at 1.01 ns; dewasm-bash is slowest at 593 µs, a span of 590000x. The table below carries every number." src="figs/wat-f64-alu.svg">
+  <img alt="wat/f64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wazero is fastest at 0.96 ns, then wasmer at 0.97 ns; dewasm-bash is slowest at 498 µs, a span of 518000x. The table below carries every number." src="figs/wat-f64-alu.svg">
 </picture>
 
 <details>
@@ -209,21 +227,24 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 282 139 948 | 1.01 | 1.01 | 5.3 ms | 291.0 ms | 1.00x | — |
-| `wasmer` | 292 510 352 | 1.01 | 1.01 | 8.2 ms | 303.5 ms | 1.00x | — |
-| `wasmedge` | 3 052 208 | 84.3 | 84.6 | 15.3 ms | 272.4 ms | 83x | — |
-| `wazero` | 294 793 259 | 1.00 | 1.00 | 5.0 ms | 298.6 ms | 0.98x | — |
-| `wasm3` | 53 840 884 | 5.57 | 5.58 | 4.1 ms | 304.0 ms | 5.50x | — |
-| `dewasm-ruby` | 2 644 416 | 105.3 | 106.0 | 38.3 ms | 316.7 ms | 104x | — |
-| `dewasm-ruby-yjit` | 3 891 525 | 79.0 | 79.0 | 38.5 ms | 345.8 ms | 78x | — |
-| `dewasm-ruby-zjit` | 2 801 353 | 85.8 | 86.1 | 38.0 ms | 278.4 ms | 85x | — |
-| `dewasm-python` | 1 801 722 | 157.2 | 157.1 | 26.7 ms | 310.0 ms | 155x | — |
-| `dewasm-pypy` | 129 125 311 | 2.21 | 2.23 | 39.6 ms | 325.1 ms | 2.18x | — |
-| `dewasm-perl` | 319 311 | 854.5 | 865.2 | 14.6 ms | 287.5 ms | 844x | — |
-| `dewasm-go` | 83 408 970 | 3.62 | 3.64 | 2.7 ms | 304.2 ms | 3.57x | — |
-| `dewasm-java` | 112 978 436 | 1.73 | 1.71 | 63.3 ms | 258.3 ms | 1.70x | — |
-| `dewasm-bash` | 512 | 591431 | 592918 | 12.3 ms | 315.1 ms | 584102x | — |
-| `pywasm-pypy` | 28 684 | 7040 | 7081 | 75.6 ms | 277.6 ms | 6953x | 3.5 ms |
+| `wasmtime` | 308 263 040 | 0.97 | 0.97 | 5.9 ms | 303.6 ms | 1.00x | — |
+| `wasmer` | 308 031 142 | 0.97 | 0.97 | 9.1 ms | 306.5 ms | 1.00x | — |
+| `wasmedge` | 3 577 591 | 81.5 | 81.7 | 16.2 ms | 307.9 ms | 84x | — |
+| `wazero` | 313 546 425 | 0.96 | 0.96 | 5.8 ms | 305.6 ms | 0.99x | — |
+| `wasm3` | 55 763 037 | 5.41 | 5.41 | 4.8 ms | 306.5 ms | 5.60x | — |
+| `dewasm-ruby` | 2 853 475 | 102.1 | 102.1 | 36.8 ms | 328.3 ms | 106x | — |
+| `dewasm-ruby-yjit` | 3 047 651 | 76.1 | 76.8 | 37.7 ms | 269.6 ms | 79x | — |
+| `dewasm-ruby-zjit` | 2 871 394 | 81.9 | 82.4 | 37.6 ms | 272.9 ms | 85x | — |
+| `dewasm-python` | 1 847 927 | 151.3 | 151.3 | 28.1 ms | 307.7 ms | 157x | — |
+| `dewasm-pypy` | 132 532 820 | 2.12 | 2.13 | 37.8 ms | 318.8 ms | 2.20x | — |
+| `dewasm-perl` | 371 789 | 821.8 | 824.4 | 15.6 ms | 321.1 ms | 851x | — |
+| `dewasm-go` | 63 778 820 | 3.46 | 3.45 | 3.4 ms | 223.8 ms | 3.58x | — |
+| `dewasm-java` | 178 763 105 | 1.61 | 1.61 | 62.5 ms | 350.7 ms | 1.67x | — |
+| `dewasm-bash` | 593 | 496847 | 498237 | 12.8 ms | 307.4 ms | 514426x | — |
+| `pywasm-cpython` | 9 415 | 28658 | 28639 | 43.9 ms | 313.8 ms | 29672x | 0.6 ms |
+| `pywasm-pypy` | 29 532 | 6609 | 6686 | 73.5 ms | 268.7 ms | 6843x | 3.2 ms |
+| `wardite` | 39 492 | 7398 | 7467 | 50.3 ms | 342.5 ms | 7660x | 3.7 ms |
+| `wardite-yjit` | 83 936 | 3473 | 3499 | 96.7 ms | 388.2 ms | 3596x | 8.2 ms |
 
 </details>
 
@@ -231,7 +252,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-i32-alu-dark.svg">
-  <img alt="wat/i32_alu: seconds per iteration for 15 runners on a log scale, fastest first. wasmtime is fastest at 2.40 ns, then wasmer at 2.40 ns; pywasm-pypy is slowest at 29.9 µs, a span of 12500x. The table below carries every number." src="figs/wat-i32-alu.svg">
+  <img alt="wat/i32_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 2.30 ns, then dewasm-java at 2.33 ns; pywasm-cpython is slowest at 53.4 µs, a span of 23200x. The table below carries every number." src="figs/wat-i32-alu.svg">
 </picture>
 
 <details>
@@ -239,21 +260,24 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 127 330 827 | 2.39 | 2.40 | 5.2 ms | 309.7 ms | 1.00x | — |
-| `wasmer` | 123 651 946 | 2.40 | 2.40 | 8.2 ms | 304.6 ms | 1.00x | — |
-| `wasmedge` | 1 741 075 | 160.7 | 161.4 | 15.7 ms | 295.5 ms | 67x | — |
-| `wazero` | 108 566 873 | 2.74 | 2.75 | 4.8 ms | 302.3 ms | 1.15x | — |
-| `wasm3` | 16 777 216 | 13.4 | 13.4 | 4.1 ms | 229.4 ms | 5.61x | — |
-| `dewasm-ruby` | 1 423 500 | 202.7 | 205.8 | 37.9 ms | 326.5 ms | 85x | — |
-| `dewasm-ruby-yjit` | 1 977 806 | 155.1 | 156.8 | 39.5 ms | 346.2 ms | 65x | — |
-| `dewasm-ruby-zjit` | 1 412 248 | 166.7 | 168.4 | 38.4 ms | 273.9 ms | 70x | — |
-| `dewasm-python` | 329 066 | 659.5 | 658.4 | 28.6 ms | 245.6 ms | 276x | — |
-| `dewasm-pypy` | 17 814 425 | 10.7 | 10.7 | 42.9 ms | 233.3 ms | 4.47x | — |
-| `dewasm-perl` | 427 044 | 710.2 | 711.9 | 16.1 ms | 319.4 ms | 297x | — |
-| `dewasm-go` | 95 129 757 | 3.15 | 3.18 | 2.5 ms | 302.0 ms | 1.32x | — |
-| `dewasm-java` | 119 592 636 | 2.45 | 2.44 | 64.9 ms | 357.4 ms | 1.02x | — |
-| `dewasm-bash` | 11 035 | 26001 | 25671 | 13.6 ms | 300.5 ms | 10873x | — |
-| `pywasm-pypy` | 6 234 | 29096 | 29906 | 82.4 ms | 263.8 ms | 12168x | 3.7 ms |
+| `wasmtime` | 130 673 147 | 2.29 | 2.30 | 5.9 ms | 305.3 ms | 1.00x | — |
+| `wasmer` | 125 657 518 | 2.34 | 2.36 | 10.0 ms | 303.5 ms | 1.02x | — |
+| `wasmedge` | 2 753 954 | 157.9 | 157.9 | 16.7 ms | 451.6 ms | 69x | — |
+| `wazero` | 115 619 881 | 2.65 | 2.68 | 5.8 ms | 312.7 ms | 1.16x | — |
+| `wasm3` | 16 131 938 | 12.8 | 12.9 | 4.9 ms | 211.8 ms | 5.60x | — |
+| `dewasm-ruby` | 1 593 876 | 180.6 | 182.4 | 36.9 ms | 324.7 ms | 79x | — |
+| `dewasm-ruby-yjit` | 1 824 076 | 137.2 | 138.9 | 36.7 ms | 286.9 ms | 60x | — |
+| `dewasm-ruby-zjit` | 1 748 235 | 148.6 | 149.5 | 37.3 ms | 297.0 ms | 65x | — |
+| `dewasm-python` | 520 156 | 557.1 | 557.8 | 27.4 ms | 317.2 ms | 243x | — |
+| `dewasm-pypy` | 29 450 684 | 9.43 | 9.42 | 38.3 ms | 316.0 ms | 4.12x | — |
+| `dewasm-perl` | 441 655 | 680.4 | 684.0 | 11.1 ms | 311.6 ms | 297x | — |
+| `dewasm-go` | 72 310 665 | 3.03 | 3.02 | 3.4 ms | 222.4 ms | 1.32x | — |
+| `dewasm-java` | 94 552 487 | 2.36 | 2.33 | 59.1 ms | 282.1 ms | 1.03x | — |
+| `dewasm-bash` | 13 965 | 22020 | 22097 | 12.9 ms | 320.4 ms | 9613x | — |
+| `pywasm-cpython` | 5 505 | 52761 | 53405 | 44.5 ms | 335.0 ms | 23033x | 0.7 ms |
+| `pywasm-pypy` | 13 808 | 16251 | 16464 | 76.2 ms | 300.6 ms | 7094x | 3.5 ms |
+| `wardite` | 16 538 | 14990 | 15050 | 50.0 ms | 297.9 ms | 6544x | 4.3 ms |
+| `wardite-yjit` | 30 797 | 6832 | 6867 | 94.6 ms | 305.0 ms | 2983x | 7.9 ms |
 
 </details>
 
@@ -261,7 +285,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-i64-alu-dark.svg">
-  <img alt="wat/i64_alu: seconds per iteration for 15 runners on a log scale, fastest first. wasmtime is fastest at 2.36 ns, then wasmer at 2.38 ns; pywasm-pypy is slowest at 390 µs, a span of 165000x. The table below carries every number." src="figs/wat-i64-alu.svg">
+  <img alt="wat/i64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 2.30 ns, then wasmer at 2.30 ns; pywasm-pypy is slowest at 359 µs, a span of 156000x. The table below carries every number." src="figs/wat-i64-alu.svg">
 </picture>
 
 <details>
@@ -269,21 +293,24 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 124 213 821 | 2.37 | 2.36 | 10.4 ms | 305.4 ms | 1.00x | — |
-| `wasmer` | 120 456 007 | 2.37 | 2.38 | 14.1 ms | 299.3 ms | 1.00x | — |
-| `wasmedge` | 1 904 816 | 158.5 | 159.9 | 22.4 ms | 324.3 ms | 67x | — |
-| `wazero` | 108 187 949 | 2.68 | 2.71 | 9.6 ms | 299.4 ms | 1.13x | — |
-| `wasm3` | 16 777 216 | 12.5 | 12.9 | 9.5 ms | 218.8 ms | 5.25x | — |
-| `dewasm-ruby` | 198 508 | 1481 | 1507 | 38.9 ms | 332.9 ms | 624x | — |
-| `dewasm-ruby-yjit` | 218 068 | 1075 | 1101 | 38.1 ms | 272.5 ms | 453x | — |
-| `dewasm-ruby-zjit` | 205 808 | 1245 | 1250 | 38.1 ms | 294.2 ms | 524x | — |
-| `dewasm-python` | 305 939 | 661.8 | 667.4 | 32.8 ms | 235.3 ms | 279x | — |
-| `dewasm-pypy` | 876 269 | 250.3 | 253.3 | 42.4 ms | 261.7 ms | 105x | — |
-| `dewasm-perl` | 267 887 | 1021 | 1024 | 13.5 ms | 286.9 ms | 430x | — |
-| `dewasm-go` | 90 929 820 | 2.67 | 2.68 | 3.7 ms | 246.2 ms | 1.12x | — |
-| `dewasm-java` | 119 442 239 | 2.43 | 2.43 | 66.6 ms | 357.3 ms | 1.03x | — |
-| `dewasm-bash` | 8 695 | 28328 | 28329 | 17.5 ms | 263.8 ms | 11929x | — |
-| `pywasm-pypy` | 467 | 389415 | 389730 | 86.4 ms | 268.2 ms | 163982x | 3.6 ms |
+| `wasmtime` | 131 618 411 | 2.30 | 2.30 | 6.2 ms | 308.7 ms | 1.00x | — |
+| `wasmer` | 130 260 558 | 2.29 | 2.30 | 9.1 ms | 308.0 ms | 1.00x | — |
+| `wasmedge` | 1 980 463 | 156.7 | 159.8 | 15.9 ms | 326.3 ms | 68x | — |
+| `wazero` | 109 897 127 | 2.63 | 2.66 | 5.8 ms | 294.8 ms | 1.14x | — |
+| `wasm3` | 16 777 216 | 12.0 | 12.1 | 5.0 ms | 206.8 ms | 5.24x | — |
+| `dewasm-ruby` | 225 605 | 1296 | 1307 | 37.3 ms | 329.6 ms | 564x | — |
+| `dewasm-ruby-yjit` | 295 187 | 939.3 | 954.0 | 37.3 ms | 314.6 ms | 409x | — |
+| `dewasm-ruby-zjit` | 281 212 | 1019 | 1025 | 37.4 ms | 324.1 ms | 444x | — |
+| `dewasm-python` | 444 939 | 611.4 | 631.2 | 28.3 ms | 300.4 ms | 266x | — |
+| `dewasm-pypy` | 971 910 | 219.1 | 221.1 | 37.9 ms | 250.8 ms | 95x | — |
+| `dewasm-perl` | 305 485 | 993.7 | 996.4 | 11.1 ms | 314.7 ms | 432x | — |
+| `dewasm-go` | 82 585 389 | 2.59 | 2.59 | 3.8 ms | 217.5 ms | 1.13x | — |
+| `dewasm-java` | 83 499 022 | 2.34 | 2.33 | 63.6 ms | 258.6 ms | 1.02x | — |
+| `dewasm-bash` | 11 101 | 24217 | 24316 | 13.4 ms | 282.3 ms | 10539x | — |
+| `pywasm-cpython` | 4 508 | 56570 | 56562 | 43.0 ms | 298.0 ms | 24619x | 0.7 ms |
+| `pywasm-pypy` | 512 | 354804 | 358787 | 77.7 ms | 259.3 ms | 154413x | 3.4 ms |
+| `wardite` | 19 188 | 16042 | 16277 | 50.2 ms | 358.0 ms | 6982x | 3.5 ms |
+| `wardite-yjit` | 33 710 | 8814 | 8906 | 94.1 ms | 391.2 ms | 3836x | 8.5 ms |
 
 </details>
 
@@ -291,7 +318,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-mem-rw-dark.svg">
-  <img alt="wat/mem_rw: seconds per iteration for 15 runners on a log scale, fastest first. wasmtime is fastest at 1.03 ns, then wasmer at 1.03 ns; dewasm-bash is slowest at 31.4 µs, a span of 30400x. The table below carries every number." src="figs/wat-mem-rw.svg">
+  <img alt="wat/mem_rw: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 0.98 ns, then wasmer at 0.99 ns; pywasm-cpython is slowest at 38.1 µs, a span of 38700x. The table below carries every number." src="figs/wat-mem-rw.svg">
 </picture>
 
 <details>
@@ -299,21 +326,24 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 257 206 799 | 1.02 | 1.03 | 9.8 ms | 272.8 ms | 1.00x | — |
-| `wasmer` | 278 093 333 | 1.03 | 1.03 | 13.6 ms | 299.1 ms | 1.00x | — |
-| `wasmedge` | 1 862 361 | 131.7 | 138.1 | 20.0 ms | 265.3 ms | 129x | — |
-| `wazero` | 191 177 912 | 1.59 | 1.70 | 11.6 ms | 315.7 ms | 1.56x | — |
-| `wasm3` | 16 777 216 | 10.6 | 10.8 | 9.3 ms | 186.5 ms | 10x | — |
-| `dewasm-ruby` | 1 530 752 | 163.4 | 163.7 | 38.7 ms | 288.9 ms | 160x | — |
-| `dewasm-ruby-yjit` | 1 615 633 | 141.2 | 141.0 | 37.2 ms | 265.4 ms | 138x | — |
-| `dewasm-ruby-zjit` | 1 948 986 | 147.7 | 147.9 | 39.1 ms | 326.9 ms | 144x | — |
-| `dewasm-python` | 375 517 | 742.8 | 741.3 | 30.6 ms | 309.5 ms | 727x | — |
-| `dewasm-pypy` | 4 841 451 | 55.2 | 55.1 | 44.0 ms | 311.2 ms | 54x | — |
-| `dewasm-perl` | 223 956 | 1005 | 990.3 | 10.6 ms | 235.5 ms | 983x | — |
-| `dewasm-go` | 174 543 475 | 1.54 | 1.56 | 2.7 ms | 271.8 ms | 1.51x | — |
-| `dewasm-java` | 134 236 327 | 1.81 | 1.83 | 64.0 ms | 306.7 ms | 1.77x | — |
-| `dewasm-bash` | 6 325 | 31825 | 31443 | 15.1 ms | 216.4 ms | 31130x | — |
-| `pywasm-pypy` | 5 591 | 25052 | 24821 | 80.4 ms | 220.4 ms | 24505x | 5.1 ms |
+| `wasmtime` | 312 876 423 | 0.98 | 0.99 | 7.2 ms | 315.3 ms | 1.00x | — |
+| `wasmer` | 299 553 254 | 0.99 | 0.99 | 8.8 ms | 304.9 ms | 1.00x | — |
+| `wasmedge` | 1 949 460 | 126.5 | 126.9 | 16.3 ms | 263.0 ms | 129x | — |
+| `wazero` | 196 106 564 | 1.52 | 1.53 | 5.5 ms | 303.7 ms | 1.54x | — |
+| `wasm3` | 33 554 432 | 9.99 | 10.0 | 4.9 ms | 340.2 ms | 10x | — |
+| `dewasm-ruby` | 1 673 508 | 174.0 | 175.5 | 37.0 ms | 328.2 ms | 177x | — |
+| `dewasm-ruby-yjit` | 2 248 511 | 130.0 | 130.7 | 37.7 ms | 330.1 ms | 132x | — |
+| `dewasm-ruby-zjit` | 2 030 148 | 138.4 | 139.9 | 37.6 ms | 318.5 ms | 140x | — |
+| `dewasm-python` | 384 461 | 732.5 | 741.9 | 27.7 ms | 309.3 ms | 744x | — |
+| `dewasm-pypy` | 5 536 715 | 52.7 | 53.1 | 38.8 ms | 330.4 ms | 53x | — |
+| `dewasm-perl` | 316 931 | 960.9 | 964.0 | 10.9 ms | 315.4 ms | 976x | — |
+| `dewasm-go` | 149 028 696 | 1.48 | 1.47 | 4.1 ms | 224.2 ms | 1.50x | — |
+| `dewasm-java` | 162 847 521 | 1.75 | 1.73 | 58.9 ms | 343.4 ms | 1.77x | — |
+| `dewasm-bash` | 11 586 | 26555 | 26618 | 12.6 ms | 320.2 ms | 26965x | — |
+| `pywasm-cpython` | 8 415 | 38144 | 38136 | 44.1 ms | 365.1 ms | 38734x | 0.7 ms |
+| `pywasm-pypy` | 16 194 | 10335 | 10439 | 74.3 ms | 241.7 ms | 10495x | 4.4 ms |
+| `wardite` | 15 360 | 12976 | 13184 | 50.2 ms | 249.5 ms | 13177x | 3.9 ms |
+| `wardite-yjit` | 36 555 | 5909 | 5942 | 94.1 ms | 310.1 ms | 6001x | 8.4 ms |
 
 </details>
 
@@ -326,7 +356,7 @@ Every runner executes the same work, so wall times compare directly.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/app-cowsay-dark.svg">
-  <img alt="app/cowsay: seconds per run for 15 runners on a log scale, fastest first. dewasm-go is fastest at 4.54 ms, then wasm3 at 11.8 ms; dewasm-bash is slowest at 1.34 s, a span of 296x. The table below carries every number." src="figs/app-cowsay.svg">
+  <img alt="app/cowsay: seconds per run for 18 runners on a log scale, fastest first. dewasm-go is fastest at 6.01 ms, then wasm3 at 8.04 ms; dewasm-bash is slowest at 1.11 s, a span of 185x. The table below carries every number." src="figs/app-cowsay.svg">
 </picture>
 
 <details>
@@ -334,21 +364,24 @@ Every runner executes the same work, so wall times compare directly.
 
 | Runner | Runs/sample | Wall time (min) | Wall time (median) | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 17 | 15.2 ms | 15.2 ms | 1.00x | — |
-| `wasmer` | 16 | 18.2 ms | 18.6 ms | 1.20x | — |
-| `wasmedge` | 10 | 30.7 ms | 31.6 ms | 2.02x | — |
-| `wazero` | 3 | 108.1 ms | 108.8 ms | 7.11x | — |
-| `wasm3` | 23 | 11.7 ms | 11.8 ms | 0.77x | — |
-| `dewasm-ruby` | 2 | 154.5 ms | 155.7 ms | 10x | — |
-| `dewasm-ruby-yjit` | 2 | 204.5 ms | 204.7 ms | 13x | — |
-| `dewasm-ruby-zjit` | 2 | 275.1 ms | 275.5 ms | 18x | — |
-| `dewasm-python` | 1 | 434.6 ms | 438.0 ms | 29x | — |
-| `dewasm-pypy` | 1 | 602.0 ms | 602.9 ms | 40x | — |
-| `dewasm-perl` | 3 | 112.2 ms | 112.4 ms | 7.38x | — |
-| `dewasm-go` | 2 | 4.1 ms | 4.5 ms | 0.27x | — |
-| `dewasm-java` | 3 | 131.2 ms | 132.5 ms | 8.63x | — |
-| `dewasm-bash` | 1 | 1.34 s | 1.34 s | 88x | — |
-| `pywasm-pypy` | 1 | 912.7 ms | 919.3 ms | 60x | 471.2 ms |
+| `wasmtime` | 24 | 10.7 ms | 10.8 ms | 1.00x | — |
+| `wasmer` | 17 | 14.5 ms | 15.2 ms | 1.36x | — |
+| `wasmedge` | 11 | 27.0 ms | 27.6 ms | 2.53x | — |
+| `wazero` | 3 | 104.5 ms | 104.8 ms | 9.80x | — |
+| `wasm3` | 35 | 7.7 ms | 8.0 ms | 0.72x | — |
+| `dewasm-ruby` | 3 | 135.9 ms | 136.7 ms | 13x | — |
+| `dewasm-ruby-yjit` | 2 | 179.8 ms | 182.5 ms | 17x | — |
+| `dewasm-ruby-zjit` | 2 | 236.6 ms | 239.0 ms | 22x | — |
+| `dewasm-python` | 1 | 408.6 ms | 409.4 ms | 38x | — |
+| `dewasm-pypy` | 1 | 604.0 ms | 604.7 ms | 57x | — |
+| `dewasm-perl` | 3 | 106.3 ms | 106.4 ms | 9.96x | — |
+| `dewasm-go` | 1 | 5.5 ms | 6.0 ms | 0.52x | — |
+| `dewasm-java` | 3 | 123.0 ms | 124.3 ms | 12x | — |
+| `dewasm-bash` | 1 | 1.11 s | 1.11 s | 104x | — |
+| `pywasm-cpython` | 1 | 482.4 ms | 484.8 ms | 45x | 274.7 ms |
+| `pywasm-pypy` | 1 | 819.0 ms | 828.8 ms | 77x | 444.4 ms |
+| `wardite` | 2 | 226.8 ms | 228.7 ms | 21x | 107.9 ms |
+| `wardite-yjit` | 2 | 250.9 ms | 253.0 ms | 24x | 77.8 ms |
 
 </details>
 
@@ -356,7 +389,7 @@ Every runner executes the same work, so wall times compare directly.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/app-sqlite3-query-dark.svg">
-  <img alt="app/sqlite3_query: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 78.9 ms, then wasmer at 89.8 ms; dewasm-perl is slowest at 114 s, a span of 1450x. The table below carries every number." src="figs/app-sqlite3-query.svg">
+  <img alt="app/sqlite3_query: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 75.5 ms, then wasmer at 85.1 ms; dewasm-perl is slowest at 108 s, a span of 1440x. The table below carries every number." src="figs/app-sqlite3-query.svg">
 </picture>
 
 <details>
@@ -364,19 +397,19 @@ Every runner executes the same work, so wall times compare directly.
 
 | Runner | Runs/sample | Wall time (min) | Wall time (median) | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 4 | 78.2 ms | 78.9 ms | 1.00x | — |
-| `wasmer` | 4 | 88.3 ms | 89.8 ms | 1.13x | — |
-| `wasmedge` | 1 | 9.84 s | 9.95 s | 126x | — |
-| `wazero` | 1 | 645.8 ms | 647.8 ms | 8.26x | — |
-| `wasm3` | 1 | 1.10 s | 1.12 s | 14x | — |
-| `dewasm-ruby` | 1 | 17.84 s | 17.90 s | 228x | — |
-| `dewasm-ruby-yjit` | 1 | 9.31 s | 9.36 s | 119x | — |
-| `dewasm-ruby-zjit` | 1 | 14.76 s | 14.86 s | 189x | — |
-| `dewasm-python` | 1 | 53.65 s | 53.92 s | 686x | — |
-| `dewasm-pypy` | 1 | 12.46 s | 12.51 s | 159x | — |
-| `dewasm-perl` | 1 | 114.21 s | 114.49 s | 1460x | — |
-| `dewasm-go` | 1 | 174.8 ms | 175.6 ms | 2.23x | — |
-| `dewasm-java` | 1 | 2.40 s | 2.43 s | 31x | — |
+| `wasmtime` | 3 | 75.4 ms | 75.5 ms | 1.00x | — |
+| `wasmer` | 3 | 84.8 ms | 85.1 ms | 1.12x | — |
+| `wasmedge` | 1 | 9.47 s | 9.55 s | 126x | — |
+| `wazero` | 1 | 614.6 ms | 621.2 ms | 8.15x | — |
+| `wasm3` | 1 | 891.0 ms | 1.07 s | 12x | — |
+| `dewasm-ruby` | 1 | 18.67 s | 18.73 s | 248x | — |
+| `dewasm-ruby-yjit` | 1 | 8.87 s | 8.88 s | 118x | — |
+| `dewasm-ruby-zjit` | 1 | 13.46 s | 13.52 s | 179x | — |
+| `dewasm-python` | 1 | 53.60 s | 53.68 s | 711x | — |
+| `dewasm-pypy` | 1 | 11.42 s | 11.48 s | 152x | — |
+| `dewasm-perl` | 1 | 108.08 s | 108.46 s | 1434x | — |
+| `dewasm-go` | 1 | 169.5 ms | 169.8 ms | 2.25x | — |
+| `dewasm-java` | 1 | 2.30 s | 2.31 s | 31x | — |
 
 </details>
 
@@ -387,39 +420,9 @@ A missing runner or an unbuilt module is stated here rather than left as a gap i
 
 | Workload | Runner | Reason |
 | --- | --- | --- |
-| `c/mandelbrot` | `pywasm-cpython` | benchmarks/cache/venv missing: run benchmarks/setup.sh |
-| `c/mandelbrot` | `wardite` | no GEM_HOME with wardite under benchmarks/cache/: run benchmarks/setup.sh |
-| `c/mandelbrot` | `wardite-yjit` | no GEM_HOME with wardite under benchmarks/cache/: run benchmarks/setup.sh |
-| `c/sha256` | `pywasm-cpython` | benchmarks/cache/venv missing: run benchmarks/setup.sh |
-| `c/sha256` | `wardite` | no GEM_HOME with wardite under benchmarks/cache/: run benchmarks/setup.sh |
-| `c/sha256` | `wardite-yjit` | no GEM_HOME with wardite under benchmarks/cache/: run benchmarks/setup.sh |
-| `c/wordcount` | `pywasm-cpython` | benchmarks/cache/venv missing: run benchmarks/setup.sh |
-| `c/wordcount` | `wardite` | no GEM_HOME with wardite under benchmarks/cache/: run benchmarks/setup.sh |
-| `c/wordcount` | `wardite-yjit` | no GEM_HOME with wardite under benchmarks/cache/: run benchmarks/setup.sh |
-| `wat/call_direct` | `pywasm-cpython` | benchmarks/cache/venv missing: run benchmarks/setup.sh |
-| `wat/call_direct` | `wardite` | no GEM_HOME with wardite under benchmarks/cache/: run benchmarks/setup.sh |
-| `wat/call_direct` | `wardite-yjit` | no GEM_HOME with wardite under benchmarks/cache/: run benchmarks/setup.sh |
-| `wat/call_indirect` | `pywasm-cpython` | benchmarks/cache/venv missing: run benchmarks/setup.sh |
-| `wat/call_indirect` | `wardite` | no GEM_HOME with wardite under benchmarks/cache/: run benchmarks/setup.sh |
-| `wat/call_indirect` | `wardite-yjit` | no GEM_HOME with wardite under benchmarks/cache/: run benchmarks/setup.sh |
-| `wat/f64_alu` | `pywasm-cpython` | benchmarks/cache/venv missing: run benchmarks/setup.sh |
-| `wat/f64_alu` | `wardite` | no GEM_HOME with wardite under benchmarks/cache/: run benchmarks/setup.sh |
-| `wat/f64_alu` | `wardite-yjit` | no GEM_HOME with wardite under benchmarks/cache/: run benchmarks/setup.sh |
-| `wat/i32_alu` | `pywasm-cpython` | benchmarks/cache/venv missing: run benchmarks/setup.sh |
-| `wat/i32_alu` | `wardite` | no GEM_HOME with wardite under benchmarks/cache/: run benchmarks/setup.sh |
-| `wat/i32_alu` | `wardite-yjit` | no GEM_HOME with wardite under benchmarks/cache/: run benchmarks/setup.sh |
-| `wat/i64_alu` | `pywasm-cpython` | benchmarks/cache/venv missing: run benchmarks/setup.sh |
-| `wat/i64_alu` | `wardite` | no GEM_HOME with wardite under benchmarks/cache/: run benchmarks/setup.sh |
-| `wat/i64_alu` | `wardite-yjit` | no GEM_HOME with wardite under benchmarks/cache/: run benchmarks/setup.sh |
-| `wat/mem_rw` | `pywasm-cpython` | benchmarks/cache/venv missing: run benchmarks/setup.sh |
-| `wat/mem_rw` | `wardite` | no GEM_HOME with wardite under benchmarks/cache/: run benchmarks/setup.sh |
-| `wat/mem_rw` | `wardite-yjit` | no GEM_HOME with wardite under benchmarks/cache/: run benchmarks/setup.sh |
-| `app/cowsay` | `pywasm-cpython` | benchmarks/cache/venv missing: run benchmarks/setup.sh |
-| `app/cowsay` | `wardite` | no GEM_HOME with wardite under benchmarks/cache/: run benchmarks/setup.sh |
-| `app/cowsay` | `wardite-yjit` | no GEM_HOME with wardite under benchmarks/cache/: run benchmarks/setup.sh |
 | `app/sqlite3_query` | `dewasm-bash` | excluded: bash runs ~10000x slower than wasmtime on compute, so 100k SQL inserts do not finish in a practical time |
-| `app/sqlite3_query` | `pywasm-cpython` | benchmarks/cache/venv missing: run benchmarks/setup.sh |
+| `app/sqlite3_query` | `pywasm-cpython` | excluded on cost, not capability: pywasm runs this program correctly (byte-identical to wasmtime under -batch) at ~17.9 ms/row: measured 358 s at 20k rows, so the 100k-row script needs roughly half an hour per sample |
 | `app/sqlite3_query` | `pywasm-pypy` | excluded on cost, not capability: pywasm runs this program correctly (byte-identical to wasmtime under -batch) at ~17.9 ms/row: measured 358 s at 20k rows, so the 100k-row script needs roughly half an hour per sample |
-| `app/sqlite3_query` | `wardite` | no GEM_HOME with wardite under benchmarks/cache/: run benchmarks/setup.sh |
-| `app/sqlite3_query` | `wardite-yjit` | no GEM_HOME with wardite under benchmarks/cache/: run benchmarks/setup.sh |
+| `app/sqlite3_query` | `wardite` | excluded: wardite loads sqlite3-shell.wasm but cannot execute a query, raising Wardite::EvalError ("maybe empty or invalid stack", convert.generated.rb:200) as soon as any SQL runs |
+| `app/sqlite3_query` | `wardite-yjit` | excluded: wardite loads sqlite3-shell.wasm but cannot execute a query, raising Wardite::EvalError ("maybe empty or invalid stack", convert.generated.rb:200) as soon as any SQL runs |
 

--- a/docs/sizes/figs/app-cowsay-dark.svg
+++ b/docs/sizes/figs/app-cowsay-dark.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="272" viewBox="0 0 820 272" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="cowsay.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 772 kB, then python at 2.03 MB; bash is largest at 7.73 MB, a span of 10x. The table below carries every number.">
-<title>cowsay.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 772 kB, then python at 2.03 MB; bash is largest at 7.73 MB, a span of 10x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="272" viewBox="0 0 820 272" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="cowsay.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 772 kB, then python at 1.83 MB; bash is largest at 7.73 MB, a span of 10x. The table below carries every number.">
+<title>cowsay.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 772 kB, then python at 1.83 MB; bash is largest at 7.73 MB, a span of 10x. The table below carries every number.</title>
 <rect width="820" height="272" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="242.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="258.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 kB</text>
@@ -11,17 +11,17 @@
 <circle cx="426.6" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">772 kB</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">python</text>
-<line x1="168.0" y1="110.0" x2="548.6" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="548.6" cy="110.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.03 MB</text>
+<line x1="168.0" y1="110.0" x2="535.7" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="535.7" cy="110.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.83 MB</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">ruby</text>
-<line x1="168.0" y1="134.0" x2="553.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="553.6" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.11 MB</text>
+<line x1="168.0" y1="134.0" x2="541.4" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="541.4" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.91 MB</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">go</text>
-<line x1="168.0" y1="158.0" x2="571.4" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="571.4" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.43 MB</text>
+<line x1="168.0" y1="158.0" x2="568.7" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="568.7" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.38 MB</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">perl</text>
 <line x1="168.0" y1="182.0" x2="577.8" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="577.8" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>

--- a/docs/sizes/figs/app-cowsay.svg
+++ b/docs/sizes/figs/app-cowsay.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="272" viewBox="0 0 820 272" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="cowsay.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 772 kB, then python at 2.03 MB; bash is largest at 7.73 MB, a span of 10x. The table below carries every number.">
-<title>cowsay.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 772 kB, then python at 2.03 MB; bash is largest at 7.73 MB, a span of 10x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="272" viewBox="0 0 820 272" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="cowsay.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 772 kB, then python at 1.83 MB; bash is largest at 7.73 MB, a span of 10x. The table below carries every number.">
+<title>cowsay.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 772 kB, then python at 1.83 MB; bash is largest at 7.73 MB, a span of 10x. The table below carries every number.</title>
 <rect width="820" height="272" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="242.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="258.0" text-anchor="middle" font-size="11" fill="#52514e">100 kB</text>
@@ -11,17 +11,17 @@
 <circle cx="426.6" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">772 kB</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">python</text>
-<line x1="168.0" y1="110.0" x2="548.6" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="548.6" cy="110.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.03 MB</text>
+<line x1="168.0" y1="110.0" x2="535.7" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="535.7" cy="110.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.83 MB</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">ruby</text>
-<line x1="168.0" y1="134.0" x2="553.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="553.6" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.11 MB</text>
+<line x1="168.0" y1="134.0" x2="541.4" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="541.4" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.91 MB</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">go</text>
-<line x1="168.0" y1="158.0" x2="571.4" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="571.4" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.43 MB</text>
+<line x1="168.0" y1="158.0" x2="568.7" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="568.7" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.38 MB</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">perl</text>
 <line x1="168.0" y1="182.0" x2="577.8" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="577.8" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>

--- a/docs/sizes/figs/app-qjs-dark.svg
+++ b/docs/sizes/figs/app-qjs-dark.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="272" viewBox="0 0 820 272" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="qjs.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 1.54 MB, then python at 7.07 MB; bash is largest at 27.0 MB, a span of 18x. The table below carries every number.">
-<title>qjs.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 1.54 MB, then python at 7.07 MB; bash is largest at 27.0 MB, a span of 18x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="272" viewBox="0 0 820 272" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="qjs.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 1.54 MB, then python at 6.56 MB; bash is largest at 27.0 MB, a span of 18x. The table below carries every number.">
+<title>qjs.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 1.54 MB, then python at 6.56 MB; bash is largest at 27.0 MB, a span of 18x. The table below carries every number.</title>
 <rect width="820" height="272" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="242.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="258.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 MB</text>
@@ -11,21 +11,21 @@
 <circle cx="239.8" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.54 MB</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">python</text>
-<line x1="168.0" y1="110.0" x2="494.6" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="494.6" cy="110.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.07 MB</text>
+<line x1="168.0" y1="110.0" x2="482.0" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="482.0" cy="110.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.56 MB</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">ruby</text>
-<line x1="168.0" y1="134.0" x2="495.0" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="495.0" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.09 MB</text>
-<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">perl</text>
-<line x1="168.0" y1="158.0" x2="560.2" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="560.2" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.5 MB</text>
-<text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">go</text>
-<line x1="168.0" y1="182.0" x2="562.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="562.7" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.6 MB</text>
+<line x1="168.0" y1="134.0" x2="482.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="482.6" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.58 MB</text>
+<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">go</text>
+<line x1="168.0" y1="158.0" x2="557.9" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="557.9" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.3 MB</text>
+<text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">perl</text>
+<line x1="168.0" y1="182.0" x2="560.2" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="560.2" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.5 MB</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">java</text>
 <line x1="168.0" y1="206.0" x2="563.0" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="563.0" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>

--- a/docs/sizes/figs/app-qjs.svg
+++ b/docs/sizes/figs/app-qjs.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="272" viewBox="0 0 820 272" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="qjs.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 1.54 MB, then python at 7.07 MB; bash is largest at 27.0 MB, a span of 18x. The table below carries every number.">
-<title>qjs.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 1.54 MB, then python at 7.07 MB; bash is largest at 27.0 MB, a span of 18x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="272" viewBox="0 0 820 272" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="qjs.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 1.54 MB, then python at 6.56 MB; bash is largest at 27.0 MB, a span of 18x. The table below carries every number.">
+<title>qjs.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 1.54 MB, then python at 6.56 MB; bash is largest at 27.0 MB, a span of 18x. The table below carries every number.</title>
 <rect width="820" height="272" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="242.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="258.0" text-anchor="middle" font-size="11" fill="#52514e">1 MB</text>
@@ -11,21 +11,21 @@
 <circle cx="239.8" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.54 MB</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">python</text>
-<line x1="168.0" y1="110.0" x2="494.6" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="494.6" cy="110.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.07 MB</text>
+<line x1="168.0" y1="110.0" x2="482.0" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="482.0" cy="110.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.56 MB</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">ruby</text>
-<line x1="168.0" y1="134.0" x2="495.0" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="495.0" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.09 MB</text>
-<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">perl</text>
-<line x1="168.0" y1="158.0" x2="560.2" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="560.2" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.5 MB</text>
-<text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">go</text>
-<line x1="168.0" y1="182.0" x2="562.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="562.7" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.6 MB</text>
+<line x1="168.0" y1="134.0" x2="482.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="482.6" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.58 MB</text>
+<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">go</text>
+<line x1="168.0" y1="158.0" x2="557.9" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="557.9" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.3 MB</text>
+<text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">perl</text>
+<line x1="168.0" y1="182.0" x2="560.2" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="560.2" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.5 MB</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">java</text>
 <line x1="168.0" y1="206.0" x2="563.0" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="563.0" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>

--- a/docs/sizes/figs/app-ruby-dark.svg
+++ b/docs/sizes/figs/app-ruby-dark.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="272" viewBox="0 0 820 272" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="ruby.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 35.0 MB, then ruby at 72.0 MB; bash is largest at 311 MB, a span of 8.87x. The table below carries every number.">
-<title>ruby.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 35.0 MB, then ruby at 72.0 MB; bash is largest at 311 MB, a span of 8.87x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="272" viewBox="0 0 820 272" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="ruby.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 35.0 MB, then ruby at 66.9 MB; bash is largest at 311 MB, a span of 8.87x. The table below carries every number.">
+<title>ruby.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 35.0 MB, then ruby at 66.9 MB; bash is largest at 311 MB, a span of 8.87x. The table below carries every number.</title>
 <rect width="820" height="272" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="242.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="258.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 MB</text>
@@ -11,17 +11,17 @@
 <circle cx="368.6" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">35.0 MB</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">ruby</text>
-<line x1="168.0" y1="110.0" x2="483.9" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="483.9" cy="110.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">72.0 MB</text>
+<line x1="168.0" y1="110.0" x2="472.1" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="472.1" cy="110.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">66.9 MB</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">python</text>
-<line x1="168.0" y1="134.0" x2="505.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="505.1" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">82.2 MB</text>
+<line x1="168.0" y1="134.0" x2="494.9" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="494.9" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">77.1 MB</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">go</text>
-<line x1="168.0" y1="158.0" x2="579.9" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="579.9" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">131 MB</text>
+<line x1="168.0" y1="158.0" x2="579.1" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="579.1" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">130 MB</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">perl</text>
 <line x1="168.0" y1="182.0" x2="584.3" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="584.3" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>

--- a/docs/sizes/figs/app-ruby.svg
+++ b/docs/sizes/figs/app-ruby.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="272" viewBox="0 0 820 272" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="ruby.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 35.0 MB, then ruby at 72.0 MB; bash is largest at 311 MB, a span of 8.87x. The table below carries every number.">
-<title>ruby.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 35.0 MB, then ruby at 72.0 MB; bash is largest at 311 MB, a span of 8.87x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="272" viewBox="0 0 820 272" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="ruby.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 35.0 MB, then ruby at 66.9 MB; bash is largest at 311 MB, a span of 8.87x. The table below carries every number.">
+<title>ruby.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 35.0 MB, then ruby at 66.9 MB; bash is largest at 311 MB, a span of 8.87x. The table below carries every number.</title>
 <rect width="820" height="272" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="242.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="258.0" text-anchor="middle" font-size="11" fill="#52514e">10 MB</text>
@@ -11,17 +11,17 @@
 <circle cx="368.6" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">35.0 MB</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">ruby</text>
-<line x1="168.0" y1="110.0" x2="483.9" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="483.9" cy="110.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">72.0 MB</text>
+<line x1="168.0" y1="110.0" x2="472.1" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="472.1" cy="110.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">66.9 MB</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">python</text>
-<line x1="168.0" y1="134.0" x2="505.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="505.1" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">82.2 MB</text>
+<line x1="168.0" y1="134.0" x2="494.9" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="494.9" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">77.1 MB</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">go</text>
-<line x1="168.0" y1="158.0" x2="579.9" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="579.9" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">131 MB</text>
+<line x1="168.0" y1="158.0" x2="579.1" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="579.1" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">130 MB</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">perl</text>
 <line x1="168.0" y1="182.0" x2="584.3" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="584.3" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>

--- a/docs/sizes/figs/app-sqlite3-shell-dark.svg
+++ b/docs/sizes/figs/app-sqlite3-shell-dark.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="272" viewBox="0 0 820 272" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="sqlite3-shell.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 1.31 MB, then ruby at 7.94 MB; bash is largest at 37.6 MB, a span of 29x. The table below carries every number.">
-<title>sqlite3-shell.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 1.31 MB, then ruby at 7.94 MB; bash is largest at 37.6 MB, a span of 29x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="272" viewBox="0 0 820 272" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="sqlite3-shell.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 1.31 MB, then ruby at 7.24 MB; bash is largest at 37.6 MB, a span of 29x. The table below carries every number.">
+<title>sqlite3-shell.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 1.31 MB, then ruby at 7.24 MB; bash is largest at 37.6 MB, a span of 29x. The table below carries every number.</title>
 <rect width="820" height="272" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="242.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="258.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 MB</text>
@@ -11,17 +11,17 @@
 <circle cx="208.6" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.31 MB</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">ruby</text>
-<line x1="168.0" y1="110.0" x2="482.1" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="482.1" cy="110.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.94 MB</text>
+<line x1="168.0" y1="110.0" x2="468.2" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="468.2" cy="110.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.24 MB</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">python</text>
-<line x1="168.0" y1="134.0" x2="490.7" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="490.7" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.40 MB</text>
+<line x1="168.0" y1="134.0" x2="477.5" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="477.5" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.70 MB</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">go</text>
-<line x1="168.0" y1="158.0" x2="554.6" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="554.6" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.8 MB</text>
+<line x1="168.0" y1="158.0" x2="552.1" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="552.1" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.6 MB</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">perl</text>
 <line x1="168.0" y1="182.0" x2="555.5" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="555.5" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>

--- a/docs/sizes/figs/app-sqlite3-shell.svg
+++ b/docs/sizes/figs/app-sqlite3-shell.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="272" viewBox="0 0 820 272" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="sqlite3-shell.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 1.31 MB, then ruby at 7.94 MB; bash is largest at 37.6 MB, a span of 29x. The table below carries every number.">
-<title>sqlite3-shell.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 1.31 MB, then ruby at 7.94 MB; bash is largest at 37.6 MB, a span of 29x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="272" viewBox="0 0 820 272" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="sqlite3-shell.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 1.31 MB, then ruby at 7.24 MB; bash is largest at 37.6 MB, a span of 29x. The table below carries every number.">
+<title>sqlite3-shell.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 1.31 MB, then ruby at 7.24 MB; bash is largest at 37.6 MB, a span of 29x. The table below carries every number.</title>
 <rect width="820" height="272" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="242.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="258.0" text-anchor="middle" font-size="11" fill="#52514e">1 MB</text>
@@ -11,17 +11,17 @@
 <circle cx="208.6" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.31 MB</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">ruby</text>
-<line x1="168.0" y1="110.0" x2="482.1" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="482.1" cy="110.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.94 MB</text>
+<line x1="168.0" y1="110.0" x2="468.2" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="468.2" cy="110.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.24 MB</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">python</text>
-<line x1="168.0" y1="134.0" x2="490.7" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="490.7" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.40 MB</text>
+<line x1="168.0" y1="134.0" x2="477.5" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="477.5" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.70 MB</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">go</text>
-<line x1="168.0" y1="158.0" x2="554.6" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="554.6" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.8 MB</text>
+<line x1="168.0" y1="158.0" x2="552.1" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="552.1" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.6 MB</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">perl</text>
 <line x1="168.0" y1="182.0" x2="555.5" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="555.5" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>

--- a/docs/sizes/results.md
+++ b/docs/sizes/results.md
@@ -7,7 +7,7 @@ How to run and read these measurements is [README.md](README.md).
 
 ## Environment
 
-Measured 2026-08-11T18:27:09Z.
+Measured 2026-08-16T09:23:36Z.
 
 | | |
 | --- | --- |
@@ -51,68 +51,68 @@ Each figure is a log axis in bytes, smallest first, with its full numbers in the
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/app-cowsay-dark.svg">
-  <img alt="cowsay.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 772 kB, then python at 2.03 MB; bash is largest at 7.73 MB, a span of 10x. The table below carries every number." src="figs/app-cowsay.svg">
+  <img alt="cowsay.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 772 kB, then python at 1.83 MB; bash is largest at 7.73 MB, a span of 10x. The table below carries every number." src="figs/app-cowsay.svg">
 </picture>
 
 | Target | Size |
 | --- | --- |
 | wasm binary | 772 kB |
-| `ruby` | 2.11 MB |
-| `python` | 2.03 MB |
+| `ruby` | 1.91 MB |
+| `python` | 1.83 MB |
 | `perl` | 2.55 MB |
 | `bash` | 7.73 MB |
-| `go` | 2.43 MB |
+| `go` | 2.38 MB |
 | `java` | 3.05 MB |
 
 ### `sqlite3-shell.wasm`
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/app-sqlite3-shell-dark.svg">
-  <img alt="sqlite3-shell.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 1.31 MB, then ruby at 7.94 MB; bash is largest at 37.6 MB, a span of 29x. The table below carries every number." src="figs/app-sqlite3-shell.svg">
+  <img alt="sqlite3-shell.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 1.31 MB, then ruby at 7.24 MB; bash is largest at 37.6 MB, a span of 29x. The table below carries every number." src="figs/app-sqlite3-shell.svg">
 </picture>
 
 | Target | Size |
 | --- | --- |
 | wasm binary | 1.31 MB |
-| `ruby` | 7.94 MB |
-| `python` | 8.40 MB |
+| `ruby` | 7.24 MB |
+| `python` | 7.70 MB |
 | `perl` | 12.9 MB |
 | `bash` | 37.6 MB |
-| `go` | 12.8 MB |
+| `go` | 12.6 MB |
 | `java` | 13.5 MB |
 
 ### `qjs.wasm`
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/app-qjs-dark.svg">
-  <img alt="qjs.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 1.54 MB, then python at 7.07 MB; bash is largest at 27.0 MB, a span of 18x. The table below carries every number." src="figs/app-qjs.svg">
+  <img alt="qjs.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 1.54 MB, then python at 6.56 MB; bash is largest at 27.0 MB, a span of 18x. The table below carries every number." src="figs/app-qjs.svg">
 </picture>
 
 | Target | Size |
 | --- | --- |
 | wasm binary | 1.54 MB |
-| `ruby` | 7.09 MB |
-| `python` | 7.07 MB |
+| `ruby` | 6.58 MB |
+| `python` | 6.56 MB |
 | `perl` | 10.5 MB |
 | `bash` | 27.0 MB |
-| `go` | 10.6 MB |
+| `go` | 10.3 MB |
 | `java` | 10.7 MB |
 
 ### `ruby.wasm`
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/app-ruby-dark.svg">
-  <img alt="ruby.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 35.0 MB, then ruby at 72.0 MB; bash is largest at 311 MB, a span of 8.87x. The table below carries every number." src="figs/app-ruby.svg">
+  <img alt="ruby.wasm: the wasm binary against the source each backend converts it into, 7 rows on a log scale, smallest first. wasm binary is smallest at 35.0 MB, then ruby at 66.9 MB; bash is largest at 311 MB, a span of 8.87x. The table below carries every number." src="figs/app-ruby.svg">
 </picture>
 
 | Target | Size |
 | --- | --- |
 | wasm binary | 35.0 MB |
-| `ruby` | 72.0 MB |
-| `python` | 82.2 MB |
+| `ruby` | 66.9 MB |
+| `python` | 77.1 MB |
 | `perl` | 135 MB |
 | `bash` | 311 MB |
-| `go` | 131 MB |
+| `go` | 130 MB |
 | `java` | 143 MB |
 
 ## Not measured

--- a/records/2026-08-16T09-22-02Z-speed.json
+++ b/records/2026-08-16T09-22-02Z-speed.json
@@ -1,0 +1,6603 @@
+{
+  "schema": 1,
+  "generated_at": "2026-08-16T09:22:02Z",
+  "host": {
+    "os": "macOS 26.5.2",
+    "arch": "aarch64",
+    "kernel": "Darwin 25.5.0",
+    "cpu": "Apple M1 Pro"
+  },
+  "settings": {
+    "reps": 5,
+    "target_ms": 300,
+    "timeout_s": 900,
+    "filter": null
+  },
+  "runtimes": [
+    {
+      "runner": "wasmtime",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "wasmtime 47.0.3 (5554cc1a6 2026-07-31)"
+    },
+    {
+      "runner": "wasmer",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "wasmer 7.2.1"
+    },
+    {
+      "runner": "wasmedge",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "wasmedge version 0.17.1"
+    },
+    {
+      "runner": "wazero",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "1.12.0"
+    },
+    {
+      "runner": "wasm3",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "Wasm3 v0.5.0 on arm64-v8a"
+    },
+    {
+      "runner": "dewasm-ruby",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "ruby 4.0.4 (2026-05-12 revision b89eb1bcbf) +PRISM [arm64-darwin25]"
+    },
+    {
+      "runner": "dewasm-ruby-yjit",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "ruby 4.0.4 (2026-05-12 revision b89eb1bcbf) +PRISM [arm64-darwin25]"
+    },
+    {
+      "runner": "dewasm-ruby-zjit",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "ruby 4.0.4 (2026-05-12 revision b89eb1bcbf) +PRISM [arm64-darwin25]"
+    },
+    {
+      "runner": "dewasm-python",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "Python 3.14.7 (main, Aug  5 2026, 10:29:49) [Clang 21.0.0 (clang-2100.1.1.101)]"
+    },
+    {
+      "runner": "dewasm-pypy",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "Python 3.11.15 (194f9f44b505, Jul 15 2026, 12:14:56)"
+    },
+    {
+      "runner": "dewasm-perl",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "v5.44.0"
+    },
+    {
+      "runner": "dewasm-go",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "go version go1.26.2 darwin/arm64"
+    },
+    {
+      "runner": "dewasm-java",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "java version \"25.0.4\" 2026-07-21 LTS"
+    },
+    {
+      "runner": "dewasm-bash",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "5.3.15(1)-release"
+    },
+    {
+      "runner": "pywasm-cpython",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "pywasm 2.2.3"
+    },
+    {
+      "runner": "pywasm-pypy",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "pywasm 2.2.3"
+    },
+    {
+      "runner": "wardite",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "wardite 0.9.0"
+    },
+    {
+      "runner": "wardite-yjit",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "wardite 0.9.0"
+    }
+  ],
+  "results": [
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 2296534,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.007647625,
+        "median_s": 0.008058042,
+        "samples_s": [
+          0.009614917,
+          0.007647625,
+          0.008439292,
+          0.008022833,
+          0.008058042
+        ]
+      },
+      "total": {
+        "min_s": 0.225330958,
+        "median_s": 0.2255245,
+        "samples_s": [
+          0.226047958,
+          0.2255245,
+          0.225330958,
+          0.2254365,
+          0.227271041
+        ]
+      },
+      "compute_s": 0.217683333,
+      "ns_per_op_min": 94.78776843713179,
+      "ns_per_op_median": 94.69333264824296,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 3189797,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.009520125,
+        "median_s": 0.010295375,
+        "samples_s": [
+          0.010815417,
+          0.009520125,
+          0.009770625,
+          0.010295375,
+          0.010432917
+        ]
+      },
+      "total": {
+        "min_s": 0.310444458,
+        "median_s": 0.311362583,
+        "samples_s": [
+          0.310702458,
+          0.3121375,
+          0.312754458,
+          0.310444458,
+          0.311362583
+        ]
+      },
+      "compute_s": 0.300924333,
+      "ns_per_op_min": 94.33965014074563,
+      "ns_per_op_median": 94.38444139235195,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 59621,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.015606458,
+        "median_s": 0.01635725,
+        "samples_s": [
+          0.01635725,
+          0.016536792,
+          0.016412708,
+          0.016317667,
+          0.015606458
+        ]
+      },
+      "total": {
+        "min_s": 0.239814083,
+        "median_s": 0.241941375,
+        "samples_s": [
+          0.243007625,
+          0.240661,
+          0.242339125,
+          0.239814083,
+          0.241941375
+        ]
+      },
+      "compute_s": 0.22420762500000002,
+      "ns_per_op_min": 3760.54787742574,
+      "ns_per_op_median": 3783.635380151289,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 2788930,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.005538042,
+        "median_s": 0.005734084,
+        "samples_s": [
+          0.006645958,
+          0.005951042,
+          0.005734084,
+          0.005566042,
+          0.005538042
+        ]
+      },
+      "total": {
+        "min_s": 0.300665625,
+        "median_s": 0.302211292,
+        "samples_s": [
+          0.301027833,
+          0.302211292,
+          0.300665625,
+          0.306606125,
+          0.303615125
+        ]
+      },
+      "compute_s": 0.29512758299999997,
+      "ns_per_op_min": 105.82107941038319,
+      "ns_per_op_median": 106.30500155973796,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 673890,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.004872834,
+        "median_s": 0.00518925,
+        "samples_s": [
+          0.006159541,
+          0.005273,
+          0.004962875,
+          0.004872834,
+          0.00518925
+        ]
+      },
+      "total": {
+        "min_s": 0.307064584,
+        "median_s": 0.308416667,
+        "samples_s": [
+          0.309059167,
+          0.308202916,
+          0.307064584,
+          0.308668916,
+          0.308416667
+        ]
+      },
+      "compute_s": 0.30219175,
+      "ns_per_op_min": 448.4288978913473,
+      "ns_per_op_median": 449.96574663520755,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 41827,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.037193375,
+        "median_s": 0.037774167,
+        "samples_s": [
+          0.037912125,
+          0.037499042,
+          0.037193375,
+          0.037774167,
+          0.039655666
+        ]
+      },
+      "total": {
+        "min_s": 0.222697125,
+        "median_s": 0.223576083,
+        "samples_s": [
+          0.224992083,
+          0.223576083,
+          0.224234333,
+          0.222697125,
+          0.2227845
+        ]
+      },
+      "compute_s": 0.18550375,
+      "ns_per_op_min": 4435.024027542018,
+      "ns_per_op_median": 4442.152580868817,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 45698,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.037445584,
+        "median_s": 0.037581666,
+        "samples_s": [
+          0.038477542,
+          0.037581666,
+          0.037445584,
+          0.037720334,
+          0.037478958
+        ]
+      },
+      "total": {
+        "min_s": 0.2388845,
+        "median_s": 0.239552459,
+        "samples_s": [
+          0.240084709,
+          0.239552459,
+          0.24238175,
+          0.239474791,
+          0.2388845
+        ]
+      },
+      "compute_s": 0.201438916,
+      "ns_per_op_min": 4408.046654120531,
+      "ns_per_op_median": 4419.685609873517,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 48422,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.037430042,
+        "median_s": 0.037820833,
+        "samples_s": [
+          0.038537292,
+          0.037820833,
+          0.037710708,
+          0.037430042,
+          0.037934167
+        ]
+      },
+      "total": {
+        "min_s": 0.25212125,
+        "median_s": 0.252276416,
+        "samples_s": [
+          0.252186375,
+          0.25212125,
+          0.252276416,
+          0.252987291,
+          0.252409375
+        ]
+      },
+      "compute_s": 0.21469120800000002,
+      "ns_per_op_min": 4433.753417867912,
+      "ns_per_op_median": 4428.887344595431,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 65536,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.02859425,
+        "median_s": 0.029177875,
+        "samples_s": [
+          0.029052542,
+          0.030488,
+          0.029662584,
+          0.029177875,
+          0.02859425
+        ]
+      },
+      "total": {
+        "min_s": 0.260623291,
+        "median_s": 0.261748958,
+        "samples_s": [
+          0.260780667,
+          0.261748958,
+          0.262654083,
+          0.266590959,
+          0.260623291
+        ]
+      },
+      "compute_s": 0.232029041,
+      "ns_per_op_min": 3540.482192993164,
+      "ns_per_op_median": 3548.7530975341792,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 2072024,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.037596625,
+        "median_s": 0.038380417,
+        "samples_s": [
+          0.038830958,
+          0.038424083,
+          0.037948541,
+          0.037596625,
+          0.038380417
+        ]
+      },
+      "total": {
+        "min_s": 0.327132084,
+        "median_s": 0.328967542,
+        "samples_s": [
+          0.330584458,
+          0.328967542,
+          0.327834083,
+          0.327132084,
+          0.32909925
+        ]
+      },
+      "compute_s": 0.289535459,
+      "ns_per_op_min": 139.7355720783157,
+      "ns_per_op_median": 140.24312701011186,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 5479,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.011116584,
+        "median_s": 0.011350875,
+        "samples_s": [
+          0.012237084,
+          0.012177333,
+          0.011258875,
+          0.011116584,
+          0.011350875
+        ]
+      },
+      "total": {
+        "min_s": 0.311986875,
+        "median_s": 0.314464542,
+        "samples_s": [
+          0.314464542,
+          0.316033042,
+          0.311986875,
+          0.312086042,
+          0.314902625
+        ]
+      },
+      "compute_s": 0.300870291,
+      "ns_per_op_min": 54913.35845957291,
+      "ns_per_op_median": 55322.80835918964,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 905207,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.003113542,
+        "median_s": 0.003187875,
+        "samples_s": [
+          0.00316325,
+          0.003471542,
+          0.003949416,
+          0.003187875,
+          0.003113542
+        ]
+      },
+      "total": {
+        "min_s": 0.213559041,
+        "median_s": 0.214004334,
+        "samples_s": [
+          0.214004334,
+          0.213862792,
+          0.215915208,
+          0.213559041,
+          0.216623875
+        ]
+      },
+      "compute_s": 0.210445499,
+      "ns_per_op_min": 232.4832872481101,
+      "ns_per_op_median": 232.89309406577718,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 2833577,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.06180175,
+        "median_s": 0.062664209,
+        "samples_s": [
+          0.06180175,
+          0.062664209,
+          0.062774083,
+          0.063019833,
+          0.062295125
+        ]
+      },
+      "total": {
+        "min_s": 0.331357417,
+        "median_s": 0.334102833,
+        "samples_s": [
+          0.334745541,
+          0.334307292,
+          0.331357417,
+          0.334102833,
+          0.332331875
+        ]
+      },
+      "compute_s": 0.269555667,
+      "ns_per_op_min": 95.12911313156481,
+      "ns_per_op_median": 95.79362904202002,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 208,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.012491125,
+        "median_s": 0.012592208,
+        "samples_s": [
+          0.013737125,
+          0.013596792,
+          0.012592208,
+          0.012491125,
+          0.012582292
+        ]
+      },
+      "total": {
+        "min_s": 3.54384925,
+        "median_s": 3.5536647500000003,
+        "samples_s": [
+          3.554614,
+          3.545739917,
+          3.5583533750000003,
+          3.54384925,
+          3.5536647500000003
+        ]
+      },
+      "compute_s": 3.531358125,
+      "ns_per_op_min": 16977683.293269232,
+      "ns_per_op_median": 17024387.221153848,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 256,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.044507375,
+        "median_s": 0.044739333,
+        "samples_s": [
+          0.045886916,
+          0.044739333,
+          0.044507375,
+          0.04577425,
+          0.044553875
+        ]
+      },
+      "total": {
+        "min_s": 0.414491042,
+        "median_s": 0.416675917,
+        "samples_s": [
+          0.414491042,
+          0.418764625,
+          0.416675917,
+          0.41749675,
+          0.416062292
+        ]
+      },
+      "compute_s": 0.36998366699999996,
+      "ns_per_op_min": 1445248.6992187498,
+      "ns_per_op_median": 1452877.28125,
+      "load_ms": 0.864,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 102,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.074863,
+        "median_s": 0.07638225,
+        "samples_s": [
+          0.07638225,
+          0.075751292,
+          0.078674083,
+          0.07733075,
+          0.074863
+        ]
+      },
+      "total": {
+        "min_s": 0.26316075,
+        "median_s": 0.264595875,
+        "samples_s": [
+          0.26316075,
+          0.271179875,
+          0.26493875,
+          0.264595875,
+          0.264569958
+        ]
+      },
+      "compute_s": 0.18829774999999999,
+      "ns_per_op_min": 1846056.3725490195,
+      "ns_per_op_median": 1845231.6176470588,
+      "load_ms": 4.893,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 670,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.050112042,
+        "median_s": 0.050418458,
+        "samples_s": [
+          0.051572125,
+          0.050418458,
+          0.050112042,
+          0.050418333,
+          0.050823708
+        ]
+      },
+      "total": {
+        "min_s": 0.298131375,
+        "median_s": 0.300192459,
+        "samples_s": [
+          0.300192459,
+          0.298131375,
+          0.299498417,
+          0.300660959,
+          0.300816125
+        ]
+      },
+      "compute_s": 0.24801933299999998,
+      "ns_per_op_min": 370178.1089552238,
+      "ns_per_op_median": 372797.0164179105,
+      "load_ms": 3.648,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 1451,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.095053208,
+        "median_s": 0.095845542,
+        "samples_s": [
+          0.097079125,
+          0.096334084,
+          0.095053208,
+          0.095845542,
+          0.095330458
+        ]
+      },
+      "total": {
+        "min_s": 0.352976667,
+        "median_s": 0.355128292,
+        "samples_s": [
+          0.35420225,
+          0.355128292,
+          0.355382125,
+          0.35617325,
+          0.352976667
+        ]
+      },
+      "compute_s": 0.257923459,
+      "ns_per_op_min": 177755.65747760166,
+      "ns_per_op_median": 178692.45348035838,
+      "load_ms": 9.055,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 1045402,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.006203084,
+        "median_s": 0.006466333,
+        "samples_s": [
+          0.006372125,
+          0.006477584,
+          0.006791042,
+          0.006203084,
+          0.006466333
+        ]
+      },
+      "total": {
+        "min_s": 0.308009542,
+        "median_s": 0.308605583,
+        "samples_s": [
+          0.311632125,
+          0.308387833,
+          0.308009542,
+          0.311243875,
+          0.308605583
+        ]
+      },
+      "compute_s": 0.301806458,
+      "ns_per_op_min": 288.698948347143,
+      "ns_per_op_median": 289.01728712973573,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 1012616,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.009293583,
+        "median_s": 0.009338958,
+        "samples_s": [
+          0.010848792,
+          0.010410625,
+          0.009293583,
+          0.009298041,
+          0.009338958
+        ]
+      },
+      "total": {
+        "min_s": 0.301476,
+        "median_s": 0.302013625,
+        "samples_s": [
+          0.302013625,
+          0.305436208,
+          0.3023405,
+          0.30153775,
+          0.301476
+        ]
+      },
+      "compute_s": 0.292182417,
+      "ns_per_op_min": 288.5421689959471,
+      "ns_per_op_median": 289.02828614203213,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 7200,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.015477209,
+        "median_s": 0.015987541,
+        "samples_s": [
+          0.015987541,
+          0.017222334,
+          0.016237792,
+          0.015603958,
+          0.015477209
+        ]
+      },
+      "total": {
+        "min_s": 0.312495,
+        "median_s": 0.314860875,
+        "samples_s": [
+          0.312495,
+          0.319562333,
+          0.314860875,
+          0.315792667,
+          0.314090041
+        ]
+      },
+      "compute_s": 0.29701779100000003,
+      "ns_per_op_min": 41252.47097222223,
+      "ns_per_op_median": 41510.185277777775,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 802468,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.005816125,
+        "median_s": 0.006187583,
+        "samples_s": [
+          0.006187583,
+          0.006796459,
+          0.006398541,
+          0.005902125,
+          0.005816125
+        ]
+      },
+      "total": {
+        "min_s": 0.305594833,
+        "median_s": 0.306548667,
+        "samples_s": [
+          0.305594833,
+          0.309996792,
+          0.308464166,
+          0.306548667,
+          0.306525375
+        ]
+      },
+      "compute_s": 0.299778708,
+      "ns_per_op_min": 373.5709187157619,
+      "ns_per_op_median": 374.2966498352582,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 59828,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.004801833,
+        "median_s": 0.00509625,
+        "samples_s": [
+          0.00548275,
+          0.005122917,
+          0.005057792,
+          0.00509625,
+          0.004801833
+        ]
+      },
+      "total": {
+        "min_s": 0.302058334,
+        "median_s": 0.303996458,
+        "samples_s": [
+          0.304274542,
+          0.303996458,
+          0.302386042,
+          0.305751791,
+          0.302058334
+        ]
+      },
+      "compute_s": 0.297256501,
+      "ns_per_op_min": 4968.51810189209,
+      "ns_per_op_median": 4995.9919770007355,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 3879,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.037254792,
+        "median_s": 0.037416041,
+        "samples_s": [
+          0.038564583,
+          0.037416041,
+          0.037254792,
+          0.037550792,
+          0.037325459
+        ]
+      },
+      "total": {
+        "min_s": 0.339625708,
+        "median_s": 0.341169042,
+        "samples_s": [
+          0.340774417,
+          0.339625708,
+          0.341608333,
+          0.343231958,
+          0.341169042
+        ]
+      },
+      "compute_s": 0.30237091600000005,
+      "ns_per_op_min": 77950.73885021915,
+      "ns_per_op_median": 78307.03815416343,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 4902,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.037646625,
+        "median_s": 0.037689833,
+        "samples_s": [
+          0.038467291,
+          0.037646625,
+          0.037689833,
+          0.037650209,
+          0.037853083
+        ]
+      },
+      "total": {
+        "min_s": 0.2722955,
+        "median_s": 0.274654542,
+        "samples_s": [
+          0.2722955,
+          0.274654542,
+          0.275746833,
+          0.276119834,
+          0.273585042
+        ]
+      },
+      "compute_s": 0.23464887500000003,
+      "ns_per_op_min": 47867.98755609956,
+      "ns_per_op_median": 48340.4139126887,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 4460,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.037597875,
+        "median_s": 0.038058583,
+        "samples_s": [
+          0.039462709,
+          0.038058583,
+          0.037861167,
+          0.037597875,
+          0.038126958
+        ]
+      },
+      "total": {
+        "min_s": 0.27066875,
+        "median_s": 0.270826708,
+        "samples_s": [
+          0.270826708,
+          0.270774125,
+          0.27066875,
+          0.271600333,
+          0.27253975
+        ]
+      },
+      "compute_s": 0.233070875,
+      "ns_per_op_min": 52258.043721973096,
+      "ns_per_op_median": 52190.162556053816,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 1130,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.028545917,
+        "median_s": 0.028620959,
+        "samples_s": [
+          0.0307665,
+          0.028620959,
+          0.02899125,
+          0.028545917,
+          0.028552625
+        ]
+      },
+      "total": {
+        "min_s": 0.327675125,
+        "median_s": 0.330137041,
+        "samples_s": [
+          0.330099542,
+          0.330432625,
+          0.330137041,
+          0.330435166,
+          0.327675125
+        ]
+      },
+      "compute_s": 0.29912920800000004,
+      "ns_per_op_min": 264716.1132743363,
+      "ns_per_op_median": 266828.3911504425,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 13124,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.039306875,
+        "median_s": 0.039767584,
+        "samples_s": [
+          0.041238667,
+          0.039306875,
+          0.039608917,
+          0.039767584,
+          0.040453
+        ]
+      },
+      "total": {
+        "min_s": 0.225012834,
+        "median_s": 0.226765375,
+        "samples_s": [
+          0.226924792,
+          0.225012834,
+          0.225172125,
+          0.232195875,
+          0.226765375
+        ]
+      },
+      "compute_s": 0.185705959,
+      "ns_per_op_min": 14150.103550746724,
+      "ns_per_op_median": 14248.536345626333,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 913,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.01146225,
+        "median_s": 0.0116375,
+        "samples_s": [
+          0.013178708,
+          0.0116375,
+          0.012127833,
+          0.011618958,
+          0.01146225
+        ]
+      },
+      "total": {
+        "min_s": 0.300279334,
+        "median_s": 0.301586292,
+        "samples_s": [
+          0.300279334,
+          0.304753958,
+          0.30130525,
+          0.301986666,
+          0.301586292
+        ]
+      },
+      "compute_s": 0.288817084,
+      "ns_per_op_min": 316338.53669222345,
+      "ns_per_op_median": 317578.0854326396,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 619024,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.004158833,
+        "median_s": 0.0047045,
+        "samples_s": [
+          0.0047045,
+          0.0046465,
+          0.00510275,
+          0.005530125,
+          0.004158833
+        ]
+      },
+      "total": {
+        "min_s": 0.215375791,
+        "median_s": 0.216556375,
+        "samples_s": [
+          0.217107209,
+          0.216651667,
+          0.216556375,
+          0.215685041,
+          0.215375791
+        ]
+      },
+      "compute_s": 0.211216958,
+      "ns_per_op_min": 341.2096429217607,
+      "ns_per_op_median": 342.2353172090258,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 661058,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.058892875,
+        "median_s": 0.06343425,
+        "samples_s": [
+          0.063681834,
+          0.063976542,
+          0.063306916,
+          0.06343425,
+          0.058892875
+        ]
+      },
+      "total": {
+        "min_s": 0.363703167,
+        "median_s": 0.370597833,
+        "samples_s": [
+          0.414184958,
+          0.363703167,
+          0.369242333,
+          0.370597833,
+          0.416696666
+        ]
+      },
+      "compute_s": 0.304810292,
+      "ns_per_op_min": 461.0946270977736,
+      "ns_per_op_median": 464.65451291717216,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 21,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.01437075,
+        "median_s": 0.014990125,
+        "samples_s": [
+          0.015228292,
+          0.015032958,
+          0.014990125,
+          0.01437075,
+          0.0145255
+        ]
+      },
+      "total": {
+        "min_s": 0.296093334,
+        "median_s": 0.298302875,
+        "samples_s": [
+          0.298732792,
+          0.29822125,
+          0.2991435,
+          0.296093334,
+          0.298302875
+        ]
+      },
+      "compute_s": 0.281722584,
+      "ns_per_op_min": 13415361.142857144,
+      "ns_per_op_median": 13491083.333333334,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 19,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.0447905,
+        "median_s": 0.045413917,
+        "samples_s": [
+          0.0447905,
+          0.045698584,
+          0.045413917,
+          0.044853583,
+          0.045559875
+        ]
+      },
+      "total": {
+        "min_s": 0.315303709,
+        "median_s": 0.316383708,
+        "samples_s": [
+          0.31632575,
+          0.315303709,
+          0.316982125,
+          0.318099458,
+          0.316383708
+        ]
+      },
+      "compute_s": 0.270513209,
+      "ns_per_op_min": 14237537.315789474,
+      "ns_per_op_median": 14261567.947368419,
+      "load_ms": 1.255,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 28,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.082017791,
+        "median_s": 0.083618708,
+        "samples_s": [
+          0.083764334,
+          0.082017791,
+          0.083331917,
+          0.086403166,
+          0.083618708
+        ]
+      },
+      "total": {
+        "min_s": 0.276724208,
+        "median_s": 0.278153875,
+        "samples_s": [
+          0.278214833,
+          0.280766542,
+          0.278153875,
+          0.276724208,
+          0.277983375
+        ]
+      },
+      "compute_s": 0.19470641700000002,
+      "ns_per_op_min": 6953800.607142858,
+      "ns_per_op_median": 6947684.535714285,
+      "load_ms": 7.245,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 62,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.05056475,
+        "median_s": 0.050609458,
+        "samples_s": [
+          0.05086075,
+          0.050578625,
+          0.050609458,
+          0.05056475,
+          0.053787167
+        ]
+      },
+      "total": {
+        "min_s": 0.299947667,
+        "median_s": 0.304169291,
+        "samples_s": [
+          0.308868917,
+          0.302740958,
+          0.299947667,
+          0.305367833,
+          0.304169291
+        ]
+      },
+      "compute_s": 0.24938291699999998,
+      "ns_per_op_min": 4022305.1129032252,
+      "ns_per_op_median": 4089674.7258064514,
+      "load_ms": 3.834,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 136,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.095963667,
+        "median_s": 0.098183084,
+        "samples_s": [
+          0.099462,
+          0.095963667,
+          0.098349083,
+          0.09689975,
+          0.098183084
+        ]
+      },
+      "total": {
+        "min_s": 0.349741667,
+        "median_s": 0.351710458,
+        "samples_s": [
+          0.351710458,
+          0.350034208,
+          0.349741667,
+          0.352961917,
+          0.352736084
+        ]
+      },
+      "compute_s": 0.25377799999999995,
+      "ns_per_op_min": 1866014.7058823525,
+      "ns_per_op_median": 1864171.867647059,
+      "load_ms": 9.101,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 157637187,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.006441792,
+        "median_s": 0.006737083,
+        "samples_s": [
+          0.006441792,
+          0.0073165,
+          0.00758725,
+          0.006737083,
+          0.00659525
+        ]
+      },
+      "total": {
+        "min_s": 0.266825917,
+        "median_s": 0.270016958,
+        "samples_s": [
+          0.271774708,
+          0.274546083,
+          0.270016958,
+          0.26852675,
+          0.266825917
+        ]
+      },
+      "compute_s": 0.260384125,
+      "ns_per_op_min": 1.6517937801059597,
+      "ns_per_op_median": 1.670163493846157,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 179760700,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.009314208,
+        "median_s": 0.01045675,
+        "samples_s": [
+          0.011690209,
+          0.010879333,
+          0.01045675,
+          0.00936725,
+          0.009314208
+        ]
+      },
+      "total": {
+        "min_s": 0.303122667,
+        "median_s": 0.312647959,
+        "samples_s": [
+          0.305394625,
+          0.312647959,
+          0.316284208,
+          0.319568708,
+          0.303122667
+        ]
+      },
+      "compute_s": 0.293808459,
+      "ns_per_op_min": 1.6344421166584242,
+      "ns_per_op_median": 1.6810749457473182,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1320980,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.016391,
+        "median_s": 0.016728125,
+        "samples_s": [
+          0.016728125,
+          0.016760625,
+          0.016551708,
+          0.016732625,
+          0.016391
+        ]
+      },
+      "total": {
+        "min_s": 0.283284666,
+        "median_s": 0.284685292,
+        "samples_s": [
+          0.285227333,
+          0.284537333,
+          0.284685292,
+          0.285058625,
+          0.283284666
+        ]
+      },
+      "compute_s": 0.26689366600000003,
+      "ns_per_op_min": 202.04217020696757,
+      "ns_per_op_median": 202.84725506820695,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 100143883,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.006200333,
+        "median_s": 0.006585292,
+        "samples_s": [
+          0.006585292,
+          0.006809459,
+          0.006200333,
+          0.006759292,
+          0.006223583
+        ]
+      },
+      "total": {
+        "min_s": 0.305463334,
+        "median_s": 0.306222166,
+        "samples_s": [
+          0.305993458,
+          0.308306625,
+          0.308870292,
+          0.305463334,
+          0.306222166
+        ]
+      },
+      "compute_s": 0.299263001,
+      "ns_per_op_min": 2.988330310699057,
+      "ns_per_op_median": 2.992063669031088,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 16777216,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.005049458,
+        "median_s": 0.005564125,
+        "samples_s": [
+          0.005582584,
+          0.005564125,
+          0.005049458,
+          0.005771875,
+          0.005194791
+        ]
+      },
+      "total": {
+        "min_s": 0.347591375,
+        "median_s": 0.349596,
+        "samples_s": [
+          0.349596,
+          0.350805708,
+          0.349989833,
+          0.347591375,
+          0.349434541
+        ]
+      },
+      "compute_s": 0.342541917,
+      "ns_per_op_min": 20.41708928346634,
+      "ns_per_op_median": 20.505897700786594,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 762010,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.038641583,
+        "median_s": 0.038923375,
+        "samples_s": [
+          0.039647167,
+          0.038641583,
+          0.038730417,
+          0.038964791,
+          0.038923375
+        ]
+      },
+      "total": {
+        "min_s": 0.346675083,
+        "median_s": 0.350832958,
+        "samples_s": [
+          0.346675083,
+          0.352653542,
+          0.356238125,
+          0.350832958,
+          0.348779333
+        ]
+      },
+      "compute_s": 0.3080335,
+      "ns_per_op_min": 404.23813335782995,
+      "ns_per_op_median": 409.32478970092257,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 1046821,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.039118291,
+        "median_s": 0.03920625,
+        "samples_s": [
+          0.040286125,
+          0.039118291,
+          0.039207542,
+          0.039168333,
+          0.03920625
+        ]
+      },
+      "total": {
+        "min_s": 0.322582625,
+        "median_s": 0.324080125,
+        "samples_s": [
+          0.322801834,
+          0.324950833,
+          0.326408375,
+          0.324080125,
+          0.322582625
+        ]
+      },
+      "compute_s": 0.28346433400000004,
+      "ns_per_op_min": 270.7858688352642,
+      "ns_per_op_median": 272.13236551425695,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 958667,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.039505458,
+        "median_s": 0.040193292,
+        "samples_s": [
+          0.040574583,
+          0.039858583,
+          0.042135708,
+          0.040193292,
+          0.039505458
+        ]
+      },
+      "total": {
+        "min_s": 0.320121666,
+        "median_s": 0.321534833,
+        "samples_s": [
+          0.321534833,
+          0.320121666,
+          0.320742042,
+          0.322897666,
+          0.321928834
+        ]
+      },
+      "compute_s": 0.28061620800000003,
+      "ns_per_op_min": 292.71499696975076,
+      "ns_per_op_median": 293.4716027567445,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 344306,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.032455416,
+        "median_s": 0.032811625,
+        "samples_s": [
+          0.03382725,
+          0.032455416,
+          0.032811625,
+          0.033954042,
+          0.032572292
+        ]
+      },
+      "total": {
+        "min_s": 0.334043334,
+        "median_s": 0.338396583,
+        "samples_s": [
+          0.338396583,
+          0.336988667,
+          0.342695125,
+          0.334043334,
+          0.34058475
+        ]
+      },
+      "compute_s": 0.301587918,
+      "ns_per_op_min": 875.9298937572972,
+      "ns_per_op_median": 887.5388694939965,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 4966832,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.04300325,
+        "median_s": 0.043982333,
+        "samples_s": [
+          0.044701958,
+          0.043993875,
+          0.043982333,
+          0.043676375,
+          0.04300325
+        ]
+      },
+      "total": {
+        "min_s": 0.320756166,
+        "median_s": 0.323418875,
+        "samples_s": [
+          0.320756166,
+          0.326197292,
+          0.323321333,
+          0.323418875,
+          0.325431625
+        ]
+      },
+      "compute_s": 0.277752916,
+      "ns_per_op_min": 55.92154435664423,
+      "ns_per_op_median": 56.26051817335477,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 202952,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.01923325,
+        "median_s": 0.019374958,
+        "samples_s": [
+          0.020341208,
+          0.019434292,
+          0.019374958,
+          0.01923325,
+          0.01932775
+        ]
+      },
+      "total": {
+        "min_s": 0.315794125,
+        "median_s": 0.316772417,
+        "samples_s": [
+          0.318944083,
+          0.316772417,
+          0.315794125,
+          0.315878625,
+          0.317408792
+        ]
+      },
+      "compute_s": 0.296560875,
+      "ns_per_op_min": 1461.2365239071307,
+      "ns_per_op_median": 1465.3586020339785,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 85795492,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.003704167,
+        "median_s": 0.004223458,
+        "samples_s": [
+          0.006027334,
+          0.003842291,
+          0.003704167,
+          0.005373167,
+          0.004223458
+        ]
+      },
+      "total": {
+        "min_s": 0.210023916,
+        "median_s": 0.213478875,
+        "samples_s": [
+          0.221947042,
+          0.210023916,
+          0.213478875,
+          0.213339,
+          0.216014792
+        ]
+      },
+      "compute_s": 0.206319749,
+      "ns_per_op_min": 2.4047854285863877,
+      "ns_per_op_median": 2.439002471132166,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 56691018,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.063632541,
+        "median_s": 0.064579042,
+        "samples_s": [
+          0.063632541,
+          0.0642995,
+          0.065112459,
+          0.064579042,
+          0.064825959
+        ]
+      },
+      "total": {
+        "min_s": 0.261307083,
+        "median_s": 0.261957166,
+        "samples_s": [
+          0.261307083,
+          0.266084542,
+          0.263334083,
+          0.261957166,
+          0.261821709
+        ]
+      },
+      "compute_s": 0.197674542,
+      "ns_per_op_min": 3.4868758574771053,
+      "ns_per_op_median": 3.481647198503298,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 5647,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.109326,
+        "median_s": 0.110155417,
+        "samples_s": [
+          0.111122333,
+          0.110534917,
+          0.110155417,
+          0.109326,
+          0.110087458
+        ]
+      },
+      "total": {
+        "min_s": 0.315631416,
+        "median_s": 0.318428583,
+        "samples_s": [
+          0.320389792,
+          0.318428583,
+          0.317262584,
+          0.315631416,
+          0.321042917
+        ]
+      },
+      "compute_s": 0.206305416,
+      "ns_per_op_min": 36533.63130865947,
+      "ns_per_op_median": 36882.09066761112,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 4741,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.278075875,
+        "median_s": 0.279967375,
+        "samples_s": [
+          0.281469417,
+          0.279967375,
+          0.278075875,
+          0.281712125,
+          0.278726458
+        ]
+      },
+      "total": {
+        "min_s": 0.552078209,
+        "median_s": 0.559225291,
+        "samples_s": [
+          0.56056175,
+          0.565625375,
+          0.559011166,
+          0.552078209,
+          0.559225291
+        ]
+      },
+      "compute_s": 0.27400233400000007,
+      "ns_per_op_min": 57794.2067074457,
+      "ns_per_op_median": 58902.74541236025,
+      "load_ms": 1.289,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 12594,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.184550416,
+        "median_s": 0.186260917,
+        "samples_s": [
+          0.186664416,
+          0.184550416,
+          0.184773208,
+          0.186260917,
+          0.187409291
+        ]
+      },
+      "total": {
+        "min_s": 0.374713042,
+        "median_s": 0.378940584,
+        "samples_s": [
+          0.382556667,
+          0.378940584,
+          0.391607875,
+          0.374713042,
+          0.375043167
+        ]
+      },
+      "compute_s": 0.190162626,
+      "ns_per_op_min": 15099.462124821344,
+      "ns_per_op_median": 15299.32245513737,
+      "load_ms": 7.61,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 15874,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.117153375,
+        "median_s": 0.117742542,
+        "samples_s": [
+          0.118001959,
+          0.117299417,
+          0.119927709,
+          0.117742542,
+          0.117153375
+        ]
+      },
+      "total": {
+        "min_s": 0.44197975,
+        "median_s": 0.443320458,
+        "samples_s": [
+          0.444707125,
+          0.44418925,
+          0.443320458,
+          0.4426925,
+          0.44197975
+        ]
+      },
+      "compute_s": 0.324826375,
+      "ns_per_op_min": 20462.792931838227,
+      "ns_per_op_median": 20510.137079501066,
+      "load_ms": 3.792,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 25217,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.134006083,
+        "median_s": 0.134767,
+        "samples_s": [
+          0.139340708,
+          0.13480325,
+          0.134006083,
+          0.134767,
+          0.134352125
+        ]
+      },
+      "total": {
+        "min_s": 0.376072584,
+        "median_s": 0.378908834,
+        "samples_s": [
+          0.378061834,
+          0.380215208,
+          0.378908834,
+          0.376072584,
+          0.379099666
+        ]
+      },
+      "compute_s": 0.242066501,
+      "ns_per_op_min": 9599.337788000159,
+      "ns_per_op_median": 9681.636752984099,
+      "load_ms": 9.139,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 86184820,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.006452333,
+        "median_s": 0.00664925,
+        "samples_s": [
+          0.006452333,
+          0.006475917,
+          0.009671958,
+          0.006826208,
+          0.00664925
+        ]
+      },
+      "total": {
+        "min_s": 0.306586375,
+        "median_s": 0.306723583,
+        "samples_s": [
+          0.306723583,
+          0.306645417,
+          0.30785075,
+          0.306586375,
+          0.309637416
+        ]
+      },
+      "compute_s": 0.30013404200000005,
+      "ns_per_op_min": 3.482446700010513,
+      "ns_per_op_median": 3.4817538981922804,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 87149968,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.009022709,
+        "median_s": 0.00910575,
+        "samples_s": [
+          0.010193625,
+          0.009022709,
+          0.009106917,
+          0.00910575,
+          0.00905525
+        ]
+      },
+      "total": {
+        "min_s": 0.308702708,
+        "median_s": 0.31115425,
+        "samples_s": [
+          0.311605375,
+          0.308702708,
+          0.31115425,
+          0.310513583,
+          0.312798583
+        ]
+      },
+      "compute_s": 0.299679999,
+      "ns_per_op_min": 3.4386702127073643,
+      "ns_per_op_median": 3.465847514711652,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1483241,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.016826834,
+        "median_s": 0.017248958,
+        "samples_s": [
+          0.017461667,
+          0.017352375,
+          0.017248958,
+          0.017168625,
+          0.016826834
+        ]
+      },
+      "total": {
+        "min_s": 0.319783334,
+        "median_s": 0.321534417,
+        "samples_s": [
+          0.319783334,
+          0.321908375,
+          0.320694,
+          0.321534417,
+          0.3231985
+        ]
+      },
+      "compute_s": 0.30295649999999996,
+      "ns_per_op_min": 204.2530512573479,
+      "ns_per_op_median": 205.14903444551496,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 50774272,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.005560875,
+        "median_s": 0.005817916,
+        "samples_s": [
+          0.006456417,
+          0.005981917,
+          0.005672792,
+          0.005817916,
+          0.005560875
+        ]
+      },
+      "total": {
+        "min_s": 0.305104875,
+        "median_s": 0.307659375,
+        "samples_s": [
+          0.305104875,
+          0.307659375,
+          0.308222458,
+          0.310147792,
+          0.307523458
+        ]
+      },
+      "compute_s": 0.299544,
+      "ns_per_op_min": 5.899523286124122,
+      "ns_per_op_median": 5.944771773389485,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 6877712,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.005239958,
+        "median_s": 0.00531375,
+        "samples_s": [
+          0.005239958,
+          0.005614417,
+          0.006121958,
+          0.005282875,
+          0.00531375
+        ]
+      },
+      "total": {
+        "min_s": 0.342135458,
+        "median_s": 0.344433917,
+        "samples_s": [
+          0.34466625,
+          0.345213458,
+          0.344433917,
+          0.342135458,
+          0.344396416
+        ]
+      },
+      "compute_s": 0.3368955,
+      "ns_per_op_min": 48.98365910058461,
+      "ns_per_op_median": 49.30711943157841,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 1371297,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.037826958,
+        "median_s": 0.038328,
+        "samples_s": [
+          0.040875125,
+          0.038424709,
+          0.038328,
+          0.03792,
+          0.037826958
+        ]
+      },
+      "total": {
+        "min_s": 0.314204,
+        "median_s": 0.317505958,
+        "samples_s": [
+          0.318261166,
+          0.31630475,
+          0.317619,
+          0.317505958,
+          0.314204
+        ]
+      },
+      "compute_s": 0.27637704199999996,
+      "ns_per_op_min": 201.54426211097956,
+      "ns_per_op_median": 203.5867926495865,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 1700601,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.037677291,
+        "median_s": 0.038059292,
+        "samples_s": [
+          0.038782125,
+          0.038059292,
+          0.038059666,
+          0.0377715,
+          0.037677291
+        ]
+      },
+      "total": {
+        "min_s": 0.2191805,
+        "median_s": 0.220948292,
+        "samples_s": [
+          0.221315333,
+          0.223871459,
+          0.2191805,
+          0.220948292,
+          0.220082708
+        ]
+      },
+      "compute_s": 0.181503209,
+      "ns_per_op_min": 106.72886173770331,
+      "ns_per_op_median": 107.54374482903397,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 1902474,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.037430167,
+        "median_s": 0.037829375,
+        "samples_s": [
+          0.038362167,
+          0.037430167,
+          0.037829375,
+          0.037714875,
+          0.037854292
+        ]
+      },
+      "total": {
+        "min_s": 0.272100875,
+        "median_s": 0.274627334,
+        "samples_s": [
+          0.272154791,
+          0.274627334,
+          0.275440208,
+          0.275110584,
+          0.272100875
+        ]
+      },
+      "compute_s": 0.234670708,
+      "ns_per_op_min": 123.35028389349867,
+      "ns_per_op_median": 124.46843373417981,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 738780,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.02768925,
+        "median_s": 0.028160334,
+        "samples_s": [
+          0.029720292,
+          0.028160334,
+          0.028305333,
+          0.028156083,
+          0.02768925
+        ]
+      },
+      "total": {
+        "min_s": 0.333313667,
+        "median_s": 0.3341425,
+        "samples_s": [
+          0.333313667,
+          0.334667666,
+          0.3341425,
+          0.334219083,
+          0.333384125
+        ]
+      },
+      "compute_s": 0.305624417,
+      "ns_per_op_min": 413.68799507295813,
+      "ns_per_op_median": 414.1722380140231,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 3392380,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.037581458,
+        "median_s": 0.037951708,
+        "samples_s": [
+          0.038468666,
+          0.037941,
+          0.037951708,
+          0.037581458,
+          0.041130416
+        ]
+      },
+      "total": {
+        "min_s": 0.336169166,
+        "median_s": 0.338765834,
+        "samples_s": [
+          0.339166708,
+          0.336741417,
+          0.336169166,
+          0.338765834,
+          0.339013917
+        ]
+      },
+      "compute_s": 0.298587708,
+      "ns_per_op_min": 88.01717614182374,
+      "ns_per_op_median": 88.6734758488141,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 276263,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.011068667,
+        "median_s": 0.011258625,
+        "samples_s": [
+          0.011832458,
+          0.01239075,
+          0.011258625,
+          0.011106333,
+          0.011068667
+        ]
+      },
+      "total": {
+        "min_s": 0.31348925,
+        "median_s": 0.314718333,
+        "samples_s": [
+          0.324863208,
+          0.316311583,
+          0.314718333,
+          0.313637667,
+          0.31348925
+        ]
+      },
+      "compute_s": 0.302420583,
+      "ns_per_op_min": 1094.6836275577982,
+      "ns_per_op_median": 1098.4449890140916,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 55884932,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.003663334,
+        "median_s": 0.00401325,
+        "samples_s": [
+          0.00424025,
+          0.00426075,
+          0.00401325,
+          0.00383375,
+          0.003663334
+        ]
+      },
+      "total": {
+        "min_s": 0.230156041,
+        "median_s": 0.231347458,
+        "samples_s": [
+          0.231347458,
+          0.231773,
+          0.232498167,
+          0.230761208,
+          0.230156041
+        ]
+      },
+      "compute_s": 0.22649270700000002,
+      "ns_per_op_min": 4.052840343439982,
+      "ns_per_op_median": 4.067898087448689,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 57779650,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.062307458,
+        "median_s": 0.063216042,
+        "samples_s": [
+          0.062623583,
+          0.063830625,
+          0.062307458,
+          0.063440416,
+          0.063216042
+        ]
+      },
+      "total": {
+        "min_s": 0.267477458,
+        "median_s": 0.267967167,
+        "samples_s": [
+          0.267967167,
+          0.267715334,
+          0.268454666,
+          0.267477458,
+          0.267972208
+        ]
+      },
+      "compute_s": 0.20517,
+      "ns_per_op_min": 3.55090416781687,
+      "ns_per_op_median": 3.5436546431139684,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 5883,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.011962833,
+        "median_s": 0.012485416,
+        "samples_s": [
+          0.013640208,
+          0.013624333,
+          0.012485416,
+          0.012205083,
+          0.011962833
+        ]
+      },
+      "total": {
+        "min_s": 0.288705625,
+        "median_s": 0.289337459,
+        "samples_s": [
+          0.29150575,
+          0.288705625,
+          0.289337459,
+          0.291762875,
+          0.288812917
+        ]
+      },
+      "compute_s": 0.276742792,
+      "ns_per_op_min": 47041.10011898691,
+      "ns_per_op_median": 47059.67074621792,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 5242,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.043915583,
+        "median_s": 0.044251917,
+        "samples_s": [
+          0.044251917,
+          0.043952042,
+          0.045095417,
+          0.044701167,
+          0.043915583
+        ]
+      },
+      "total": {
+        "min_s": 0.296526,
+        "median_s": 0.301199542,
+        "samples_s": [
+          0.297402833,
+          0.296526,
+          0.304302125,
+          0.301199542,
+          0.301569625
+        ]
+      },
+      "compute_s": 0.25261041700000003,
+      "ns_per_op_min": 48189.70183136208,
+      "ns_per_op_median": 49017.09748187714,
+      "load_ms": 0.679,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 28000,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.073889583,
+        "median_s": 0.074204208,
+        "samples_s": [
+          0.074204208,
+          0.0766115,
+          0.07505275,
+          0.073966792,
+          0.073889583
+        ]
+      },
+      "total": {
+        "min_s": 0.317928792,
+        "median_s": 0.322579208,
+        "samples_s": [
+          0.325093583,
+          0.322579208,
+          0.322918458,
+          0.317928792,
+          0.320900583
+        ]
+      },
+      "compute_s": 0.24403920900000003,
+      "ns_per_op_min": 8715.686035714287,
+      "ns_per_op_median": 8870.535714285714,
+      "load_ms": 3.439,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 13135,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.050376333,
+        "median_s": 0.050598084,
+        "samples_s": [
+          0.052655541,
+          0.05055975,
+          0.050851042,
+          0.050598084,
+          0.050376333
+        ]
+      },
+      "total": {
+        "min_s": 0.281285417,
+        "median_s": 0.285779292,
+        "samples_s": [
+          0.289027209,
+          0.297202333,
+          0.285779292,
+          0.282458334,
+          0.281285417
+        ]
+      },
+      "compute_s": 0.230909084,
+      "ns_per_op_min": 17579.679025504378,
+      "ns_per_op_median": 17904.92637990103,
+      "load_ms": 3.478,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 36475,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.095954042,
+        "median_s": 0.098018958,
+        "samples_s": [
+          0.095954042,
+          0.098018958,
+          0.098111625,
+          0.098041416,
+          0.096709625
+        ]
+      },
+      "total": {
+        "min_s": 0.39051375,
+        "median_s": 0.394540584,
+        "samples_s": [
+          0.39051375,
+          0.397910916,
+          0.3923805,
+          0.397348125,
+          0.394540584
+        ]
+      },
+      "compute_s": 0.294559708,
+      "ns_per_op_min": 8075.660260452365,
+      "ns_per_op_median": 8129.448279643593,
+      "load_ms": 8.929,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 33554432,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.006028958,
+        "median_s": 0.006166583,
+        "samples_s": [
+          0.006028958,
+          0.006166583,
+          0.00664,
+          0.006082708,
+          0.006491584
+        ]
+      },
+      "total": {
+        "min_s": 0.352965875,
+        "median_s": 0.355041375,
+        "samples_s": [
+          0.352965875,
+          0.35624675,
+          0.355041375,
+          0.354096208,
+          0.356551041
+        ]
+      },
+      "compute_s": 0.346936917,
+      "ns_per_op_min": 10.33952584862709,
+      "ns_per_op_median": 10.397279024124146,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 33554432,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.0091315,
+        "median_s": 0.010480833,
+        "samples_s": [
+          0.010542125,
+          0.010993083,
+          0.010480833,
+          0.0099645,
+          0.0091315
+        ]
+      },
+      "total": {
+        "min_s": 0.35438025,
+        "median_s": 0.356156875,
+        "samples_s": [
+          0.35438025,
+          0.35579575,
+          0.35949075,
+          0.356156875,
+          0.356552167
+        ]
+      },
+      "compute_s": 0.34524875,
+      "ns_per_op_min": 10.289214551448822,
+      "ns_per_op_median": 10.301948845386503,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 730531,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.01629975,
+        "median_s": 0.016408584,
+        "samples_s": [
+          0.016490792,
+          0.016408584,
+          0.016398375,
+          0.01629975,
+          0.016408958
+        ]
+      },
+      "total": {
+        "min_s": 0.319027875,
+        "median_s": 0.32059175,
+        "samples_s": [
+          0.319027875,
+          0.321936625,
+          0.320270708,
+          0.32059175,
+          0.3222045
+        ]
+      },
+      "compute_s": 0.302728125,
+      "ns_per_op_min": 414.39463212375654,
+      "ns_per_op_median": 416.38639017372293,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 16777216,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.005794583,
+        "median_s": 0.005989041,
+        "samples_s": [
+          0.005989041,
+          0.006883084,
+          0.006216542,
+          0.005875792,
+          0.005794583
+        ]
+      },
+      "total": {
+        "min_s": 0.202804625,
+        "median_s": 0.204009792,
+        "samples_s": [
+          0.209755417,
+          0.204109875,
+          0.203162167,
+          0.204009792,
+          0.202804625
+        ]
+      },
+      "compute_s": 0.197010042,
+      "ns_per_op_min": 11.742713570594788,
+      "ns_per_op_median": 11.802956521511078,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 4244635,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.004882583,
+        "median_s": 0.005008667,
+        "samples_s": [
+          0.005341666,
+          0.005147,
+          0.004976125,
+          0.004882583,
+          0.005008667
+        ]
+      },
+      "total": {
+        "min_s": 0.295080958,
+        "median_s": 0.299476792,
+        "samples_s": [
+          0.302337791,
+          0.299476792,
+          0.295080958,
+          0.298543167,
+          0.302668208
+        ]
+      },
+      "compute_s": 0.290198375,
+      "ns_per_op_min": 68.368275481873,
+      "ns_per_op_median": 69.37419236282977,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 441211,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.037416375,
+        "median_s": 0.037861083,
+        "samples_s": [
+          0.038404291,
+          0.037861083,
+          0.037558333,
+          0.037416375,
+          0.039910958
+        ]
+      },
+      "total": {
+        "min_s": 0.327453917,
+        "median_s": 0.327938667,
+        "samples_s": [
+          0.327681083,
+          0.327453917,
+          0.330791125,
+          0.328252666,
+          0.327938667
+        ]
+      },
+      "compute_s": 0.290037542,
+      "ns_per_op_min": 657.3669786111407,
+      "ns_per_op_median": 657.4577333747345,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 674449,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.037589958,
+        "median_s": 0.037909375,
+        "samples_s": [
+          0.03831625,
+          0.037909375,
+          0.037589958,
+          0.03763225,
+          0.038017083
+        ]
+      },
+      "total": {
+        "min_s": 0.3083855,
+        "median_s": 0.312347708,
+        "samples_s": [
+          0.312347708,
+          0.312536334,
+          0.312023666,
+          0.3083855,
+          0.314343417
+        ]
+      },
+      "compute_s": 0.270795542,
+      "ns_per_op_min": 401.5063288699368,
+      "ns_per_op_median": 406.90746520493025,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 573612,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.037353417,
+        "median_s": 0.037582209,
+        "samples_s": [
+          0.038542,
+          0.037383,
+          0.037353417,
+          0.03770225,
+          0.037582209
+        ]
+      },
+      "total": {
+        "min_s": 0.301147584,
+        "median_s": 0.30668575,
+        "samples_s": [
+          0.306408875,
+          0.30668575,
+          0.301147584,
+          0.308103667,
+          0.307030917
+        ]
+      },
+      "compute_s": 0.263794167,
+      "ns_per_op_min": 459.88258090834927,
+      "ns_per_op_median": 469.1386180902771,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 362583,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.027888834,
+        "median_s": 0.02860625,
+        "samples_s": [
+          0.029207375,
+          0.027888834,
+          0.028416667,
+          0.0290165,
+          0.02860625
+        ]
+      },
+      "total": {
+        "min_s": 0.309432958,
+        "median_s": 0.310454584,
+        "samples_s": [
+          0.310561084,
+          0.309432958,
+          0.310454584,
+          0.313782166,
+          0.309820042
+        ]
+      },
+      "compute_s": 0.28154412399999995,
+      "ns_per_op_min": 776.495654788007,
+      "ns_per_op_median": 777.3346626841303,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 1981557,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.038044958,
+        "median_s": 0.038411959,
+        "samples_s": [
+          0.038893166,
+          0.038192708,
+          0.038411959,
+          0.038044958,
+          0.038483375
+        ]
+      },
+      "total": {
+        "min_s": 0.305960417,
+        "median_s": 0.308333292,
+        "samples_s": [
+          0.305960417,
+          0.31116,
+          0.30782675,
+          0.313000292,
+          0.308333292
+        ]
+      },
+      "compute_s": 0.26791545899999997,
+      "ns_per_op_min": 135.20451796239016,
+      "ns_per_op_median": 136.21678962553185,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 131072,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.011356375,
+        "median_s": 0.011823625,
+        "samples_s": [
+          0.013042041,
+          0.011533042,
+          0.011823625,
+          0.011924125,
+          0.011356375
+        ]
+      },
+      "total": {
+        "min_s": 0.329692792,
+        "median_s": 0.331083583,
+        "samples_s": [
+          0.332355083,
+          0.331837667,
+          0.330095875,
+          0.331083583,
+          0.329692792
+        ]
+      },
+      "compute_s": 0.31833641700000004,
+      "ns_per_op_min": 2428.71411895752,
+      "ns_per_op_median": 2435.7601776123047,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 16777216,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.004585958,
+        "median_s": 0.005068375,
+        "samples_s": [
+          0.0052045,
+          0.006451917,
+          0.004585958,
+          0.00474675,
+          0.005068375
+        ]
+      },
+      "total": {
+        "min_s": 0.18234525,
+        "median_s": 0.185127708,
+        "samples_s": [
+          0.182844834,
+          0.18234525,
+          0.1865965,
+          0.185127708,
+          0.1851355
+        ]
+      },
+      "compute_s": 0.17775929199999999,
+      "ns_per_op_min": 10.595279455184937,
+      "ns_per_op_median": 10.73237258195877,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 3700208,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.062382417,
+        "median_s": 0.06432975,
+        "samples_s": [
+          0.062382417,
+          0.067684292,
+          0.064443375,
+          0.062707542,
+          0.06432975
+        ]
+      },
+      "total": {
+        "min_s": 0.26393325,
+        "median_s": 0.273122625,
+        "samples_s": [
+          0.273425666,
+          0.273709,
+          0.272170584,
+          0.26393325,
+          0.273122625
+        ]
+      },
+      "compute_s": 0.201550833,
+      "ns_per_op_min": 54.47013600316523,
+      "ns_per_op_median": 56.42733462551294,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 4385,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.012320875,
+        "median_s": 0.012379417,
+        "samples_s": [
+          0.013741208,
+          0.013499,
+          0.012379417,
+          0.012356209,
+          0.012320875
+        ]
+      },
+      "total": {
+        "min_s": 0.295136291,
+        "median_s": 0.299131458,
+        "samples_s": [
+          0.300121208,
+          0.299270042,
+          0.297269542,
+          0.299131458,
+          0.295136291
+        ]
+      },
+      "compute_s": 0.282815416,
+      "ns_per_op_min": 64496.10399087799,
+      "ns_per_op_median": 65393.851995439,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 2427,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.04300675,
+        "median_s": 0.044690416,
+        "samples_s": [
+          0.045644666,
+          0.04300675,
+          0.044690416,
+          0.044387042,
+          0.048696917
+        ]
+      },
+      "total": {
+        "min_s": 0.239155542,
+        "median_s": 0.240311375,
+        "samples_s": [
+          0.243325916,
+          0.24220325,
+          0.240311375,
+          0.239155542,
+          0.239438083
+        ]
+      },
+      "compute_s": 0.196148792,
+      "ns_per_op_min": 80819.44458178822,
+      "ns_per_op_median": 80601.96085702511,
+      "load_ms": 0.725,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 9308,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.074344292,
+        "median_s": 0.074690834,
+        "samples_s": [
+          0.075152333,
+          0.074344292,
+          0.074623667,
+          0.074690834,
+          0.076060333
+        ]
+      },
+      "total": {
+        "min_s": 0.294401042,
+        "median_s": 0.296140542,
+        "samples_s": [
+          0.296739208,
+          0.296140542,
+          0.29674325,
+          0.295189417,
+          0.294401042
+        ]
+      },
+      "compute_s": 0.22005675,
+      "ns_per_op_min": 23641.67920068758,
+      "ns_per_op_median": 23791.33089815213,
+      "load_ms": 4.093,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 8108,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.050876666,
+        "median_s": 0.051474542,
+        "samples_s": [
+          0.051890125,
+          0.050876666,
+          0.055192667,
+          0.051474542,
+          0.051156417
+        ]
+      },
+      "total": {
+        "min_s": 0.271916,
+        "median_s": 0.273485583,
+        "samples_s": [
+          0.274989375,
+          0.271916,
+          0.275386334,
+          0.273485583,
+          0.272275917
+        ]
+      },
+      "compute_s": 0.22103933399999998,
+      "ns_per_op_min": 27261.88135175135,
+      "ns_per_op_median": 27381.72681302417,
+      "load_ms": 3.6,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 16995,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.095557083,
+        "median_s": 0.095911292,
+        "samples_s": [
+          0.096621416,
+          0.09673925,
+          0.0955585,
+          0.095557083,
+          0.095911292
+        ]
+      },
+      "total": {
+        "min_s": 0.325886375,
+        "median_s": 0.330933292,
+        "samples_s": [
+          0.3314055,
+          0.330933292,
+          0.333364916,
+          0.327817458,
+          0.325886375
+        ]
+      },
+      "compute_s": 0.23032929200000002,
+      "ns_per_op_min": 13552.767990585467,
+      "ns_per_op_median": 13828.890850250074,
+      "load_ms": 8.343,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 308263040,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.005911875,
+        "median_s": 0.006239084,
+        "samples_s": [
+          0.005911875,
+          0.006155209,
+          0.006671625,
+          0.006239084,
+          0.00639575
+        ]
+      },
+      "total": {
+        "min_s": 0.303641,
+        "median_s": 0.304761667,
+        "samples_s": [
+          0.303641,
+          0.304761667,
+          0.304680917,
+          0.305863084,
+          0.305265625
+        ]
+      },
+      "compute_s": 0.297729125,
+      "ns_per_op_min": 0.9658281609108896,
+      "ns_per_op_median": 0.9684021250163497,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 308031142,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.009086333,
+        "median_s": 0.00943425,
+        "samples_s": [
+          0.010849083,
+          0.00943425,
+          0.009653417,
+          0.009224625,
+          0.009086333
+        ]
+      },
+      "total": {
+        "min_s": 0.306527875,
+        "median_s": 0.307198334,
+        "samples_s": [
+          0.310364375,
+          0.306855417,
+          0.306527875,
+          0.307198334,
+          0.309075291
+        ]
+      },
+      "compute_s": 0.297441542,
+      "ns_per_op_min": 0.9656216578257533,
+      "ns_per_op_median": 0.9666687662379282,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 3577591,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.01622425,
+        "median_s": 0.016479042,
+        "samples_s": [
+          0.01646675,
+          0.016479042,
+          0.016912625,
+          0.017091292,
+          0.01622425
+        ]
+      },
+      "total": {
+        "min_s": 0.307908667,
+        "median_s": 0.308658333,
+        "samples_s": [
+          0.308961625,
+          0.308658333,
+          0.307908667,
+          0.308850583,
+          0.307970584
+        ]
+      },
+      "compute_s": 0.29168441700000003,
+      "ns_per_op_min": 81.53095672479051,
+      "ns_per_op_median": 81.66928276597297,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 313546425,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.005757708,
+        "median_s": 0.005800416,
+        "samples_s": [
+          0.006487917,
+          0.006411042,
+          0.005764417,
+          0.005800416,
+          0.005757708
+        ]
+      },
+      "total": {
+        "min_s": 0.305628875,
+        "median_s": 0.30751375,
+        "samples_s": [
+          0.308708083,
+          0.30751375,
+          0.305628875,
+          0.307316833,
+          0.312350917
+        ]
+      },
+      "compute_s": 0.29987116700000005,
+      "ns_per_op_min": 0.9563852211040201,
+      "ns_per_op_median": 0.9622604818409267,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 55763037,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.004834417,
+        "median_s": 0.005043459,
+        "samples_s": [
+          0.005280917,
+          0.005173042,
+          0.005043459,
+          0.004834417,
+          0.004910417
+        ]
+      },
+      "total": {
+        "min_s": 0.306464417,
+        "median_s": 0.30649025,
+        "samples_s": [
+          0.309233583,
+          0.30649025,
+          0.30684875,
+          0.306474916,
+          0.306464417
+        ]
+      },
+      "compute_s": 0.30163,
+      "ns_per_op_min": 5.409138673706025,
+      "ns_per_op_median": 5.405853181920491,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 2853475,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.036830292,
+        "median_s": 0.037410834,
+        "samples_s": [
+          0.038115209,
+          0.037410834,
+          0.036830292,
+          0.037679333,
+          0.037123167
+        ]
+      },
+      "total": {
+        "min_s": 0.328251,
+        "median_s": 0.328788792,
+        "samples_s": [
+          0.329493291,
+          0.329547875,
+          0.328788792,
+          0.328251,
+          0.328451625
+        ]
+      },
+      "compute_s": 0.29142070800000003,
+      "ns_per_op_min": 102.1283550758286,
+      "ns_per_op_median": 102.11337334302911,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 3047651,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.037725958,
+        "median_s": 0.038761667,
+        "samples_s": [
+          0.038761667,
+          0.038214916,
+          0.037725958,
+          0.040679083,
+          0.041600916
+        ]
+      },
+      "total": {
+        "min_s": 0.269634208,
+        "median_s": 0.272924958,
+        "samples_s": [
+          0.269634208,
+          0.270343875,
+          0.273167584,
+          0.272924958,
+          0.277860541
+        ]
+      },
+      "compute_s": 0.23190824999999998,
+      "ns_per_op_min": 76.09409673220456,
+      "ns_per_op_median": 76.83402430265146,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 2871394,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.037603292,
+        "median_s": 0.03815275,
+        "samples_s": [
+          0.038851083,
+          0.040778083,
+          0.03786225,
+          0.037603292,
+          0.03815275
+        ]
+      },
+      "total": {
+        "min_s": 0.272886792,
+        "median_s": 0.27482025,
+        "samples_s": [
+          0.275281917,
+          0.274097167,
+          0.27482025,
+          0.272886792,
+          0.275871417
+        ]
+      },
+      "compute_s": 0.23528349999999998,
+      "ns_per_op_min": 81.94051391066499,
+      "ns_per_op_median": 82.42250976355038,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 1847927,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.028113625,
+        "median_s": 0.028604083,
+        "samples_s": [
+          0.028294416,
+          0.028604083,
+          0.028113625,
+          0.029987042,
+          0.029156042
+        ]
+      },
+      "total": {
+        "min_s": 0.307661708,
+        "median_s": 0.308112,
+        "samples_s": [
+          0.307661708,
+          0.308295541,
+          0.307725625,
+          0.308112,
+          0.308388292
+        ]
+      },
+      "compute_s": 0.279548083,
+      "ns_per_op_min": 151.27658343646692,
+      "ns_per_op_median": 151.2548477293746,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 132532820,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.037825625,
+        "median_s": 0.03852875,
+        "samples_s": [
+          0.039062625,
+          0.03852875,
+          0.03793875,
+          0.037825625,
+          0.038659459
+        ]
+      },
+      "total": {
+        "min_s": 0.318795417,
+        "median_s": 0.320686291,
+        "samples_s": [
+          0.319808791,
+          0.320686291,
+          0.318795417,
+          0.321105833,
+          0.322812583
+        ]
+      },
+      "compute_s": 0.28096979200000005,
+      "ns_per_op_min": 2.1200016116762628,
+      "ns_per_op_median": 2.128963535220936,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 371789,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.015556917,
+        "median_s": 0.016717916,
+        "samples_s": [
+          0.016717916,
+          0.017819667,
+          0.016777125,
+          0.015648084,
+          0.015556917
+        ]
+      },
+      "total": {
+        "min_s": 0.321081834,
+        "median_s": 0.323233417,
+        "samples_s": [
+          0.326042834,
+          0.323233417,
+          0.323842333,
+          0.321576334,
+          0.321081834
+        ]
+      },
+      "compute_s": 0.305524917,
+      "ns_per_op_min": 821.7696516034632,
+      "ns_per_op_median": 824.4340230614677,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 63778820,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.00335875,
+        "median_s": 0.004101125,
+        "samples_s": [
+          0.003915583,
+          0.00335875,
+          0.005520083,
+          0.004101125,
+          0.004129125
+        ]
+      },
+      "total": {
+        "min_s": 0.223769667,
+        "median_s": 0.223908709,
+        "samples_s": [
+          0.223908709,
+          0.227081666,
+          0.223769667,
+          0.227536,
+          0.223831125
+        ]
+      },
+      "compute_s": 0.220410917,
+      "ns_per_op_min": 3.4558638275214246,
+      "ns_per_op_median": 3.4464040570208105,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 178763105,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.062484083,
+        "median_s": 0.063911459,
+        "samples_s": [
+          0.062484083,
+          0.06403025,
+          0.063928375,
+          0.063601,
+          0.063911459
+        ]
+      },
+      "total": {
+        "min_s": 0.350722709,
+        "median_s": 0.352121792,
+        "samples_s": [
+          0.351209459,
+          0.353148917,
+          0.354907833,
+          0.352121792,
+          0.350722709
+        ]
+      },
+      "compute_s": 0.288238626,
+      "ns_per_op_min": 1.6124055688113048,
+      "ns_per_op_median": 1.6122472978974045,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 593,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.012776917,
+        "median_s": 0.013255875,
+        "samples_s": [
+          0.013966292,
+          0.013255875,
+          0.012776917,
+          0.013313166,
+          0.013001292
+        ]
+      },
+      "total": {
+        "min_s": 0.307407,
+        "median_s": 0.308710666,
+        "samples_s": [
+          0.30884125,
+          0.307407,
+          0.308710666,
+          0.311932709,
+          0.308415208
+        ]
+      },
+      "compute_s": 0.294630083,
+      "ns_per_op_min": 496846.68296795955,
+      "ns_per_op_median": 498237.4215851603,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 9415,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.043938542,
+        "median_s": 0.04644525,
+        "samples_s": [
+          0.04644525,
+          0.047037458,
+          0.045711125,
+          0.043938542,
+          0.046687958
+        ]
+      },
+      "total": {
+        "min_s": 0.313752875,
+        "median_s": 0.3160845,
+        "samples_s": [
+          0.317023458,
+          0.314711667,
+          0.3160845,
+          0.317115042,
+          0.313752875
+        ]
+      },
+      "compute_s": 0.269814333,
+      "ns_per_op_min": 28657.921720658524,
+      "ns_per_op_median": 28639.32554434413,
+      "load_ms": 0.601,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 29532,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.073544,
+        "median_s": 0.074177958,
+        "samples_s": [
+          0.076877375,
+          0.074177958,
+          0.073544,
+          0.074212875,
+          0.073886291
+        ]
+      },
+      "total": {
+        "min_s": 0.268712084,
+        "median_s": 0.27163625,
+        "samples_s": [
+          0.268712084,
+          0.271814792,
+          0.271317666,
+          0.271674333,
+          0.27163625
+        ]
+      },
+      "compute_s": 0.19516808400000002,
+      "ns_per_op_min": 6608.698496546121,
+      "ns_per_op_median": 6686.248543952324,
+      "load_ms": 3.184,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 39492,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.050310542,
+        "median_s": 0.050349959,
+        "samples_s": [
+          0.051819125,
+          0.050310542,
+          0.050328791,
+          0.050349959,
+          0.050564417
+        ]
+      },
+      "total": {
+        "min_s": 0.342477292,
+        "median_s": 0.345246792,
+        "samples_s": [
+          0.347275709,
+          0.342477292,
+          0.345246792,
+          0.34361325,
+          0.346502291
+        ]
+      },
+      "compute_s": 0.29216675,
+      "ns_per_op_min": 7398.12493669604,
+      "ns_per_op_median": 7467.2549630304875,
+      "load_ms": 3.713,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 83936,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.096653291,
+        "median_s": 0.097594083,
+        "samples_s": [
+          0.096911708,
+          0.097938667,
+          0.096653291,
+          0.098327083,
+          0.097594083
+        ]
+      },
+      "total": {
+        "min_s": 0.3881775,
+        "median_s": 0.391265833,
+        "samples_s": [
+          0.391265833,
+          0.391430958,
+          0.3881775,
+          0.39258225,
+          0.388754333
+        ]
+      },
+      "compute_s": 0.291524209,
+      "ns_per_op_min": 3473.172524304232,
+      "ns_per_op_median": 3498.7579822722073,
+      "load_ms": 8.23,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 130673147,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.005936834,
+        "median_s": 0.006285209,
+        "samples_s": [
+          0.007611,
+          0.006285209,
+          0.009296458,
+          0.006268083,
+          0.005936834
+        ]
+      },
+      "total": {
+        "min_s": 0.305271792,
+        "median_s": 0.306814375,
+        "samples_s": [
+          0.306246959,
+          0.305271792,
+          0.307627416,
+          0.306814375,
+          0.311186208
+        ]
+      },
+      "compute_s": 0.299334958,
+      "ns_per_op_min": 2.290715153588518,
+      "ns_per_op_median": 2.2998540472894553,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 125657518,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.009974875,
+        "median_s": 0.010261042,
+        "samples_s": [
+          0.0106555,
+          0.010021209,
+          0.009974875,
+          0.010335375,
+          0.010261042
+        ]
+      },
+      "total": {
+        "min_s": 0.303534042,
+        "median_s": 0.30652975,
+        "samples_s": [
+          0.303534042,
+          0.319291875,
+          0.316469875,
+          0.30652975,
+          0.306457167
+        ]
+      },
+      "compute_s": 0.293559167,
+      "ns_per_op_min": 2.336184668234494,
+      "ns_per_op_median": 2.357747572254292,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 2753954,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.016651833,
+        "median_s": 0.018665916,
+        "samples_s": [
+          0.019392334,
+          0.017841958,
+          0.01909125,
+          0.018665916,
+          0.016651833
+        ]
+      },
+      "total": {
+        "min_s": 0.451584209,
+        "median_s": 0.453532167,
+        "samples_s": [
+          0.468454875,
+          0.451584209,
+          0.454922167,
+          0.453532167,
+          0.452561042
+        ]
+      },
+      "compute_s": 0.434932376,
+      "ns_per_op_min": 157.9301527912231,
+      "ns_per_op_median": 157.90614186003106,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 115619881,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.005833166,
+        "median_s": 0.006195209,
+        "samples_s": [
+          0.006238667,
+          0.006195209,
+          0.0063925,
+          0.005833166,
+          0.005981958
+        ]
+      },
+      "total": {
+        "min_s": 0.312687583,
+        "median_s": 0.3154815,
+        "samples_s": [
+          0.312687583,
+          0.316891833,
+          0.315999875,
+          0.315463334,
+          0.3154815
+        ]
+      },
+      "compute_s": 0.306854417,
+      "ns_per_op_min": 2.6539935376684913,
+      "ns_per_op_median": 2.675026892650063,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 16131938,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.004852542,
+        "median_s": 0.005305834,
+        "samples_s": [
+          0.005661167,
+          0.005624,
+          0.005305834,
+          0.004947417,
+          0.004852542
+        ]
+      },
+      "total": {
+        "min_s": 0.211773709,
+        "median_s": 0.212891583,
+        "samples_s": [
+          0.212891583,
+          0.215097,
+          0.213492334,
+          0.211773709,
+          0.212559666
+        ]
+      },
+      "compute_s": 0.20692116700000002,
+      "ns_per_op_min": 12.82680152874379,
+      "ns_per_op_median": 12.867998190917916,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 1593876,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.036921792,
+        "median_s": 0.037538666,
+        "samples_s": [
+          0.038074834,
+          0.037538666,
+          0.037602333,
+          0.037328708,
+          0.036921792
+        ]
+      },
+      "total": {
+        "min_s": 0.324719667,
+        "median_s": 0.328197666,
+        "samples_s": [
+          0.32564625,
+          0.329776042,
+          0.328197666,
+          0.329782625,
+          0.324719667
+        ]
+      },
+      "compute_s": 0.287797875,
+      "ns_per_op_min": 180.5647835841684,
+      "ns_per_op_median": 182.35985735402252,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 1824076,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.036696584,
+        "median_s": 0.036903458,
+        "samples_s": [
+          0.037747125,
+          0.036785625,
+          0.036696584,
+          0.036903458,
+          0.03719
+        ]
+      },
+      "total": {
+        "min_s": 0.286921208,
+        "median_s": 0.290256625,
+        "samples_s": [
+          0.286921208,
+          0.290256625,
+          0.2897715,
+          0.290577416,
+          0.290395667
+        ]
+      },
+      "compute_s": 0.250224624,
+      "ns_per_op_min": 137.17883684671034,
+      "ns_per_op_median": 138.89397536067577,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 1748235,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.037278417,
+        "median_s": 0.037493208,
+        "samples_s": [
+          0.038506042,
+          0.037853834,
+          0.037493208,
+          0.037418958,
+          0.037278417
+        ]
+      },
+      "total": {
+        "min_s": 0.297043833,
+        "median_s": 0.298768333,
+        "samples_s": [
+          0.298768333,
+          0.297461167,
+          0.297043833,
+          0.302307333,
+          0.299403458
+        ]
+      },
+      "compute_s": 0.25976541599999997,
+      "ns_per_op_min": 148.58724141777276,
+      "ns_per_op_median": 149.45080323869502,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 520156,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.027434959,
+        "median_s": 0.028176292,
+        "samples_s": [
+          0.029808291,
+          0.0287825,
+          0.027811375,
+          0.027434959,
+          0.028176292
+        ]
+      },
+      "total": {
+        "min_s": 0.317227958,
+        "median_s": 0.318335334,
+        "samples_s": [
+          0.323115042,
+          0.323886833,
+          0.318138708,
+          0.318335334,
+          0.317227958
+        ]
+      },
+      "compute_s": 0.289792999,
+      "ns_per_op_min": 557.1270907189381,
+      "ns_per_op_median": 557.8308084497729,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 29450684,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.038281,
+        "median_s": 0.03890025,
+        "samples_s": [
+          0.040480542,
+          0.039288833,
+          0.03890025,
+          0.038488375,
+          0.038281
+        ]
+      },
+      "total": {
+        "min_s": 0.31600325,
+        "median_s": 0.316445917,
+        "samples_s": [
+          0.316156625,
+          0.317854958,
+          0.31600325,
+          0.316458167,
+          0.316445917
+        ]
+      },
+      "compute_s": 0.27772225,
+      "ns_per_op_min": 9.43007809258352,
+      "ns_per_op_median": 9.424082204678168,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 441655,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.011131625,
+        "median_s": 0.011428542,
+        "samples_s": [
+          0.012173584,
+          0.012276708,
+          0.011428542,
+          0.011131625,
+          0.011265083
+        ]
+      },
+      "total": {
+        "min_s": 0.311617583,
+        "median_s": 0.31354,
+        "samples_s": [
+          0.311617583,
+          0.314617875,
+          0.314210792,
+          0.31354,
+          0.312234542
+        ]
+      },
+      "compute_s": 0.300485958,
+      "ns_per_op_min": 680.3635371500379,
+      "ns_per_op_median": 684.0440117286117,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 72310665,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.003416416,
+        "median_s": 0.004722209,
+        "samples_s": [
+          0.005215917,
+          0.006258209,
+          0.003681125,
+          0.003416416,
+          0.004722209
+        ]
+      },
+      "total": {
+        "min_s": 0.2224035,
+        "median_s": 0.223199084,
+        "samples_s": [
+          0.225511584,
+          0.223981666,
+          0.223199084,
+          0.22307525,
+          0.2224035
+        ]
+      },
+      "compute_s": 0.218987084,
+      "ns_per_op_min": 3.028420275211132,
+      "ns_per_op_median": 3.021364483371851,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 94552487,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.059094917,
+        "median_s": 0.063390083,
+        "samples_s": [
+          0.063755125,
+          0.063390083,
+          0.064740834,
+          0.059980084,
+          0.059094917
+        ]
+      },
+      "total": {
+        "min_s": 0.2820895,
+        "median_s": 0.283415709,
+        "samples_s": [
+          0.2820895,
+          0.282584042,
+          0.283808542,
+          0.283415709,
+          0.284260834
+        ]
+      },
+      "compute_s": 0.222994583,
+      "ns_per_op_min": 2.3584211275161913,
+      "ns_per_op_median": 2.327021033301853,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 13965,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.012897875,
+        "median_s": 0.013281209,
+        "samples_s": [
+          0.013547416,
+          0.013281209,
+          0.013671875,
+          0.012897875,
+          0.013277209
+        ]
+      },
+      "total": {
+        "min_s": 0.320402708,
+        "median_s": 0.321865333,
+        "samples_s": [
+          0.321865333,
+          0.322087958,
+          0.3215215,
+          0.320402708,
+          0.322379334
+        ]
+      },
+      "compute_s": 0.307504833,
+      "ns_per_op_min": 22019.680128893662,
+      "ns_per_op_median": 22096.96555674901,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 5505,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.044541125,
+        "median_s": 0.044654625,
+        "samples_s": [
+          0.044641792,
+          0.044654625,
+          0.044541125,
+          0.045178916,
+          0.044769041
+        ]
+      },
+      "total": {
+        "min_s": 0.33499125,
+        "median_s": 0.338646583,
+        "samples_s": [
+          0.338646583,
+          0.33599025,
+          0.363471875,
+          0.345310583,
+          0.33499125
+        ]
+      },
+      "compute_s": 0.290450125,
+      "ns_per_op_min": 52761.148955495,
+      "ns_per_op_median": 53404.53369663942,
+      "load_ms": 0.653,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 13808,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.076246417,
+        "median_s": 0.076707791,
+        "samples_s": [
+          0.077911167,
+          0.077567458,
+          0.076247541,
+          0.076707791,
+          0.076246417
+        ]
+      },
+      "total": {
+        "min_s": 0.300641958,
+        "median_s": 0.304045416,
+        "samples_s": [
+          0.304841083,
+          0.300641958,
+          0.304045416,
+          0.301908084,
+          0.304086292
+        ]
+      },
+      "compute_s": 0.22439554099999998,
+      "ns_per_op_min": 16251.125506952489,
+      "ns_per_op_median": 16464.196480301278,
+      "load_ms": 3.452,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 16538,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.049966333,
+        "median_s": 0.050272292,
+        "samples_s": [
+          0.051071917,
+          0.051241334,
+          0.049966333,
+          0.050272292,
+          0.050068041
+        ]
+      },
+      "total": {
+        "min_s": 0.297875959,
+        "median_s": 0.299170083,
+        "samples_s": [
+          0.298101042,
+          0.297875959,
+          0.299857791,
+          0.299170083,
+          0.30322575
+        ]
+      },
+      "compute_s": 0.24790962600000002,
+      "ns_per_op_min": 14990.302696819448,
+      "ns_per_op_median": 15050.053875922116,
+      "load_ms": 4.277,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 30797,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.094640375,
+        "median_s": 0.095436167,
+        "samples_s": [
+          0.09529175,
+          0.098882333,
+          0.095436167,
+          0.094640375,
+          0.0977035
+        ]
+      },
+      "total": {
+        "min_s": 0.305047334,
+        "median_s": 0.306915417,
+        "samples_s": [
+          0.306915417,
+          0.308783459,
+          0.305047334,
+          0.306858292,
+          0.309561833
+        ]
+      },
+      "compute_s": 0.210406959,
+      "ns_per_op_min": 6832.060233139591,
+      "ns_per_op_median": 6866.878267363704,
+      "load_ms": 7.886,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 131618411,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.006245917,
+        "median_s": 0.006698667,
+        "samples_s": [
+          0.006869625,
+          0.0068655,
+          0.006698667,
+          0.006246042,
+          0.006245917
+        ]
+      },
+      "total": {
+        "min_s": 0.308673875,
+        "median_s": 0.3093125,
+        "samples_s": [
+          0.30918575,
+          0.31074375,
+          0.311147208,
+          0.308673875,
+          0.3093125
+        ]
+      },
+      "compute_s": 0.302427958,
+      "ns_per_op_min": 2.297763327350913,
+      "ns_per_op_median": 2.299175553790875,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 130260558,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.009128375,
+        "median_s": 0.009424958,
+        "samples_s": [
+          0.009597166,
+          0.009328041,
+          0.009128375,
+          0.00950025,
+          0.009424958
+        ]
+      },
+      "total": {
+        "min_s": 0.307984958,
+        "median_s": 0.309274083,
+        "samples_s": [
+          0.312665625,
+          0.30907675,
+          0.309274083,
+          0.311358833,
+          0.307984958
+        ]
+      },
+      "compute_s": 0.29885658299999995,
+      "ns_per_op_min": 2.2942983477776897,
+      "ns_per_op_median": 2.3019180142004303,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1980463,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.015937209,
+        "median_s": 0.016254833,
+        "samples_s": [
+          0.016189375,
+          0.016696458,
+          0.017419542,
+          0.015937209,
+          0.016254833
+        ]
+      },
+      "total": {
+        "min_s": 0.326330292,
+        "median_s": 0.332822584,
+        "samples_s": [
+          0.326330292,
+          0.331530042,
+          0.334040583,
+          0.332822584,
+          0.333811667
+        ]
+      },
+      "compute_s": 0.310393083,
+      "ns_per_op_min": 156.7275344199816,
+      "ns_per_op_median": 159.84532455289494,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 109897127,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.005806667,
+        "median_s": 0.005932375,
+        "samples_s": [
+          0.007862125,
+          0.006357208,
+          0.005806667,
+          0.005897042,
+          0.005932375
+        ]
+      },
+      "total": {
+        "min_s": 0.29476275,
+        "median_s": 0.297979958,
+        "samples_s": [
+          0.301962625,
+          0.299829041,
+          0.29476275,
+          0.297979958,
+          0.294891875
+        ]
+      },
+      "compute_s": 0.28895608300000003,
+      "ns_per_op_min": 2.6293324574353982,
+      "ns_per_op_median": 2.6574633111200443,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 16777216,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.004964125,
+        "median_s": 0.005078833,
+        "samples_s": [
+          0.005986208,
+          0.004964125,
+          0.005078833,
+          0.005151292,
+          0.005046084
+        ]
+      },
+      "total": {
+        "min_s": 0.206828959,
+        "median_s": 0.208632709,
+        "samples_s": [
+          0.208632709,
+          0.206828959,
+          0.20887675,
+          0.208069375,
+          0.209265167
+        ]
+      },
+      "compute_s": 0.201864834,
+      "ns_per_op_min": 12.032081723213196,
+      "ns_per_op_median": 12.132756471633911,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 225605,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.037270667,
+        "median_s": 0.037496166,
+        "samples_s": [
+          0.040169167,
+          0.038161208,
+          0.037270667,
+          0.037496166,
+          0.037494667
+        ]
+      },
+      "total": {
+        "min_s": 0.329620458,
+        "median_s": 0.332270583,
+        "samples_s": [
+          0.337029084,
+          0.329620458,
+          0.332270583,
+          0.336890208,
+          0.331707333
+        ]
+      },
+      "compute_s": 0.292349791,
+      "ns_per_op_min": 1295.8480131202766,
+      "ns_per_op_median": 1306.5952306021586,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 295187,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.037295375,
+        "median_s": 0.037488708,
+        "samples_s": [
+          0.038332917,
+          0.037793917,
+          0.037488708,
+          0.037295375,
+          0.037399666
+        ]
+      },
+      "total": {
+        "min_s": 0.314555,
+        "median_s": 0.319082667,
+        "samples_s": [
+          0.319082667,
+          0.324370917,
+          0.317795,
+          0.314555,
+          0.321613959
+        ]
+      },
+      "compute_s": 0.27725962499999995,
+      "ns_per_op_min": 939.2677353677498,
+      "ns_per_op_median": 953.9510852442689,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 281212,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.037392875,
+        "median_s": 0.038468667,
+        "samples_s": [
+          0.038468667,
+          0.037392875,
+          0.037430959,
+          0.040496,
+          0.03863525
+        ]
+      },
+      "total": {
+        "min_s": 0.324071708,
+        "median_s": 0.326705583,
+        "samples_s": [
+          0.326587875,
+          0.324071708,
+          0.330997083,
+          0.326705583,
+          0.329034458
+        ]
+      },
+      "compute_s": 0.286678833,
+      "ns_per_op_min": 1019.440255038903,
+      "ns_per_op_median": 1024.9808543020924,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 444939,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.028325792,
+        "median_s": 0.029327625,
+        "samples_s": [
+          0.028657667,
+          0.028325792,
+          0.029327625,
+          0.030007875,
+          0.03062075
+        ]
+      },
+      "total": {
+        "min_s": 0.3003525,
+        "median_s": 0.310177,
+        "samples_s": [
+          0.310177,
+          0.308526375,
+          0.3003525,
+          0.313980458,
+          0.310966125
+        ]
+      },
+      "compute_s": 0.272026708,
+      "ns_per_op_min": 611.3797801496385,
+      "ns_per_op_median": 631.2087162509915,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 971910,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.037854708,
+        "median_s": 0.038682958,
+        "samples_s": [
+          0.039631292,
+          0.037854708,
+          0.038682958,
+          0.039156833,
+          0.038008709
+        ]
+      },
+      "total": {
+        "min_s": 0.25083925,
+        "median_s": 0.25354475,
+        "samples_s": [
+          0.258690084,
+          0.251893292,
+          0.25354475,
+          0.254101708,
+          0.25083925
+        ]
+      },
+      "compute_s": 0.212984542,
+      "ns_per_op_min": 219.14018993528208,
+      "ns_per_op_median": 221.0716959389244,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 305485,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.011102416,
+        "median_s": 0.011179625,
+        "samples_s": [
+          0.012132958,
+          0.012986959,
+          0.011179625,
+          0.011102416,
+          0.011139458
+        ]
+      },
+      "total": {
+        "min_s": 0.314665458,
+        "median_s": 0.315550541,
+        "samples_s": [
+          0.315255041,
+          0.315560583,
+          0.314665458,
+          0.316528958,
+          0.315550541
+        ]
+      },
+      "compute_s": 0.303563042,
+      "ns_per_op_min": 993.7085028724815,
+      "ns_per_op_median": 996.3530647985989,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 82585389,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.003759208,
+        "median_s": 0.004436291,
+        "samples_s": [
+          0.006017375,
+          0.003759208,
+          0.006244166,
+          0.004436291,
+          0.0043665
+        ]
+      },
+      "total": {
+        "min_s": 0.217494833,
+        "median_s": 0.218593583,
+        "samples_s": [
+          0.217494833,
+          0.219378333,
+          0.220016625,
+          0.217820333,
+          0.218593583
+        ]
+      },
+      "compute_s": 0.21373562499999998,
+      "ns_per_op_min": 2.5880561633002657,
+      "ns_per_op_median": 2.5931619938243555,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 83499022,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.063575083,
+        "median_s": 0.064117,
+        "samples_s": [
+          0.063575083,
+          0.063714292,
+          0.065555125,
+          0.065098125,
+          0.064117
+        ]
+      },
+      "total": {
+        "min_s": 0.258639541,
+        "median_s": 0.258882583,
+        "samples_s": [
+          0.258681041,
+          0.258639541,
+          0.259474917,
+          0.258882583,
+          0.260457125
+        ]
+      },
+      "compute_s": 0.19506445799999997,
+      "ns_per_op_min": 2.3361286554949108,
+      "ns_per_op_median": 2.332549272253752,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 11101,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.013442083,
+        "median_s": 0.014271041,
+        "samples_s": [
+          0.014342209,
+          0.01445325,
+          0.014271041,
+          0.013618375,
+          0.013442083
+        ]
+      },
+      "total": {
+        "min_s": 0.28227175,
+        "median_s": 0.284205458,
+        "samples_s": [
+          0.28227175,
+          0.283838291,
+          0.289154959,
+          0.286468208,
+          0.284205458
+        ]
+      },
+      "compute_s": 0.268829667,
+      "ns_per_op_min": 24216.70723358256,
+      "ns_per_op_median": 24316.225295018474,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 4508,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.042986375,
+        "median_s": 0.0447365,
+        "samples_s": [
+          0.046337208,
+          0.045044375,
+          0.042986375,
+          0.0447365,
+          0.043486958
+        ]
+      },
+      "total": {
+        "min_s": 0.298001875,
+        "median_s": 0.299716209,
+        "samples_s": [
+          0.299716209,
+          0.307548834,
+          0.298001875,
+          0.300645125,
+          0.29838525
+        ]
+      },
+      "compute_s": 0.2550155,
+      "ns_per_op_min": 56569.54303460514,
+      "ns_per_op_median": 56561.603593611355,
+      "load_ms": 0.65,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 512,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.077674042,
+        "median_s": 0.078011334,
+        "samples_s": [
+          0.078098792,
+          0.078011334,
+          0.077967,
+          0.077674042,
+          0.078417708
+        ]
+      },
+      "total": {
+        "min_s": 0.259333541,
+        "median_s": 0.261710166,
+        "samples_s": [
+          0.259333541,
+          0.26515175,
+          0.261710166,
+          0.26499325,
+          0.261635791
+        ]
+      },
+      "compute_s": 0.181659499,
+      "ns_per_op_min": 354803.708984375,
+      "ns_per_op_median": 358786.78125000006,
+      "load_ms": 3.415,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 19188,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.050223834,
+        "median_s": 0.050631209,
+        "samples_s": [
+          0.052114167,
+          0.050223834,
+          0.05046725,
+          0.050904917,
+          0.050631209
+        ]
+      },
+      "total": {
+        "min_s": 0.358045625,
+        "median_s": 0.362953083,
+        "samples_s": [
+          0.359806625,
+          0.362953083,
+          0.358045625,
+          0.365991417,
+          0.366341333
+        ]
+      },
+      "compute_s": 0.30782179099999996,
+      "ns_per_op_min": 16042.411455076086,
+      "ns_per_op_median": 16276.93735668126,
+      "load_ms": 3.509,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 33710,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.094114834,
+        "median_s": 0.095411833,
+        "samples_s": [
+          0.095330666,
+          0.095424,
+          0.095411833,
+          0.098970667,
+          0.094114834
+        ]
+      },
+      "total": {
+        "min_s": 0.391234833,
+        "median_s": 0.395640459,
+        "samples_s": [
+          0.395491125,
+          0.391234833,
+          0.395660709,
+          0.396265333,
+          0.395640459
+        ]
+      },
+      "compute_s": 0.297119999,
+      "ns_per_op_min": 8814.001750222485,
+      "ns_per_op_median": 8906.218510827648,
+      "load_ms": 8.513,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 312876423,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.007169917,
+        "median_s": 0.007884542,
+        "samples_s": [
+          0.007169917,
+          0.007884542,
+          0.0085605,
+          0.007377459,
+          0.009240417
+        ]
+      },
+      "total": {
+        "min_s": 0.315280041,
+        "median_s": 0.316180417,
+        "samples_s": [
+          0.317159916,
+          0.315280041,
+          0.316180417,
+          0.322320917,
+          0.315914375
+        ]
+      },
+      "compute_s": 0.308110124,
+      "ns_per_op_min": 0.9847661931368986,
+      "ns_per_op_median": 0.9853598812077956,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 299553254,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.008775458,
+        "median_s": 0.009566084,
+        "samples_s": [
+          0.010680125,
+          0.009647292,
+          0.009159583,
+          0.009566084,
+          0.008775458
+        ]
+      },
+      "total": {
+        "min_s": 0.304933333,
+        "median_s": 0.305750459,
+        "samples_s": [
+          0.304967625,
+          0.305750459,
+          0.306656417,
+          0.304933333,
+          0.306375542
+        ]
+      },
+      "compute_s": 0.29615787499999996,
+      "ns_per_op_min": 0.9886651907309941,
+      "ns_per_op_median": 0.9887536558023836,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1949460,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.016331292,
+        "median_s": 0.016486541,
+        "samples_s": [
+          0.016848417,
+          0.016331292,
+          0.016486541,
+          0.01653775,
+          0.016384833
+        ]
+      },
+      "total": {
+        "min_s": 0.263035042,
+        "median_s": 0.263904333,
+        "samples_s": [
+          0.263904333,
+          0.264200666,
+          0.263035042,
+          0.263930416,
+          0.263223708
+        ]
+      },
+      "compute_s": 0.24670375,
+      "ns_per_op_min": 126.54978814646107,
+      "ns_per_op_median": 126.91606496157911,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 196106564,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.005532125,
+        "median_s": 0.006267541,
+        "samples_s": [
+          0.006267541,
+          0.007004125,
+          0.005936333,
+          0.005532125,
+          0.006366084
+        ]
+      },
+      "total": {
+        "min_s": 0.303725875,
+        "median_s": 0.305999709,
+        "samples_s": [
+          0.307845458,
+          0.303725875,
+          0.304655875,
+          0.305999709,
+          0.306169084
+        ]
+      },
+      "compute_s": 0.29819375,
+      "ns_per_op_min": 1.5205699590963206,
+      "ns_per_op_median": 1.5284147653517606,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 33554432,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.004865667,
+        "median_s": 0.005388958,
+        "samples_s": [
+          0.005784333,
+          0.005613917,
+          0.005388958,
+          0.004919333,
+          0.004865667
+        ]
+      },
+      "total": {
+        "min_s": 0.340180542,
+        "median_s": 0.341607667,
+        "samples_s": [
+          0.340180542,
+          0.341607667,
+          0.34049975,
+          0.342542417,
+          0.342103625
+        ]
+      },
+      "compute_s": 0.33531487499999996,
+      "ns_per_op_min": 9.993162006139753,
+      "ns_per_op_median": 10.020098358392715,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 1673508,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.036993042,
+        "median_s": 0.037686958,
+        "samples_s": [
+          0.040490583,
+          0.038403792,
+          0.037686958,
+          0.036993042,
+          0.037342167
+        ]
+      },
+      "total": {
+        "min_s": 0.328232625,
+        "median_s": 0.331381958,
+        "samples_s": [
+          0.328232625,
+          0.330950041,
+          0.331381958,
+          0.331424208,
+          0.331885291
+        ]
+      },
+      "compute_s": 0.291239583,
+      "ns_per_op_min": 174.02939394373973,
+      "ns_per_op_median": 175.49662146819733,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 2248511,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.037718334,
+        "median_s": 0.038429125,
+        "samples_s": [
+          0.038430125,
+          0.037744583,
+          0.040111334,
+          0.038429125,
+          0.037718334
+        ]
+      },
+      "total": {
+        "min_s": 0.330105125,
+        "median_s": 0.332264375,
+        "samples_s": [
+          0.331058292,
+          0.330105125,
+          0.3324285,
+          0.332264375,
+          0.343316125
+        ]
+      },
+      "compute_s": 0.292386791,
+      "ns_per_op_min": 130.03573965170727,
+      "ns_per_op_median": 130.67992551515204,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 2030148,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.037611875,
+        "median_s": 0.037820417,
+        "samples_s": [
+          0.03829275,
+          0.037641959,
+          0.037611875,
+          0.038216291,
+          0.037820417
+        ]
+      },
+      "total": {
+        "min_s": 0.318491458,
+        "median_s": 0.321745167,
+        "samples_s": [
+          0.318491458,
+          0.3187735,
+          0.323589708,
+          0.321745167,
+          0.322394708
+        ]
+      },
+      "compute_s": 0.280879583,
+      "ns_per_op_min": 138.3542396908994,
+      "ns_per_op_median": 139.85421259927847,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 384461,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.027686917,
+        "median_s": 0.028261708,
+        "samples_s": [
+          0.0282495,
+          0.030604916,
+          0.028261708,
+          0.02870075,
+          0.027686917
+        ]
+      },
+      "total": {
+        "min_s": 0.309303125,
+        "median_s": 0.313494917,
+        "samples_s": [
+          0.313494917,
+          0.3136215,
+          0.309303125,
+          0.312518084,
+          0.317078709
+        ]
+      },
+      "compute_s": 0.28161620800000003,
+      "ns_per_op_min": 732.4961647605351,
+      "ns_per_op_median": 741.9041437232905,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 5536715,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.038802125,
+        "median_s": 0.039426875,
+        "samples_s": [
+          0.0401195,
+          0.040024208,
+          0.039426875,
+          0.039308792,
+          0.038802125
+        ]
+      },
+      "total": {
+        "min_s": 0.330440958,
+        "median_s": 0.333684708,
+        "samples_s": [
+          0.333606208,
+          0.3350835,
+          0.330440958,
+          0.335077209,
+          0.333684708
+        ]
+      },
+      "compute_s": 0.291638833,
+      "ns_per_op_min": 52.67362199426916,
+      "ns_per_op_median": 53.14664616112621,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 316931,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.010878875,
+        "median_s": 0.011196125,
+        "samples_s": [
+          0.012921292,
+          0.011105417,
+          0.011196125,
+          0.010878875,
+          0.011227458
+        ]
+      },
+      "total": {
+        "min_s": 0.315426,
+        "median_s": 0.316714292,
+        "samples_s": [
+          0.317607416,
+          0.315746542,
+          0.316714292,
+          0.315426,
+          0.31681525
+        ]
+      },
+      "compute_s": 0.304547125,
+      "ns_per_op_min": 960.9256431210579,
+      "ns_per_op_median": 963.989533999514,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 149028696,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.004120084,
+        "median_s": 0.005168792,
+        "samples_s": [
+          0.006927542,
+          0.005094041,
+          0.005168792,
+          0.005449167,
+          0.004120084
+        ]
+      },
+      "total": {
+        "min_s": 0.224217208,
+        "median_s": 0.224832833,
+        "samples_s": [
+          0.224217208,
+          0.225193208,
+          0.224268583,
+          0.226868708,
+          0.224832833
+        ]
+      },
+      "compute_s": 0.220097124,
+      "ns_per_op_min": 1.476877473315609,
+      "ns_per_op_median": 1.4739714356757172,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 162847521,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.058895959,
+        "median_s": 0.063606917,
+        "samples_s": [
+          0.064354916,
+          0.063606917,
+          0.058895959,
+          0.062414292,
+          0.065318708
+        ]
+      },
+      "total": {
+        "min_s": 0.34342575,
+        "median_s": 0.34563175,
+        "samples_s": [
+          0.344209042,
+          0.347297959,
+          0.346055792,
+          0.34563175,
+          0.34342575
+        ]
+      },
+      "compute_s": 0.284529791,
+      "ns_per_op_min": 1.7472159800332483,
+      "ns_per_op_median": 1.7318337501741894,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 11586,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.012561209,
+        "median_s": 0.012749792,
+        "samples_s": [
+          0.013652375,
+          0.013834792,
+          0.012561209,
+          0.012739375,
+          0.012749792
+        ]
+      },
+      "total": {
+        "min_s": 0.320223042,
+        "median_s": 0.321145917,
+        "samples_s": [
+          0.321145917,
+          0.320223042,
+          0.320484,
+          0.32654,
+          0.321351291
+        ]
+      },
+      "compute_s": 0.307661833,
+      "ns_per_op_min": 26554.62049024685,
+      "ns_per_op_median": 26617.998014845503,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 8415,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.044072334,
+        "median_s": 0.045072084,
+        "samples_s": [
+          0.045476333,
+          0.044799625,
+          0.044072334,
+          0.047702209,
+          0.045072084
+        ]
+      },
+      "total": {
+        "min_s": 0.365057625,
+        "median_s": 0.365982958,
+        "samples_s": [
+          0.368809042,
+          0.36553425,
+          0.365982958,
+          0.374243459,
+          0.365057625
+        ]
+      },
+      "compute_s": 0.320985291,
+      "ns_per_op_min": 38144.419607843134,
+      "ns_per_op_median": 38135.57623291741,
+      "load_ms": 0.682,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 16194,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.074321292,
+        "median_s": 0.075648916,
+        "samples_s": [
+          0.075648916,
+          0.07500075,
+          0.078473541,
+          0.075710041,
+          0.074321292
+        ]
+      },
+      "total": {
+        "min_s": 0.241692667,
+        "median_s": 0.244690292,
+        "samples_s": [
+          0.244690292,
+          0.24498825,
+          0.242724958,
+          0.246953875,
+          0.241692667
+        ]
+      },
+      "compute_s": 0.167371375,
+      "ns_per_op_min": 10335.394281832778,
+      "ns_per_op_median": 10438.518957638633,
+      "load_ms": 4.448,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 15360,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.050150458,
+        "median_s": 0.05105825,
+        "samples_s": [
+          0.05105825,
+          0.050498375,
+          0.050150458,
+          0.0527315,
+          0.054188
+        ]
+      },
+      "total": {
+        "min_s": 0.24946725,
+        "median_s": 0.2535705,
+        "samples_s": [
+          0.2535705,
+          0.256151292,
+          0.253018042,
+          0.258451458,
+          0.24946725
+        ]
+      },
+      "compute_s": 0.199316792,
+      "ns_per_op_min": 12976.353645833333,
+      "ns_per_op_median": 13184.391276041664,
+      "load_ms": 3.86,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 36555,
+      "runs_per_sample": null,
+      "reps": 5,
+      "cold_start": {
+        "min_s": 0.09411325,
+        "median_s": 0.100631584,
+        "samples_s": [
+          0.099317125,
+          0.104687875,
+          0.100631584,
+          0.09411325,
+          0.101530125
+        ]
+      },
+      "total": {
+        "min_s": 0.310129042,
+        "median_s": 0.31784825,
+        "samples_s": [
+          0.310129042,
+          0.31784825,
+          0.313663916,
+          0.322131958,
+          0.320813083
+        ]
+      },
+      "compute_s": 0.21601579200000004,
+      "ns_per_op_min": 5909.336397209685,
+      "ns_per_op_median": 5942.187553002325,
+      "load_ms": 8.447,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 24,
+      "reps": 5,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.010666008625,
+        "median_s": 0.010766466958333333,
+        "samples_s": [
+          0.01102244275,
+          0.010766466958333333,
+          0.010748206583333334,
+          0.010666008625,
+          0.01101622925
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 17,
+      "reps": 5,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.014519769647058825,
+        "median_s": 0.01523060041176471,
+        "samples_s": [
+          0.01523060041176471,
+          0.014519769647058825,
+          0.014775512294117646,
+          0.015318061352941177,
+          0.015494107941176475
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 11,
+      "reps": 5,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.02697718918181818,
+        "median_s": 0.02758814390909091,
+        "samples_s": [
+          0.02697718918181818,
+          0.02802229518181818,
+          0.028111333454545452,
+          0.02758814390909091,
+          0.02751546954545454
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 3,
+      "reps": 5,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.10452525,
+        "median_s": 0.104813889,
+        "samples_s": [
+          0.10463113866666666,
+          0.10490404133333335,
+          0.10520163933333333,
+          0.104813889,
+          0.10452525
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 35,
+      "reps": 5,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.007684796428571429,
+        "median_s": 0.008043233314285714,
+        "samples_s": [
+          0.00806598934285714,
+          0.008682458257142856,
+          0.008043233314285714,
+          0.007994739342857144,
+          0.007684796428571429
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 3,
+      "reps": 5,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.13590945866666668,
+        "median_s": 0.13674191633333335,
+        "samples_s": [
+          0.139990972,
+          0.13674191633333335,
+          0.13595330566666666,
+          0.13590945866666668,
+          0.14037159733333335
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 2,
+      "reps": 5,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.179756729,
+        "median_s": 0.18247352049999999,
+        "samples_s": [
+          0.186414688,
+          0.18247352049999999,
+          0.179756729,
+          0.1828352295,
+          0.18091012499999998
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 2,
+      "reps": 5,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.2366229165,
+        "median_s": 0.239001458,
+        "samples_s": [
+          0.2366229165,
+          0.24199635400000002,
+          0.2396209165,
+          0.239001458,
+          0.23809512500000002
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 5,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.40857775,
+        "median_s": 0.409427042,
+        "samples_s": [
+          0.412667,
+          0.40876875,
+          0.411796416,
+          0.40857775,
+          0.409427042
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 5,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.60400825,
+        "median_s": 0.604689375,
+        "samples_s": [
+          0.604689375,
+          0.607553166,
+          0.608809667,
+          0.604452042,
+          0.60400825
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 3,
+      "reps": 5,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.10626331966666668,
+        "median_s": 0.10643929166666666,
+        "samples_s": [
+          0.10626331966666668,
+          0.10642226366666667,
+          0.106567861,
+          0.106879416,
+          0.10643929166666666
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 5,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.00551475,
+        "median_s": 0.006012875,
+        "samples_s": [
+          0.007479875,
+          0.005599584,
+          0.006618083,
+          0.00551475,
+          0.006012875
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 3,
+      "reps": 5,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.122962236,
+        "median_s": 0.124323903,
+        "samples_s": [
+          0.12716158366666666,
+          0.124323903,
+          0.12369424966666666,
+          0.12445015233333334,
+          0.122962236
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 5,
+      "cold_start": null,
+      "total": {
+        "min_s": 1.107831167,
+        "median_s": 1.113884084,
+        "samples_s": [
+          1.113884084,
+          1.107831167,
+          1.113545834,
+          1.1250005,
+          1.132345208
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 5,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.482352875,
+        "median_s": 0.484843167,
+        "samples_s": [
+          0.483775042,
+          0.487151125,
+          0.484843167,
+          0.482352875,
+          0.501466083
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": 274.678,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 5,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.819035875,
+        "median_s": 0.828753292,
+        "samples_s": [
+          0.848698958,
+          0.828753292,
+          0.819035875,
+          0.820896375,
+          0.830923125
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": 444.378,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 2,
+      "reps": 5,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.226811458,
+        "median_s": 0.2287435,
+        "samples_s": [
+          0.2287435,
+          0.2289058335,
+          0.228146375,
+          0.226811458,
+          0.230142458
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": 107.86,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 2,
+      "reps": 5,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.250913271,
+        "median_s": 0.252970958,
+        "samples_s": [
+          0.2550633335,
+          0.2518728125,
+          0.252970958,
+          0.250913271,
+          0.2539859375
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": 77.844,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 3,
+      "reps": 5,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.07537987533333333,
+        "median_s": 0.075530361,
+        "samples_s": [
+          0.07548230566666667,
+          0.07537987533333333,
+          0.07603973600000001,
+          0.07615134766666666,
+          0.075530361
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 3,
+      "reps": 5,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.08478215233333335,
+        "median_s": 0.08507505533333333,
+        "samples_s": [
+          0.08512968066666667,
+          0.08584263866666668,
+          0.08507505533333333,
+          0.08478215233333335,
+          0.085072431
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 5,
+      "cold_start": null,
+      "total": {
+        "min_s": 9.4734695,
+        "median_s": 9.551609375,
+        "samples_s": [
+          9.609792458,
+          9.551609375,
+          9.513315459,
+          9.4734695,
+          9.577895583
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 5,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.614636541,
+        "median_s": 0.621188584,
+        "samples_s": [
+          0.621065209,
+          0.622586458,
+          0.621188584,
+          0.621706625,
+          0.614636541
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 5,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.891038667,
+        "median_s": 1.071629541,
+        "samples_s": [
+          1.076376458,
+          1.071629541,
+          1.077169417,
+          1.061512542,
+          0.891038667
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 5,
+      "cold_start": null,
+      "total": {
+        "min_s": 18.669057959,
+        "median_s": 18.726266458,
+        "samples_s": [
+          18.669057959,
+          18.797421125,
+          18.722659833,
+          18.743038124999998,
+          18.726266458
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 5,
+      "cold_start": null,
+      "total": {
+        "min_s": 8.867494875,
+        "median_s": 8.881839292,
+        "samples_s": [
+          8.867494875,
+          8.874280375,
+          8.881839292,
+          8.925131875,
+          8.88439525
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 5,
+      "cold_start": null,
+      "total": {
+        "min_s": 13.462454666,
+        "median_s": 13.522070084,
+        "samples_s": [
+          13.486933042,
+          13.462454666,
+          13.522070084,
+          13.546292542,
+          13.547807833
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 5,
+      "cold_start": null,
+      "total": {
+        "min_s": 53.601863834,
+        "median_s": 53.682187083,
+        "samples_s": [
+          53.931364792,
+          53.601863834,
+          54.023299959,
+          53.682187083,
+          53.662579708
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 5,
+      "cold_start": null,
+      "total": {
+        "min_s": 11.420610417,
+        "median_s": 11.479423125,
+        "samples_s": [
+          11.504600125,
+          11.505212583,
+          11.420610417,
+          11.46926925,
+          11.479423125
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 5,
+      "cold_start": null,
+      "total": {
+        "min_s": 108.083372666,
+        "median_s": 108.461800959,
+        "samples_s": [
+          108.897889834,
+          108.3316215,
+          108.568440917,
+          108.461800959,
+          108.083372666
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 5,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.1695055,
+        "median_s": 0.169786375,
+        "samples_s": [
+          0.169532,
+          0.170966583,
+          0.1695055,
+          0.169786375,
+          0.171232917
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 5,
+      "cold_start": null,
+      "total": {
+        "min_s": 2.303552959,
+        "median_s": 2.314227916,
+        "samples_s": [
+          2.316060666,
+          2.303552959,
+          2.317581333,
+          2.311739334,
+          2.314227916
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-bash",
+      "status": "skipped",
+      "reason": "excluded: bash runs ~10000x slower than wasmtime on compute, so 100k SQL inserts do not finish in a practical time"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "pywasm-cpython",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: pywasm runs this program correctly (byte-identical to wasmtime under -batch) at ~17.9 ms/row: measured 358 s at 20k rows, so the 100k-row script needs roughly half an hour per sample"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "pywasm-pypy",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: pywasm runs this program correctly (byte-identical to wasmtime under -batch) at ~17.9 ms/row: measured 358 s at 20k rows, so the 100k-row script needs roughly half an hour per sample"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wardite",
+      "status": "skipped",
+      "reason": "excluded: wardite loads sqlite3-shell.wasm but cannot execute a query, raising Wardite::EvalError (\"maybe empty or invalid stack\", convert.generated.rb:200) as soon as any SQL runs"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wardite-yjit",
+      "status": "skipped",
+      "reason": "excluded: wardite loads sqlite3-shell.wasm but cannot execute a query, raising Wardite::EvalError (\"maybe empty or invalid stack\", convert.generated.rb:200) as soon as any SQL runs"
+    }
+  ]
+}

--- a/records/2026-08-16T09-23-36Z-size.json
+++ b/records/2026-08-16T09-23-36Z-size.json
@@ -1,0 +1,238 @@
+{
+  "schema": 1,
+  "generated_at": "2026-08-16T09:23:36Z",
+  "host": {
+    "os": "macOS 26.5.2",
+    "arch": "aarch64",
+    "kernel": "Darwin 25.5.0",
+    "cpu": "Apple M1 Pro"
+  },
+  "runtimes": [
+    {
+      "runtime": "wasmtime",
+      "version": "wasmtime 47.0.3 (5554cc1a6 2026-07-31)",
+      "components": [
+        {
+          "path": "/opt/homebrew/Cellar/wasmtime/47.0.3/bin/wasmtime",
+          "bytes": 48083168
+        }
+      ],
+      "status": "ok",
+      "bytes": 48083168
+    },
+    {
+      "runtime": "wasmer",
+      "version": "wasmer 7.2.1",
+      "components": [
+        {
+          "path": "/opt/homebrew/Cellar/wasmer/7.2.1/bin/wasmer",
+          "bytes": 53396944
+        }
+      ],
+      "status": "ok",
+      "bytes": 53396944
+    },
+    {
+      "runtime": "wasmedge",
+      "version": "wasmedge version 0.17.1",
+      "components": [
+        {
+          "path": "/opt/homebrew/Cellar/wasmedge/0.17.1/bin/wasmedge",
+          "bytes": 33600
+        },
+        {
+          "path": "/opt/homebrew/Cellar/wasmedge/0.17.1/lib/libwasmedge.0.1.1.dylib",
+          "bytes": 2380464
+        }
+      ],
+      "status": "ok",
+      "bytes": 2414064
+    },
+    {
+      "runtime": "wazero",
+      "version": "1.12.0",
+      "components": [
+        {
+          "path": "/opt/homebrew/Cellar/wazero/1.12.0/bin/wazero",
+          "bytes": 5502034
+        }
+      ],
+      "status": "ok",
+      "bytes": 5502034
+    },
+    {
+      "runtime": "wasm3",
+      "version": "Wasm3 v0.5.0 on arm64-v8a",
+      "components": [
+        {
+          "path": "/opt/homebrew/Cellar/wasm3/0.5.0/bin/wasm3",
+          "bytes": 174832
+        }
+      ],
+      "status": "ok",
+      "bytes": 174832
+    }
+  ],
+  "apps": [
+    {
+      "app": "cowsay",
+      "file": "cowsay.wasm",
+      "wasm": {
+        "status": "ok",
+        "bytes": 771979
+      },
+      "targets": [
+        {
+          "target": "ruby",
+          "status": "ok",
+          "bytes": 1913288
+        },
+        {
+          "target": "python",
+          "status": "ok",
+          "bytes": 1829789
+        },
+        {
+          "target": "perl",
+          "status": "ok",
+          "bytes": 2551269
+        },
+        {
+          "target": "bash",
+          "status": "ok",
+          "bytes": 7728646
+        },
+        {
+          "target": "go",
+          "status": "ok",
+          "bytes": 2375072
+        },
+        {
+          "target": "java",
+          "status": "ok",
+          "bytes": 3052569
+        }
+      ]
+    },
+    {
+      "app": "sqlite3-shell",
+      "file": "sqlite3-shell.wasm",
+      "wasm": {
+        "status": "ok",
+        "bytes": 1306769
+      },
+      "targets": [
+        {
+          "target": "ruby",
+          "status": "ok",
+          "bytes": 7242414
+        },
+        {
+          "target": "python",
+          "status": "ok",
+          "bytes": 7699506
+        },
+        {
+          "target": "perl",
+          "status": "ok",
+          "bytes": 12884113
+        },
+        {
+          "target": "bash",
+          "status": "ok",
+          "bytes": 37625765
+        },
+        {
+          "target": "go",
+          "status": "ok",
+          "bytes": 12599372
+        },
+        {
+          "target": "java",
+          "status": "ok",
+          "bytes": 13456182
+        }
+      ]
+    },
+    {
+      "app": "qjs",
+      "file": "qjs.wasm",
+      "wasm": {
+        "status": "ok",
+        "bytes": 1537571
+      },
+      "targets": [
+        {
+          "target": "ruby",
+          "status": "ok",
+          "bytes": 6581532
+        },
+        {
+          "target": "python",
+          "status": "ok",
+          "bytes": 6560599
+        },
+        {
+          "target": "perl",
+          "status": "ok",
+          "bytes": 10481604
+        },
+        {
+          "target": "bash",
+          "status": "ok",
+          "bytes": 26967241
+        },
+        {
+          "target": "go",
+          "status": "ok",
+          "bytes": 10335465
+        },
+        {
+          "target": "java",
+          "status": "ok",
+          "bytes": 10653208
+        }
+      ]
+    },
+    {
+      "app": "ruby",
+      "file": "ruby.wasm",
+      "wasm": {
+        "status": "ok",
+        "bytes": 35028911
+      },
+      "targets": [
+        {
+          "target": "ruby",
+          "status": "ok",
+          "bytes": 66853856
+        },
+        {
+          "target": "python",
+          "status": "ok",
+          "bytes": 77089036
+        },
+        {
+          "target": "perl",
+          "status": "ok",
+          "bytes": 134792876
+        },
+        {
+          "target": "bash",
+          "status": "ok",
+          "bytes": 310734965
+        },
+        {
+          "target": "go",
+          "status": "ok",
+          "bytes": 130493245
+        },
+        {
+          "target": "java",
+          "status": "ok",
+          "bytes": 143356093
+        }
+      ]
+    }
+  ]
+}

--- a/records/README.md
+++ b/records/README.md
@@ -12,6 +12,7 @@ A run appends its line with a `TODO`; fill it in when committing the record.
 - `2026-08-02T02-41-22Z-speed.json`: the first record, with the suite that introduced it (#106).
 - `2026-08-03T16-23-15Z-speed.json`: value-addressed branches and the halved generated source (#113).
 - `2026-08-11T18-25-24Z-speed.json`: re-baseline after #176, #167/#168, and #195's unit-comment rewrites.
+- `2026-08-16T09-22-02Z-speed.json`: re-baseline after the issue #164 mask elision and memory-unit rework (#224 to #245).
 
 ## Size records
 
@@ -19,3 +20,4 @@ A run appends its line with a `TODO`; fill it in when committing the record.
 - `2026-08-06T03-52-05Z-size.json`: the generated-source shrink (#167).
 - `2026-08-06T04-31-17Z-size.json`: Ruby parenthesis elision (#168).
 - `2026-08-11T18-27-09Z-size.json`: re-baseline beside the same day's speed record.
+- `2026-08-16T09-23-36Z-size.json`: the issue #164 reductions measured: every Ruby and Python output shrinks (sqlite3-shell 7.94 to 7.24 MB).


### PR DESCRIPTION
The issue #164 work (mask elision, offset-argument and reduced-operand memory units, one-character unit names) changed every Ruby and Python output, so both suites were re-measured; this commits the two records, fills their index lines in records/README.md, and refreshes the rendered documents.

Size results shrink across the suite for the reworked backends, for example (from docs/sizes/results.md):

| artifact | before | after |
| --- | --- | --- |
| cowsay, ruby | 2.11 MB | 1.91 MB |
| sqlite3-shell, ruby | 7.94 MB | 7.24 MB |
| sqlite3-shell, python | 8.40 MB | 7.70 MB |
| qjs, ruby | 7.09 MB | 6.58 MB |

The speed record also picks up the runtime updates since the previous record (Python 3.14.7, the pywasm-cpython and wardite rows), so per-benchmark speed deltas mix the two causes; the record exists as the dated baseline, not as an isolated #164 measurement.