### PR TITLE
Seed each loop's liveness fixpoint from its last convergence

### DIFF
--- a/crates/dewasm-backend/src/extract.rs
+++ b/crates/dewasm-backend/src/extract.rs
@@ -743,6 +743,8 @@ struct Liveness {
     labels: BTreeMap<u32, BTreeSet<Var>>,
     /// Union of the live sets at the catch targets of enclosing try_tables: what an exception thrown here may expose.
     catch_live: BTreeSet<Var>,
+    /// Converged head set of every loop analyzed so far, keyed by its label id, which is unique within one function.
+    loop_heads: BTreeMap<u32, BTreeSet<Var>>,
     boundaries: BTreeMap<usize, Vec<BTreeSet<Var>>>,
 }
 
@@ -751,6 +753,7 @@ impl Liveness {
         let mut lv = Liveness {
             labels: BTreeMap::new(),
             catch_live: BTreeSet::new(),
+            loop_heads: BTreeMap::new(),
             boundaries: BTreeMap::new(),
         };
         lv.seq(&func.body, BTreeSet::new(), false);
@@ -856,7 +859,8 @@ impl Liveness {
             }
             Stmt::Loop { label, body } => {
                 // Fixpoint on the live set at the loop head: a back edge re-enters the body, and falling off its end exits the loop.
-                let mut head = BTreeSet::new();
+                // An enclosing loop re-enters this one with inputs that only grow, and the transfer functions are monotone, so the previous convergence is at or below the new least fixpoint and iterating from it reaches that same least fixpoint. Starting over from the empty set costs one full fixpoint per entry, which doubles the body passes per nesting level.
+                let mut head = self.loop_heads.get(&label.id).cloned().unwrap_or_default();
                 loop {
                     self.labels.insert(label.id, head.clone());
                     let new_head = self.seq(body, live.clone(), true);
@@ -866,6 +870,7 @@ impl Liveness {
                     head = new_head;
                 }
                 self.labels.remove(&label.id);
+                self.loop_heads.insert(label.id, head.clone());
                 head
             }
             Stmt::If {


### PR DESCRIPTION
Fixes #258.

The extraction pass's liveness analysis restarted every nested loop's fixpoint from the empty set on each re-entry, and each fixpoint pays one extra confirming pass, so body passes doubled per nesting level.
QuickJS's interpreter dispatch function nests loops 21 deep, so converting qjs.wasm ran 4.19M body passes: 34 s in release, 539 s in the dev profile the test suite uses, four times per Ruby CI run.
That is what moved CI from about 5.5 min to 10-12 min.

The fix seeds each loop's fixpoint with its previously converged head set.
Liveness transfer functions are monotone and every input to a nested loop only grows between re-entries, so the seed is at or below the new least fixpoint and iteration reaches the same least fixpoint; only intermediate iterations are skipped.
`fuse` and `licm` were measured at 1 to 20 ms per app and are untouched.

Measurements (release conversion, seconds):

| app | before | after |
| --- | --- | --- |
| qjs | 34.4 | 0.23 |
| zeroperl | 1.9 | 1.3 |
| ruby-min | 2.6 | 2.4 |
| ruby | 2.3 | 2.3 |
| cpython | 0.9 | 0.9 |

The dev-profile `cargo test -p dewasm-backend-ruby --test convert qjs` drops from 539 s to 1.5 s.

Verification: converting all 20 cached apps before and after gives byte-identical output; `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and full `cargo test` pass.