### PR TITLE
Mask before shifting in the i64 rotate units

### DIFF
--- a/runtime/ruby/units/rt/i32_rotl.rb
+++ b/runtime/ruby/units/rt/i32_rotl.rb
@@ -1,4 +1,5 @@
+# The left shift can leave MRI's fixnum range; masking it before the OR confines the bignum to that one operand.
 def i32_rotl(a, b)
   r = b & 31
-  ((a << r) | (a >> (32 - r))) & M32
+  ((a << r) & M32) | (a >> (32 - r))
 end

--- a/runtime/ruby/units/rt/i32_rotr.rb
+++ b/runtime/ruby/units/rt/i32_rotr.rb
@@ -1,4 +1,5 @@
+# The left shift can leave MRI's fixnum range; masking it before the OR confines the bignum to that one operand.
 def i32_rotr(a, b)
   r = b & 31
-  ((a >> r) | (a << (32 - r))) & M32
+  (a >> r) | ((a << (32 - r)) & M32)
 end

--- a/runtime/ruby/units/rt/i64_rotl.rb
+++ b/runtime/ruby/units/rt/i64_rotl.rb
@@ -1,5 +1,5 @@
-# requires: rt/m64
+# requires: rt/low_mask
 def i64_rotl(a, b)
   r = b & 63
-  m64((a << r) | (a >> (64 - r)))
+  ((a & LOW_MASK[64 - r]) << r) | (a >> (64 - r))
 end

--- a/runtime/ruby/units/rt/i64_rotr.rb
+++ b/runtime/ruby/units/rt/i64_rotr.rb
@@ -1,5 +1,5 @@
-# requires: rt/m64
+# requires: rt/low_mask
 def i64_rotr(a, b)
   r = b & 63
-  m64((a >> r) | (a << (64 - r)))
+  (a >> r) | ((a & LOW_MASK[r]) << (64 - r))
 end

--- a/runtime/ruby/units/rt/low_mask.rb
+++ b/runtime/ruby/units/rt/low_mask.rb
@@ -1,0 +1,3 @@
+# Masking a left-shift operand with LOW_MASK[width - shift] before the shift keeps the intermediate within the wasm width, so MRI never allocates a bignum wider than the result.
+# Kept out of the always-bundled rt/_module prelude so a module without rotates does not build the table.
+LOW_MASK = Array.new(65) { |n| (1 << n) - 1 }


### PR DESCRIPTION
`i64.rotl` and `i64.rotr` built an intermediate of up to 127 bits and masked it afterwards, so a rotate of a value with high bits set allocated several bignums beyond the unavoidable one for the result.
Masking the left shift's operand first keeps every intermediate within 64 bits.

Rotates are hot in converted Rust binaries because std HashMap's SipHash is built from them.
The measurements motivating #260: 387k rotate calls per sghtmltopdf receipt render, where this rewrite removed about 250k of the 3.66M objects allocated per render and about 1.5% of wall time, and 8% of the allocations on dewasm-merman's flowchart render.

## The mask table

`LOW_MASK[n]` keeps the low n bits, so `i64_rotl` masks with `LOW_MASK[64 - r]` and `i64_rotr` with `LOW_MASK[r]`.
It sits in its own unit rather than in the `rt/_module` prelude, so a module without rotates does not build the table.
Computing the mask per call as `M64 >> r` instead was measured too: it allocates more than the code it replaces, because shifting the bignum `M64` allocates on its own.

## Micro benchmark

A `.wat` loop of 3M iterations with 4 rotates each (2 at a constant count, 2 at a count varying with the induction variable) over values with the high bits set, converted with `--mode standalone` and run under ruby 4.0.4 (arm64-darwin25).
`alloc` is the `GC.stat[:total_allocated_objects]` delta of the whole run, `wall` the median of 3 runs.
The old and the new artifact produce byte-identical output in every row below.

12M i64 rotates:

| i64 unit shape | alloc | wall |
| --- | --- | --- |
| mask after the shift (before this PR) | 54,914,266 | 4.28 s |
| mask before the shift, `LOW_MASK` table (this PR) | 49,027,427 | 3.11 s |

The two variants that lost out were measured in a plain Ruby stand-in for the same loop, whose baseline is 54,913,133 objects / 4.53 s.
Computing `M64 >> r` per call gives 60,979,377 / 3.81 s.
Adding an early return for `r == 0` on top of the table gives 48,838,597 / 3.44 s, so the early return costs wall time for the allocations it saves and is not in this PR.

12M i32 rotates, at two rotate-count patterns: A is counts 13 and 29 plus a varying count (the intermediate rarely leaves fixnum range), B is counts 30 and 31 (it leaves on every call).

| i32 unit shape | A alloc | A wall | B alloc | B wall |
| --- | --- | --- | --- | --- |
| mask after the OR (before this PR) | 540,184 | 0.823 s | 5,040,763 | 0.999 s |
| mask before the shift, `LOW_MASK` table | 1,151 | 0.862 s | 1,151 | 0.868 s |
| mask after the left shift (this PR) | 376,101 | 0.817 s | 3,376,525 | 0.943 s |

So the i64 pattern does not carry over to i32: the table removes every allocation but costs 5% of wall time at pattern A, and A is where real i32 rotate code sits, since the old i32 shape leaves fixnum range only at rotl count 31 and rotr counts 0 and 1.
Masking straight after the left shift is neutral or better on both numbers at every count, so that is what the i32 units do now.

## Real app

Converted ripgrep 14.1.1 (`cache/rg.wasm`, a Rust binary, so SipHash) searching a 2 MB source tree: 289,383 to 292,471 allocated objects before, 275,765 to 282,814 after (3 runs each), identical output, wall time unchanged within noise.
That case is dominated by startup and directory walking, so it is a lower bound on the effect rather than a display of it.

## Verification

- The four unit bodies were checked against a reference rotate over counts 0..70 (plus `M64`, `M64 - 1` and `1 << 40` as i64 counts) for the boundary values of each width and 200 random values per width: every case matches.
- `cargo test -p dewasm-backend-ruby --test spec i64` and `... --test spec i32` pass, and a deliberately broken `i64_rotl` was confirmed to fail the `i64` trial, so the trial does exercise these units.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` and `cargo test` all pass.

Closes #260.
