### PR TITLE
Shorten the benchmark suite and broaden the wat microbenchmarks

### DIFF
--- a/benchmarks/wat/br_table.wat
+++ b/benchmarks/wat/br_table.wat
@@ -1,7 +1,7 @@
-;; mem_rw: i32 store/load over linear memory.
+;; br_table: a 16-arm branch table.
 ;;
-;; One iteration reads one i32 and writes one i32 at a pseudo-random offset in a 256 KiB window, so the address stream defeats any locality the backend's memory representation might otherwise get for free.
-;; Against i32_alu this separates memory-access cost from arithmetic cost.
+;; The index is derived from a pseudo-random sequence, so no runtime can predict the arm, and each arm applies a different ordered pair of operators with constants no other arm uses, so the table cannot be folded back into arithmetic.
+;; Against i32_alu, whose body is straight-line arithmetic of comparable size, the difference is what the dispatch costs.
 ;;
 ;; ---------------------------------------------------------------------------
 ;; Shared preamble.
@@ -37,7 +37,7 @@
   (import "wasi_snapshot_preview1" "proc_exit"
     (func $proc_exit (param i32)))
 
-  (memory (export "memory") 8)
+  (memory (export "memory") 2)
 
   (data (i32.const 0x1800) "usage: <module> <iterations>\n")
 
@@ -97,21 +97,89 @@
       (i32.const 1) (i32.const 0x1400) (i32.const 1) (i32.const 0x1408))))
 
   (func (export "_start")
-    (local $n i32) (local $i i32) (local $h i32) (local $a i32) (local $p i32)
+    (local $n i32) (local $i i32) (local $h i32) (local $k i32) (local $a i32)
     (local.set $n (call $iterations))
     (local.set $h (i32.const 0x12345678))
+    (local.set $a (i32.const 1))
     (block $done
       (loop $next
         (br_if $done (i32.ge_u (local.get $i) (local.get $n)))
         (local.set $h
           (i32.add (i32.mul (local.get $h) (i32.const 1664525))
                    (i32.const 1013904223)))
-        ;; 0x3fffc keeps the offset i32-aligned inside the 256 KiB window that starts one page in, clear of the preamble's scratch area.
-        (local.set $p
-          (i32.add (i32.const 0x10000)
-                   (i32.and (local.get $h) (i32.const 0x3fffc))))
-        (local.set $a (i32.add (local.get $a) (i32.load (local.get $p))))
-        (i32.store (local.get $p) (i32.xor (local.get $a) (local.get $i)))
+        (local.set $k
+          (i32.and (i32.shr_u (local.get $h) (i32.const 12)) (i32.const 15)))
+        (block $sw
+          (block $c0 (block $c1 (block $c2 (block $c3
+          (block $c4 (block $c5 (block $c6 (block $c7
+          (block $c8 (block $c9 (block $c10 (block $c11
+          (block $c12 (block $c13 (block $c14 (block $c15
+            ;; $k is masked to 0..15, so the default target is never taken.
+            (br_table $c0 $c1 $c2 $c3 $c4 $c5 $c6 $c7 $c8 $c9 $c10 $c11 $c12 $c13 $c14 $c15 $c0 (local.get $k)))
+          ;; $c15
+          (local.set $a (i32.mul (local.get $a) (i32.const 0x28b7bd67)))
+          (local.set $a (i32.mul (local.get $a) (i32.const 0xbd794d61)))
+          (br $sw))
+          ;; $c14
+          (local.set $a (i32.mul (local.get $a) (i32.const 0xec48c9f5)))
+          (local.set $a (i32.sub (local.get $a) (i32.const 0xb1a1b88b)))
+          (br $sw))
+          ;; $c13
+          (local.set $a (i32.mul (local.get $a) (i32.const 0xafd9d683)))
+          (local.set $a (i32.xor (local.get $a) (i32.const 0xa5ca23b5)))
+          (br $sw))
+          ;; $c12
+          (local.set $a (i32.mul (local.get $a) (i32.const 0x736ae311)))
+          (local.set $a (i32.add (local.get $a) (i32.const 0x99f28edf)))
+          (br $sw))
+          ;; $c11
+          (local.set $a (i32.sub (local.get $a) (i32.const 0x36fbef9f)))
+          (local.set $a (i32.mul (local.get $a) (i32.const 0x8e1afa09)))
+          (br $sw))
+          ;; $c10
+          (local.set $a (i32.sub (local.get $a) (i32.const 0xfa8cfc2d)))
+          (local.set $a (i32.sub (local.get $a) (i32.const 0x82436533)))
+          (br $sw))
+          ;; $c9
+          (local.set $a (i32.sub (local.get $a) (i32.const 0xbe1e08bb)))
+          (local.set $a (i32.xor (local.get $a) (i32.const 0x766bd05d)))
+          (br $sw))
+          ;; $c8
+          (local.set $a (i32.sub (local.get $a) (i32.const 0x81af1549)))
+          (local.set $a (i32.add (local.get $a) (i32.const 0x6a943b87)))
+          (br $sw))
+          ;; $c7
+          (local.set $a (i32.xor (local.get $a) (i32.const 0x454021d7)))
+          (local.set $a (i32.mul (local.get $a) (i32.const 0x5ebca6b1)))
+          (br $sw))
+          ;; $c6
+          (local.set $a (i32.xor (local.get $a) (i32.const 0x08d12e65)))
+          (local.set $a (i32.sub (local.get $a) (i32.const 0x52e511db)))
+          (br $sw))
+          ;; $c5
+          (local.set $a (i32.xor (local.get $a) (i32.const 0xcc623af3)))
+          (local.set $a (i32.xor (local.get $a) (i32.const 0x470d7d05)))
+          (br $sw))
+          ;; $c4
+          (local.set $a (i32.xor (local.get $a) (i32.const 0x8ff34781)))
+          (local.set $a (i32.add (local.get $a) (i32.const 0x3b35e82f)))
+          (br $sw))
+          ;; $c3
+          (local.set $a (i32.add (local.get $a) (i32.const 0x5384540f)))
+          (local.set $a (i32.mul (local.get $a) (i32.const 0x2f5e5359)))
+          (br $sw))
+          ;; $c2
+          (local.set $a (i32.add (local.get $a) (i32.const 0x1715609d)))
+          (local.set $a (i32.sub (local.get $a) (i32.const 0x2386be83)))
+          (br $sw))
+          ;; $c1
+          (local.set $a (i32.add (local.get $a) (i32.const 0xdaa66d2b)))
+          (local.set $a (i32.xor (local.get $a) (i32.const 0x17af29ad)))
+          (br $sw))
+          ;; $c0
+          (local.set $a (i32.add (local.get $a) (i32.const 0x9e3779b9)))
+          (local.set $a (i32.add (local.get $a) (i32.const 0x0bd794d7)))
+          (br $sw))
         (local.set $i (i32.add (local.get $i) (i32.const 1)))
         (br $next)))
     (call $print (i64.extend_i32_u (local.get $a))))

--- a/benchmarks/wat/build.sh
+++ b/benchmarks/wat/build.sh
@@ -23,6 +23,10 @@ require_tool wat2wasm "install wabt (brew install wabt / apt install wabt)"
 
 for src in wat/*.wat; do
   id=$(basename "$src" .wat)
-  wat2wasm "$src" -o "cache/wat/$id.wasm"
+  # eh_throw and eh_try are the only cases allowed past wasm 1.0, so the exception-handling proposal is enabled for them alone: any other case that reaches for a post-1.0 instruction fails to assemble here.
+  case "$id" in
+    eh_*) wat2wasm --enable-exceptions "$src" -o "cache/wat/$id.wasm" ;;
+    *) wat2wasm "$src" -o "cache/wat/$id.wasm" ;;
+  esac
   echo "$id: $src -> cache/wat/$id.wasm"
 done

--- a/benchmarks/wat/call_direct.wat
+++ b/benchmarks/wat/call_direct.wat
@@ -12,7 +12,8 @@
 ;; A microbenchmark is a WASI command module invoked as `<module> <iterations>`.
 ;; It does
 ;; <iterations> units of work, writes exactly one line (the decimal result followed by a newline) to stdout, and exits 0. <iterations> = 0 does no work but still prints, which is how the harness measures startup in isolation.
-;; Only args_sizes_get / args_get / fd_write / proc_exit are imported and the bodies stick to i32/i64/f64, because the pure-Ruby and pure-Python interpreters this suite compares cannot do more than that.
+;; Only args_sizes_get / args_get / fd_write / proc_exit are imported, and a body stays inside i32/i64/f64 except for the one axis its case exists to measure: f32 in f32_alu, exception handling in eh_throw and eh_try.
+;; That keeps every other case within reach of the pure-Ruby and pure-Python interpreters this suite compares, and a runner that cannot execute a case's axis is excluded for that case in the harness workload table, with the reason stated there.
 ;;
 ;; Memory map, shared by every microbenchmark.
 ;; It starts at 0x1000 rather than at 0 because wasm3 traps with "out of bounds memory access" whenever a WASI out param is written to linear-memory address 0: address 0 is perfectly valid linear memory and every other runtime in the matrix accepts it, so the whole block is simply moved up out of wasm3's way:

--- a/benchmarks/wat/call_indirect.wat
+++ b/benchmarks/wat/call_indirect.wat
@@ -13,7 +13,8 @@
 ;; A microbenchmark is a WASI command module invoked as `<module> <iterations>`.
 ;; It does
 ;; <iterations> units of work, writes exactly one line (the decimal result followed by a newline) to stdout, and exits 0. <iterations> = 0 does no work but still prints, which is how the harness measures startup in isolation.
-;; Only args_sizes_get / args_get / fd_write / proc_exit are imported and the bodies stick to i32/i64/f64, because the pure-Ruby and pure-Python interpreters this suite compares cannot do more than that.
+;; Only args_sizes_get / args_get / fd_write / proc_exit are imported, and a body stays inside i32/i64/f64 except for the one axis its case exists to measure: f32 in f32_alu, exception handling in eh_throw and eh_try.
+;; That keeps every other case within reach of the pure-Ruby and pure-Python interpreters this suite compares, and a runner that cannot execute a case's axis is excluded for that case in the harness workload table, with the reason stated there.
 ;;
 ;; Memory map, shared by every microbenchmark.
 ;; It starts at 0x1000 rather than at 0 because wasm3 traps with "out of bounds memory access" whenever a WASI out param is written to linear-memory address 0: address 0 is perfectly valid linear memory and every other runtime in the matrix accepts it, so the whole block is simply moved up out of wasm3's way:

--- a/benchmarks/wat/conv.wat
+++ b/benchmarks/wat/conv.wat
@@ -1,7 +1,9 @@
-;; mem_rw: i32 store/load over linear memory.
+;; conv: conversions between f64, i32 and i64.
 ;;
-;; One iteration reads one i32 and writes one i32 at a pseudo-random offset in a 256 KiB window, so the address stream defeats any locality the backend's memory representation might otherwise get for free.
-;; Against i32_alu this separates memory-access cost from arithmetic cost.
+;; One iteration truncates a double to i32 and to i64, converts integers back to double in both signednesses, and moves a value through i64.reinterpret_f64 and f64.reinterpret_i64.
+;; The backends implement these as runtime helpers rather than as host operators, which neither the arithmetic nor the memory cases exercise.
+;;
+;; Two constraints hold every value in range: each truncation input is built from a 24-bit integer, because an out-of-range truncation traps, and the only bits ever reinterpreted into f64 are mantissa bits of a value that came out of finite f64 arithmetic, because a NaN would not be comparable across runtimes (its payload bits differ).
 ;;
 ;; ---------------------------------------------------------------------------
 ;; Shared preamble.
@@ -37,7 +39,7 @@
   (import "wasi_snapshot_preview1" "proc_exit"
     (func $proc_exit (param i32)))
 
-  (memory (export "memory") 8)
+  (memory (export "memory") 2)
 
   (data (i32.const 0x1800) "usage: <module> <iterations>\n")
 
@@ -97,7 +99,8 @@
       (i32.const 1) (i32.const 0x1400) (i32.const 1) (i32.const 0x1408))))
 
   (func (export "_start")
-    (local $n i32) (local $i i32) (local $h i32) (local $a i32) (local $p i32)
+    (local $n i32) (local $i i32) (local $h i32)
+    (local $x f64) (local $y f64) (local $bits i64) (local $a i64)
     (local.set $n (call $iterations))
     (local.set $h (i32.const 0x12345678))
     (block $done
@@ -106,13 +109,28 @@
         (local.set $h
           (i32.add (i32.mul (local.get $h) (i32.const 1664525))
                    (i32.const 1013904223)))
-        ;; 0x3fffc keeps the offset i32-aligned inside the 256 KiB window that starts one page in, clear of the preamble's scratch area.
-        (local.set $p
-          (i32.add (i32.const 0x10000)
-                   (i32.and (local.get $h) (i32.const 0x3fffc))))
-        (local.set $a (i32.add (local.get $a) (i32.load (local.get $p))))
-        (i32.store (local.get $p) (i32.xor (local.get $a) (local.get $i)))
+        (local.set $x
+          (f64.add (f64.convert_i32_u (i32.shr_u (local.get $h) (i32.const 8)))
+                   (f64.const 1.5)))
+        (local.set $bits (i64.reinterpret_f64 (local.get $x)))
+        ;; The exponent field is left alone, so the value stays finite.
+        (local.set $bits (i64.xor (local.get $bits) (i64.const 0x3ff)))
+        (local.set $x (f64.reinterpret_i64 (local.get $bits)))
+        (local.set $a
+          (i64.add (local.get $a) (i64.trunc_f64_s (local.get $x))))
+        (local.set $a
+          (i64.xor (local.get $a)
+                   (i64.extend_i32_u
+                     (i32.trunc_f64_s
+                       (f64.mul (local.get $x) (f64.const -0.25))))))
+        (local.set $y
+          (f64.convert_i64_s
+            (i64.sub (i64.and (local.get $a) (i64.const 0xffffff))
+                     (i64.const 0x800000))))
+        (local.set $a
+          (i64.add (local.get $a)
+                   (i64.trunc_f64_s (f64.mul (local.get $y) (f64.const 1.25)))))
         (local.set $i (i32.add (local.get $i) (i32.const 1)))
         (br $next)))
-    (call $print (i64.extend_i32_u (local.get $a))))
+    (call $print (local.get $a)))
 )

--- a/benchmarks/wat/eh_throw.wat
+++ b/benchmarks/wat/eh_throw.wat
@@ -1,7 +1,7 @@
-;; mem_rw: i32 store/load over linear memory.
+;; eh_throw: one exception thrown and caught per iteration.
 ;;
-;; One iteration reads one i32 and writes one i32 at a pseudo-random offset in a 256 KiB window, so the address stream defeats any locality the backend's memory representation might otherwise get for free.
-;; Against i32_alu this separates memory-access cost from arithmetic cost.
+;; The callee throws a tag carrying one i32 and the loop catches it with try_table, so what is measured is a throw plus a catch on top of a direct call.
+;; eh_try runs the same loop with a callee that returns the value instead of throwing it, and prints the same number, so the difference between the two cases is the cost of the throw and the catch.
 ;;
 ;; ---------------------------------------------------------------------------
 ;; Shared preamble.
@@ -37,7 +37,7 @@
   (import "wasi_snapshot_preview1" "proc_exit"
     (func $proc_exit (param i32)))
 
-  (memory (export "memory") 8)
+  (memory (export "memory") 2)
 
   (data (i32.const 0x1800) "usage: <module> <iterations>\n")
 
@@ -96,8 +96,13 @@
     (drop (call $fd_write
       (i32.const 1) (i32.const 0x1400) (i32.const 1) (i32.const 0x1408))))
 
+  (tag $carry (param i32))
+
+  (func $raise (param $x i32)
+    (throw $carry (local.get $x)))
+
   (func (export "_start")
-    (local $n i32) (local $i i32) (local $h i32) (local $a i32) (local $p i32)
+    (local $n i32) (local $i i32) (local $h i32) (local $acc i32)
     (local.set $n (call $iterations))
     (local.set $h (i32.const 0x12345678))
     (block $done
@@ -106,13 +111,14 @@
         (local.set $h
           (i32.add (i32.mul (local.get $h) (i32.const 1664525))
                    (i32.const 1013904223)))
-        ;; 0x3fffc keeps the offset i32-aligned inside the 256 KiB window that starts one page in, clear of the preamble's scratch area.
-        (local.set $p
-          (i32.add (i32.const 0x10000)
-                   (i32.and (local.get $h) (i32.const 0x3fffc))))
-        (local.set $a (i32.add (local.get $a) (i32.load (local.get $p))))
-        (i32.store (local.get $p) (i32.xor (local.get $a) (local.get $i)))
+        (local.set $acc
+          (i32.add (local.get $acc)
+            (block $caught (result i32)
+              (try_table (catch $carry $caught)
+                (call $raise (local.get $h)))
+              ;; $raise never returns normally.
+              (unreachable))))
         (local.set $i (i32.add (local.get $i) (i32.const 1)))
         (br $next)))
-    (call $print (i64.extend_i32_u (local.get $a))))
+    (call $print (i64.extend_i32_u (local.get $acc))))
 )

--- a/benchmarks/wat/eh_try.wat
+++ b/benchmarks/wat/eh_try.wat
@@ -1,7 +1,7 @@
-;; mem_rw: i32 store/load over linear memory.
+;; eh_try: exception handling scaffolding with nothing thrown.
 ;;
-;; One iteration reads one i32 and writes one i32 at a pseudo-random offset in a 256 KiB window, so the address stream defeats any locality the backend's memory representation might otherwise get for free.
-;; Against i32_alu this separates memory-access cost from arithmetic cost.
+;; The eh_throw loop with a callee that returns its argument instead of throwing it, with the call still inside a try_table that has a catch arm.
+;; This is what the scaffolding costs on the path where no exception occurs; the two cases print the same number by construction.
 ;;
 ;; ---------------------------------------------------------------------------
 ;; Shared preamble.
@@ -37,7 +37,7 @@
   (import "wasi_snapshot_preview1" "proc_exit"
     (func $proc_exit (param i32)))
 
-  (memory (export "memory") 8)
+  (memory (export "memory") 2)
 
   (data (i32.const 0x1800) "usage: <module> <iterations>\n")
 
@@ -96,8 +96,13 @@
     (drop (call $fd_write
       (i32.const 1) (i32.const 0x1400) (i32.const 1) (i32.const 0x1408))))
 
+  (tag $carry (param i32))
+
+  (func $pass (param $x i32) (result i32)
+    (local.get $x))
+
   (func (export "_start")
-    (local $n i32) (local $i i32) (local $h i32) (local $a i32) (local $p i32)
+    (local $n i32) (local $i i32) (local $h i32) (local $acc i32)
     (local.set $n (call $iterations))
     (local.set $h (i32.const 0x12345678))
     (block $done
@@ -106,13 +111,12 @@
         (local.set $h
           (i32.add (i32.mul (local.get $h) (i32.const 1664525))
                    (i32.const 1013904223)))
-        ;; 0x3fffc keeps the offset i32-aligned inside the 256 KiB window that starts one page in, clear of the preamble's scratch area.
-        (local.set $p
-          (i32.add (i32.const 0x10000)
-                   (i32.and (local.get $h) (i32.const 0x3fffc))))
-        (local.set $a (i32.add (local.get $a) (i32.load (local.get $p))))
-        (i32.store (local.get $p) (i32.xor (local.get $a) (local.get $i)))
+        (local.set $acc
+          (i32.add (local.get $acc)
+            (block $caught (result i32)
+              (try_table (result i32) (catch $carry $caught)
+                (call $pass (local.get $h))))))
         (local.set $i (i32.add (local.get $i) (i32.const 1)))
         (br $next)))
-    (call $print (i64.extend_i32_u (local.get $a))))
+    (call $print (i64.extend_i32_u (local.get $acc))))
 )

--- a/benchmarks/wat/f32_alu.wat
+++ b/benchmarks/wat/f32_alu.wat
@@ -1,7 +1,8 @@
-;; mem_rw: i32 store/load over linear memory.
+;; f32_alu: f32 add / mul / sqrt in a tight loop.
 ;;
-;; One iteration reads one i32 and writes one i32 at a pseudo-random offset in a 256 KiB window, so the address stream defeats any locality the backend's memory representation might otherwise get for free.
-;; Against i32_alu this separates memory-access cost from arithmetic cost.
+;; The f64_alu body in single precision with the same constants, so the difference between the two cases is the cost of re-rounding every result to f32.
+;; The printed number is the accumulator's bit pattern rather than a scaled integer, so a backend that carries the intermediates in double precision fails the harness's byte comparison instead of reporting a fast wrong number.
+;; Each accumulator stops growing once its ulp exceeds what is added to it, near 2^24 and 2^37, so no iteration count reaches infinity or NaN.
 ;;
 ;; ---------------------------------------------------------------------------
 ;; Shared preamble.
@@ -37,7 +38,7 @@
   (import "wasi_snapshot_preview1" "proc_exit"
     (func $proc_exit (param i32)))
 
-  (memory (export "memory") 8)
+  (memory (export "memory") 2)
 
   (data (i32.const 0x1800) "usage: <module> <iterations>\n")
 
@@ -97,22 +98,16 @@
       (i32.const 1) (i32.const 0x1400) (i32.const 1) (i32.const 0x1408))))
 
   (func (export "_start")
-    (local $n i32) (local $i i32) (local $h i32) (local $a i32) (local $p i32)
+    (local $n i32) (local $i i32) (local $a f32) (local $b f32)
     (local.set $n (call $iterations))
-    (local.set $h (i32.const 0x12345678))
     (block $done
       (loop $next
         (br_if $done (i32.ge_u (local.get $i) (local.get $n)))
-        (local.set $h
-          (i32.add (i32.mul (local.get $h) (i32.const 1664525))
-                   (i32.const 1013904223)))
-        ;; 0x3fffc keeps the offset i32-aligned inside the 256 KiB window that starts one page in, clear of the preamble's scratch area.
-        (local.set $p
-          (i32.add (i32.const 0x10000)
-                   (i32.and (local.get $h) (i32.const 0x3fffc))))
-        (local.set $a (i32.add (local.get $a) (i32.load (local.get $p))))
-        (i32.store (local.get $p) (i32.xor (local.get $a) (local.get $i)))
+        (local.set $a (f32.add (local.get $a) (f32.const 1)))
+        (local.set $b
+          (f32.add (local.get $b)
+                   (f32.mul (f32.sqrt (local.get $a)) (f32.const 1.5))))
         (local.set $i (i32.add (local.get $i) (i32.const 1)))
         (br $next)))
-    (call $print (i64.extend_i32_u (local.get $a))))
+    (call $print (i64.extend_i32_u (i32.reinterpret_f32 (local.get $b)))))
 )

--- a/benchmarks/wat/f64_alu.wat
+++ b/benchmarks/wat/f64_alu.wat
@@ -13,7 +13,8 @@
 ;; A microbenchmark is a WASI command module invoked as `<module> <iterations>`.
 ;; It does
 ;; <iterations> units of work, writes exactly one line (the decimal result followed by a newline) to stdout, and exits 0. <iterations> = 0 does no work but still prints, which is how the harness measures startup in isolation.
-;; Only args_sizes_get / args_get / fd_write / proc_exit are imported and the bodies stick to i32/i64/f64, because the pure-Ruby and pure-Python interpreters this suite compares cannot do more than that.
+;; Only args_sizes_get / args_get / fd_write / proc_exit are imported, and a body stays inside i32/i64/f64 except for the one axis its case exists to measure: f32 in f32_alu, exception handling in eh_throw and eh_try.
+;; That keeps every other case within reach of the pure-Ruby and pure-Python interpreters this suite compares, and a runner that cannot execute a case's axis is excluded for that case in the harness workload table, with the reason stated there.
 ;;
 ;; Memory map, shared by every microbenchmark.
 ;; It starts at 0x1000 rather than at 0 because wasm3 traps with "out of bounds memory access" whenever a WASI out param is written to linear-memory address 0: address 0 is perfectly valid linear memory and every other runtime in the matrix accepts it, so the whole block is simply moved up out of wasm3's way:

--- a/benchmarks/wat/i32_alu.wat
+++ b/benchmarks/wat/i32_alu.wat
@@ -10,7 +10,8 @@
 ;; A microbenchmark is a WASI command module invoked as `<module> <iterations>`.
 ;; It does
 ;; <iterations> units of work, writes exactly one line (the decimal result followed by a newline) to stdout, and exits 0. <iterations> = 0 does no work but still prints, which is how the harness measures startup in isolation.
-;; Only args_sizes_get / args_get / fd_write / proc_exit are imported and the bodies stick to i32/i64/f64, because the pure-Ruby and pure-Python interpreters this suite compares cannot do more than that.
+;; Only args_sizes_get / args_get / fd_write / proc_exit are imported, and a body stays inside i32/i64/f64 except for the one axis its case exists to measure: f32 in f32_alu, exception handling in eh_throw and eh_try.
+;; That keeps every other case within reach of the pure-Ruby and pure-Python interpreters this suite compares, and a runner that cannot execute a case's axis is excluded for that case in the harness workload table, with the reason stated there.
 ;;
 ;; Memory map, shared by every microbenchmark.
 ;; It starts at 0x1000 rather than at 0 because wasm3 traps with "out of bounds memory access" whenever a WASI out param is written to linear-memory address 0: address 0 is perfectly valid linear memory and every other runtime in the matrix accepts it, so the whole block is simply moved up out of wasm3's way:

--- a/benchmarks/wat/i32_div.wat
+++ b/benchmarks/wat/i32_div.wat
@@ -1,7 +1,10 @@
-;; mem_rw: i32 store/load over linear memory.
+;; i32_div: i32 division and remainder, signed and unsigned.
 ;;
-;; One iteration reads one i32 and writes one i32 at a pseudo-random offset in a 256 KiB window, so the address stream defeats any locality the backend's memory representation might otherwise get for free.
-;; Against i32_alu this separates memory-access cost from arithmetic cost.
+;; wasm truncates integer division toward zero and keeps the signed and the unsigned forms apart, which several of the host languages do not, so each of these four instructions carries a correction in the generated code.
+;; i32_alu covers the integer instructions that need no such correction, and the difference between the two cases is what the correction costs.
+;; Every divisor is `(x & 0xffff) | 3`, which is at least 3, and that covers two requirements at once.
+;; Nothing traps: division by zero and the INT_MIN / -1 overflow are both out of reach.
+;; No unsigned quotient reaches 2^31: pywasm 2.2.3 stores an i32.div_u result as a signed value and raises OverflowError above that point, and this case is here to measure division, not to reproduce that bug.
 ;;
 ;; ---------------------------------------------------------------------------
 ;; Shared preamble.
@@ -37,7 +40,7 @@
   (import "wasi_snapshot_preview1" "proc_exit"
     (func $proc_exit (param i32)))
 
-  (memory (export "memory") 8)
+  (memory (export "memory") 2)
 
   (data (i32.const 0x1800) "usage: <module> <iterations>\n")
 
@@ -97,7 +100,7 @@
       (i32.const 1) (i32.const 0x1400) (i32.const 1) (i32.const 0x1408))))
 
   (func (export "_start")
-    (local $n i32) (local $i i32) (local $h i32) (local $a i32) (local $p i32)
+    (local $n i32) (local $i i32) (local $h i32) (local $d i32) (local $a i32)
     (local.set $n (call $iterations))
     (local.set $h (i32.const 0x12345678))
     (block $done
@@ -106,12 +109,21 @@
         (local.set $h
           (i32.add (i32.mul (local.get $h) (i32.const 1664525))
                    (i32.const 1013904223)))
-        ;; 0x3fffc keeps the offset i32-aligned inside the 256 KiB window that starts one page in, clear of the preamble's scratch area.
-        (local.set $p
-          (i32.add (i32.const 0x10000)
-                   (i32.and (local.get $h) (i32.const 0x3fffc))))
-        (local.set $a (i32.add (local.get $a) (i32.load (local.get $p))))
-        (i32.store (local.get $p) (i32.xor (local.get $a) (local.get $i)))
+        (local.set $d
+          (i32.or (i32.and (local.get $h) (i32.const 0xffff)) (i32.const 3)))
+        (local.set $a
+          (i32.add (local.get $a)
+                   (i32.div_s (local.get $h) (local.get $d))))
+        (local.set $a
+          (i32.xor (local.get $a)
+                   (i32.div_u (local.get $a) (local.get $d))))
+        (local.set $a
+          (i32.add (local.get $a)
+                   (i32.rem_s (local.get $h) (local.get $d))))
+        (local.set $a
+          (i32.sub (local.get $a)
+                   (i32.rem_u (i32.xor (local.get $h) (local.get $a))
+                              (local.get $d))))
         (local.set $i (i32.add (local.get $i) (i32.const 1)))
         (br $next)))
     (call $print (i64.extend_i32_u (local.get $a))))

--- a/benchmarks/wat/i64_alu.wat
+++ b/benchmarks/wat/i64_alu.wat
@@ -11,7 +11,8 @@
 ;; A microbenchmark is a WASI command module invoked as `<module> <iterations>`.
 ;; It does
 ;; <iterations> units of work, writes exactly one line (the decimal result followed by a newline) to stdout, and exits 0. <iterations> = 0 does no work but still prints, which is how the harness measures startup in isolation.
-;; Only args_sizes_get / args_get / fd_write / proc_exit are imported and the bodies stick to i32/i64/f64, because the pure-Ruby and pure-Python interpreters this suite compares cannot do more than that.
+;; Only args_sizes_get / args_get / fd_write / proc_exit are imported, and a body stays inside i32/i64/f64 except for the one axis its case exists to measure: f32 in f32_alu, exception handling in eh_throw and eh_try.
+;; That keeps every other case within reach of the pure-Ruby and pure-Python interpreters this suite compares, and a runner that cannot execute a case's axis is excluded for that case in the harness workload table, with the reason stated there.
 ;;
 ;; Memory map, shared by every microbenchmark.
 ;; It starts at 0x1000 rather than at 0 because wasm3 traps with "out of bounds memory access" whenever a WASI out param is written to linear-memory address 0: address 0 is perfectly valid linear memory and every other runtime in the matrix accepts it, so the whole block is simply moved up out of wasm3's way:

--- a/benchmarks/wat/i64_div.wat
+++ b/benchmarks/wat/i64_div.wat
@@ -1,7 +1,10 @@
-;; mem_rw: i32 store/load over linear memory.
+;; i64_div: i64 division and remainder, signed and unsigned.
 ;;
-;; One iteration reads one i32 and writes one i32 at a pseudo-random offset in a 256 KiB window, so the address stream defeats any locality the backend's memory representation might otherwise get for free.
-;; Against i32_alu this separates memory-access cost from arithmetic cost.
+;; The i32_div chain widened to i64.
+;; Against i32_div it separates the cost of the 64-bit value representation from the cost of the division correction itself, the way i64_alu does against i32_alu.
+;; Every divisor is `(x & 0xffff) | 3`, which is at least 3, and that covers two requirements at once.
+;; Nothing traps: division by zero and the INT64_MIN / -1 overflow are both out of reach.
+;; No unsigned quotient reaches 2^63: pywasm 2.2.3 stores an i64.div_u result as a signed value and raises OverflowError above that point, and this case is here to measure division, not to reproduce that bug.
 ;;
 ;; ---------------------------------------------------------------------------
 ;; Shared preamble.
@@ -37,7 +40,7 @@
   (import "wasi_snapshot_preview1" "proc_exit"
     (func $proc_exit (param i32)))
 
-  (memory (export "memory") 8)
+  (memory (export "memory") 2)
 
   (data (i32.const 0x1800) "usage: <module> <iterations>\n")
 
@@ -97,22 +100,31 @@
       (i32.const 1) (i32.const 0x1400) (i32.const 1) (i32.const 0x1408))))
 
   (func (export "_start")
-    (local $n i32) (local $i i32) (local $h i32) (local $a i32) (local $p i32)
+    (local $n i32) (local $i i32) (local $h i64) (local $d i64) (local $a i64)
     (local.set $n (call $iterations))
-    (local.set $h (i32.const 0x12345678))
+    (local.set $h (i64.const 0x123456789abcdef))
     (block $done
       (loop $next
         (br_if $done (i32.ge_u (local.get $i) (local.get $n)))
         (local.set $h
-          (i32.add (i32.mul (local.get $h) (i32.const 1664525))
-                   (i32.const 1013904223)))
-        ;; 0x3fffc keeps the offset i32-aligned inside the 256 KiB window that starts one page in, clear of the preamble's scratch area.
-        (local.set $p
-          (i32.add (i32.const 0x10000)
-                   (i32.and (local.get $h) (i32.const 0x3fffc))))
-        (local.set $a (i32.add (local.get $a) (i32.load (local.get $p))))
-        (i32.store (local.get $p) (i32.xor (local.get $a) (local.get $i)))
+          (i64.add (i64.mul (local.get $h) (i64.const 6364136223846793005))
+                   (i64.const 1442695040888963407)))
+        (local.set $d
+          (i64.or (i64.and (local.get $h) (i64.const 0xffff)) (i64.const 3)))
+        (local.set $a
+          (i64.add (local.get $a)
+                   (i64.div_s (local.get $h) (local.get $d))))
+        (local.set $a
+          (i64.xor (local.get $a)
+                   (i64.div_u (local.get $a) (local.get $d))))
+        (local.set $a
+          (i64.add (local.get $a)
+                   (i64.rem_s (local.get $h) (local.get $d))))
+        (local.set $a
+          (i64.sub (local.get $a)
+                   (i64.rem_u (i64.xor (local.get $h) (local.get $a))
+                              (local.get $d))))
         (local.set $i (i32.add (local.get $i) (i32.const 1)))
         (br $next)))
-    (call $print (i64.extend_i32_u (local.get $a))))
+    (call $print (local.get $a)))
 )

--- a/benchmarks/wat/mem_narrow.wat
+++ b/benchmarks/wat/mem_narrow.wat
@@ -1,7 +1,8 @@
-;; mem_rw: i32 store/load over linear memory.
+;; mem_narrow: 8-bit and 16-bit loads and stores.
 ;;
-;; One iteration reads one i32 and writes one i32 at a pseudo-random offset in a 256 KiB window, so the address stream defeats any locality the backend's memory representation might otherwise get for free.
-;; Against i32_alu this separates memory-access cost from arithmetic cost.
+;; The mem_rw access pattern at the narrow widths: two 8-bit loads (zero and sign extending), two 16-bit loads (likewise), one i32.store8 and one i32.store16 per iteration, over the same 256 KiB window.
+;; mem_rw's traffic is 32-bit only, so it pays neither for assembling a value out of bytes nor for sign extension, and the difference between the two cases is what those cost.
+;; The 16-bit offsets are 2-byte aligned; the 8-bit offsets are anywhere in the window.
 ;;
 ;; ---------------------------------------------------------------------------
 ;; Shared preamble.
@@ -97,7 +98,8 @@
       (i32.const 1) (i32.const 0x1400) (i32.const 1) (i32.const 0x1408))))
 
   (func (export "_start")
-    (local $n i32) (local $i i32) (local $h i32) (local $a i32) (local $p i32)
+    (local $n i32) (local $i i32) (local $h i32)
+    (local $p i32) (local $q i32) (local $a i32)
     (local.set $n (call $iterations))
     (local.set $h (i32.const 0x12345678))
     (block $done
@@ -106,12 +108,28 @@
         (local.set $h
           (i32.add (i32.mul (local.get $h) (i32.const 1664525))
                    (i32.const 1013904223)))
-        ;; 0x3fffc keeps the offset i32-aligned inside the 256 KiB window that starts one page in, clear of the preamble's scratch area.
+        ;; The masks keep every access inside the 256 KiB window that starts one page in, clear of the preamble's scratch area, and keep the 16-bit ones 2-byte aligned.
         (local.set $p
           (i32.add (i32.const 0x10000)
-                   (i32.and (local.get $h) (i32.const 0x3fffc))))
-        (local.set $a (i32.add (local.get $a) (i32.load (local.get $p))))
-        (i32.store (local.get $p) (i32.xor (local.get $a) (local.get $i)))
+                   (i32.and (local.get $h) (i32.const 0x3ffff))))
+        (local.set $q
+          (i32.add (i32.const 0x10000)
+                   (i32.and (i32.shr_u (local.get $h) (i32.const 8))
+                            (i32.const 0x3fffe))))
+        (local.set $a
+          (i32.add (local.get $a) (i32.load8_u (local.get $p))))
+        (local.set $a
+          (i32.xor (local.get $a) (i32.load8_s (local.get $q))))
+        (local.set $a
+          (i32.add (local.get $a) (i32.load16_u (local.get $q))))
+        (local.set $a
+          (i32.xor (local.get $a)
+                   (i32.load16_s
+                     (i32.add (i32.const 0x10000)
+                              (i32.and (i32.shr_u (local.get $h) (i32.const 4))
+                                       (i32.const 0x3fffe))))))
+        (i32.store8 (local.get $p) (local.get $a))
+        (i32.store16 (local.get $q) (i32.xor (local.get $a) (local.get $i)))
         (local.set $i (i32.add (local.get $i) (i32.const 1)))
         (br $next)))
     (call $print (i64.extend_i32_u (local.get $a))))

--- a/crates/xtask/src/bench/mod.rs
+++ b/crates/xtask/src/bench/mod.rs
@@ -36,7 +36,8 @@ use crate::bench::runner::{Kind, Launch, Runner, Workshop};
 use crate::bench::workload::Workload;
 
 /// Default timed repetitions per measurement, after one discarded warmup.
-const DEFAULT_REPS: usize = 5;
+/// Across the 219 measured pairs of the 2026-08-21 full record, the spread between the fastest and slowest of 5 samples had a median of 0.9% and a 90th percentile of 3.1%, so 3 loses little.
+const DEFAULT_REPS: usize = 3;
 /// Default compute time the iteration calibrator aims each sample at.
 const DEFAULT_TARGET_MS: u64 = 300;
 /// Default per-process wall-clock ceiling.
@@ -392,11 +393,13 @@ fn measure_workload(
             let iters = m
                 .iterations
                 .map_or_else(String::new, |n| format!("{n} iters, "));
-            let cold = m
-                .cold_start
-                .as_ref()
-                .map_or_else(String::new, |s| format!(", cold start {} ms", ms(s.min_s)));
-            println!("    {iters}{} ms total (min){cold}", ms(m.total.min_s));
+            let cold = m.cold_start.as_ref().map_or_else(String::new, |s| {
+                format!(", cold start {} ms", ms(s.median_s))
+            });
+            println!(
+                "    {iters}{} ms total (median){cold}",
+                ms(m.total.median_s)
+            );
         }
         results.push(Cell {
             workload: workload.label.clone(),

--- a/crates/xtask/src/bench/workload.rs
+++ b/crates/xtask/src/bench/workload.rs
@@ -22,13 +22,70 @@ const MICRO_ITER_CAPS: &[(&str, u64)] = &[
     ("wat/i32_alu", 500_000_000),
     ("wat/i64_alu", 500_000_000),
     ("wat/f64_alu", 500_000_000),
+    ("wat/f32_alu", 900_000_000),
     ("wat/mem_rw", 500_000_000),
+    ("wat/mem_narrow", 600_000_000),
     ("wat/call_direct", 500_000_000),
     ("wat/call_indirect", 500_000_000),
+    ("wat/eh_throw", 4_000_000),
+    ("wat/eh_try", 330_000_000),
+    ("wat/i32_div", 120_000_000),
+    ("wat/i64_div", 110_000_000),
+    ("wat/conv", 120_000_000),
+    ("wat/br_table", 105_000_000),
     ("c/sha256", 10_000_000),
     ("c/mandelbrot", 20_000_000),
     ("c/wordcount", 500_000_000),
 ];
+
+/// Runners excluded from one microbenchmark, keyed by its id.
+/// Same discipline as [`SQLITE_QUERY_EXCLUDES`]: every reason is a measurement or an observed error, never a guess.
+const MICRO_EXCLUDES: &[(&str, &[(&str, &str)])] = &[
+    ("wat/eh_throw", EH_EXCLUDES),
+    ("wat/eh_try", EH_EXCLUDES),
+    ("wat/f32_alu", F32_ALU_EXCLUDES),
+    ("wat/i64_div", I64_DIV_EXCLUDES),
+];
+
+/// Runners excluded from both exception-handling microbenchmarks, since the reason is the same axis on both: none of these five decode or accept the tag section that `try_table`/`throw` needs.
+const EH_EXCLUDES: &[(&str, &str)] = &[
+    (
+        "dewasm-bash",
+        "excluded: the bash backend has no exception-handling lowering and rejects the module at conversion time with \"unsupported (exception-handling): tag, exnref value, or try_table/throw/throw_ref instruction\" (see docs/support.md)",
+    ),
+    (
+        "wazero",
+        "excluded: wazero 1.12.0 rejects the module: \"tag section not supported as feature \\\"exception-handling\\\" is disabled\"",
+    ),
+    (
+        "wasm3",
+        "excluded: wasm3 0.5.0 fails to load it: \"out of order Wasm section\" (the tag section is unknown to it)",
+    ),
+    ("pywasm-cpython", PYWASM_EH_REASON),
+    ("pywasm-pypy", PYWASM_EH_REASON),
+    ("wardite", WARDITE_EH_REASON),
+    ("wardite-yjit", WARDITE_EH_REASON),
+];
+
+const PYWASM_EH_REASON: &str = "excluded: pywasm 2.2.3 has no exception-handling opcodes; decoding dies with AssertionError on the throw/try_table opcode (pywasm/core.py, from_reader)";
+
+const WARDITE_EH_REASON: &str = "excluded: wardite 0.9.0 fails to load the tag section: Wardite::LoadError \"unknown code: 13\"";
+
+/// wardite does not re-round f32 arithmetic to single precision between operations, so a chain of dependent f32 ops accumulates double-precision bits and diverges from wasmtime; the byte-for-byte verification would fail the whole run.
+const F32_ALU_EXCLUDES: &[(&str, &str)] = &[
+    ("wardite", WARDITE_F32_ALU_REASON),
+    ("wardite-yjit", WARDITE_F32_ALU_REASON),
+];
+
+const WARDITE_F32_ALU_REASON: &str = "excluded: wardite 0.9.0 does not re-round f32 arithmetic to single precision, so a dependent operation chain diverges from wasmtime (1232349357 vs 1232349355 at 10000 iterations) and the byte-for-byte verification would fail the whole run";
+
+/// wardite computes `i64.div_s` at `f64` precision, which loses bits for operands beyond 2^53 and gives a wrong quotient.
+const I64_DIV_EXCLUDES: &[(&str, &str)] = &[
+    ("wardite", WARDITE_I64_DIV_REASON),
+    ("wardite-yjit", WARDITE_I64_DIV_REASON),
+];
+
+const WARDITE_I64_DIV_REASON: &str = "excluded: wardite 0.9.0 computes i64.div_s at f64 precision, wrong for operands beyond 2^53: i64.div_s(0x8000000000000000, 3) gives -3074457345618258432 where -3074457345618258602 is correct";
 
 /// The `sqlite3_query` script: a 100k-row table in one transaction (recursive CTE, so the work is the engine's), then an aggregate and a `LIKE` scan. 100k rows because at 20k wasmtime finished in ~30 ms (nearly all process startup), leaving the baseline unresolvable.
 /// The script is fixed rather than calibrated per runner (that is what makes it realistic), which is why the slowest runners are excluded instead of measured at their own size.
@@ -141,7 +198,15 @@ pub fn workloads() -> Vec<Workload> {
             ids.push(found);
         }
     }
-    ids.sort();
+    // Family-major (in `MICRO_FAMILIES`'s declared order), alphabetical within a family, rather than a plain alphabetical sort, which would put `c/*` before `wat/*` and scatter run order, results.md sections and charts out of the families' declared order.
+    ids.sort_by_key(|id| {
+        let family = id.split('/').next().unwrap_or(id.as_str());
+        let family_rank = MICRO_FAMILIES
+            .iter()
+            .position(|known| *known == family)
+            .unwrap_or(MICRO_FAMILIES.len());
+        (family_rank, id.clone())
+    });
 
     let cache = bench_cache_dir();
     let mut out: Vec<Workload> = ids
@@ -151,11 +216,15 @@ pub fn workloads() -> Vec<Workload> {
                 .iter()
                 .find(|(known, _)| *known == id)
                 .map_or(DEFAULT_ITER_CAP, |(_, cap)| *cap);
+            let exclude = MICRO_EXCLUDES
+                .iter()
+                .find(|(known, _)| *known == id)
+                .map_or(&[][..], |(_, excludes)| *excludes);
             Workload {
                 wasm: cache.join(format!("{id}.wasm")),
                 label: id,
                 kind: Kind::Micro { iter_cap },
-                exclude: &[],
+                exclude,
             }
         })
         .collect();
@@ -244,6 +313,8 @@ const SQLITE_QUERY_EXCLUDES: &[(&str, &str)] = &[
     ("pywasm-pypy", PYWASM_SQLITE_REASON),
     ("wardite", WARDITE_SQLITE_REASON),
     ("wardite-yjit", WARDITE_SQLITE_REASON),
+    ("dewasm-perl", DEWASM_PERL_SQLITE_REASON),
+    ("dewasm-python", DEWASM_PYTHON_SQLITE_REASON),
 ];
 
 /// wardite loads the module and handles a bare `.quit`, but any actual query dies.
@@ -252,6 +323,13 @@ const WARDITE_SQLITE_REASON: &str = "excluded: wardite loads the sqlite3 shell b
 /// Cost, not capability: pywasm runs this correctly (byte-identical under `-batch`) at ~17.9 ms/row, so 100k rows is ~half an hour per sample.
 /// The row count cannot be lowered to meet it: below ~20k rows wasmtime's side is all process startup and the baseline dissolves.
 const PYWASM_SQLITE_REASON: &str = "excluded on cost, not capability: pywasm runs this program correctly (byte-identical to wasmtime under -batch) at ~17.9 ms/row: measured 358 s at 20k rows, so the 100k-row script needs roughly half an hour per sample";
+
+/// Cost, not capability: dewasm-perl runs this correctly but at 113 s and 115 s per run (median, sqlite3_query and sqlite3_mod_query), measured in the 2026-08-21 full record.
+/// One warmup plus the timed repetitions across both query cases alone cost roughly 19 of the suite's roughly 65 minutes.
+const DEWASM_PERL_SQLITE_REASON: &str = "excluded on cost, not capability: dewasm-perl runs this program correctly but at 113 s and 115 s per run (median, sqlite3_query and sqlite3_mod_query), so one warmup plus the timed repetitions across both cases alone cost roughly 19 minutes of the roughly 65 minute full suite; dewasm-perl stays measured on the other app cases and the microbenchmarks";
+
+/// Cost, not capability: dewasm-python runs this correctly but at 56 s and 57 s per run (median, sqlite3_query and sqlite3_mod_query), measured in the 2026-08-21 full record.
+const DEWASM_PYTHON_SQLITE_REASON: &str = "excluded on cost, not capability: dewasm-python runs this program correctly but at 56 s and 57 s per run (median, sqlite3_query and sqlite3_mod_query), costing roughly 9 minutes of the roughly 65 minute full suite; dewasm-python stays measured on the other app cases and the microbenchmarks";
 
 /// Runners excluded from the compression case; each reason is a measurement, not a guess (see the module doc comment on [`SQLITE_QUERY_EXCLUDES`] for why that discipline matters here too).
 const MINIGZIP_EXCLUDES: &[(&str, &str)] = &[
@@ -266,7 +344,7 @@ const MINIGZIP_EXCLUDES: &[(&str, &str)] = &[
 ];
 
 /// Extrapolated linearly from two prefix sizes (20000 and 50000 bytes) of the same generated text, both close enough to the per-byte rate that the fit is not just two points hiding curvature.
-/// At 6 runs per cell (one warmup plus 5 reps) that is over an hour on this workload alone, which is why the input size is fixed for wasmtime rather than calibrated down to fit bash: the doc comment on [`minigzip_input`] gives the reason it must stay put.
+/// At 4 runs per cell (one warmup plus the default 3 reps) that is roughly 48 minutes on this workload alone, which is why the input size is fixed for wasmtime rather than calibrated down to fit bash: the doc comment on [`minigzip_input`] gives the reason it must stay put.
 const BASH_MINIGZIP_REASON: &str = "excluded on cost, not capability: bash compresses this workload's generated text at ~0.61 ms/byte (measured 30.6 s on a 50000-byte prefix), so the full 1.2 MB input needs roughly 12 minutes per run";
 
 /// Extrapolated the same way as [`BASH_MINIGZIP_REASON`], from prefixes of 5000 and 20000 bytes.

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -8,7 +8,7 @@ The results are in [results.md](results.md) with its figures under `figs/`; the 
 ```console
 $ examples/apps/setup.sh             # the cached apps (sqlite3-shell, cowsay, ...)
 $ benchmarks/setup.sh                # builds the microbenchmarks, pins pywasm and wardite
-$ cargo xtask record-speed           # the full matrix, roughly 25 minutes
+$ cargo xtask record-speed           # the full matrix, roughly 30 minutes
 $ cargo xtask render-speed           # results.md and its charts, from that record
 ```
 

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -8,19 +8,19 @@ The results are in [results.md](results.md) with its figures under `figs/`; the 
 ```console
 $ examples/apps/setup.sh             # the cached apps (sqlite3-shell, cowsay, ...)
 $ benchmarks/setup.sh                # builds the microbenchmarks, pins pywasm and wardite
-$ cargo xtask record-speed           # the full matrix, roughly an hour
+$ cargo xtask record-speed           # the full matrix, roughly 25 minutes
 $ cargo xtask render-speed           # results.md and its charts, from that record
 ```
 
 Measuring and rendering are two commands: a run writes a dated `<timestamp>Z-speed.json` to [`records/`](../../records/README.md) and nothing else, and rendering turns a record into `docs/benchmarks/results.md` with its charts.
-That way a wording fix in the document costs a second, not an hour.
+That way a wording fix in the document costs a second, not a re-measurement of the whole suite.
 Useful options:
 
 | Command | Effect |
 | --- | --- |
 | `cargo xtask record-speed --list` | Show the matrix and each runner's availability without running anything. |
 | `cargo xtask record-speed <filter>` | Only pairs whose workload or runner label contains the substring, e.g. `dewasm-ruby` or `app/`. A record from a filtered run covers only those pairs, so publish from a full run. |
-| `--reps N`, `--target-ms MS`, `--timeout SECS` | Timed runs per measurement (default 5), calibration target per sample (default 300), per-process ceiling (default 900). |
+| `--reps N`, `--target-ms MS`, `--timeout SECS` | Timed runs per measurement (default 3), calibration target per sample (default 300), per-process ceiling (default 900). |
 | `cargo xtask render-speed <record>` | Render an older record instead of the newest one; a `-size.json` path is refused. |
 
 `wasmtime` is required; any other missing runner is reported as skipped with the reason, and the run continues.

--- a/docs/benchmarks/figs/app-cowsay-dark.svg
+++ b/docs/benchmarks/figs/app-cowsay-dark.svg
@@ -1,87 +1,87 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/cowsay: seconds per run for 18 runners on a log scale, fastest first. dewasm-go is fastest at 4.87 ms, then wasm3 at 7.43 ms; dewasm-bash is slowest at 1.36 s, a span of 279x. The table below carries every number.">
-<title>app/cowsay: seconds per run for 18 runners on a log scale, fastest first. dewasm-go is fastest at 4.87 ms, then wasm3 at 7.43 ms; dewasm-bash is slowest at 1.36 s, a span of 279x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/cowsay: seconds per run for 18 runners on a log scale, fastest first. dewasm-go is fastest at 4.56 ms, then wasm3 at 7.08 ms; dewasm-bash is slowest at 1.34 s, a span of 293x. The table below carries every number.">
+<title>app/cowsay: seconds per run for 18 runners on a log scale, fastest first. dewasm-go is fastest at 4.56 ms, then wasm3 at 7.08 ms; dewasm-bash is slowest at 1.34 s, a span of 293x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ms</text>
-<line x1="343.6" y1="68.0" x2="343.6" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="343.6" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
-<line x1="519.1" y1="68.0" x2="519.1" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="519.1" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
-<line x1="694.7" y1="68.0" x2="694.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="694.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
+<line x1="343.9" y1="68.0" x2="343.9" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="343.9" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
+<line x1="519.9" y1="68.0" x2="519.9" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="519.9" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
+<line x1="695.8" y1="68.0" x2="695.8" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="695.8" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="86.0" x2="288.6" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="288.6" cy="86.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.87 ms</text>
+<line x1="168.0" y1="86.0" x2="283.9" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="283.9" cy="86.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.56 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="110.0" x2="320.9" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="320.9" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.43 ms</text>
+<line x1="168.0" y1="110.0" x2="317.6" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="317.6" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.08 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="134.0" x2="346.2" y2="134.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="346.2" cy="134.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.4 ms</text>
+<line x1="168.0" y1="134.0" x2="344.8" y2="134.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="344.8" cy="134.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.1 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="158.0" x2="374.1" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="374.1" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.9 ms</text>
+<line x1="168.0" y1="158.0" x2="370.2" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="370.2" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.1 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="182.0" x2="423.6" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="423.6" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">28.6 ms</text>
+<line x1="168.0" y1="182.0" x2="419.3" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="419.3" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">26.8 ms</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="206.0" x2="528.1" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="528.1" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">113 ms</text>
+<line x1="168.0" y1="206.0" x2="524.8" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="524.8" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">107 ms</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="230.0" x2="529.7" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="529.7" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">115 ms</text>
+<line x1="168.0" y1="230.0" x2="528.5" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="528.5" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">112 ms</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="254.0" x2="545.3" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="545.3" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">141 ms</text>
+<line x1="168.0" y1="254.0" x2="541.7" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="541.7" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">133 ms</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="278.0" x2="549.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="549.5" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">149 ms</text>
+<line x1="168.0" y1="278.0" x2="548.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="548.1" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">145 ms</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="302.0" x2="573.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="573.5" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">204 ms</text>
+<line x1="168.0" y1="302.0" x2="571.9" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="571.9" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">198 ms</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="326.0" x2="585.4" y2="326.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="585.4" cy="326.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">239 ms</text>
+<line x1="168.0" y1="326.0" x2="586.2" y2="326.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="586.2" cy="326.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">238 ms</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="350.0" x2="591.5" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="591.5" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">258 ms</text>
+<line x1="168.0" y1="350.0" x2="592.0" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="592.0" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">257 ms</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="374.0" x2="596.0" y2="374.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="596.0" cy="374.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">274 ms</text>
+<line x1="168.0" y1="374.0" x2="596.4" y2="374.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="596.4" cy="374.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">272 ms</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="398.0" x2="627.2" y2="398.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="627.2" cy="398.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">413 ms</text>
+<line x1="168.0" y1="398.0" x2="630.3" y2="398.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="630.3" cy="398.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">424 ms</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="422.0" x2="642.7" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="642.7" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">506 ms</text>
+<line x1="168.0" y1="422.0" x2="642.6" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="642.6" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">498 ms</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="661.0" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="661.0" cy="446.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">643 ms</text>
+<line x1="168.0" y1="446.0" x2="660.5" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="660.5" cy="446.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">630 ms</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="470.0" x2="688.6" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="688.6" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">923 ms</text>
+<line x1="168.0" y1="470.0" x2="689.9" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="689.9" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">925 ms</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.36 s</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.34 s</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">app/cowsay: seconds per run, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/app-cowsay.svg
+++ b/docs/benchmarks/figs/app-cowsay.svg
@@ -1,87 +1,87 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/cowsay: seconds per run for 18 runners on a log scale, fastest first. dewasm-go is fastest at 4.87 ms, then wasm3 at 7.43 ms; dewasm-bash is slowest at 1.36 s, a span of 279x. The table below carries every number.">
-<title>app/cowsay: seconds per run for 18 runners on a log scale, fastest first. dewasm-go is fastest at 4.87 ms, then wasm3 at 7.43 ms; dewasm-bash is slowest at 1.36 s, a span of 279x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/cowsay: seconds per run for 18 runners on a log scale, fastest first. dewasm-go is fastest at 4.56 ms, then wasm3 at 7.08 ms; dewasm-bash is slowest at 1.34 s, a span of 293x. The table below carries every number.">
+<title>app/cowsay: seconds per run for 18 runners on a log scale, fastest first. dewasm-go is fastest at 4.56 ms, then wasm3 at 7.08 ms; dewasm-bash is slowest at 1.34 s, a span of 293x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ms</text>
-<line x1="343.6" y1="68.0" x2="343.6" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="343.6" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
-<line x1="519.1" y1="68.0" x2="519.1" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="519.1" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
-<line x1="694.7" y1="68.0" x2="694.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="694.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
+<line x1="343.9" y1="68.0" x2="343.9" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="343.9" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
+<line x1="519.9" y1="68.0" x2="519.9" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="519.9" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
+<line x1="695.8" y1="68.0" x2="695.8" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="695.8" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="86.0" x2="288.6" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="288.6" cy="86.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.87 ms</text>
+<line x1="168.0" y1="86.0" x2="283.9" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="283.9" cy="86.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.56 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="110.0" x2="320.9" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="320.9" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.43 ms</text>
+<line x1="168.0" y1="110.0" x2="317.6" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="317.6" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.08 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="134.0" x2="346.2" y2="134.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="346.2" cy="134.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.4 ms</text>
+<line x1="168.0" y1="134.0" x2="344.8" y2="134.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="344.8" cy="134.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.1 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="158.0" x2="374.1" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="374.1" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.9 ms</text>
+<line x1="168.0" y1="158.0" x2="370.2" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="370.2" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.1 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="182.0" x2="423.6" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="423.6" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">28.6 ms</text>
+<line x1="168.0" y1="182.0" x2="419.3" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="419.3" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">26.8 ms</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="206.0" x2="528.1" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="528.1" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">113 ms</text>
+<line x1="168.0" y1="206.0" x2="524.8" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="524.8" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">107 ms</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="230.0" x2="529.7" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="529.7" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">115 ms</text>
+<line x1="168.0" y1="230.0" x2="528.5" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="528.5" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">112 ms</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="254.0" x2="545.3" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="545.3" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">141 ms</text>
+<line x1="168.0" y1="254.0" x2="541.7" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="541.7" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">133 ms</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="278.0" x2="549.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="549.5" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">149 ms</text>
+<line x1="168.0" y1="278.0" x2="548.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="548.1" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">145 ms</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="302.0" x2="573.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="573.5" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">204 ms</text>
+<line x1="168.0" y1="302.0" x2="571.9" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="571.9" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">198 ms</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="326.0" x2="585.4" y2="326.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="585.4" cy="326.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">239 ms</text>
+<line x1="168.0" y1="326.0" x2="586.2" y2="326.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="586.2" cy="326.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">238 ms</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="350.0" x2="591.5" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="591.5" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">258 ms</text>
+<line x1="168.0" y1="350.0" x2="592.0" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="592.0" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">257 ms</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="374.0" x2="596.0" y2="374.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="596.0" cy="374.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">274 ms</text>
+<line x1="168.0" y1="374.0" x2="596.4" y2="374.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="596.4" cy="374.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">272 ms</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="398.0" x2="627.2" y2="398.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="627.2" cy="398.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">413 ms</text>
+<line x1="168.0" y1="398.0" x2="630.3" y2="398.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="630.3" cy="398.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">424 ms</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="422.0" x2="642.7" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="642.7" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">506 ms</text>
+<line x1="168.0" y1="422.0" x2="642.6" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="642.6" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">498 ms</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="661.0" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="661.0" cy="446.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">643 ms</text>
+<line x1="168.0" y1="446.0" x2="660.5" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="660.5" cy="446.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">630 ms</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="470.0" x2="688.6" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="688.6" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">923 ms</text>
+<line x1="168.0" y1="470.0" x2="689.9" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="689.9" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">925 ms</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.36 s</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.34 s</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">app/cowsay: seconds per run, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/app-minigzip-dark.svg
+++ b/docs/benchmarks/figs/app-minigzip-dark.svg
@@ -1,58 +1,58 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="416" viewBox="0 0 820 416" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/minigzip: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 46.9 ms, then wasmer at 52.7 ms; pywasm-pypy is slowest at 81.5 s, a span of 1740x. The table below carries every number.">
-<title>app/minigzip: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 46.9 ms, then wasmer at 52.7 ms; pywasm-pypy is slowest at 81.5 s, a span of 1740x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="416" viewBox="0 0 820 416" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/minigzip: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 45.1 ms, then wasmer at 52.5 ms; pywasm-pypy is slowest at 81.5 s, a span of 1810x. The table below carries every number.">
+<title>app/minigzip: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 45.1 ms, then wasmer at 52.5 ms; pywasm-pypy is slowest at 81.5 s, a span of 1810x. The table below carries every number.</title>
 <rect width="820" height="416" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
 <line x1="308.6" y1="68.0" x2="308.6" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="308.6" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
-<line x1="449.3" y1="68.0" x2="449.3" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="449.3" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
+<line x1="449.2" y1="68.0" x2="449.2" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="449.2" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
 <line x1="589.9" y1="68.0" x2="589.9" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="589.9" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 s</text>
 <line x1="168.0" y1="386.0" x2="726.0" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="262.4" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="262.4" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">46.9 ms</text>
+<line x1="168.0" y1="86.0" x2="260.0" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="260.0" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">45.1 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="269.5" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="269.5" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">52.7 ms</text>
+<line x1="168.0" y1="110.0" x2="269.3" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="269.3" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">52.5 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="275.5" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="275.5" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">58.1 ms</text>
+<line x1="168.0" y1="134.0" x2="275.8" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="275.8" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">58.4 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="301.2" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="301.2" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">88.5 ms</text>
+<line x1="168.0" y1="158.0" x2="301.1" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="301.1" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">88.4 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="410.1" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="410.1" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">527 ms</text>
+<line x1="168.0" y1="182.0" x2="415.2" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="415.2" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">573 ms</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="206.0" x2="479.5" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="479.5" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.64 s</text>
+<line x1="168.0" y1="206.0" x2="479.7" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="479.7" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.65 s</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="230.0" x2="499.0" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="499.0" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.26 s</text>
+<line x1="168.0" y1="230.0" x2="498.8" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="498.8" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.25 s</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="254.0" x2="513.7" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="513.7" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.87 s</text>
+<line x1="168.0" y1="254.0" x2="513.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="513.5" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.86 s</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="278.0" x2="523.3" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="523.3" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.36 s</text>
+<line x1="168.0" y1="278.0" x2="523.4" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="523.4" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.37 s</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="302.0" x2="550.9" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="550.9" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.28 s</text>
+<line x1="168.0" y1="302.0" x2="550.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="550.7" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.27 s</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="326.0" x2="616.1" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="616.1" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="326.0" x2="616.2" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="616.2" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.4 s</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
 <line x1="168.0" y1="350.0" x2="644.3" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>

--- a/docs/benchmarks/figs/app-minigzip.svg
+++ b/docs/benchmarks/figs/app-minigzip.svg
@@ -1,58 +1,58 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="416" viewBox="0 0 820 416" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/minigzip: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 46.9 ms, then wasmer at 52.7 ms; pywasm-pypy is slowest at 81.5 s, a span of 1740x. The table below carries every number.">
-<title>app/minigzip: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 46.9 ms, then wasmer at 52.7 ms; pywasm-pypy is slowest at 81.5 s, a span of 1740x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="416" viewBox="0 0 820 416" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/minigzip: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 45.1 ms, then wasmer at 52.5 ms; pywasm-pypy is slowest at 81.5 s, a span of 1810x. The table below carries every number.">
+<title>app/minigzip: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 45.1 ms, then wasmer at 52.5 ms; pywasm-pypy is slowest at 81.5 s, a span of 1810x. The table below carries every number.</title>
 <rect width="820" height="416" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
 <line x1="308.6" y1="68.0" x2="308.6" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="308.6" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
-<line x1="449.3" y1="68.0" x2="449.3" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="449.3" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
+<line x1="449.2" y1="68.0" x2="449.2" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="449.2" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
 <line x1="589.9" y1="68.0" x2="589.9" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="589.9" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">10 s</text>
 <line x1="168.0" y1="386.0" x2="726.0" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="262.4" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="262.4" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">46.9 ms</text>
+<line x1="168.0" y1="86.0" x2="260.0" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="260.0" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">45.1 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="269.5" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="269.5" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">52.7 ms</text>
+<line x1="168.0" y1="110.0" x2="269.3" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="269.3" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">52.5 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="275.5" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="275.5" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">58.1 ms</text>
+<line x1="168.0" y1="134.0" x2="275.8" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="275.8" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">58.4 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="301.2" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="301.2" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">88.5 ms</text>
+<line x1="168.0" y1="158.0" x2="301.1" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="301.1" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">88.4 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="410.1" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="410.1" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">527 ms</text>
+<line x1="168.0" y1="182.0" x2="415.2" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="415.2" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">573 ms</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="206.0" x2="479.5" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="479.5" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.64 s</text>
+<line x1="168.0" y1="206.0" x2="479.7" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="479.7" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.65 s</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="230.0" x2="499.0" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="499.0" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.26 s</text>
+<line x1="168.0" y1="230.0" x2="498.8" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="498.8" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.25 s</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="254.0" x2="513.7" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="513.7" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.87 s</text>
+<line x1="168.0" y1="254.0" x2="513.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="513.5" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.86 s</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="278.0" x2="523.3" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="523.3" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.36 s</text>
+<line x1="168.0" y1="278.0" x2="523.4" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="523.4" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.37 s</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="302.0" x2="550.9" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="550.9" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.28 s</text>
+<line x1="168.0" y1="302.0" x2="550.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="550.7" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.27 s</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="326.0" x2="616.1" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="616.1" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="326.0" x2="616.2" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="616.2" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.4 s</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
 <line x1="168.0" y1="350.0" x2="644.3" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>

--- a/docs/benchmarks/figs/app-sqlite3-mod-query-dark.svg
+++ b/docs/benchmarks/figs/app-sqlite3-mod-query-dark.svg
@@ -1,69 +1,59 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="416" viewBox="0 0 820 416" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_mod_query: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 83.2 ms, then wasmer at 91.6 ms; dewasm-perl is slowest at 115 s, a span of 1380x. The table below carries every number.">
-<title>app/sqlite3_mod_query: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 83.2 ms, then wasmer at 91.6 ms; dewasm-perl is slowest at 115 s, a span of 1380x. The table below carries every number.</title>
-<rect width="820" height="416" fill="#1a1a19"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
-<line x1="303.4" y1="68.0" x2="303.4" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="303.4" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
-<line x1="438.9" y1="68.0" x2="438.9" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="438.9" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
-<line x1="574.3" y1="68.0" x2="574.3" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="574.3" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 s</text>
-<line x1="709.7" y1="68.0" x2="709.7" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="709.7" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 s</text>
-<line x1="168.0" y1="386.0" x2="726.0" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 86.9 ms, then wasmer at 91.1 ms; dewasm-ruby is slowest at 20.4 s, a span of 235x. The table below carries every number.">
+<title>app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 86.9 ms, then wasmer at 91.1 ms; dewasm-ruby is slowest at 20.4 s, a span of 235x. The table below carries every number.</title>
+<rect width="820" height="368" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
+<line x1="334.2" y1="68.0" x2="334.2" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="334.2" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
+<line x1="500.4" y1="68.0" x2="500.4" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="500.4" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
+<line x1="666.6" y1="68.0" x2="666.6" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="666.6" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 s</text>
+<line x1="168.0" y1="338.0" x2="726.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="292.6" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="292.6" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">83.2 ms</text>
+<line x1="168.0" y1="86.0" x2="324.1" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="324.1" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">86.9 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="298.2" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="298.2" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">91.6 ms</text>
+<line x1="168.0" y1="110.0" x2="327.5" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="327.5" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">91.1 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="317.2" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="317.2" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">126 ms</text>
+<line x1="168.0" y1="134.0" x2="351.8" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="351.8" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">128 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="412.4" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="412.4" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">638 ms</text>
+<line x1="168.0" y1="158.0" x2="468.1" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="468.1" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">639 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="182.0" x2="449.9" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="449.9" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.21 s</text>
+<line x1="168.0" y1="182.0" x2="512.9" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="512.9" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.19 s</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="206.0" x2="539.5" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="539.5" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="206.0" x2="623.9" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="623.9" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.54 s</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="230.0" x2="563.0" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="563.0" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.26 s</text>
+<line x1="168.0" y1="230.0" x2="653.9" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="653.9" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.38 s</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="575.1" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="575.1" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="254.0" x2="667.5" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="667.5" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.1 s</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="278.0" x2="588.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="588.8" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="278.0" x2="684.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="684.1" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.8 s</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="596.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="596.5" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.6 s</text>
+<line x1="168.0" y1="302.0" x2="694.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="694.5" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.7 s</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="616.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="616.0" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.3 s</text>
-<text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="676.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="676.7" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">57.0 s</text>
-<text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="718.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">115 s</text>
+<line x1="168.0" y1="326.0" x2="718.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.4 s</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">app/sqlite3_mod_query: seconds per run, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/app-sqlite3-mod-query.svg
+++ b/docs/benchmarks/figs/app-sqlite3-mod-query.svg
@@ -1,69 +1,59 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="416" viewBox="0 0 820 416" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_mod_query: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 83.2 ms, then wasmer at 91.6 ms; dewasm-perl is slowest at 115 s, a span of 1380x. The table below carries every number.">
-<title>app/sqlite3_mod_query: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 83.2 ms, then wasmer at 91.6 ms; dewasm-perl is slowest at 115 s, a span of 1380x. The table below carries every number.</title>
-<rect width="820" height="416" fill="#fcfcfb"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
-<line x1="303.4" y1="68.0" x2="303.4" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="303.4" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
-<line x1="438.9" y1="68.0" x2="438.9" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="438.9" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
-<line x1="574.3" y1="68.0" x2="574.3" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="574.3" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">10 s</text>
-<line x1="709.7" y1="68.0" x2="709.7" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="709.7" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">100 s</text>
-<line x1="168.0" y1="386.0" x2="726.0" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 86.9 ms, then wasmer at 91.1 ms; dewasm-ruby is slowest at 20.4 s, a span of 235x. The table below carries every number.">
+<title>app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 86.9 ms, then wasmer at 91.1 ms; dewasm-ruby is slowest at 20.4 s, a span of 235x. The table below carries every number.</title>
+<rect width="820" height="368" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
+<line x1="334.2" y1="68.0" x2="334.2" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="334.2" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
+<line x1="500.4" y1="68.0" x2="500.4" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="500.4" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
+<line x1="666.6" y1="68.0" x2="666.6" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="666.6" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 s</text>
+<line x1="168.0" y1="338.0" x2="726.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="292.6" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="292.6" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">83.2 ms</text>
+<line x1="168.0" y1="86.0" x2="324.1" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="324.1" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">86.9 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="298.2" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="298.2" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">91.6 ms</text>
+<line x1="168.0" y1="110.0" x2="327.5" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="327.5" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">91.1 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="317.2" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="317.2" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">126 ms</text>
+<line x1="168.0" y1="134.0" x2="351.8" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="351.8" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">128 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="412.4" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="412.4" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">638 ms</text>
+<line x1="168.0" y1="158.0" x2="468.1" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="468.1" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">639 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="182.0" x2="449.9" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="449.9" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.21 s</text>
+<line x1="168.0" y1="182.0" x2="512.9" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="512.9" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.19 s</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="206.0" x2="539.5" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="539.5" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="206.0" x2="623.9" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="623.9" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.54 s</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="230.0" x2="563.0" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="563.0" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.26 s</text>
+<line x1="168.0" y1="230.0" x2="653.9" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="653.9" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.38 s</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="575.1" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="575.1" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="254.0" x2="667.5" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="667.5" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.1 s</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="278.0" x2="588.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="588.8" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="278.0" x2="684.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="684.1" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.8 s</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="596.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="596.5" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.6 s</text>
+<line x1="168.0" y1="302.0" x2="694.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="694.5" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.7 s</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="616.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="616.0" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.3 s</text>
-<text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="676.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="676.7" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">57.0 s</text>
-<text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="718.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">115 s</text>
+<line x1="168.0" y1="326.0" x2="718.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.4 s</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">app/sqlite3_mod_query: seconds per run, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/app-sqlite3-query-dark.svg
+++ b/docs/benchmarks/figs/app-sqlite3-query-dark.svg
@@ -1,69 +1,59 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="416" viewBox="0 0 820 416" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_query: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 76.3 ms, then wasmer at 86.4 ms; dewasm-perl is slowest at 113 s, a span of 1480x. The table below carries every number.">
-<title>app/sqlite3_query: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 76.3 ms, then wasmer at 86.4 ms; dewasm-perl is slowest at 113 s, a span of 1480x. The table below carries every number.</title>
-<rect width="820" height="416" fill="#1a1a19"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
-<line x1="303.7" y1="68.0" x2="303.7" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="303.7" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
-<line x1="439.3" y1="68.0" x2="439.3" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="439.3" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
-<line x1="575.0" y1="68.0" x2="575.0" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="575.0" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 s</text>
-<line x1="710.7" y1="68.0" x2="710.7" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="710.7" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 s</text>
-<line x1="168.0" y1="386.0" x2="726.0" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 79.2 ms, then wasmer at 87.5 ms; dewasm-ruby is slowest at 19.3 s, a span of 244x. The table below carries every number.">
+<title>app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 79.2 ms, then wasmer at 87.5 ms; dewasm-ruby is slowest at 19.3 s, a span of 244x. The table below carries every number.</title>
+<rect width="820" height="368" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
+<line x1="335.4" y1="68.0" x2="335.4" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="335.4" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
+<line x1="502.7" y1="68.0" x2="502.7" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="502.7" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
+<line x1="670.1" y1="68.0" x2="670.1" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="670.1" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 s</text>
+<line x1="168.0" y1="338.0" x2="726.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="287.7" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="287.7" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">76.3 ms</text>
+<line x1="168.0" y1="86.0" x2="318.4" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="318.4" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">79.2 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="295.0" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="295.0" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">86.4 ms</text>
+<line x1="168.0" y1="110.0" x2="325.6" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="325.6" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">87.5 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="335.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="335.6" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">172 ms</text>
+<line x1="168.0" y1="134.0" x2="375.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="375.1" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">173 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="413.7" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="413.7" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">647 ms</text>
+<line x1="168.0" y1="158.0" x2="471.1" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="471.1" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">648 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="182.0" x2="444.4" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="444.4" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="182.0" x2="509.2" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="509.2" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.09 s</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="206.0" x2="490.8" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="490.8" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.39 s</text>
+<line x1="168.0" y1="206.0" x2="566.9" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="566.9" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.42 s</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="230.0" x2="570.0" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="570.0" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.19 s</text>
+<line x1="168.0" y1="230.0" x2="666.3" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="666.3" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.50 s</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="574.1" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="574.1" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.86 s</text>
+<line x1="168.0" y1="254.0" x2="668.3" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="668.3" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.76 s</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="278.0" x2="585.3" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="585.3" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="278.0" x2="682.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="682.8" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">11.9 s</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="595.3" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="595.3" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.1 s</text>
+<line x1="168.0" y1="302.0" x2="695.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="695.8" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.2 s</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="613.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="613.7" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="326.0" x2="718.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">19.3 s</text>
-<text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="676.0" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="676.0" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">55.5 s</text>
-<text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="718.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">113 s</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">app/sqlite3_query: seconds per run, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/app-sqlite3-query.svg
+++ b/docs/benchmarks/figs/app-sqlite3-query.svg
@@ -1,69 +1,59 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="416" viewBox="0 0 820 416" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_query: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 76.3 ms, then wasmer at 86.4 ms; dewasm-perl is slowest at 113 s, a span of 1480x. The table below carries every number.">
-<title>app/sqlite3_query: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 76.3 ms, then wasmer at 86.4 ms; dewasm-perl is slowest at 113 s, a span of 1480x. The table below carries every number.</title>
-<rect width="820" height="416" fill="#fcfcfb"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
-<line x1="303.7" y1="68.0" x2="303.7" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="303.7" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
-<line x1="439.3" y1="68.0" x2="439.3" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="439.3" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
-<line x1="575.0" y1="68.0" x2="575.0" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="575.0" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">10 s</text>
-<line x1="710.7" y1="68.0" x2="710.7" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="710.7" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">100 s</text>
-<line x1="168.0" y1="386.0" x2="726.0" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 79.2 ms, then wasmer at 87.5 ms; dewasm-ruby is slowest at 19.3 s, a span of 244x. The table below carries every number.">
+<title>app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 79.2 ms, then wasmer at 87.5 ms; dewasm-ruby is slowest at 19.3 s, a span of 244x. The table below carries every number.</title>
+<rect width="820" height="368" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
+<line x1="335.4" y1="68.0" x2="335.4" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="335.4" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
+<line x1="502.7" y1="68.0" x2="502.7" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="502.7" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
+<line x1="670.1" y1="68.0" x2="670.1" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="670.1" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 s</text>
+<line x1="168.0" y1="338.0" x2="726.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="287.7" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="287.7" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">76.3 ms</text>
+<line x1="168.0" y1="86.0" x2="318.4" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="318.4" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">79.2 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="295.0" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="295.0" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">86.4 ms</text>
+<line x1="168.0" y1="110.0" x2="325.6" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="325.6" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">87.5 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="335.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="335.6" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">172 ms</text>
+<line x1="168.0" y1="134.0" x2="375.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="375.1" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">173 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="413.7" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="413.7" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">647 ms</text>
+<line x1="168.0" y1="158.0" x2="471.1" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="471.1" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">648 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="182.0" x2="444.4" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="444.4" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="182.0" x2="509.2" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="509.2" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.09 s</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="206.0" x2="490.8" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="490.8" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.39 s</text>
+<line x1="168.0" y1="206.0" x2="566.9" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="566.9" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.42 s</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="230.0" x2="570.0" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="570.0" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.19 s</text>
+<line x1="168.0" y1="230.0" x2="666.3" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="666.3" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.50 s</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="574.1" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="574.1" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.86 s</text>
+<line x1="168.0" y1="254.0" x2="668.3" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="668.3" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.76 s</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="278.0" x2="585.3" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="585.3" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="278.0" x2="682.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="682.8" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">11.9 s</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="595.3" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="595.3" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.1 s</text>
+<line x1="168.0" y1="302.0" x2="695.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="695.8" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.2 s</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="613.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="613.7" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="326.0" x2="718.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">19.3 s</text>
-<text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="676.0" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="676.0" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">55.5 s</text>
-<text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="718.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">113 s</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">app/sqlite3_query: seconds per run, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/c-mandelbrot-dark.svg
+++ b/docs/benchmarks/figs/c-mandelbrot-dark.svg
@@ -1,93 +1,93 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/mandelbrot: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 95.7 ns, then wasmtime at 96.3 ns; dewasm-bash is slowest at 20.1 ms, a span of 211000x. The table below carries every number.">
-<title>c/mandelbrot: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 95.7 ns, then wasmtime at 96.3 ns; dewasm-bash is slowest at 20.1 ms, a span of 211000x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/mandelbrot: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 96.0 ns, then wasmtime at 96.2 ns; dewasm-bash is slowest at 20.4 ms, a span of 213000x. The table below carries every number.">
+<title>c/mandelbrot: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 96.0 ns, then wasmtime at 96.2 ns; dewasm-bash is slowest at 20.4 ms, a span of 213000x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
 <line x1="255.2" y1="68.0" x2="255.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="255.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="342.5" y1="68.0" x2="342.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="342.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="429.7" y1="68.0" x2="429.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="429.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="517.0" y1="68.0" x2="517.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="517.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
-<line x1="604.2" y1="68.0" x2="604.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="604.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ms</text>
-<line x1="691.5" y1="68.0" x2="691.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="691.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
+<line x1="342.3" y1="68.0" x2="342.3" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="342.3" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="429.5" y1="68.0" x2="429.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="429.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="516.7" y1="68.0" x2="516.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="516.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="603.8" y1="68.0" x2="603.8" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="603.8" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ms</text>
+<line x1="691.0" y1="68.0" x2="691.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="691.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
 <line x1="168.0" y1="86.0" x2="253.6" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="253.6" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">95.7 ns</text>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">96.0 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="253.8" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="253.8" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">96.3 ns</text>
+<line x1="168.0" y1="110.0" x2="253.7" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="253.7" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">96.2 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="254.3" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="254.3" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">97.5 ns</text>
+<line x1="168.0" y1="134.0" x2="254.0" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="254.0" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">97.1 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
 <line x1="168.0" y1="158.0" x2="257.9" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="257.9" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">107 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="182.0" x2="268.5" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="268.5" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">142 ns</text>
+<line x1="168.0" y1="182.0" x2="268.9" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="268.9" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">144 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="206.0" x2="287.7" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="287.7" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="206.0" x2="287.6" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="287.6" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">235 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="230.0" x2="312.7" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="312.7" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">455 ns</text>
+<line x1="168.0" y1="230.0" x2="312.4" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="312.4" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">453 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="359.0" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="359.0" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="254.0" x2="358.9" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="358.9" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.55 µs</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="278.0" x2="389.9" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="389.9" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.50 µs</text>
+<line x1="168.0" y1="278.0" x2="390.0" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="390.0" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.53 µs</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="302.0" x2="390.9" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="390.9" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="302.0" x2="390.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="390.8" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.59 µs</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
 <line x1="168.0" y1="326.0" x2="393.1" y2="326.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="393.1" cy="326.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.80 µs</text>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.82 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="350.0" x2="399.8" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="399.8" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.54 µs</text>
+<line x1="168.0" y1="350.0" x2="399.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="399.7" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.56 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
 <line x1="168.0" y1="374.0" x2="494.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="494.8" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">55.7 µs</text>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">56.1 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="540.6" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="540.6" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">186 µs</text>
+<line x1="168.0" y1="398.0" x2="539.7" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="539.7" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">184 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="422.0" x2="568.4" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="568.4" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="422.0" x2="568.1" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="568.1" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">389 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="446.0" x2="619.2" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="619.2" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.48 ms</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="470.0" x2="632.8" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="632.8" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.12 ms</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="446.0" x2="618.3" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="618.3" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.46 ms</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="470.0" x2="618.8" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="618.8" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.49 ms</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.1 ms</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.4 ms</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">c/mandelbrot: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/c-mandelbrot.svg
+++ b/docs/benchmarks/figs/c-mandelbrot.svg
@@ -1,93 +1,93 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/mandelbrot: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 95.7 ns, then wasmtime at 96.3 ns; dewasm-bash is slowest at 20.1 ms, a span of 211000x. The table below carries every number.">
-<title>c/mandelbrot: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 95.7 ns, then wasmtime at 96.3 ns; dewasm-bash is slowest at 20.1 ms, a span of 211000x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/mandelbrot: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 96.0 ns, then wasmtime at 96.2 ns; dewasm-bash is slowest at 20.4 ms, a span of 213000x. The table below carries every number.">
+<title>c/mandelbrot: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 96.0 ns, then wasmtime at 96.2 ns; dewasm-bash is slowest at 20.4 ms, a span of 213000x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
 <line x1="255.2" y1="68.0" x2="255.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="255.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="342.5" y1="68.0" x2="342.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="342.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="429.7" y1="68.0" x2="429.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="429.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="517.0" y1="68.0" x2="517.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="517.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
-<line x1="604.2" y1="68.0" x2="604.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="604.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ms</text>
-<line x1="691.5" y1="68.0" x2="691.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="691.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
+<line x1="342.3" y1="68.0" x2="342.3" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="342.3" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="429.5" y1="68.0" x2="429.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="429.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="516.7" y1="68.0" x2="516.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="516.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="603.8" y1="68.0" x2="603.8" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="603.8" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ms</text>
+<line x1="691.0" y1="68.0" x2="691.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="691.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
 <line x1="168.0" y1="86.0" x2="253.6" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="253.6" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">95.7 ns</text>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">96.0 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="253.8" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="253.8" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">96.3 ns</text>
+<line x1="168.0" y1="110.0" x2="253.7" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="253.7" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">96.2 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="254.3" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="254.3" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">97.5 ns</text>
+<line x1="168.0" y1="134.0" x2="254.0" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="254.0" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">97.1 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
 <line x1="168.0" y1="158.0" x2="257.9" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="257.9" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">107 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="182.0" x2="268.5" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="268.5" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">142 ns</text>
+<line x1="168.0" y1="182.0" x2="268.9" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="268.9" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">144 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="206.0" x2="287.7" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="287.7" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="206.0" x2="287.6" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="287.6" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">235 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="230.0" x2="312.7" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="312.7" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">455 ns</text>
+<line x1="168.0" y1="230.0" x2="312.4" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="312.4" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">453 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="359.0" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="359.0" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="254.0" x2="358.9" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="358.9" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.55 µs</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="278.0" x2="389.9" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="389.9" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.50 µs</text>
+<line x1="168.0" y1="278.0" x2="390.0" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="390.0" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.53 µs</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="302.0" x2="390.9" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="390.9" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="302.0" x2="390.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="390.8" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.59 µs</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
 <line x1="168.0" y1="326.0" x2="393.1" y2="326.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="393.1" cy="326.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.80 µs</text>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.82 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="350.0" x2="399.8" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="399.8" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.54 µs</text>
+<line x1="168.0" y1="350.0" x2="399.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="399.7" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.56 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
 <line x1="168.0" y1="374.0" x2="494.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="494.8" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">55.7 µs</text>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">56.1 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="540.6" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="540.6" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">186 µs</text>
+<line x1="168.0" y1="398.0" x2="539.7" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="539.7" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">184 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="422.0" x2="568.4" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="568.4" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="422.0" x2="568.1" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="568.1" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">389 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="446.0" x2="619.2" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="619.2" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.48 ms</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="470.0" x2="632.8" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="632.8" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.12 ms</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="446.0" x2="618.3" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="618.3" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.46 ms</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="470.0" x2="618.8" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="618.8" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.49 ms</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.1 ms</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.4 ms</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">c/mandelbrot: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/c-sha256-dark.svg
+++ b/docs/benchmarks/figs/c-sha256-dark.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/sha256: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 293 ns, then wasmtime at 293 ns; dewasm-bash is slowest at 16.0 ms, a span of 54500x. The table below carries every number.">
-<title>c/sha256: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 293 ns, then wasmtime at 293 ns; dewasm-bash is slowest at 16.0 ms, a span of 54500x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/sha256: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 293 ns, then wasmer at 294 ns; dewasm-bash is slowest at 16.0 ms, a span of 54400x. The table below carries every number.">
+<title>c/sha256: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 293 ns, then wasmer at 294 ns; dewasm-bash is slowest at 16.0 ms, a span of 54400x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
@@ -14,74 +14,74 @@
 <line x1="696.5" y1="68.0" x2="696.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="696.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="86.0" x2="217.3" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="217.3" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="217.4" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="217.4" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">293 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="217.4" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="217.4" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">293 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="110.0" x2="217.4" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="217.4" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">294 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="225.3" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="225.3" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="134.0" x2="225.4" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="225.4" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">349 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="229.5" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="229.5" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">381 ns</text>
+<line x1="168.0" y1="158.0" x2="229.0" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="229.0" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">378 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="246.3" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="246.3" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">550 ns</text>
+<line x1="168.0" y1="182.0" x2="242.2" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="242.2" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">504 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="348.2" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="348.2" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.07 µs</text>
+<line x1="168.0" y1="206.0" x2="347.9" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="347.9" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.03 µs</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="394.9" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="394.9" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.0 µs</text>
+<line x1="168.0" y1="230.0" x2="393.8" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="393.8" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.7 µs</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="436.4" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="436.4" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">34.6 µs</text>
+<line x1="168.0" y1="254.0" x2="435.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="435.8" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">34.2 µs</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="278.0" x2="445.2" y2="278.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="445.2" cy="278.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">41.9 µs</text>
+<line x1="168.0" y1="278.0" x2="445.3" y2="278.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="445.3" cy="278.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">42.0 µs</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="456.9" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="456.9" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">54.1 µs</text>
+<line x1="168.0" y1="302.0" x2="456.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="456.6" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">53.7 µs</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="474.4" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="474.4" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">79.1 µs</text>
+<line x1="168.0" y1="326.0" x2="474.3" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="474.3" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">78.9 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="531.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="531.1" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">272 µs</text>
+<line x1="168.0" y1="350.0" x2="530.6" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="530.6" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">269 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="538.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="538.8" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">322 µs</text>
+<line x1="168.0" y1="374.0" x2="538.7" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="538.7" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">321 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="621.3" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="621.3" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.94 ms</text>
+<line x1="168.0" y1="398.0" x2="621.7" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="621.7" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.96 ms</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="422.0" x2="656.7" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="656.7" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.20 ms</text>
+<line x1="168.0" y1="422.0" x2="656.8" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="656.8" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.21 ms</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="682.2" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="682.2" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.33 ms</text>
+<line x1="168.0" y1="446.0" x2="708.1" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="708.1" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.9 ms</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="470.0" x2="713.7" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="713.7" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.5 ms</text>
+<line x1="168.0" y1="470.0" x2="714.3" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="714.3" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.7 ms</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>

--- a/docs/benchmarks/figs/c-sha256.svg
+++ b/docs/benchmarks/figs/c-sha256.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/sha256: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 293 ns, then wasmtime at 293 ns; dewasm-bash is slowest at 16.0 ms, a span of 54500x. The table below carries every number.">
-<title>c/sha256: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 293 ns, then wasmtime at 293 ns; dewasm-bash is slowest at 16.0 ms, a span of 54500x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/sha256: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 293 ns, then wasmer at 294 ns; dewasm-bash is slowest at 16.0 ms, a span of 54400x. The table below carries every number.">
+<title>c/sha256: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 293 ns, then wasmer at 294 ns; dewasm-bash is slowest at 16.0 ms, a span of 54400x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
@@ -14,74 +14,74 @@
 <line x1="696.5" y1="68.0" x2="696.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="696.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="86.0" x2="217.3" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="217.3" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="217.4" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="217.4" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">293 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="217.4" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="217.4" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">293 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="110.0" x2="217.4" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="217.4" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">294 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="225.3" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="225.3" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="134.0" x2="225.4" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="225.4" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">349 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="229.5" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="229.5" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">381 ns</text>
+<line x1="168.0" y1="158.0" x2="229.0" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="229.0" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">378 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="246.3" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="246.3" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">550 ns</text>
+<line x1="168.0" y1="182.0" x2="242.2" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="242.2" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">504 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="348.2" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="348.2" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.07 µs</text>
+<line x1="168.0" y1="206.0" x2="347.9" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="347.9" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.03 µs</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="394.9" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="394.9" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.0 µs</text>
+<line x1="168.0" y1="230.0" x2="393.8" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="393.8" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.7 µs</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="436.4" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="436.4" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">34.6 µs</text>
+<line x1="168.0" y1="254.0" x2="435.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="435.8" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">34.2 µs</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="278.0" x2="445.2" y2="278.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="445.2" cy="278.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">41.9 µs</text>
+<line x1="168.0" y1="278.0" x2="445.3" y2="278.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="445.3" cy="278.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">42.0 µs</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="456.9" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="456.9" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">54.1 µs</text>
+<line x1="168.0" y1="302.0" x2="456.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="456.6" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">53.7 µs</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="474.4" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="474.4" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">79.1 µs</text>
+<line x1="168.0" y1="326.0" x2="474.3" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="474.3" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">78.9 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="531.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="531.1" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">272 µs</text>
+<line x1="168.0" y1="350.0" x2="530.6" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="530.6" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">269 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="538.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="538.8" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">322 µs</text>
+<line x1="168.0" y1="374.0" x2="538.7" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="538.7" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">321 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="621.3" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="621.3" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.94 ms</text>
+<line x1="168.0" y1="398.0" x2="621.7" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="621.7" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.96 ms</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="422.0" x2="656.7" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="656.7" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.20 ms</text>
+<line x1="168.0" y1="422.0" x2="656.8" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="656.8" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.21 ms</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="682.2" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="682.2" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.33 ms</text>
+<line x1="168.0" y1="446.0" x2="708.1" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="708.1" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.9 ms</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="470.0" x2="713.7" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="713.7" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.5 ms</text>
+<line x1="168.0" y1="470.0" x2="714.3" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="714.3" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.7 ms</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>

--- a/docs/benchmarks/figs/c-wordcount-dark.svg
+++ b/docs/benchmarks/figs/c-wordcount-dark.svg
@@ -1,89 +1,89 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/wordcount: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 1.61 ns, then wasmtime at 1.67 ns; pywasm-cpython is slowest at 59.8 µs, a span of 37100x. The table below carries every number.">
-<title>c/wordcount: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 1.61 ns, then wasmtime at 1.67 ns; pywasm-cpython is slowest at 59.8 µs, a span of 37100x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/wordcount: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.51 ns, then wasmer at 1.63 ns; pywasm-cpython is slowest at 59.7 µs, a span of 39600x. The table below carries every number.">
+<title>c/wordcount: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.51 ns, then wasmer at 1.63 ns; pywasm-cpython is slowest at 59.7 µs, a span of 39600x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="283.1" y1="68.0" x2="283.1" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="283.1" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="283.2" y1="68.0" x2="283.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="283.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
 <line x1="398.3" y1="68.0" x2="398.3" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="398.3" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="513.4" y1="68.0" x2="513.4" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="513.4" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="628.6" y1="68.0" x2="628.6" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="628.6" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="513.5" y1="68.0" x2="513.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="513.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="628.7" y1="68.0" x2="628.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="628.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="86.0" x2="191.9" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="191.9" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.61 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="193.6" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="193.6" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.67 ns</text>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="188.5" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="188.5" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.51 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="110.0" x2="192.5" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="192.5" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.63 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="211.9" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="211.9" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.41 ns</text>
+<line x1="168.0" y1="134.0" x2="212.2" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="212.2" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.42 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="223.1" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="223.1" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.01 ns</text>
+<line x1="168.0" y1="158.0" x2="223.3" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="223.3" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.02 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="227.1" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="227.1" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.26 ns</text>
+<line x1="168.0" y1="182.0" x2="232.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="232.7" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.65 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="319.4" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="319.4" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="206.0" x2="319.3" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="319.3" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.6 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="370.3" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="370.3" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">57.1 ns</text>
+<line x1="168.0" y1="230.0" x2="370.4" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="370.4" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">57.2 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="434.0" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="434.0" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">204 ns</text>
+<line x1="168.0" y1="254.0" x2="434.1" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="434.1" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">205 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
 <line x1="168.0" y1="278.0" x2="448.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="448.8" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">275 ns</text>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">274 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="452.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="452.6" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">296 ns</text>
+<line x1="168.0" y1="302.0" x2="452.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="452.7" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">297 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
 <line x1="168.0" y1="326.0" x2="468.8" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="468.8" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">409 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="507.9" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="507.9" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">896 ns</text>
+<line x1="168.0" y1="350.0" x2="508.5" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="508.5" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">904 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="533.3" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="533.3" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="374.0" x2="533.5" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="533.5" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.49 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="627.8" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="627.8" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.85 µs</text>
+<line x1="168.0" y1="398.0" x2="627.5" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="627.5" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.77 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="422.0" x2="650.2" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="650.2" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.4 µs</text>
+<line x1="168.0" y1="422.0" x2="656.6" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="656.6" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">17.5 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="446.0" x2="665.4" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="665.4" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="446.0" x2="665.5" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="665.5" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.9 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="470.0" x2="701.3" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="701.3" cy="470.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="470.0" x2="701.4" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="701.4" cy="470.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">42.8 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">59.8 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">59.7 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">c/wordcount: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/c-wordcount.svg
+++ b/docs/benchmarks/figs/c-wordcount.svg
@@ -1,89 +1,89 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/wordcount: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 1.61 ns, then wasmtime at 1.67 ns; pywasm-cpython is slowest at 59.8 µs, a span of 37100x. The table below carries every number.">
-<title>c/wordcount: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 1.61 ns, then wasmtime at 1.67 ns; pywasm-cpython is slowest at 59.8 µs, a span of 37100x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/wordcount: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.51 ns, then wasmer at 1.63 ns; pywasm-cpython is slowest at 59.7 µs, a span of 39600x. The table below carries every number.">
+<title>c/wordcount: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.51 ns, then wasmer at 1.63 ns; pywasm-cpython is slowest at 59.7 µs, a span of 39600x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="283.1" y1="68.0" x2="283.1" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="283.1" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="283.2" y1="68.0" x2="283.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="283.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
 <line x1="398.3" y1="68.0" x2="398.3" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="398.3" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="513.4" y1="68.0" x2="513.4" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="513.4" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="628.6" y1="68.0" x2="628.6" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="628.6" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="513.5" y1="68.0" x2="513.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="513.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="628.7" y1="68.0" x2="628.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="628.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="86.0" x2="191.9" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="191.9" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.61 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="193.6" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="193.6" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.67 ns</text>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="188.5" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="188.5" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.51 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="110.0" x2="192.5" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="192.5" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.63 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="211.9" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="211.9" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.41 ns</text>
+<line x1="168.0" y1="134.0" x2="212.2" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="212.2" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.42 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="223.1" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="223.1" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.01 ns</text>
+<line x1="168.0" y1="158.0" x2="223.3" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="223.3" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.02 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="227.1" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="227.1" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.26 ns</text>
+<line x1="168.0" y1="182.0" x2="232.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="232.7" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.65 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="319.4" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="319.4" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="206.0" x2="319.3" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="319.3" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.6 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="370.3" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="370.3" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">57.1 ns</text>
+<line x1="168.0" y1="230.0" x2="370.4" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="370.4" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">57.2 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="434.0" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="434.0" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">204 ns</text>
+<line x1="168.0" y1="254.0" x2="434.1" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="434.1" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">205 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
 <line x1="168.0" y1="278.0" x2="448.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="448.8" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">275 ns</text>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">274 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="452.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="452.6" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">296 ns</text>
+<line x1="168.0" y1="302.0" x2="452.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="452.7" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">297 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
 <line x1="168.0" y1="326.0" x2="468.8" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="468.8" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">409 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="507.9" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="507.9" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">896 ns</text>
+<line x1="168.0" y1="350.0" x2="508.5" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="508.5" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">904 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="533.3" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="533.3" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="374.0" x2="533.5" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="533.5" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.49 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="627.8" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="627.8" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.85 µs</text>
+<line x1="168.0" y1="398.0" x2="627.5" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="627.5" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.77 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="422.0" x2="650.2" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="650.2" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.4 µs</text>
+<line x1="168.0" y1="422.0" x2="656.6" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="656.6" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">17.5 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="446.0" x2="665.4" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="665.4" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="446.0" x2="665.5" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="665.5" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.9 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="470.0" x2="701.3" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="701.3" cy="470.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="470.0" x2="701.4" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="701.4" cy="470.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">42.8 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">59.8 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">59.7 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">c/wordcount: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-br-table-dark.svg
+++ b/docs/benchmarks/figs/wat-br-table-dark.svg
@@ -1,0 +1,96 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/br_table: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-go is fastest at 7.65 ns, then wasmer at 8.50 ns; pywasm-cpython is slowest at 51.1 µs, a span of 6690x. The table below carries every number.">
+<title>wat/br_table: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-go is fastest at 7.65 ns, then wasmer at 8.50 ns; pywasm-cpython is slowest at 51.1 µs, a span of 6690x. The table below carries every number.</title>
+<rect width="820" height="536" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
+<line x1="284.8" y1="68.0" x2="284.8" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="284.8" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="401.6" y1="68.0" x2="401.6" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="401.6" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="518.4" y1="68.0" x2="518.4" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="518.4" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="635.2" y1="68.0" x2="635.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="635.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
+<line x1="168.0" y1="86.0" x2="271.2" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="271.2" cy="86.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.65 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="110.0" x2="276.6" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="276.6" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.50 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="134.0" x2="276.6" y2="134.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="276.6" cy="134.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.51 ns</text>
+<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
+<line x1="168.0" y1="158.0" x2="278.8" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="278.8" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.88 ns</text>
+<text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
+<line x1="168.0" y1="182.0" x2="283.5" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="283.5" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.74 ns</text>
+<text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
+<line x1="168.0" y1="206.0" x2="333.9" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="333.9" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">26.3 ns</text>
+<text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
+<line x1="168.0" y1="230.0" x2="377.5" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="377.5" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">62.2 ns</text>
+<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
+<line x1="168.0" y1="254.0" x2="441.0" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="441.0" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">218 ns</text>
+<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
+<line x1="168.0" y1="278.0" x2="441.2" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="441.2" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">218 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
+<line x1="168.0" y1="302.0" x2="441.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="441.2" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">218 ns</text>
+<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
+<line x1="168.0" y1="326.0" x2="442.2" y2="326.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="442.2" cy="326.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">222 ns</text>
+<text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
+<line x1="168.0" y1="350.0" x2="471.4" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="471.4" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">396 ns</text>
+<text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
+<line x1="168.0" y1="374.0" x2="511.6" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="511.6" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">875 ns</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
+<line x1="168.0" y1="398.0" x2="628.5" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="628.5" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.77 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
+<line x1="168.0" y1="422.0" x2="673.3" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="673.3" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">21.2 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="446.0" x2="701.0" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="701.0" cy="446.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">36.6 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="470.0" x2="717.7" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="717.7" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">50.8 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">51.1 µs</text>
+<text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/br_table: seconds per iteration, median of the timed runs (log scale)</text>
+<circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>
+<circle cx="179.9" cy="48.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="191.4" y="52.0" font-size="12" fill="#c3c2b7">dewasm backends</text>
+<circle cx="313.9" cy="48.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="325.4" y="52.0" font-size="12" fill="#c3c2b7">native runtimes</text>
+<circle cx="447.9" cy="48.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="459.4" y="52.0" font-size="12" fill="#c3c2b7">wasm interpreters in a host language</text>
+</svg>

--- a/docs/benchmarks/figs/wat-br-table.svg
+++ b/docs/benchmarks/figs/wat-br-table.svg
@@ -1,0 +1,96 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/br_table: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-go is fastest at 7.65 ns, then wasmer at 8.50 ns; pywasm-cpython is slowest at 51.1 µs, a span of 6690x. The table below carries every number.">
+<title>wat/br_table: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-go is fastest at 7.65 ns, then wasmer at 8.50 ns; pywasm-cpython is slowest at 51.1 µs, a span of 6690x. The table below carries every number.</title>
+<rect width="820" height="536" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
+<line x1="284.8" y1="68.0" x2="284.8" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="284.8" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="401.6" y1="68.0" x2="401.6" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="401.6" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="518.4" y1="68.0" x2="518.4" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="518.4" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="635.2" y1="68.0" x2="635.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="635.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
+<line x1="168.0" y1="86.0" x2="271.2" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="271.2" cy="86.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.65 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="110.0" x2="276.6" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="276.6" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.50 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="134.0" x2="276.6" y2="134.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="276.6" cy="134.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.51 ns</text>
+<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
+<line x1="168.0" y1="158.0" x2="278.8" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="278.8" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.88 ns</text>
+<text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
+<line x1="168.0" y1="182.0" x2="283.5" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="283.5" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.74 ns</text>
+<text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
+<line x1="168.0" y1="206.0" x2="333.9" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="333.9" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">26.3 ns</text>
+<text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
+<line x1="168.0" y1="230.0" x2="377.5" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="377.5" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">62.2 ns</text>
+<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
+<line x1="168.0" y1="254.0" x2="441.0" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="441.0" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">218 ns</text>
+<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
+<line x1="168.0" y1="278.0" x2="441.2" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="441.2" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">218 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
+<line x1="168.0" y1="302.0" x2="441.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="441.2" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">218 ns</text>
+<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
+<line x1="168.0" y1="326.0" x2="442.2" y2="326.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="442.2" cy="326.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">222 ns</text>
+<text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
+<line x1="168.0" y1="350.0" x2="471.4" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="471.4" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">396 ns</text>
+<text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
+<line x1="168.0" y1="374.0" x2="511.6" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="511.6" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">875 ns</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
+<line x1="168.0" y1="398.0" x2="628.5" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="628.5" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.77 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
+<line x1="168.0" y1="422.0" x2="673.3" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="673.3" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">21.2 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="446.0" x2="701.0" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="701.0" cy="446.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">36.6 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="470.0" x2="717.7" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="717.7" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">50.8 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">51.1 µs</text>
+<text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/br_table: seconds per iteration, median of the timed runs (log scale)</text>
+<circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>
+<circle cx="179.9" cy="48.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="191.4" y="52.0" font-size="12" fill="#52514e">dewasm backends</text>
+<circle cx="313.9" cy="48.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="325.4" y="52.0" font-size="12" fill="#52514e">native runtimes</text>
+<circle cx="447.9" cy="48.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="459.4" y="52.0" font-size="12" fill="#52514e">wasm interpreters in a host language</text>
+</svg>

--- a/docs/benchmarks/figs/wat-call-direct-dark.svg
+++ b/docs/benchmarks/figs/wat-call-direct-dark.svg
@@ -1,89 +1,89 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_direct: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 3.48 ns, then wasmtime at 3.50 ns; dewasm-bash is slowest at 55.9 µs, a span of 16100x. The table below carries every number.">
-<title>wat/call_direct: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 3.48 ns, then wasmtime at 3.50 ns; dewasm-bash is slowest at 55.9 µs, a span of 16100x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_direct: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 3.49 ns, then wasmtime at 3.49 ns; dewasm-bash is slowest at 55.6 µs, a span of 15900x. The table below carries every number.">
+<title>wat/call_direct: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 3.49 ns, then wasmtime at 3.49 ns; dewasm-bash is slowest at 55.6 µs, a span of 15900x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="283.8" y1="68.0" x2="283.8" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="283.8" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="399.7" y1="68.0" x2="399.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="399.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="515.5" y1="68.0" x2="515.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="515.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="631.4" y1="68.0" x2="631.4" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="631.4" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="283.9" y1="68.0" x2="283.9" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="283.9" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="399.8" y1="68.0" x2="399.8" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="399.8" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="515.7" y1="68.0" x2="515.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="515.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="631.6" y1="68.0" x2="631.6" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="631.6" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="86.0" x2="230.7" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="230.7" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.48 ns</text>
+<line x1="168.0" y1="86.0" x2="230.9" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="230.9" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.49 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="231.0" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="231.0" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.50 ns</text>
+<line x1="168.0" y1="110.0" x2="230.9" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="230.9" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.49 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="232.2" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="232.2" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.58 ns</text>
+<line x1="168.0" y1="134.0" x2="232.8" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="232.8" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.62 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="158.0" x2="239.3" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="239.3" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.12 ns</text>
+<line x1="168.0" y1="158.0" x2="239.4" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="239.4" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.13 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
 <line x1="168.0" y1="182.0" x2="258.2" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="258.2" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.01 ns</text>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.00 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="364.7" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="364.7" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">49.9 ns</text>
+<line x1="168.0" y1="206.0" x2="364.3" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="364.3" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">49.4 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="393.9" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="393.9" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">89.2 ns</text>
+<line x1="168.0" y1="230.0" x2="393.8" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="393.8" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">88.7 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="404.2" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="404.2" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="254.0" x2="404.1" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="404.1" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">109 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="278.0" x2="411.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="411.6" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">127 ns</text>
+<line x1="168.0" y1="278.0" x2="411.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="411.1" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">125 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="302.0" x2="436.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="436.5" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">208 ns</text>
+<line x1="168.0" y1="302.0" x2="436.3" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="436.3" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">207 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="326.0" x2="436.8" y2="326.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="436.8" cy="326.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">209 ns</text>
+<line x1="168.0" y1="326.0" x2="436.4" y2="326.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="436.4" cy="326.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">207 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="472.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="472.1" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">422 ns</text>
+<line x1="168.0" y1="350.0" x2="471.6" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="471.6" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">416 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="520.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="520.8" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.11 µs</text>
+<line x1="168.0" y1="374.0" x2="520.3" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="520.3" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.10 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="622.2" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="622.2" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.33 µs</text>
+<line x1="168.0" y1="398.0" x2="622.4" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="622.4" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.32 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="422.0" x2="631.8" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="631.8" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.1 µs</text>
+<line x1="168.0" y1="422.0" x2="636.0" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="636.0" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.9 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
 <line x1="168.0" y1="446.0" x2="661.0" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="661.0" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">18.0 µs</text>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">17.9 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="470.0" x2="711.7" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="711.7" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">49.3 µs</text>
+<line x1="168.0" y1="470.0" x2="711.5" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="711.5" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">48.9 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">55.9 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">55.6 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/call_direct: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-call-direct.svg
+++ b/docs/benchmarks/figs/wat-call-direct.svg
@@ -1,89 +1,89 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_direct: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 3.48 ns, then wasmtime at 3.50 ns; dewasm-bash is slowest at 55.9 µs, a span of 16100x. The table below carries every number.">
-<title>wat/call_direct: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 3.48 ns, then wasmtime at 3.50 ns; dewasm-bash is slowest at 55.9 µs, a span of 16100x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_direct: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 3.49 ns, then wasmtime at 3.49 ns; dewasm-bash is slowest at 55.6 µs, a span of 15900x. The table below carries every number.">
+<title>wat/call_direct: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 3.49 ns, then wasmtime at 3.49 ns; dewasm-bash is slowest at 55.6 µs, a span of 15900x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="283.8" y1="68.0" x2="283.8" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="283.8" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="399.7" y1="68.0" x2="399.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="399.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="515.5" y1="68.0" x2="515.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="515.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="631.4" y1="68.0" x2="631.4" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="631.4" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="283.9" y1="68.0" x2="283.9" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="283.9" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="399.8" y1="68.0" x2="399.8" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="399.8" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="515.7" y1="68.0" x2="515.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="515.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="631.6" y1="68.0" x2="631.6" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="631.6" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="86.0" x2="230.7" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="230.7" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.48 ns</text>
+<line x1="168.0" y1="86.0" x2="230.9" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="230.9" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.49 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="231.0" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="231.0" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.50 ns</text>
+<line x1="168.0" y1="110.0" x2="230.9" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="230.9" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.49 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="232.2" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="232.2" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.58 ns</text>
+<line x1="168.0" y1="134.0" x2="232.8" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="232.8" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.62 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="158.0" x2="239.3" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="239.3" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.12 ns</text>
+<line x1="168.0" y1="158.0" x2="239.4" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="239.4" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.13 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
 <line x1="168.0" y1="182.0" x2="258.2" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="258.2" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.01 ns</text>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.00 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="364.7" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="364.7" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">49.9 ns</text>
+<line x1="168.0" y1="206.0" x2="364.3" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="364.3" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">49.4 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="393.9" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="393.9" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">89.2 ns</text>
+<line x1="168.0" y1="230.0" x2="393.8" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="393.8" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">88.7 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="404.2" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="404.2" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="254.0" x2="404.1" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="404.1" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">109 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="278.0" x2="411.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="411.6" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">127 ns</text>
+<line x1="168.0" y1="278.0" x2="411.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="411.1" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">125 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="302.0" x2="436.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="436.5" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">208 ns</text>
+<line x1="168.0" y1="302.0" x2="436.3" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="436.3" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">207 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="326.0" x2="436.8" y2="326.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="436.8" cy="326.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">209 ns</text>
+<line x1="168.0" y1="326.0" x2="436.4" y2="326.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="436.4" cy="326.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">207 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="472.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="472.1" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">422 ns</text>
+<line x1="168.0" y1="350.0" x2="471.6" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="471.6" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">416 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="520.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="520.8" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.11 µs</text>
+<line x1="168.0" y1="374.0" x2="520.3" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="520.3" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.10 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="622.2" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="622.2" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.33 µs</text>
+<line x1="168.0" y1="398.0" x2="622.4" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="622.4" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.32 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="422.0" x2="631.8" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="631.8" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.1 µs</text>
+<line x1="168.0" y1="422.0" x2="636.0" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="636.0" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.9 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
 <line x1="168.0" y1="446.0" x2="661.0" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="661.0" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">18.0 µs</text>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">17.9 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="470.0" x2="711.7" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="711.7" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">49.3 µs</text>
+<line x1="168.0" y1="470.0" x2="711.5" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="711.5" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">48.9 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">55.9 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">55.6 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/call_direct: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-call-indirect-dark.svg
+++ b/docs/benchmarks/figs/wat-call-indirect-dark.svg
@@ -1,87 +1,87 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_indirect: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 10.5 ns, then wasmtime at 10.5 ns; pywasm-cpython is slowest at 82.2 µs, a span of 7860x. The table below carries every number.">
-<title>wat/call_indirect: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 10.5 ns, then wasmtime at 10.5 ns; pywasm-cpython is slowest at 82.2 µs, a span of 7860x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_indirect: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 10.5 ns, then wasmer at 10.5 ns; pywasm-cpython is slowest at 81.6 µs, a span of 7810x. The table below carries every number.">
+<title>wat/call_indirect: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 10.5 ns, then wasmer at 10.5 ns; pywasm-cpython is slowest at 81.6 µs, a span of 7810x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="308.5" y1="68.0" x2="308.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="308.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="449.0" y1="68.0" x2="449.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="449.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="589.5" y1="68.0" x2="589.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="589.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="308.6" y1="68.0" x2="308.6" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="308.6" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="449.2" y1="68.0" x2="449.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="449.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="589.8" y1="68.0" x2="589.8" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="589.8" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="86.0" x2="170.7" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="170.7" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="170.7" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="170.7" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.5 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="170.8" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="170.8" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="110.0" x2="170.8" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="170.8" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.5 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="172.8" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="172.8" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="134.0" x2="172.7" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="172.7" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.8 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="178.2" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="178.2" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="158.0" x2="178.0" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="178.0" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">11.8 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="272.0" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="272.0" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">55.0 ns</text>
+<line x1="168.0" y1="182.0" x2="274.0" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="274.0" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">56.8 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="286.5" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="286.5" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">69.7 ns</text>
+<line x1="168.0" y1="206.0" x2="286.0" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="286.0" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">69.0 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="329.2" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="329.2" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">140 ns</text>
+<line x1="168.0" y1="230.0" x2="328.6" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="328.6" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">139 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="395.1" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="395.1" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">414 ns</text>
+<line x1="168.0" y1="254.0" x2="394.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="394.6" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">409 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="278.0" x2="396.1" y2="278.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="396.1" cy="278.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">420 ns</text>
+<line x1="168.0" y1="278.0" x2="395.7" y2="278.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="395.7" cy="278.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">416 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="404.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="404.1" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">479 ns</text>
+<line x1="168.0" y1="302.0" x2="403.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="403.7" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">475 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="424.3" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="424.3" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">667 ns</text>
+<line x1="168.0" y1="326.0" x2="424.5" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="424.5" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">668 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="434.4" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="434.4" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">787 ns</text>
+<line x1="168.0" y1="350.0" x2="433.8" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="433.8" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">777 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="504.2" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="504.2" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.47 µs</text>
+<line x1="168.0" y1="374.0" x2="503.7" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="503.7" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.44 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="610.5" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="610.5" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.1 µs</text>
+<line x1="168.0" y1="398.0" x2="611.6" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="611.6" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.3 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="422.0" x2="653.1" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="653.1" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">28.4 µs</text>
+<line x1="168.0" y1="422.0" x2="652.5" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="652.5" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">27.9 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="662.6" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="662.6" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">33.1 µs</text>
+<line x1="168.0" y1="446.0" x2="660.2" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="660.2" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">31.7 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="470.0" x2="712.7" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="712.7" cy="470.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">75.3 µs</text>
+<line x1="168.0" y1="470.0" x2="713.2" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="713.2" cy="470.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">75.4 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">82.2 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">81.6 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/call_indirect: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-call-indirect.svg
+++ b/docs/benchmarks/figs/wat-call-indirect.svg
@@ -1,87 +1,87 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_indirect: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 10.5 ns, then wasmtime at 10.5 ns; pywasm-cpython is slowest at 82.2 µs, a span of 7860x. The table below carries every number.">
-<title>wat/call_indirect: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 10.5 ns, then wasmtime at 10.5 ns; pywasm-cpython is slowest at 82.2 µs, a span of 7860x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_indirect: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 10.5 ns, then wasmer at 10.5 ns; pywasm-cpython is slowest at 81.6 µs, a span of 7810x. The table below carries every number.">
+<title>wat/call_indirect: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 10.5 ns, then wasmer at 10.5 ns; pywasm-cpython is slowest at 81.6 µs, a span of 7810x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="308.5" y1="68.0" x2="308.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="308.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="449.0" y1="68.0" x2="449.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="449.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="589.5" y1="68.0" x2="589.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="589.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="308.6" y1="68.0" x2="308.6" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="308.6" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="449.2" y1="68.0" x2="449.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="449.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="589.8" y1="68.0" x2="589.8" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="589.8" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="86.0" x2="170.7" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="170.7" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="170.7" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="170.7" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.5 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="170.8" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="170.8" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="110.0" x2="170.8" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="170.8" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.5 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="172.8" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="172.8" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="134.0" x2="172.7" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="172.7" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.8 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="178.2" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="178.2" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="158.0" x2="178.0" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="178.0" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">11.8 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="272.0" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="272.0" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">55.0 ns</text>
+<line x1="168.0" y1="182.0" x2="274.0" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="274.0" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">56.8 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="286.5" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="286.5" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">69.7 ns</text>
+<line x1="168.0" y1="206.0" x2="286.0" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="286.0" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">69.0 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="329.2" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="329.2" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">140 ns</text>
+<line x1="168.0" y1="230.0" x2="328.6" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="328.6" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">139 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="395.1" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="395.1" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">414 ns</text>
+<line x1="168.0" y1="254.0" x2="394.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="394.6" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">409 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="278.0" x2="396.1" y2="278.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="396.1" cy="278.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">420 ns</text>
+<line x1="168.0" y1="278.0" x2="395.7" y2="278.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="395.7" cy="278.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">416 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="404.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="404.1" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">479 ns</text>
+<line x1="168.0" y1="302.0" x2="403.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="403.7" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">475 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="424.3" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="424.3" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">667 ns</text>
+<line x1="168.0" y1="326.0" x2="424.5" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="424.5" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">668 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="434.4" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="434.4" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">787 ns</text>
+<line x1="168.0" y1="350.0" x2="433.8" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="433.8" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">777 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="504.2" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="504.2" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.47 µs</text>
+<line x1="168.0" y1="374.0" x2="503.7" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="503.7" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.44 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="610.5" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="610.5" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.1 µs</text>
+<line x1="168.0" y1="398.0" x2="611.6" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="611.6" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.3 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="422.0" x2="653.1" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="653.1" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">28.4 µs</text>
+<line x1="168.0" y1="422.0" x2="652.5" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="652.5" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">27.9 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="662.6" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="662.6" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">33.1 µs</text>
+<line x1="168.0" y1="446.0" x2="660.2" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="660.2" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">31.7 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="470.0" x2="712.7" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="712.7" cy="470.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">75.3 µs</text>
+<line x1="168.0" y1="470.0" x2="713.2" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="713.2" cy="470.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">75.4 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">82.2 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">81.6 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/call_indirect: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-conv-dark.svg
+++ b/docs/benchmarks/figs/wat-conv-dark.svg
@@ -1,0 +1,98 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/conv: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 7.63 ns, then wasmtime at 7.63 ns; pywasm-pypy is slowest at 834 µs, a span of 109000x. The table below carries every number.">
+<title>wat/conv: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 7.63 ns, then wasmtime at 7.63 ns; pywasm-pypy is slowest at 834 µs, a span of 109000x. The table below carries every number.</title>
+<rect width="820" height="536" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
+<line x1="260.9" y1="68.0" x2="260.9" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="260.9" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="353.8" y1="68.0" x2="353.8" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="353.8" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="446.7" y1="68.0" x2="446.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="446.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="539.6" y1="68.0" x2="539.6" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="539.6" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="632.4" y1="68.0" x2="632.4" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="632.4" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="86.0" x2="250.0" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="250.0" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.63 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="110.0" x2="250.0" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="250.0" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.63 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
+<line x1="168.0" y1="134.0" x2="262.7" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="262.7" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.5 ns</text>
+<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
+<line x1="168.0" y1="158.0" x2="284.7" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="284.7" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">18.1 ns</text>
+<text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
+<line x1="168.0" y1="182.0" x2="291.2" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="291.2" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">21.2 ns</text>
+<text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
+<line x1="168.0" y1="206.0" x2="331.0" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="331.0" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">56.9 ns</text>
+<text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
+<line x1="168.0" y1="230.0" x2="388.2" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="388.2" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">235 ns</text>
+<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
+<line x1="168.0" y1="254.0" x2="392.2" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="392.2" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">259 ns</text>
+<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
+<line x1="168.0" y1="278.0" x2="441.0" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="441.0" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">870 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
+<line x1="168.0" y1="302.0" x2="446.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="446.0" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">983 ns</text>
+<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
+<line x1="168.0" y1="326.0" x2="459.1" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="459.1" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.36 µs</text>
+<text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
+<line x1="168.0" y1="350.0" x2="460.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="460.1" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.39 µs</text>
+<text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
+<line x1="168.0" y1="374.0" x2="479.2" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="479.2" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.24 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
+<line x1="168.0" y1="398.0" x2="558.1" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="558.1" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.8 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
+<line x1="168.0" y1="422.0" x2="577.9" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="577.9" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">25.8 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="446.0" x2="632.8" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="632.8" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">101 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="470.0" x2="699.1" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="699.1" cy="470.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">522 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">834 µs</text>
+<text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/conv: seconds per iteration, median of the timed runs (log scale)</text>
+<circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>
+<circle cx="179.9" cy="48.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="191.4" y="52.0" font-size="12" fill="#c3c2b7">dewasm backends</text>
+<circle cx="313.9" cy="48.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="325.4" y="52.0" font-size="12" fill="#c3c2b7">native runtimes</text>
+<circle cx="447.9" cy="48.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="459.4" y="52.0" font-size="12" fill="#c3c2b7">wasm interpreters in a host language</text>
+</svg>

--- a/docs/benchmarks/figs/wat-conv.svg
+++ b/docs/benchmarks/figs/wat-conv.svg
@@ -1,0 +1,98 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/conv: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 7.63 ns, then wasmtime at 7.63 ns; pywasm-pypy is slowest at 834 µs, a span of 109000x. The table below carries every number.">
+<title>wat/conv: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 7.63 ns, then wasmtime at 7.63 ns; pywasm-pypy is slowest at 834 µs, a span of 109000x. The table below carries every number.</title>
+<rect width="820" height="536" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
+<line x1="260.9" y1="68.0" x2="260.9" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="260.9" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="353.8" y1="68.0" x2="353.8" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="353.8" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="446.7" y1="68.0" x2="446.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="446.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="539.6" y1="68.0" x2="539.6" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="539.6" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="632.4" y1="68.0" x2="632.4" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="632.4" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="86.0" x2="250.0" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="250.0" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.63 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="110.0" x2="250.0" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="250.0" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.63 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
+<line x1="168.0" y1="134.0" x2="262.7" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="262.7" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.5 ns</text>
+<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
+<line x1="168.0" y1="158.0" x2="284.7" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="284.7" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">18.1 ns</text>
+<text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
+<line x1="168.0" y1="182.0" x2="291.2" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="291.2" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">21.2 ns</text>
+<text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
+<line x1="168.0" y1="206.0" x2="331.0" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="331.0" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">56.9 ns</text>
+<text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
+<line x1="168.0" y1="230.0" x2="388.2" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="388.2" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">235 ns</text>
+<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
+<line x1="168.0" y1="254.0" x2="392.2" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="392.2" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">259 ns</text>
+<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
+<line x1="168.0" y1="278.0" x2="441.0" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="441.0" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">870 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
+<line x1="168.0" y1="302.0" x2="446.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="446.0" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">983 ns</text>
+<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
+<line x1="168.0" y1="326.0" x2="459.1" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="459.1" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.36 µs</text>
+<text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
+<line x1="168.0" y1="350.0" x2="460.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="460.1" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.39 µs</text>
+<text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
+<line x1="168.0" y1="374.0" x2="479.2" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="479.2" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.24 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
+<line x1="168.0" y1="398.0" x2="558.1" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="558.1" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.8 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
+<line x1="168.0" y1="422.0" x2="577.9" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="577.9" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">25.8 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="446.0" x2="632.8" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="632.8" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">101 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="470.0" x2="699.1" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="699.1" cy="470.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">522 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">834 µs</text>
+<text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/conv: seconds per iteration, median of the timed runs (log scale)</text>
+<circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>
+<circle cx="179.9" cy="48.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="191.4" y="52.0" font-size="12" fill="#52514e">dewasm backends</text>
+<circle cx="313.9" cy="48.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="325.4" y="52.0" font-size="12" fill="#52514e">native runtimes</text>
+<circle cx="447.9" cy="48.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="459.4" y="52.0" font-size="12" fill="#52514e">wasm interpreters in a host language</text>
+</svg>

--- a/docs/benchmarks/figs/wat-eh-throw-dark.svg
+++ b/docs/benchmarks/figs/wat-eh-throw-dark.svg
@@ -1,0 +1,68 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.37 ns, then wasmedge at 115 ns; wasmer is slowest at 10.3 µs, a span of 2370x. The table below carries every number.">
+<title>wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.37 ns, then wasmedge at 115 ns; wasmer is slowest at 10.3 µs, a span of 2370x. The table below carries every number.</title>
+<rect width="820" height="368" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
+<line x1="305.0" y1="68.0" x2="305.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="305.0" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="442.0" y1="68.0" x2="442.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="442.0" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="579.0" y1="68.0" x2="579.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="579.0" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="716.1" y1="68.0" x2="716.1" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="716.1" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="168.0" y1="338.0" x2="726.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
+<line x1="168.0" y1="86.0" x2="255.7" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="255.7" cy="86.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.37 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
+<line x1="168.0" y1="110.0" x2="450.5" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="450.5" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">115 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
+<line x1="168.0" y1="134.0" x2="483.2" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="483.2" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">200 ns</text>
+<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="158.0" x2="489.2" y2="158.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="489.2" cy="158.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">221 ns</text>
+<text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
+<line x1="168.0" y1="182.0" x2="533.8" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="533.8" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">467 ns</text>
+<text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
+<line x1="168.0" y1="206.0" x2="541.7" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="541.7" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">534 ns</text>
+<text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
+<line x1="168.0" y1="230.0" x2="549.7" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="549.7" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">610 ns</text>
+<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
+<line x1="168.0" y1="254.0" x2="551.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="551.6" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">631 ns</text>
+<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
+<line x1="168.0" y1="278.0" x2="555.0" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="555.0" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">667 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
+<line x1="168.0" y1="302.0" x2="589.4" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="589.4" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.19 µs</text>
+<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="326.0" x2="718.0" y2="326.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="326.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.3 µs</text>
+<text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/eh_throw: seconds per iteration, median of the timed runs (log scale)</text>
+<circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>
+<circle cx="179.9" cy="48.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="191.4" y="52.0" font-size="12" fill="#c3c2b7">dewasm backends</text>
+<circle cx="313.9" cy="48.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="325.4" y="52.0" font-size="12" fill="#c3c2b7">native runtimes</text>
+<circle cx="447.9" cy="48.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="459.4" y="52.0" font-size="12" fill="#c3c2b7">wasm interpreters in a host language</text>
+</svg>

--- a/docs/benchmarks/figs/wat-eh-throw.svg
+++ b/docs/benchmarks/figs/wat-eh-throw.svg
@@ -1,0 +1,68 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.37 ns, then wasmedge at 115 ns; wasmer is slowest at 10.3 µs, a span of 2370x. The table below carries every number.">
+<title>wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.37 ns, then wasmedge at 115 ns; wasmer is slowest at 10.3 µs, a span of 2370x. The table below carries every number.</title>
+<rect width="820" height="368" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
+<line x1="305.0" y1="68.0" x2="305.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="305.0" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="442.0" y1="68.0" x2="442.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="442.0" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="579.0" y1="68.0" x2="579.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="579.0" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="716.1" y1="68.0" x2="716.1" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="716.1" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="168.0" y1="338.0" x2="726.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
+<line x1="168.0" y1="86.0" x2="255.7" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="255.7" cy="86.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.37 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
+<line x1="168.0" y1="110.0" x2="450.5" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="450.5" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">115 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
+<line x1="168.0" y1="134.0" x2="483.2" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="483.2" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">200 ns</text>
+<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="158.0" x2="489.2" y2="158.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="489.2" cy="158.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">221 ns</text>
+<text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
+<line x1="168.0" y1="182.0" x2="533.8" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="533.8" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">467 ns</text>
+<text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
+<line x1="168.0" y1="206.0" x2="541.7" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="541.7" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">534 ns</text>
+<text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
+<line x1="168.0" y1="230.0" x2="549.7" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="549.7" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">610 ns</text>
+<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
+<line x1="168.0" y1="254.0" x2="551.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="551.6" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">631 ns</text>
+<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
+<line x1="168.0" y1="278.0" x2="555.0" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="555.0" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">667 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
+<line x1="168.0" y1="302.0" x2="589.4" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="589.4" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.19 µs</text>
+<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="326.0" x2="718.0" y2="326.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="326.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.3 µs</text>
+<text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/eh_throw: seconds per iteration, median of the timed runs (log scale)</text>
+<circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>
+<circle cx="179.9" cy="48.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="191.4" y="52.0" font-size="12" fill="#52514e">dewasm backends</text>
+<circle cx="313.9" cy="48.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="325.4" y="52.0" font-size="12" fill="#52514e">native runtimes</text>
+<circle cx="447.9" cy="48.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="459.4" y="52.0" font-size="12" fill="#52514e">wasm interpreters in a host language</text>
+</svg>

--- a/docs/benchmarks/figs/wat-eh-try-dark.svg
+++ b/docs/benchmarks/figs/wat-eh-try-dark.svg
@@ -1,0 +1,64 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.27 ns, then dewasm-java at 1.43 ns; dewasm-perl is slowest at 515 ns, a span of 407x. The table below carries every number.">
+<title>wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.27 ns, then dewasm-java at 1.43 ns; dewasm-perl is slowest at 515 ns, a span of 407x. The table below carries every number.</title>
+<rect width="820" height="368" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
+<line x1="370.8" y1="68.0" x2="370.8" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="370.8" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="573.6" y1="68.0" x2="573.6" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="573.6" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="168.0" y1="338.0" x2="726.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="86.0" x2="188.8" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="188.8" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.27 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
+<line x1="168.0" y1="110.0" x2="199.5" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="199.5" cy="110.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.43 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
+<line x1="168.0" y1="134.0" x2="251.9" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="251.9" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.59 ns</text>
+<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="158.0" x2="258.2" y2="158.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="258.2" cy="158.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.78 ns</text>
+<text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
+<line x1="168.0" y1="182.0" x2="294.8" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="294.8" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.22 ns</text>
+<text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
+<line x1="168.0" y1="206.0" x2="587.4" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="587.4" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">117 ns</text>
+<text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
+<line x1="168.0" y1="230.0" x2="591.4" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="591.4" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">122 ns</text>
+<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
+<line x1="168.0" y1="254.0" x2="591.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="591.5" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">123 ns</text>
+<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
+<line x1="168.0" y1="278.0" x2="591.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="591.6" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">123 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
+<line x1="168.0" y1="302.0" x2="635.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="635.1" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">201 ns</text>
+<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
+<line x1="168.0" y1="326.0" x2="718.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">515 ns</text>
+<text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/eh_try: seconds per iteration, median of the timed runs (log scale)</text>
+<circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>
+<circle cx="179.9" cy="48.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="191.4" y="52.0" font-size="12" fill="#c3c2b7">dewasm backends</text>
+<circle cx="313.9" cy="48.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="325.4" y="52.0" font-size="12" fill="#c3c2b7">native runtimes</text>
+<circle cx="447.9" cy="48.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="459.4" y="52.0" font-size="12" fill="#c3c2b7">wasm interpreters in a host language</text>
+</svg>

--- a/docs/benchmarks/figs/wat-eh-try.svg
+++ b/docs/benchmarks/figs/wat-eh-try.svg
@@ -1,0 +1,64 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.27 ns, then dewasm-java at 1.43 ns; dewasm-perl is slowest at 515 ns, a span of 407x. The table below carries every number.">
+<title>wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.27 ns, then dewasm-java at 1.43 ns; dewasm-perl is slowest at 515 ns, a span of 407x. The table below carries every number.</title>
+<rect width="820" height="368" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
+<line x1="370.8" y1="68.0" x2="370.8" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="370.8" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="573.6" y1="68.0" x2="573.6" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="573.6" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="168.0" y1="338.0" x2="726.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="86.0" x2="188.8" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="188.8" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.27 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
+<line x1="168.0" y1="110.0" x2="199.5" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="199.5" cy="110.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.43 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
+<line x1="168.0" y1="134.0" x2="251.9" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="251.9" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.59 ns</text>
+<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="158.0" x2="258.2" y2="158.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="258.2" cy="158.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.78 ns</text>
+<text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
+<line x1="168.0" y1="182.0" x2="294.8" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="294.8" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.22 ns</text>
+<text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
+<line x1="168.0" y1="206.0" x2="587.4" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="587.4" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">117 ns</text>
+<text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
+<line x1="168.0" y1="230.0" x2="591.4" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="591.4" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">122 ns</text>
+<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
+<line x1="168.0" y1="254.0" x2="591.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="591.5" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">123 ns</text>
+<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
+<line x1="168.0" y1="278.0" x2="591.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="591.6" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">123 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
+<line x1="168.0" y1="302.0" x2="635.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="635.1" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">201 ns</text>
+<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
+<line x1="168.0" y1="326.0" x2="718.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">515 ns</text>
+<text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/eh_try: seconds per iteration, median of the timed runs (log scale)</text>
+<circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>
+<circle cx="179.9" cy="48.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="191.4" y="52.0" font-size="12" fill="#52514e">dewasm backends</text>
+<circle cx="313.9" cy="48.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="325.4" y="52.0" font-size="12" fill="#52514e">native runtimes</text>
+<circle cx="447.9" cy="48.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="459.4" y="52.0" font-size="12" fill="#52514e">wasm interpreters in a host language</text>
+</svg>

--- a/docs/benchmarks/figs/wat-f32-alu-dark.svg
+++ b/docs/benchmarks/figs/wat-f32-alu-dark.svg
@@ -1,0 +1,94 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="488" viewBox="0 0 820 488" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f32_alu: seconds per iteration for 16 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmer at 1.00 ns; dewasm-bash is slowest at 1.21 ms, a span of 1240000x. The table below carries every number.">
+<title>wat/f32_alu: seconds per iteration for 16 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmer at 1.00 ns; dewasm-bash is slowest at 1.21 ms, a span of 1240000x. The table below carries every number.</title>
+<rect width="820" height="488" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">0 ns</text>
+<line x1="245.7" y1="68.0" x2="245.7" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="245.7" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
+<line x1="323.3" y1="68.0" x2="323.3" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="323.3" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="401.0" y1="68.0" x2="401.0" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="401.0" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="478.7" y1="68.0" x2="478.7" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="478.7" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="556.3" y1="68.0" x2="556.3" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="556.3" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="634.0" y1="68.0" x2="634.0" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="634.0" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="711.7" y1="68.0" x2="711.7" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="711.7" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ms</text>
+<line x1="168.0" y1="458.0" x2="726.0" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
+<line x1="168.0" y1="86.0" x2="244.7" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="244.7" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.97 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="110.0" x2="245.5" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="245.5" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.00 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="134.0" x2="245.6" y2="134.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="245.6" cy="134.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.00 ns</text>
+<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
+<line x1="168.0" y1="158.0" x2="262.4" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="262.4" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.64 ns</text>
+<text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
+<line x1="168.0" y1="182.0" x2="287.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="287.7" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.48 ns</text>
+<text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
+<line x1="168.0" y1="206.0" x2="309.9" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="309.9" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.72 ns</text>
+<text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
+<line x1="168.0" y1="230.0" x2="394.3" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="394.3" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">82.0 ns</text>
+<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
+<line x1="168.0" y1="254.0" x2="445.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="445.8" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">377 ns</text>
+<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
+<line x1="168.0" y1="278.0" x2="460.7" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="460.7" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">587 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
+<line x1="168.0" y1="302.0" x2="465.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="465.5" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">677 ns</text>
+<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
+<line x1="168.0" y1="326.0" x2="465.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="465.7" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">681 ns</text>
+<text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
+<line x1="168.0" y1="350.0" x2="473.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="473.2" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">849 ns</text>
+<text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
+<line x1="168.0" y1="374.0" x2="493.4" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="493.4" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.55 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="398.0" x2="551.9" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="551.9" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.78 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="422.0" x2="592.1" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="592.1" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">28.9 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="446.0" x2="718.0" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="446.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.21 ms</text>
+<text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/f32_alu: seconds per iteration, median of the timed runs (log scale)</text>
+<circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>
+<circle cx="179.9" cy="48.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="191.4" y="52.0" font-size="12" fill="#c3c2b7">dewasm backends</text>
+<circle cx="313.9" cy="48.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="325.4" y="52.0" font-size="12" fill="#c3c2b7">native runtimes</text>
+<circle cx="447.9" cy="48.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="459.4" y="52.0" font-size="12" fill="#c3c2b7">wasm interpreters in a host language</text>
+</svg>

--- a/docs/benchmarks/figs/wat-f32-alu.svg
+++ b/docs/benchmarks/figs/wat-f32-alu.svg
@@ -1,0 +1,94 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="488" viewBox="0 0 820 488" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f32_alu: seconds per iteration for 16 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmer at 1.00 ns; dewasm-bash is slowest at 1.21 ms, a span of 1240000x. The table below carries every number.">
+<title>wat/f32_alu: seconds per iteration for 16 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmer at 1.00 ns; dewasm-bash is slowest at 1.21 ms, a span of 1240000x. The table below carries every number.</title>
+<rect width="820" height="488" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">0 ns</text>
+<line x1="245.7" y1="68.0" x2="245.7" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="245.7" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
+<line x1="323.3" y1="68.0" x2="323.3" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="323.3" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="401.0" y1="68.0" x2="401.0" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="401.0" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="478.7" y1="68.0" x2="478.7" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="478.7" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="556.3" y1="68.0" x2="556.3" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="556.3" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="634.0" y1="68.0" x2="634.0" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="634.0" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="711.7" y1="68.0" x2="711.7" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="711.7" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">1 ms</text>
+<line x1="168.0" y1="458.0" x2="726.0" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
+<line x1="168.0" y1="86.0" x2="244.7" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="244.7" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.97 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="110.0" x2="245.5" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="245.5" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.00 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="134.0" x2="245.6" y2="134.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="245.6" cy="134.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.00 ns</text>
+<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
+<line x1="168.0" y1="158.0" x2="262.4" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="262.4" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.64 ns</text>
+<text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
+<line x1="168.0" y1="182.0" x2="287.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="287.7" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.48 ns</text>
+<text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
+<line x1="168.0" y1="206.0" x2="309.9" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="309.9" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.72 ns</text>
+<text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
+<line x1="168.0" y1="230.0" x2="394.3" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="394.3" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">82.0 ns</text>
+<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
+<line x1="168.0" y1="254.0" x2="445.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="445.8" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">377 ns</text>
+<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
+<line x1="168.0" y1="278.0" x2="460.7" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="460.7" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">587 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
+<line x1="168.0" y1="302.0" x2="465.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="465.5" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">677 ns</text>
+<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
+<line x1="168.0" y1="326.0" x2="465.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="465.7" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">681 ns</text>
+<text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
+<line x1="168.0" y1="350.0" x2="473.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="473.2" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">849 ns</text>
+<text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
+<line x1="168.0" y1="374.0" x2="493.4" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="493.4" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.55 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="398.0" x2="551.9" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="551.9" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.78 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="422.0" x2="592.1" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="592.1" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">28.9 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="446.0" x2="718.0" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="446.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.21 ms</text>
+<text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/f32_alu: seconds per iteration, median of the timed runs (log scale)</text>
+<circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>
+<circle cx="179.9" cy="48.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="191.4" y="52.0" font-size="12" fill="#52514e">dewasm backends</text>
+<circle cx="313.9" cy="48.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="325.4" y="52.0" font-size="12" fill="#52514e">native runtimes</text>
+<circle cx="447.9" cy="48.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="459.4" y="52.0" font-size="12" fill="#52514e">wasm interpreters in a host language</text>
+</svg>

--- a/docs/benchmarks/figs/wat-f64-alu-dark.svg
+++ b/docs/benchmarks/figs/wat-f64-alu-dark.svg
@@ -1,93 +1,93 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 0.97 ns, then wazero at 0.97 ns; dewasm-bash is slowest at 581 µs, a span of 599000x. The table below carries every number.">
-<title>wat/f64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 0.97 ns, then wazero at 0.97 ns; dewasm-bash is slowest at 581 µs, a span of 599000x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmtime at 0.97 ns; dewasm-bash is slowest at 578 µs, a span of 598000x. The table below carries every number.">
+<title>wat/f64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmtime at 0.97 ns; dewasm-bash is slowest at 578 µs, a span of 598000x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">0 ns</text>
 <line x1="249.3" y1="68.0" x2="249.3" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="249.3" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="330.6" y1="68.0" x2="330.6" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="330.6" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="411.9" y1="68.0" x2="411.9" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="411.9" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="493.2" y1="68.0" x2="493.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="493.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="574.6" y1="68.0" x2="574.6" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="574.6" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="655.9" y1="68.0" x2="655.9" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="655.9" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="330.7" y1="68.0" x2="330.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="330.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="412.0" y1="68.0" x2="412.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="412.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="493.4" y1="68.0" x2="493.4" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="493.4" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="574.7" y1="68.0" x2="574.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="574.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="656.0" y1="68.0" x2="656.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="656.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="248.2" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="248.2" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
+<line x1="168.0" y1="86.0" x2="248.1" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="248.1" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.97 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="110.0" x2="248.3" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="248.3" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="110.0" x2="248.4" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="248.4" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.97 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="134.0" x2="248.5" y2="134.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="248.5" cy="134.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="134.0" x2="248.6" y2="134.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="248.6" cy="134.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.98 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="158.0" x2="266.7" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="266.7" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.64 ns</text>
+<line x1="168.0" y1="158.0" x2="266.6" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="266.6" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.63 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="182.0" x2="276.5" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="276.5" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.16 ns</text>
+<line x1="168.0" y1="182.0" x2="276.4" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="276.4" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.15 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="206.0" x2="293.7" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="293.7" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="206.0" x2="293.8" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="293.8" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.52 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="230.0" x2="309.1" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="309.1" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.43 ns</text>
+<line x1="168.0" y1="230.0" x2="309.0" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="309.0" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.42 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="402.3" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="402.3" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="254.0" x2="402.4" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="402.4" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">76.2 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="278.0" x2="405.1" y2="278.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="405.1" cy="278.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">82.3 ns</text>
+<line x1="168.0" y1="278.0" x2="404.9" y2="278.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="404.9" cy="278.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">81.7 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="405.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="405.1" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="302.0" x2="405.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="405.2" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">82.5 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="412.8" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="412.8" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">103 ns</text>
+<line x1="168.0" y1="326.0" x2="412.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="412.7" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">102 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="426.8" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="426.8" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="350.0" x2="426.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="426.7" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">152 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
 <line x1="168.0" y1="374.0" x2="486.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="486.8" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">834 ns</text>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">831 ns</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="538.5" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="538.5" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.60 µs</text>
+<line x1="168.0" y1="398.0" x2="538.1" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="538.1" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.55 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="422.0" x2="564.9" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="564.9" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.61 µs</text>
+<line x1="168.0" y1="422.0" x2="558.5" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="558.5" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.32 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
 <line x1="168.0" y1="446.0" x2="565.4" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="565.4" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.73 µs</text>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.68 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="470.0" x2="612.6" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="612.6" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="470.0" x2="612.8" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="612.8" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">29.4 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">581 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">578 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/f64_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-f64-alu.svg
+++ b/docs/benchmarks/figs/wat-f64-alu.svg
@@ -1,93 +1,93 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 0.97 ns, then wazero at 0.97 ns; dewasm-bash is slowest at 581 µs, a span of 599000x. The table below carries every number.">
-<title>wat/f64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 0.97 ns, then wazero at 0.97 ns; dewasm-bash is slowest at 581 µs, a span of 599000x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmtime at 0.97 ns; dewasm-bash is slowest at 578 µs, a span of 598000x. The table below carries every number.">
+<title>wat/f64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmtime at 0.97 ns; dewasm-bash is slowest at 578 µs, a span of 598000x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">0 ns</text>
 <line x1="249.3" y1="68.0" x2="249.3" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="249.3" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="330.6" y1="68.0" x2="330.6" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="330.6" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="411.9" y1="68.0" x2="411.9" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="411.9" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="493.2" y1="68.0" x2="493.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="493.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="574.6" y1="68.0" x2="574.6" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="574.6" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="655.9" y1="68.0" x2="655.9" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="655.9" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="330.7" y1="68.0" x2="330.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="330.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="412.0" y1="68.0" x2="412.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="412.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="493.4" y1="68.0" x2="493.4" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="493.4" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="574.7" y1="68.0" x2="574.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="574.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="656.0" y1="68.0" x2="656.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="656.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="248.2" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="248.2" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
+<line x1="168.0" y1="86.0" x2="248.1" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="248.1" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.97 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="110.0" x2="248.3" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="248.3" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="110.0" x2="248.4" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="248.4" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.97 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="134.0" x2="248.5" y2="134.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="248.5" cy="134.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="134.0" x2="248.6" y2="134.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="248.6" cy="134.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.98 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="158.0" x2="266.7" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="266.7" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.64 ns</text>
+<line x1="168.0" y1="158.0" x2="266.6" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="266.6" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.63 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="182.0" x2="276.5" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="276.5" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.16 ns</text>
+<line x1="168.0" y1="182.0" x2="276.4" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="276.4" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.15 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="206.0" x2="293.7" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="293.7" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="206.0" x2="293.8" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="293.8" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.52 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="230.0" x2="309.1" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="309.1" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.43 ns</text>
+<line x1="168.0" y1="230.0" x2="309.0" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="309.0" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.42 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="402.3" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="402.3" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="254.0" x2="402.4" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="402.4" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">76.2 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="278.0" x2="405.1" y2="278.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="405.1" cy="278.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">82.3 ns</text>
+<line x1="168.0" y1="278.0" x2="404.9" y2="278.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="404.9" cy="278.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">81.7 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="405.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="405.1" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="302.0" x2="405.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="405.2" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">82.5 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="412.8" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="412.8" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">103 ns</text>
+<line x1="168.0" y1="326.0" x2="412.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="412.7" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">102 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="426.8" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="426.8" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="350.0" x2="426.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="426.7" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">152 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
 <line x1="168.0" y1="374.0" x2="486.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="486.8" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">834 ns</text>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">831 ns</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="538.5" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="538.5" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.60 µs</text>
+<line x1="168.0" y1="398.0" x2="538.1" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="538.1" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.55 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="422.0" x2="564.9" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="564.9" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.61 µs</text>
+<line x1="168.0" y1="422.0" x2="558.5" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="558.5" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.32 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
 <line x1="168.0" y1="446.0" x2="565.4" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="565.4" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.73 µs</text>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.68 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="470.0" x2="612.6" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="612.6" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="470.0" x2="612.8" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="612.8" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">29.4 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">581 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">578 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/f64_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i32-alu-dark.svg
+++ b/docs/benchmarks/figs/wat-i32-alu-dark.svg
@@ -1,89 +1,89 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.32 ns, then wasmtime at 2.32 ns; pywasm-cpython is slowest at 53.9 µs, a span of 23200x. The table below carries every number.">
-<title>wat/i32_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.32 ns, then wasmtime at 2.32 ns; pywasm-cpython is slowest at 53.9 µs, a span of 23200x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.32 ns, then wasmtime at 2.32 ns; pywasm-cpython is slowest at 54.1 µs, a span of 23300x. The table below carries every number.">
+<title>wat/i32_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.32 ns, then wasmtime at 2.32 ns; pywasm-cpython is slowest at 54.1 µs, a span of 23300x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
 <line x1="284.2" y1="68.0" x2="284.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="284.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="400.5" y1="68.0" x2="400.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="400.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="516.7" y1="68.0" x2="516.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="516.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="633.0" y1="68.0" x2="633.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="633.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="400.4" y1="68.0" x2="400.4" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="400.4" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="516.6" y1="68.0" x2="516.6" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="516.6" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="632.8" y1="68.0" x2="632.8" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="632.8" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="86.0" x2="210.4" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="210.4" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="86.0" x2="210.5" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="210.5" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.32 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
 <line x1="168.0" y1="110.0" x2="210.5" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="210.5" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.32 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="211.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="211.1" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.35 ns</text>
+<line x1="168.0" y1="134.0" x2="211.5" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="211.5" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.37 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="217.4" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="217.4" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.66 ns</text>
+<line x1="168.0" y1="158.0" x2="217.5" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="217.5" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.67 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
 <line x1="168.0" y1="182.0" x2="224.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="224.7" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.07 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="206.0" x2="282.2" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="282.2" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.60 ns</text>
+<line x1="168.0" y1="206.0" x2="282.3" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="282.3" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.64 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="230.0" x2="297.7" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="297.7" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="230.0" x2="297.4" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="297.4" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.0 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="417.4" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="417.4" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">140 ns</text>
+<line x1="168.0" y1="254.0" x2="416.9" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="416.9" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">139 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="278.0" x2="421.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="421.1" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="278.0" x2="420.9" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="420.9" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">150 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="302.0" x2="423.5" y2="302.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="423.5" cy="302.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">158 ns</text>
+<line x1="168.0" y1="302.0" x2="423.3" y2="302.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="423.3" cy="302.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">157 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="431.2" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="431.2" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">184 ns</text>
+<line x1="168.0" y1="326.0" x2="430.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="430.7" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">182 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="487.6" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="487.6" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">561 ns</text>
+<line x1="168.0" y1="350.0" x2="487.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="487.7" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">564 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="498.4" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="498.4" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">695 ns</text>
+<line x1="168.0" y1="374.0" x2="498.2" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="498.2" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">694 ns</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="615.2" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="615.2" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.04 µs</text>
+<line x1="168.0" y1="398.0" x2="615.4" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="615.4" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.09 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="422.0" x2="654.9" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="654.9" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.4 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="677.7" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="677.7" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">24.2 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="470.0" x2="679.4" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="679.4" cy="470.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">25.1 µs</text>
+<line x1="168.0" y1="422.0" x2="654.4" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="654.4" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.3 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="446.0" x2="679.5" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="679.5" cy="446.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">25.2 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="470.0" x2="680.3" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="680.3" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">25.6 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">53.9 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">54.1 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/i32_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i32-alu.svg
+++ b/docs/benchmarks/figs/wat-i32-alu.svg
@@ -1,89 +1,89 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.32 ns, then wasmtime at 2.32 ns; pywasm-cpython is slowest at 53.9 µs, a span of 23200x. The table below carries every number.">
-<title>wat/i32_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.32 ns, then wasmtime at 2.32 ns; pywasm-cpython is slowest at 53.9 µs, a span of 23200x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.32 ns, then wasmtime at 2.32 ns; pywasm-cpython is slowest at 54.1 µs, a span of 23300x. The table below carries every number.">
+<title>wat/i32_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.32 ns, then wasmtime at 2.32 ns; pywasm-cpython is slowest at 54.1 µs, a span of 23300x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
 <line x1="284.2" y1="68.0" x2="284.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="284.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="400.5" y1="68.0" x2="400.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="400.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="516.7" y1="68.0" x2="516.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="516.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="633.0" y1="68.0" x2="633.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="633.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="400.4" y1="68.0" x2="400.4" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="400.4" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="516.6" y1="68.0" x2="516.6" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="516.6" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="632.8" y1="68.0" x2="632.8" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="632.8" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="86.0" x2="210.4" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="210.4" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="86.0" x2="210.5" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="210.5" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.32 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
 <line x1="168.0" y1="110.0" x2="210.5" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="210.5" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.32 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="211.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="211.1" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.35 ns</text>
+<line x1="168.0" y1="134.0" x2="211.5" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="211.5" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.37 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="217.4" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="217.4" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.66 ns</text>
+<line x1="168.0" y1="158.0" x2="217.5" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="217.5" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.67 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
 <line x1="168.0" y1="182.0" x2="224.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="224.7" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.07 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="206.0" x2="282.2" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="282.2" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.60 ns</text>
+<line x1="168.0" y1="206.0" x2="282.3" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="282.3" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.64 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="230.0" x2="297.7" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="297.7" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="230.0" x2="297.4" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="297.4" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.0 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="417.4" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="417.4" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">140 ns</text>
+<line x1="168.0" y1="254.0" x2="416.9" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="416.9" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">139 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="278.0" x2="421.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="421.1" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="278.0" x2="420.9" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="420.9" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">150 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="302.0" x2="423.5" y2="302.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="423.5" cy="302.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">158 ns</text>
+<line x1="168.0" y1="302.0" x2="423.3" y2="302.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="423.3" cy="302.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">157 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="431.2" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="431.2" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">184 ns</text>
+<line x1="168.0" y1="326.0" x2="430.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="430.7" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">182 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="487.6" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="487.6" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">561 ns</text>
+<line x1="168.0" y1="350.0" x2="487.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="487.7" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">564 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="498.4" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="498.4" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">695 ns</text>
+<line x1="168.0" y1="374.0" x2="498.2" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="498.2" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">694 ns</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="615.2" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="615.2" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.04 µs</text>
+<line x1="168.0" y1="398.0" x2="615.4" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="615.4" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.09 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="422.0" x2="654.9" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="654.9" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.4 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="677.7" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="677.7" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">24.2 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="470.0" x2="679.4" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="679.4" cy="470.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">25.1 µs</text>
+<line x1="168.0" y1="422.0" x2="654.4" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="654.4" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.3 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="446.0" x2="679.5" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="679.5" cy="446.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">25.2 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="470.0" x2="680.3" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="680.3" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">25.6 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">53.9 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">54.1 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/i32_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i32-div-dark.svg
+++ b/docs/benchmarks/figs/wat-i32-div-dark.svg
@@ -1,0 +1,98 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_div: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-go is fastest at 7.63 ns, then wasmer at 7.63 ns; pywasm-pypy is slowest at 214 µs, a span of 28100x. The table below carries every number.">
+<title>wat/i32_div: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-go is fastest at 7.63 ns, then wasmer at 7.63 ns; pywasm-pypy is slowest at 214 µs, a span of 28100x. The table below carries every number.</title>
+<rect width="820" height="536" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
+<line x1="271.2" y1="68.0" x2="271.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="271.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="374.4" y1="68.0" x2="374.4" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="374.4" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="477.5" y1="68.0" x2="477.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="477.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="580.7" y1="68.0" x2="580.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="580.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="683.9" y1="68.0" x2="683.9" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="683.9" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
+<line x1="168.0" y1="86.0" x2="259.1" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="259.1" cy="86.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.63 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="110.0" x2="259.1" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="259.1" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.63 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="134.0" x2="259.1" y2="134.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="259.1" cy="134.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.64 ns</text>
+<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
+<line x1="168.0" y1="158.0" x2="259.2" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="259.2" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.65 ns</text>
+<text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
+<line x1="168.0" y1="182.0" x2="261.1" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="261.1" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.99 ns</text>
+<text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
+<line x1="168.0" y1="206.0" x2="286.4" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="286.4" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.0 ns</text>
+<text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
+<line x1="168.0" y1="230.0" x2="295.2" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="295.2" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">17.1 ns</text>
+<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
+<line x1="168.0" y1="254.0" x2="402.9" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="402.9" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">189 ns</text>
+<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
+<line x1="168.0" y1="278.0" x2="404.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="404.6" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">197 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
+<line x1="168.0" y1="302.0" x2="414.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="414.1" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">243 ns</text>
+<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
+<line x1="168.0" y1="326.0" x2="432.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="432.7" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">368 ns</text>
+<text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
+<line x1="168.0" y1="350.0" x2="476.8" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="476.8" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">984 ns</text>
+<text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
+<line x1="168.0" y1="374.0" x2="486.5" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="486.5" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.22 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
+<line x1="168.0" y1="398.0" x2="573.6" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="573.6" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.53 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
+<line x1="168.0" y1="422.0" x2="608.0" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="608.0" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">18.4 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="446.0" x2="661.8" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="661.8" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">61.0 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="470.0" x2="667.1" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="667.1" cy="470.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">68.8 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">214 µs</text>
+<text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/i32_div: seconds per iteration, median of the timed runs (log scale)</text>
+<circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>
+<circle cx="179.9" cy="48.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="191.4" y="52.0" font-size="12" fill="#c3c2b7">dewasm backends</text>
+<circle cx="313.9" cy="48.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="325.4" y="52.0" font-size="12" fill="#c3c2b7">native runtimes</text>
+<circle cx="447.9" cy="48.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="459.4" y="52.0" font-size="12" fill="#c3c2b7">wasm interpreters in a host language</text>
+</svg>

--- a/docs/benchmarks/figs/wat-i32-div.svg
+++ b/docs/benchmarks/figs/wat-i32-div.svg
@@ -1,0 +1,98 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_div: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-go is fastest at 7.63 ns, then wasmer at 7.63 ns; pywasm-pypy is slowest at 214 µs, a span of 28100x. The table below carries every number.">
+<title>wat/i32_div: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-go is fastest at 7.63 ns, then wasmer at 7.63 ns; pywasm-pypy is slowest at 214 µs, a span of 28100x. The table below carries every number.</title>
+<rect width="820" height="536" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
+<line x1="271.2" y1="68.0" x2="271.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="271.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="374.4" y1="68.0" x2="374.4" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="374.4" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="477.5" y1="68.0" x2="477.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="477.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="580.7" y1="68.0" x2="580.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="580.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="683.9" y1="68.0" x2="683.9" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="683.9" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
+<line x1="168.0" y1="86.0" x2="259.1" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="259.1" cy="86.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.63 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="110.0" x2="259.1" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="259.1" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.63 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="134.0" x2="259.1" y2="134.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="259.1" cy="134.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.64 ns</text>
+<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
+<line x1="168.0" y1="158.0" x2="259.2" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="259.2" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.65 ns</text>
+<text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
+<line x1="168.0" y1="182.0" x2="261.1" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="261.1" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.99 ns</text>
+<text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
+<line x1="168.0" y1="206.0" x2="286.4" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="286.4" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.0 ns</text>
+<text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
+<line x1="168.0" y1="230.0" x2="295.2" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="295.2" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">17.1 ns</text>
+<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
+<line x1="168.0" y1="254.0" x2="402.9" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="402.9" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">189 ns</text>
+<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
+<line x1="168.0" y1="278.0" x2="404.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="404.6" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">197 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
+<line x1="168.0" y1="302.0" x2="414.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="414.1" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">243 ns</text>
+<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
+<line x1="168.0" y1="326.0" x2="432.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="432.7" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">368 ns</text>
+<text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
+<line x1="168.0" y1="350.0" x2="476.8" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="476.8" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">984 ns</text>
+<text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
+<line x1="168.0" y1="374.0" x2="486.5" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="486.5" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.22 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
+<line x1="168.0" y1="398.0" x2="573.6" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="573.6" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.53 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
+<line x1="168.0" y1="422.0" x2="608.0" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="608.0" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">18.4 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="446.0" x2="661.8" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="661.8" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">61.0 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="470.0" x2="667.1" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="667.1" cy="470.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">68.8 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">214 µs</text>
+<text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/i32_div: seconds per iteration, median of the timed runs (log scale)</text>
+<circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>
+<circle cx="179.9" cy="48.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="191.4" y="52.0" font-size="12" fill="#52514e">dewasm backends</text>
+<circle cx="313.9" cy="48.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="325.4" y="52.0" font-size="12" fill="#52514e">native runtimes</text>
+<circle cx="447.9" cy="48.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="459.4" y="52.0" font-size="12" fill="#52514e">wasm interpreters in a host language</text>
+</svg>

--- a/docs/benchmarks/figs/wat-i64-alu-dark.svg
+++ b/docs/benchmarks/figs/wat-i64-alu-dark.svg
@@ -1,91 +1,91 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.33 ns, then wasmtime at 2.33 ns; pywasm-pypy is slowest at 338 µs, a span of 145000x. The table below carries every number.">
-<title>wat/i64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.33 ns, then wasmtime at 2.33 ns; pywasm-pypy is slowest at 338 µs, a span of 145000x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.32 ns, then wasmtime at 2.33 ns; pywasm-pypy is slowest at 397 µs, a span of 171000x. The table below carries every number.">
+<title>wat/i64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.32 ns, then wasmtime at 2.33 ns; pywasm-pypy is slowest at 397 µs, a span of 171000x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="267.5" y1="68.0" x2="267.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="267.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="367.0" y1="68.0" x2="367.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="367.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="466.4" y1="68.0" x2="466.4" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="466.4" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="565.9" y1="68.0" x2="565.9" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="565.9" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="665.4" y1="68.0" x2="665.4" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="665.4" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="266.2" y1="68.0" x2="266.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="266.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="364.5" y1="68.0" x2="364.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="364.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="462.7" y1="68.0" x2="462.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="462.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="560.9" y1="68.0" x2="560.9" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="560.9" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="659.2" y1="68.0" x2="659.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="659.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="86.0" x2="204.5" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="204.5" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.33 ns</text>
+<line x1="168.0" y1="86.0" x2="204.0" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="204.0" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.32 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="204.5" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="204.5" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="110.0" x2="204.1" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="204.1" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.33 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="204.8" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="204.8" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.34 ns</text>
+<line x1="168.0" y1="134.0" x2="204.7" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="204.7" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.36 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="158.0" x2="210.0" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="210.0" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="158.0" x2="209.4" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="209.4" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.64 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="182.0" x2="210.3" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="210.3" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.66 ns</text>
+<line x1="168.0" y1="182.0" x2="209.9" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="209.9" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.67 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="276.1" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="276.1" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.2 ns</text>
+<line x1="168.0" y1="206.0" x2="274.4" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="274.4" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.1 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="230.0" x2="386.7" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="386.7" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="230.0" x2="383.9" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="383.9" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">158 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="254.0" x2="402.2" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="402.2" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">226 ns</text>
+<line x1="168.0" y1="254.0" x2="398.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="398.8" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">223 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="278.0" x2="447.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="447.1" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">639 ns</text>
+<line x1="168.0" y1="278.0" x2="443.2" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="443.2" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">633 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="302.0" x2="466.3" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="466.3" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">997 ns</text>
+<line x1="168.0" y1="302.0" x2="462.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="462.2" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">989 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="326.0" x2="466.9" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="466.9" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="326.0" x2="463.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="463.0" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.01 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="350.0" x2="469.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="469.1" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.06 µs</text>
+<line x1="168.0" y1="350.0" x2="465.0" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="465.0" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.05 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="374.0" x2="479.6" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="479.6" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.36 µs</text>
+<line x1="168.0" y1="374.0" x2="475.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="475.1" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.34 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="562.9" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="562.9" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.32 µs</text>
+<line x1="168.0" y1="398.0" x2="557.8" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="557.8" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.30 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="422.0" x2="588.6" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="588.6" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">16.9 µs</text>
+<line x1="168.0" y1="422.0" x2="583.0" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="583.0" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">16.8 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="446.0" x2="610.5" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="610.5" cy="446.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">28.0 µs</text>
+<line x1="168.0" y1="446.0" x2="604.5" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="604.5" cy="446.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">27.7 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="470.0" x2="642.1" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="642.1" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">58.2 µs</text>
+<line x1="168.0" y1="470.0" x2="635.4" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="635.4" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">57.2 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">338 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">397 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/i64_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i64-alu.svg
+++ b/docs/benchmarks/figs/wat-i64-alu.svg
@@ -1,91 +1,91 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.33 ns, then wasmtime at 2.33 ns; pywasm-pypy is slowest at 338 µs, a span of 145000x. The table below carries every number.">
-<title>wat/i64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.33 ns, then wasmtime at 2.33 ns; pywasm-pypy is slowest at 338 µs, a span of 145000x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.32 ns, then wasmtime at 2.33 ns; pywasm-pypy is slowest at 397 µs, a span of 171000x. The table below carries every number.">
+<title>wat/i64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.32 ns, then wasmtime at 2.33 ns; pywasm-pypy is slowest at 397 µs, a span of 171000x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="267.5" y1="68.0" x2="267.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="267.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="367.0" y1="68.0" x2="367.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="367.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="466.4" y1="68.0" x2="466.4" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="466.4" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="565.9" y1="68.0" x2="565.9" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="565.9" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="665.4" y1="68.0" x2="665.4" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="665.4" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="266.2" y1="68.0" x2="266.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="266.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="364.5" y1="68.0" x2="364.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="364.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="462.7" y1="68.0" x2="462.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="462.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="560.9" y1="68.0" x2="560.9" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="560.9" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="659.2" y1="68.0" x2="659.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="659.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="86.0" x2="204.5" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="204.5" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.33 ns</text>
+<line x1="168.0" y1="86.0" x2="204.0" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="204.0" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.32 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="204.5" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="204.5" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="110.0" x2="204.1" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="204.1" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.33 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="204.8" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="204.8" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.34 ns</text>
+<line x1="168.0" y1="134.0" x2="204.7" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="204.7" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.36 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="158.0" x2="210.0" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="210.0" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="158.0" x2="209.4" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="209.4" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.64 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="182.0" x2="210.3" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="210.3" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.66 ns</text>
+<line x1="168.0" y1="182.0" x2="209.9" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="209.9" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.67 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="276.1" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="276.1" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.2 ns</text>
+<line x1="168.0" y1="206.0" x2="274.4" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="274.4" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.1 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="230.0" x2="386.7" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="386.7" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="230.0" x2="383.9" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="383.9" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">158 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="254.0" x2="402.2" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="402.2" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">226 ns</text>
+<line x1="168.0" y1="254.0" x2="398.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="398.8" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">223 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="278.0" x2="447.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="447.1" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">639 ns</text>
+<line x1="168.0" y1="278.0" x2="443.2" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="443.2" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">633 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="302.0" x2="466.3" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="466.3" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">997 ns</text>
+<line x1="168.0" y1="302.0" x2="462.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="462.2" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">989 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="326.0" x2="466.9" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="466.9" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="326.0" x2="463.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="463.0" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.01 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="350.0" x2="469.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="469.1" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.06 µs</text>
+<line x1="168.0" y1="350.0" x2="465.0" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="465.0" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.05 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="374.0" x2="479.6" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="479.6" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.36 µs</text>
+<line x1="168.0" y1="374.0" x2="475.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="475.1" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.34 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="562.9" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="562.9" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.32 µs</text>
+<line x1="168.0" y1="398.0" x2="557.8" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="557.8" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.30 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="422.0" x2="588.6" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="588.6" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">16.9 µs</text>
+<line x1="168.0" y1="422.0" x2="583.0" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="583.0" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">16.8 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="446.0" x2="610.5" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="610.5" cy="446.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">28.0 µs</text>
+<line x1="168.0" y1="446.0" x2="604.5" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="604.5" cy="446.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">27.7 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="470.0" x2="642.1" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="642.1" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">58.2 µs</text>
+<line x1="168.0" y1="470.0" x2="635.4" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="635.4" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">57.2 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">338 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">397 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/i64_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i64-div-dark.svg
+++ b/docs/benchmarks/figs/wat-i64-div-dark.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="488" viewBox="0 0 820 488" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_div: seconds per iteration for 16 runners on a log scale, fastest first. dewasm-go is fastest at 8.24 ns, then wasmer at 8.28 ns; pywasm-pypy is slowest at 392 µs, a span of 47600x. The table below carries every number.">
+<title>wat/i64_div: seconds per iteration for 16 runners on a log scale, fastest first. dewasm-go is fastest at 8.24 ns, then wasmer at 8.28 ns; pywasm-pypy is slowest at 392 µs, a span of 47600x. The table below carries every number.</title>
+<rect width="820" height="488" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
+<line x1="266.3" y1="68.0" x2="266.3" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="266.3" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="364.7" y1="68.0" x2="364.7" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="364.7" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="463.0" y1="68.0" x2="463.0" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="463.0" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="561.3" y1="68.0" x2="561.3" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="561.3" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="659.7" y1="68.0" x2="659.7" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="659.7" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="168.0" y1="458.0" x2="726.0" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
+<line x1="168.0" y1="86.0" x2="258.1" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="258.1" cy="86.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.24 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="110.0" x2="258.3" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="258.3" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.28 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="134.0" x2="258.3" y2="134.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="258.3" cy="134.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.29 ns</text>
+<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
+<line x1="168.0" y1="158.0" x2="258.4" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="258.4" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.31 ns</text>
+<text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
+<line x1="168.0" y1="182.0" x2="259.9" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="259.9" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.60 ns</text>
+<text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
+<line x1="168.0" y1="206.0" x2="286.9" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="286.9" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">16.2 ns</text>
+<text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
+<line x1="168.0" y1="230.0" x2="391.7" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="391.7" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">188 ns</text>
+<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
+<line x1="168.0" y1="254.0" x2="406.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="406.6" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">267 ns</text>
+<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
+<line x1="168.0" y1="278.0" x2="464.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="464.6" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.04 µs</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
+<line x1="168.0" y1="302.0" x2="469.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="469.0" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.15 µs</text>
+<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
+<line x1="168.0" y1="326.0" x2="477.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="477.7" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.41 µs</text>
+<text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
+<line x1="168.0" y1="350.0" x2="480.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="480.7" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.51 µs</text>
+<text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
+<line x1="168.0" y1="374.0" x2="485.5" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="485.5" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.70 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="398.0" x2="641.8" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="641.8" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">65.9 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="422.0" x2="648.7" y2="422.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="648.7" cy="422.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">77.4 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="446.0" x2="718.0" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">392 µs</text>
+<text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/i64_div: seconds per iteration, median of the timed runs (log scale)</text>
+<circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>
+<circle cx="179.9" cy="48.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="191.4" y="52.0" font-size="12" fill="#c3c2b7">dewasm backends</text>
+<circle cx="313.9" cy="48.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="325.4" y="52.0" font-size="12" fill="#c3c2b7">native runtimes</text>
+<circle cx="447.9" cy="48.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="459.4" y="52.0" font-size="12" fill="#c3c2b7">wasm interpreters in a host language</text>
+</svg>

--- a/docs/benchmarks/figs/wat-i64-div.svg
+++ b/docs/benchmarks/figs/wat-i64-div.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="488" viewBox="0 0 820 488" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_div: seconds per iteration for 16 runners on a log scale, fastest first. dewasm-go is fastest at 8.24 ns, then wasmer at 8.28 ns; pywasm-pypy is slowest at 392 µs, a span of 47600x. The table below carries every number.">
+<title>wat/i64_div: seconds per iteration for 16 runners on a log scale, fastest first. dewasm-go is fastest at 8.24 ns, then wasmer at 8.28 ns; pywasm-pypy is slowest at 392 µs, a span of 47600x. The table below carries every number.</title>
+<rect width="820" height="488" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
+<line x1="266.3" y1="68.0" x2="266.3" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="266.3" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="364.7" y1="68.0" x2="364.7" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="364.7" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="463.0" y1="68.0" x2="463.0" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="463.0" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="561.3" y1="68.0" x2="561.3" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="561.3" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="659.7" y1="68.0" x2="659.7" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="659.7" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="168.0" y1="458.0" x2="726.0" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
+<line x1="168.0" y1="86.0" x2="258.1" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="258.1" cy="86.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.24 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="110.0" x2="258.3" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="258.3" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.28 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="134.0" x2="258.3" y2="134.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="258.3" cy="134.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.29 ns</text>
+<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
+<line x1="168.0" y1="158.0" x2="258.4" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="258.4" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.31 ns</text>
+<text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
+<line x1="168.0" y1="182.0" x2="259.9" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="259.9" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.60 ns</text>
+<text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
+<line x1="168.0" y1="206.0" x2="286.9" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="286.9" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">16.2 ns</text>
+<text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
+<line x1="168.0" y1="230.0" x2="391.7" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="391.7" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">188 ns</text>
+<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
+<line x1="168.0" y1="254.0" x2="406.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="406.6" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">267 ns</text>
+<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
+<line x1="168.0" y1="278.0" x2="464.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="464.6" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.04 µs</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
+<line x1="168.0" y1="302.0" x2="469.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="469.0" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.15 µs</text>
+<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
+<line x1="168.0" y1="326.0" x2="477.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="477.7" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.41 µs</text>
+<text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
+<line x1="168.0" y1="350.0" x2="480.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="480.7" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.51 µs</text>
+<text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
+<line x1="168.0" y1="374.0" x2="485.5" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="485.5" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.70 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="398.0" x2="641.8" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="641.8" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">65.9 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="422.0" x2="648.7" y2="422.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="648.7" cy="422.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">77.4 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="446.0" x2="718.0" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">392 µs</text>
+<text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/i64_div: seconds per iteration, median of the timed runs (log scale)</text>
+<circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>
+<circle cx="179.9" cy="48.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="191.4" y="52.0" font-size="12" fill="#52514e">dewasm backends</text>
+<circle cx="313.9" cy="48.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="325.4" y="52.0" font-size="12" fill="#52514e">native runtimes</text>
+<circle cx="447.9" cy="48.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="459.4" y="52.0" font-size="12" fill="#52514e">wasm interpreters in a host language</text>
+</svg>

--- a/docs/benchmarks/figs/wat-mem-narrow-dark.svg
+++ b/docs/benchmarks/figs/wat-mem-narrow-dark.svg
@@ -1,0 +1,96 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_narrow: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.58 ns; pywasm-cpython is slowest at 87.7 µs, a span of 58500x. The table below carries every number.">
+<title>wat/mem_narrow: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.58 ns; pywasm-cpython is slowest at 87.7 µs, a span of 58500x. The table below carries every number.</title>
+<rect width="820" height="536" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
+<line x1="279.3" y1="68.0" x2="279.3" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="279.3" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="390.5" y1="68.0" x2="390.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="390.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="501.8" y1="68.0" x2="501.8" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="501.8" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="613.1" y1="68.0" x2="613.1" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="613.1" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="187.5" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="187.5" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.50 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="110.0" x2="190.2" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="190.2" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.58 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
+<line x1="168.0" y1="134.0" x2="211.9" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="211.9" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.48 ns</text>
+<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
+<line x1="168.0" y1="158.0" x2="212.8" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="212.8" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.53 ns</text>
+<text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
+<line x1="168.0" y1="182.0" x2="240.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="240.7" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.51 ns</text>
+<text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
+<line x1="168.0" y1="206.0" x2="314.2" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="314.2" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.6 ns</text>
+<text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
+<line x1="168.0" y1="230.0" x2="375.2" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="375.2" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">72.8 ns</text>
+<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
+<line x1="168.0" y1="254.0" x2="438.4" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="438.4" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">269 ns</text>
+<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
+<line x1="168.0" y1="278.0" x2="445.2" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="445.2" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">310 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
+<line x1="168.0" y1="302.0" x2="449.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="449.6" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">340 ns</text>
+<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
+<line x1="168.0" y1="326.0" x2="461.5" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="461.5" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">435 ns</text>
+<text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
+<line x1="168.0" y1="350.0" x2="533.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="533.1" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.91 µs</text>
+<text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
+<line x1="168.0" y1="374.0" x2="558.7" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="558.7" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.25 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
+<line x1="168.0" y1="398.0" x2="632.1" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="632.1" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.8 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
+<line x1="168.0" y1="422.0" x2="663.8" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="663.8" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">28.5 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="446.0" x2="692.1" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="692.1" cy="446.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">51.3 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="470.0" x2="697.5" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="697.5" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">57.3 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">87.7 µs</text>
+<text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/mem_narrow: seconds per iteration, median of the timed runs (log scale)</text>
+<circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>
+<circle cx="179.9" cy="48.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="191.4" y="52.0" font-size="12" fill="#c3c2b7">dewasm backends</text>
+<circle cx="313.9" cy="48.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="325.4" y="52.0" font-size="12" fill="#c3c2b7">native runtimes</text>
+<circle cx="447.9" cy="48.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="459.4" y="52.0" font-size="12" fill="#c3c2b7">wasm interpreters in a host language</text>
+</svg>

--- a/docs/benchmarks/figs/wat-mem-narrow.svg
+++ b/docs/benchmarks/figs/wat-mem-narrow.svg
@@ -1,0 +1,96 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_narrow: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.58 ns; pywasm-cpython is slowest at 87.7 µs, a span of 58500x. The table below carries every number.">
+<title>wat/mem_narrow: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.58 ns; pywasm-cpython is slowest at 87.7 µs, a span of 58500x. The table below carries every number.</title>
+<rect width="820" height="536" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
+<line x1="279.3" y1="68.0" x2="279.3" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="279.3" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="390.5" y1="68.0" x2="390.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="390.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="501.8" y1="68.0" x2="501.8" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="501.8" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="613.1" y1="68.0" x2="613.1" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="613.1" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="187.5" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="187.5" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.50 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="110.0" x2="190.2" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="190.2" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.58 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
+<line x1="168.0" y1="134.0" x2="211.9" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="211.9" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.48 ns</text>
+<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
+<line x1="168.0" y1="158.0" x2="212.8" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="212.8" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.53 ns</text>
+<text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
+<line x1="168.0" y1="182.0" x2="240.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="240.7" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.51 ns</text>
+<text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
+<line x1="168.0" y1="206.0" x2="314.2" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="314.2" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.6 ns</text>
+<text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
+<line x1="168.0" y1="230.0" x2="375.2" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="375.2" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">72.8 ns</text>
+<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
+<line x1="168.0" y1="254.0" x2="438.4" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="438.4" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">269 ns</text>
+<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
+<line x1="168.0" y1="278.0" x2="445.2" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="445.2" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">310 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
+<line x1="168.0" y1="302.0" x2="449.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="449.6" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">340 ns</text>
+<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
+<line x1="168.0" y1="326.0" x2="461.5" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="461.5" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">435 ns</text>
+<text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
+<line x1="168.0" y1="350.0" x2="533.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="533.1" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.91 µs</text>
+<text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
+<line x1="168.0" y1="374.0" x2="558.7" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="558.7" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.25 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
+<line x1="168.0" y1="398.0" x2="632.1" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="632.1" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.8 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
+<line x1="168.0" y1="422.0" x2="663.8" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="663.8" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">28.5 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="446.0" x2="692.1" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="692.1" cy="446.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">51.3 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="470.0" x2="697.5" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="697.5" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">57.3 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">87.7 µs</text>
+<text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/mem_narrow: seconds per iteration, median of the timed runs (log scale)</text>
+<circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>
+<circle cx="179.9" cy="48.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="191.4" y="52.0" font-size="12" fill="#52514e">dewasm backends</text>
+<circle cx="313.9" cy="48.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="325.4" y="52.0" font-size="12" fill="#52514e">native runtimes</text>
+<circle cx="447.9" cy="48.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="459.4" y="52.0" font-size="12" fill="#52514e">wasm interpreters in a host language</text>
+</svg>

--- a/docs/benchmarks/figs/wat-mem-rw-dark.svg
+++ b/docs/benchmarks/figs/wat-mem-rw-dark.svg
@@ -1,88 +1,87 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_rw: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.02 ns, then wasmer at 1.02 ns; pywasm-cpython is slowest at 39.9 µs, a span of 39200x. The table below carries every number.">
-<title>wat/mem_rw: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.02 ns, then wasmer at 1.02 ns; pywasm-cpython is slowest at 39.9 µs, a span of 39200x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_rw: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 1.01 ns, then wasmtime at 1.01 ns; pywasm-cpython is slowest at 39.5 µs, a span of 39200x. The table below carries every number.">
+<title>wat/mem_rw: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 1.01 ns, then wasmtime at 1.01 ns; pywasm-cpython is slowest at 39.5 µs, a span of 39200x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
 <line x1="287.6" y1="68.0" x2="287.6" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="287.6" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="407.1" y1="68.0" x2="407.1" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="407.1" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="526.7" y1="68.0" x2="526.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="526.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="646.2" y1="68.0" x2="646.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="646.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="407.3" y1="68.0" x2="407.3" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="407.3" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="526.9" y1="68.0" x2="526.9" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="526.9" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="646.6" y1="68.0" x2="646.6" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="646.6" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<circle cx="168.9" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.02 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="169.2" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="169.2" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.02 ns</text>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<circle cx="168.4" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.01 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<circle cx="168.6" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.01 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="189.7" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="189.7" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.52 ns</text>
+<line x1="168.0" y1="134.0" x2="189.5" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="189.5" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.51 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="190.9" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="190.9" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.56 ns</text>
+<line x1="168.0" y1="158.0" x2="190.8" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="190.8" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.55 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="197.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="197.7" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="182.0" x2="197.8" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="197.8" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.77 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="288.9" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="288.9" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="206.0" x2="289.0" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="289.0" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.3 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
 <line x1="168.0" y1="230.0" x2="375.8" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="375.8" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">54.7 ns</text>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">54.6 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="421.9" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="421.9" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">133 ns</text>
+<line x1="168.0" y1="254.0" x2="421.7" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="421.7" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">132 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="422.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="422.8" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">135 ns</text>
+<line x1="168.0" y1="278.0" x2="423.2" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="423.2" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">136 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="425.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="425.8" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="302.0" x2="425.9" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="425.9" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">143 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="438.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="438.0" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">181 ns</text>
+<line x1="168.0" y1="326.0" x2="437.9" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="437.9" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">180 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="513.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="513.2" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">772 ns</text>
+<line x1="168.0" y1="350.0" x2="513.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="513.1" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">766 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="526.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="526.8" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.00 µs</text>
+<line x1="168.0" y1="374.0" x2="527.3" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="527.3" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.01 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="625.1" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="625.1" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.66 µs</text>
+<line x1="168.0" y1="398.0" x2="623.1" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="623.1" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.37 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="422.0" x2="640.6" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="640.6" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.99 µs</text>
+<line x1="168.0" y1="422.0" x2="636.6" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="636.6" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.25 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="446.0" x2="662.7" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="662.7" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.7 µs</text>
+<line x1="168.0" y1="446.0" x2="661.1" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="661.1" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.2 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
 <line x1="168.0" y1="470.0" x2="706.7" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="706.7" cy="470.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">32.1 µs</text>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">31.8 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">39.9 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">39.5 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/mem_rw: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-mem-rw.svg
+++ b/docs/benchmarks/figs/wat-mem-rw.svg
@@ -1,88 +1,87 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_rw: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.02 ns, then wasmer at 1.02 ns; pywasm-cpython is slowest at 39.9 µs, a span of 39200x. The table below carries every number.">
-<title>wat/mem_rw: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.02 ns, then wasmer at 1.02 ns; pywasm-cpython is slowest at 39.9 µs, a span of 39200x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_rw: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 1.01 ns, then wasmtime at 1.01 ns; pywasm-cpython is slowest at 39.5 µs, a span of 39200x. The table below carries every number.">
+<title>wat/mem_rw: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 1.01 ns, then wasmtime at 1.01 ns; pywasm-cpython is slowest at 39.5 µs, a span of 39200x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
 <line x1="287.6" y1="68.0" x2="287.6" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="287.6" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="407.1" y1="68.0" x2="407.1" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="407.1" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="526.7" y1="68.0" x2="526.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="526.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="646.2" y1="68.0" x2="646.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="646.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="407.3" y1="68.0" x2="407.3" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="407.3" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="526.9" y1="68.0" x2="526.9" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="526.9" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="646.6" y1="68.0" x2="646.6" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="646.6" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<circle cx="168.9" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.02 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="169.2" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="169.2" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.02 ns</text>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<circle cx="168.4" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.01 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<circle cx="168.6" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.01 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="189.7" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="189.7" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.52 ns</text>
+<line x1="168.0" y1="134.0" x2="189.5" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="189.5" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.51 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="190.9" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="190.9" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.56 ns</text>
+<line x1="168.0" y1="158.0" x2="190.8" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="190.8" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.55 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="197.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="197.7" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="182.0" x2="197.8" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="197.8" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.77 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="288.9" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="288.9" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="206.0" x2="289.0" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="289.0" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.3 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
 <line x1="168.0" y1="230.0" x2="375.8" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="375.8" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">54.7 ns</text>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">54.6 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="421.9" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="421.9" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">133 ns</text>
+<line x1="168.0" y1="254.0" x2="421.7" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="421.7" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">132 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="422.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="422.8" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">135 ns</text>
+<line x1="168.0" y1="278.0" x2="423.2" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="423.2" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">136 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="425.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="425.8" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="302.0" x2="425.9" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="425.9" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">143 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="438.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="438.0" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">181 ns</text>
+<line x1="168.0" y1="326.0" x2="437.9" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="437.9" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">180 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="513.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="513.2" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">772 ns</text>
+<line x1="168.0" y1="350.0" x2="513.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="513.1" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">766 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="526.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="526.8" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.00 µs</text>
+<line x1="168.0" y1="374.0" x2="527.3" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="527.3" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.01 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="625.1" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="625.1" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.66 µs</text>
+<line x1="168.0" y1="398.0" x2="623.1" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="623.1" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.37 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="422.0" x2="640.6" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="640.6" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.99 µs</text>
+<line x1="168.0" y1="422.0" x2="636.6" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="636.6" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.25 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="446.0" x2="662.7" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="662.7" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.7 µs</text>
+<line x1="168.0" y1="446.0" x2="661.1" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="661.1" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.2 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
 <line x1="168.0" y1="470.0" x2="706.7" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="706.7" cy="470.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">32.1 µs</text>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">31.8 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">39.9 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">39.5 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/mem_rw: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/results.md
+++ b/docs/benchmarks/results.md
@@ -7,7 +7,7 @@ How to run and read these measurements is [README.md](README.md).
 
 ## Environment
 
-Measured 2026-08-21T03:50:04Z.
+Measured 2026-08-22T06:26:23Z.
 
 | | |
 | --- | --- |
@@ -21,8 +21,8 @@ A runner missing from this table was unavailable on this host; its cells appear 
 
 | Runner | Version |
 | --- | --- |
-| `wasmtime` | wasmtime 47.0.3 (5554cc1a6 2026-07-31) |
-| `wasmer` | wasmer 7.2.1 |
+| `wasmtime` | wasmtime 48.0.0 (f1412a598 2026-08-20) |
+| `wasmer` | wasmer 7.3.0 |
 | `wasmedge` | wasmedge version 0.17.1 |
 | `wazero` | 1.12.0 |
 | `wasm3` | Wasm3 v0.5.0 on arm64-v8a |
@@ -50,102 +50,36 @@ Color is the runner family.
 Seconds per **iteration**.
 Iteration counts are calibrated per runner, so compare the per-iteration figures, not the raw wall times.
 
-#### `c/mandelbrot`
+#### `wat/br_table`
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="figs/c-mandelbrot-dark.svg">
-  <img alt="c/mandelbrot: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 95.7 ns, then wasmtime at 96.3 ns; dewasm-bash is slowest at 20.1 ms, a span of 211000x. The table below carries every number." src="figs/c-mandelbrot.svg">
+  <source media="(prefers-color-scheme: dark)" srcset="figs/wat-br-table-dark.svg">
+  <img alt="wat/br_table: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-go is fastest at 7.65 ns, then wasmer at 8.50 ns; pywasm-cpython is slowest at 51.1 µs, a span of 6690x. The table below carries every number." src="figs/wat-br-table.svg">
 </picture>
 
 <details>
-<summary>Full numbers for <code>c/mandelbrot</code></summary>
+<summary>Full numbers for <code>wat/br_table</code></summary>
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 3 013 457 | 96.3 | 96.3 | 5.5 ms | 295.7 ms | 1.00x | — |
-| `wasmer` | 3 172 418 | 95.6 | 95.7 | 8.9 ms | 312.3 ms | 0.99x | — |
-| `wasmedge` | 65 536 | 3804 | 3798 | 16.3 ms | 265.6 ms | 39x | — |
-| `wazero` | 2 659 665 | 107.2 | 107.2 | 5.0 ms | 290.2 ms | 1.11x | — |
-| `wasm3` | 664 849 | 455.4 | 455.4 | 4.5 ms | 307.3 ms | 4.73x | — |
-| `dewasm-ruby` | 66 071 | 4549 | 4543 | 39.0 ms | 339.5 ms | 47x | — |
-| `dewasm-ruby-yjit` | 148 614 | 1513 | 1545 | 39.2 ms | 264.2 ms | 16x | — |
-| `dewasm-ruby-zjit` | 77 310 | 3499 | 3495 | 39.5 ms | 310.0 ms | 36x | — |
-| `dewasm-python` | 55 895 | 3556 | 3587 | 29.1 ms | 227.8 ms | 37x | — |
-| `dewasm-pypy` | 2 011 993 | 141.3 | 142.0 | 40.3 ms | 324.7 ms | 1.47x | — |
-| `dewasm-perl` | 5 195 | 55842 | 55736 | 10.7 ms | 300.8 ms | 580x | — |
-| `dewasm-go` | 1 250 554 | 235.2 | 235.5 | 2.5 ms | 296.7 ms | 2.44x | — |
-| `dewasm-java` | 2 496 717 | 97.6 | 97.5 | 64.5 ms | 308.1 ms | 1.01x | — |
-| `dewasm-bash` | 155 | 20110026 | 20134565 | 12.8 ms | 3.13 s | 208797x | — |
-| `pywasm-cpython` | 256 | 1486756 | 1483625 | 42.4 ms | 423.0 ms | 15437x | 0.8 ms |
-| `pywasm-pypy` | 86 | 2125275 | 2122493 | 79.5 ms | 262.3 ms | 22066x | 5.5 ms |
-| `wardite` | 752 | 387238 | 388788 | 52.9 ms | 344.1 ms | 4021x | 4.2 ms |
-| `wardite-yjit` | 1 249 | 186553 | 186253 | 102.7 ms | 335.7 ms | 1937x | 10.2 ms |
-
-</details>
-
-#### `c/sha256`
-
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="figs/c-sha256-dark.svg">
-  <img alt="c/sha256: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 293 ns, then wasmtime at 293 ns; dewasm-bash is slowest at 16.0 ms, a span of 54500x. The table below carries every number." src="figs/c-sha256.svg">
-</picture>
-
-<details>
-<summary>Full numbers for <code>c/sha256</code></summary>
-
-| Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 996 305 | 293.1 | 293.2 | 5.2 ms | 297.3 ms | 1.00x | — |
-| `wasmer` | 1 005 425 | 293.0 | 292.7 | 8.7 ms | 303.3 ms | 1.00x | — |
-| `wasmedge` | 6 959 | 41899 | 41910 | 16.4 ms | 308.0 ms | 143x | — |
-| `wazero` | 774 028 | 379.2 | 381.4 | 4.9 ms | 298.4 ms | 1.29x | — |
-| `wasm3` | 55 167 | 5050 | 5070 | 4.4 ms | 283.0 ms | 17x | — |
-| `dewasm-ruby` | 3 773 | 78742 | 79139 | 39.5 ms | 336.6 ms | 269x | — |
-| `dewasm-ruby-yjit` | 8 371 | 34491 | 34574 | 39.8 ms | 328.5 ms | 118x | — |
-| `dewasm-ruby-zjit` | 5 343 | 54140 | 54098 | 39.5 ms | 328.8 ms | 185x | — |
-| `dewasm-python` | 1 073 | 270549 | 272155 | 29.5 ms | 319.8 ms | 923x | — |
-| `dewasm-pypy` | 18 698 | 14045 | 14025 | 40.7 ms | 303.3 ms | 48x | — |
-| `dewasm-perl` | 929 | 319741 | 322177 | 11.1 ms | 308.2 ms | 1091x | — |
-| `dewasm-go` | 838 956 | 348.2 | 348.6 | 2.5 ms | 294.7 ms | 1.19x | — |
-| `dewasm-java` | 431 222 | 501.3 | 550.1 | 65.7 ms | 281.9 ms | 1.71x | — |
-| `dewasm-bash` | 18 | 15972104 | 15965894 | 14.8 ms | 302.3 ms | 54486x | — |
-| `pywasm-cpython` | 19 | 14456011 | 14546243 | 44.5 ms | 319.2 ms | 49314x | 1.4 ms |
-| `pywasm-pypy` | 28 | 7255569 | 7325629 | 87.4 ms | 290.6 ms | 24751x | 7.8 ms |
-| `wardite` | 59 | 4160818 | 4196952 | 53.9 ms | 299.4 ms | 14194x | 4.3 ms |
-| `wardite-yjit` | 124 | 1936726 | 1940946 | 103.6 ms | 343.8 ms | 6607x | 10.5 ms |
-
-</details>
-
-#### `c/wordcount`
-
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="figs/c-wordcount-dark.svg">
-  <img alt="c/wordcount: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 1.61 ns, then wasmtime at 1.67 ns; pywasm-cpython is slowest at 59.8 µs, a span of 37100x. The table below carries every number." src="figs/c-wordcount.svg">
-</picture>
-
-<details>
-<summary>Full numbers for <code>c/wordcount</code></summary>
-
-| Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 161 150 873 | 1.66 | 1.67 | 5.0 ms | 272.3 ms | 1.00x | — |
-| `wasmer` | 171 058 135 | 1.59 | 1.61 | 8.7 ms | 280.5 ms | 0.96x | — |
-| `wasmedge` | 1 395 269 | 204.5 | 204.4 | 17.2 ms | 302.6 ms | 123x | — |
-| `wazero` | 96 819 483 | 3.01 | 3.01 | 5.0 ms | 296.6 ms | 1.82x | — |
-| `wasm3` | 11 086 656 | 20.6 | 20.6 | 4.4 ms | 233.0 ms | 12x | — |
-| `dewasm-ruby` | 701 024 | 408.8 | 409.5 | 40.7 ms | 327.3 ms | 246x | — |
-| `dewasm-ruby-yjit` | 1 042 101 | 273.8 | 274.7 | 41.6 ms | 327.0 ms | 165x | — |
-| `dewasm-ruby-zjit` | 923 260 | 295.5 | 296.4 | 41.6 ms | 314.4 ms | 178x | — |
-| `dewasm-python` | 329 172 | 897.9 | 896.1 | 32.5 ms | 328.1 ms | 541x | — |
-| `dewasm-pypy` | 4 577 810 | 57.3 | 57.1 | 45.2 ms | 307.6 ms | 35x | — |
-| `dewasm-perl` | 202 622 | 1485 | 1489 | 18.6 ms | 319.6 ms | 896x | — |
-| `dewasm-go` | 117 698 366 | 2.39 | 2.41 | 2.6 ms | 283.5 ms | 1.44x | — |
-| `dewasm-java` | 94 644 064 | 3.22 | 3.26 | 66.8 ms | 371.7 ms | 1.94x | — |
-| `dewasm-bash` | 6 844 | 42570 | 42789 | 124.6 ms | 416.0 ms | 25664x | — |
-| `pywasm-cpython` | 4 619 | 59383 | 59799 | 281.4 ms | 555.7 ms | 35800x | 1.3 ms |
-| `pywasm-pypy` | 13 360 | 15301 | 15408 | 195.8 ms | 400.2 ms | 9225x | 8.3 ms |
-| `wardite` | 9 313 | 21003 | 20885 | 121.5 ms | 317.1 ms | 12662x | 4.5 ms |
-| `wardite-yjit` | 29 884 | 9655 | 9849 | 144.3 ms | 432.8 ms | 5820x | 10.3 ms |
+| `wasmtime` | 35 287 220 | 8.49 | 8.51 | 5.9 ms | 305.4 ms | 1.00x | — |
+| `wasmer` | 35 089 490 | 8.51 | 8.50 | 8.9 ms | 307.6 ms | 1.00x | — |
+| `wasmedge` | 1 136 802 | 223.2 | 222.5 | 15.7 ms | 269.4 ms | 26x | — |
+| `wazero` | 33 781 226 | 8.86 | 8.88 | 5.1 ms | 304.5 ms | 1.04x | — |
+| `wasm3` | 13 248 133 | 26.3 | 26.3 | 4.4 ms | 352.7 ms | 3.10x | — |
+| `dewasm-ruby` | 1 202 302 | 217.8 | 217.6 | 39.3 ms | 301.2 ms | 26x | — |
+| `dewasm-ruby-yjit` | 1 290 279 | 217.4 | 218.1 | 39.8 ms | 320.3 ms | 26x | — |
+| `dewasm-ruby-zjit` | 1 265 131 | 218.1 | 218.1 | 39.5 ms | 315.5 ms | 26x | — |
+| `dewasm-python` | 774 703 | 395.9 | 396.1 | 29.7 ms | 336.4 ms | 47x | — |
+| `dewasm-pypy` | 4 281 164 | 62.4 | 62.2 | 41.3 ms | 308.3 ms | 7.35x | — |
+| `dewasm-perl` | 334 562 | 874.0 | 874.7 | 10.6 ms | 303.0 ms | 103x | — |
+| `dewasm-go` | 37 149 182 | 7.68 | 7.65 | 4.5 ms | 289.7 ms | 0.90x | — |
+| `dewasm-java` | 26 509 159 | 9.75 | 9.74 | 67.6 ms | 326.0 ms | 1.15x | — |
+| `dewasm-bash` | 7 436 | 36553 | 36586 | 12.6 ms | 284.4 ms | 4307x | — |
+| `pywasm-cpython` | 4 485 | 51101 | 51139 | 43.0 ms | 272.1 ms | 6021x | 1.1 ms |
+| `pywasm-pypy` | 3 705 | 50497 | 50826 | 80.5 ms | 267.6 ms | 5949x | 5.5 ms |
+| `wardite` | 12 234 | 21184 | 21167 | 52.4 ms | 311.6 ms | 2496x | 4.3 ms |
+| `wardite-yjit` | 24 853 | 8773 | 8767 | 101.7 ms | 319.7 ms | 1034x | 10.0 ms |
 
 </details>
 
@@ -153,7 +87,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-call-direct-dark.svg">
-  <img alt="wat/call_direct: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 3.48 ns, then wasmtime at 3.50 ns; dewasm-bash is slowest at 55.9 µs, a span of 16100x. The table below carries every number." src="figs/wat-call-direct.svg">
+  <img alt="wat/call_direct: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 3.49 ns, then wasmtime at 3.49 ns; dewasm-bash is slowest at 55.6 µs, a span of 15900x. The table below carries every number." src="figs/wat-call-direct.svg">
 </picture>
 
 <details>
@@ -161,24 +95,24 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 85 786 245 | 3.50 | 3.50 | 5.3 ms | 305.4 ms | 1.00x | — |
-| `wasmer` | 84 985 160 | 3.48 | 3.48 | 8.7 ms | 304.3 ms | 0.99x | — |
-| `wasmedge` | 1 369 049 | 208.6 | 209.0 | 15.7 ms | 301.3 ms | 60x | — |
-| `wazero` | 49 741 199 | 6.00 | 6.01 | 4.8 ms | 303.3 ms | 1.72x | — |
-| `wasm3` | 5 378 538 | 49.8 | 49.9 | 4.1 ms | 271.9 ms | 14x | — |
-| `dewasm-ruby` | 1 175 188 | 207.6 | 207.7 | 39.0 ms | 282.9 ms | 59x | — |
-| `dewasm-ruby-yjit` | 2 639 513 | 109.1 | 109.4 | 38.9 ms | 326.9 ms | 31x | — |
-| `dewasm-ruby-zjit` | 1 650 242 | 126.8 | 126.6 | 39.1 ms | 248.4 ms | 36x | — |
-| `dewasm-python` | 706 262 | 417.8 | 421.8 | 29.0 ms | 324.0 ms | 119x | — |
-| `dewasm-pypy` | 2 220 565 | 88.9 | 89.2 | 40.3 ms | 237.8 ms | 25x | — |
-| `dewasm-perl` | 270 211 | 1105 | 1110 | 10.9 ms | 309.5 ms | 316x | — |
-| `dewasm-go` | 72 773 600 | 4.11 | 4.12 | 2.6 ms | 301.7 ms | 1.17x | — |
-| `dewasm-java` | 74 536 376 | 3.57 | 3.58 | 65.6 ms | 331.5 ms | 1.02x | — |
-| `dewasm-bash` | 4 925 | 55494 | 55940 | 12.5 ms | 285.8 ms | 15865x | — |
-| `pywasm-cpython` | 5 950 | 49133 | 49347 | 43.4 ms | 335.8 ms | 14046x | 0.6 ms |
-| `pywasm-pypy` | 23 014 | 10063 | 10085 | 77.3 ms | 308.9 ms | 2877x | 3.8 ms |
-| `wardite` | 11 860 | 17957 | 18011 | 53.2 ms | 266.2 ms | 5134x | 4.4 ms |
-| `wardite-yjit` | 33 393 | 8313 | 8327 | 102.7 ms | 380.3 ms | 2376x | 8.9 ms |
+| `wasmtime` | 87 191 798 | 3.49 | 3.49 | 5.4 ms | 309.9 ms | 1.00x | — |
+| `wasmer` | 86 070 965 | 3.49 | 3.49 | 8.8 ms | 309.3 ms | 1.00x | — |
+| `wasmedge` | 1 378 333 | 205.7 | 206.7 | 15.8 ms | 299.3 ms | 59x | — |
+| `wazero` | 49 810 957 | 6.00 | 6.00 | 5.2 ms | 304.1 ms | 1.72x | — |
+| `wasm3` | 5 437 668 | 49.3 | 49.4 | 4.3 ms | 272.3 ms | 14x | — |
+| `dewasm-ruby` | 1 287 818 | 206.7 | 206.6 | 39.5 ms | 305.6 ms | 59x | — |
+| `dewasm-ruby-yjit` | 2 671 849 | 108.7 | 108.8 | 39.1 ms | 329.6 ms | 31x | — |
+| `dewasm-ruby-zjit` | 2 333 855 | 124.8 | 125.1 | 40.1 ms | 331.4 ms | 36x | — |
+| `dewasm-python` | 678 642 | 410.9 | 416.0 | 29.2 ms | 308.0 ms | 118x | — |
+| `dewasm-pypy` | 2 123 426 | 88.7 | 88.7 | 40.2 ms | 228.5 ms | 25x | — |
+| `dewasm-perl` | 271 182 | 1097 | 1096 | 10.7 ms | 308.2 ms | 314x | — |
+| `dewasm-go` | 72 675 219 | 4.13 | 4.13 | 2.7 ms | 302.5 ms | 1.18x | — |
+| `dewasm-java` | 58 724 210 | 3.60 | 3.62 | 65.9 ms | 277.2 ms | 1.03x | — |
+| `dewasm-bash` | 5 017 | 55592 | 55606 | 12.5 ms | 291.4 ms | 15918x | — |
+| `pywasm-cpython` | 6 841 | 48765 | 48915 | 44.1 ms | 377.7 ms | 13963x | 0.6 ms |
+| `pywasm-pypy` | 18 808 | 10855 | 10913 | 77.8 ms | 282.0 ms | 3108x | 4.0 ms |
+| `wardite` | 13 438 | 17987 | 17916 | 52.1 ms | 293.8 ms | 5150x | 4.4 ms |
+| `wardite-yjit` | 34 981 | 8325 | 8321 | 102.1 ms | 393.3 ms | 2384x | 9.1 ms |
 
 </details>
 
@@ -186,7 +120,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-call-indirect-dark.svg">
-  <img alt="wat/call_indirect: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 10.5 ns, then wasmtime at 10.5 ns; pywasm-cpython is slowest at 82.2 µs, a span of 7860x. The table below carries every number." src="figs/wat-call-indirect.svg">
+  <img alt="wat/call_indirect: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 10.5 ns, then wasmer at 10.5 ns; pywasm-cpython is slowest at 81.6 µs, a span of 7810x. The table below carries every number." src="figs/wat-call-indirect.svg">
 </picture>
 
 <details>
@@ -194,24 +128,140 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 33 554 432 | 10.5 | 10.5 | 5.2 ms | 356.6 ms | 1.00x | — |
-| `wasmer` | 33 554 432 | 10.4 | 10.5 | 9.0 ms | 359.3 ms | 1.00x | — |
-| `wasmedge` | 706 498 | 419.6 | 420.3 | 16.2 ms | 312.6 ms | 40x | — |
-| `wazero` | 15 401 113 | 11.8 | 11.8 | 5.0 ms | 187.0 ms | 1.13x | — |
-| `wasm3` | 4 079 357 | 69.1 | 69.7 | 4.1 ms | 286.2 ms | 6.60x | — |
-| `dewasm-ruby` | 428 091 | 668.0 | 667.4 | 39.5 ms | 325.5 ms | 64x | — |
-| `dewasm-ruby-yjit` | 534 089 | 414.7 | 413.8 | 39.2 ms | 260.7 ms | 40x | — |
-| `dewasm-ruby-zjit` | 534 433 | 478.4 | 479.1 | 39.2 ms | 294.9 ms | 46x | — |
-| `dewasm-python` | 382 580 | 785.4 | 787.0 | 29.3 ms | 329.8 ms | 75x | — |
-| `dewasm-pypy` | 1 724 163 | 140.4 | 140.3 | 39.7 ms | 281.8 ms | 13x | — |
-| `dewasm-perl` | 131 072 | 2461 | 2472 | 11.1 ms | 333.7 ms | 235x | — |
+| `wasmtime` | 33 554 432 | 10.5 | 10.5 | 5.4 ms | 356.1 ms | 1.00x | — |
+| `wasmer` | 28 686 823 | 10.5 | 10.5 | 8.9 ms | 309.0 ms | 1.00x | — |
+| `wasmedge` | 697 957 | 414.8 | 416.5 | 15.8 ms | 305.3 ms | 40x | — |
+| `wazero` | 16 777 216 | 11.8 | 11.8 | 5.0 ms | 202.8 ms | 1.13x | — |
+| `wasm3` | 3 823 043 | 68.8 | 69.0 | 4.2 ms | 267.1 ms | 6.58x | — |
+| `dewasm-ruby` | 337 885 | 668.2 | 667.7 | 38.0 ms | 263.8 ms | 64x | — |
+| `dewasm-ruby-yjit` | 662 171 | 411.0 | 409.1 | 39.3 ms | 311.5 ms | 39x | — |
+| `dewasm-ruby-zjit` | 586 998 | 464.0 | 474.8 | 41.0 ms | 313.3 ms | 44x | — |
+| `dewasm-python` | 363 467 | 776.5 | 777.3 | 29.4 ms | 311.6 ms | 74x | — |
+| `dewasm-pypy` | 1 890 998 | 137.7 | 138.7 | 40.6 ms | 301.1 ms | 13x | — |
+| `dewasm-perl` | 131 072 | 2441 | 2444 | 10.5 ms | 330.4 ms | 234x | — |
 | `dewasm-go` | 16 777 216 | 10.8 | 10.8 | 2.7 ms | 183.9 ms | 1.03x | — |
-| `dewasm-java` | 3 623 667 | 52.2 | 55.0 | 63.9 ms | 253.1 ms | 4.98x | — |
-| `dewasm-bash` | 3 739 | 75137 | 75343 | 12.7 ms | 293.7 ms | 7175x | — |
-| `pywasm-cpython` | 3 239 | 82202 | 82176 | 42.7 ms | 308.9 ms | 7849x | 0.9 ms |
-| `pywasm-pypy` | 5 968 | 33379 | 33148 | 77.4 ms | 276.6 ms | 3187x | 4.5 ms |
-| `wardite` | 7 626 | 28371 | 28376 | 52.5 ms | 268.8 ms | 2709x | 4.4 ms |
-| `wardite-yjit` | 18 045 | 14065 | 14118 | 102.5 ms | 356.3 ms | 1343x | 9.7 ms |
+| `dewasm-java` | 3 726 232 | 52.0 | 56.8 | 65.9 ms | 259.7 ms | 4.98x | — |
+| `dewasm-bash` | 3 514 | 75165 | 75406 | 11.5 ms | 275.6 ms | 7192x | — |
+| `pywasm-cpython` | 3 121 | 81588 | 81640 | 42.1 ms | 296.7 ms | 7806x | 0.7 ms |
+| `pywasm-pypy` | 6 320 | 31731 | 31693 | 80.1 ms | 280.7 ms | 3036x | 4.2 ms |
+| `wardite` | 7 583 | 28146 | 27930 | 52.2 ms | 265.7 ms | 2693x | 4.2 ms |
+| `wardite-yjit` | 14 270 | 14239 | 14286 | 101.7 ms | 304.9 ms | 1362x | 9.1 ms |
+
+</details>
+
+#### `wat/conv`
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="figs/wat-conv-dark.svg">
+  <img alt="wat/conv: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 7.63 ns, then wasmtime at 7.63 ns; pywasm-pypy is slowest at 834 µs, a span of 109000x. The table below carries every number." src="figs/wat-conv.svg">
+</picture>
+
+<details>
+<summary>Full numbers for <code>wat/conv</code></summary>
+
+| Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `wasmtime` | 39 213 418 | 7.63 | 7.63 | 5.5 ms | 304.9 ms | 1.00x | — |
+| `wasmer` | 39 248 647 | 7.63 | 7.63 | 9.3 ms | 308.9 ms | 1.00x | — |
+| `wasmedge` | 1 203 280 | 234.6 | 234.5 | 15.8 ms | 298.1 ms | 31x | — |
+| `wazero` | 6 059 341 | 57.0 | 56.9 | 5.1 ms | 350.4 ms | 7.47x | — |
+| `wasm3` | 16 777 216 | 21.2 | 21.2 | 4.4 ms | 360.2 ms | 2.78x | — |
+| `dewasm-ruby` | 201 936 | 1359 | 1360 | 38.3 ms | 312.6 ms | 178x | — |
+| `dewasm-ruby-yjit` | 295 406 | 868.2 | 869.9 | 40.1 ms | 296.5 ms | 114x | — |
+| `dewasm-ruby-zjit` | 247 727 | 981.5 | 983.5 | 39.2 ms | 282.4 ms | 129x | — |
+| `dewasm-python` | 217 040 | 1386 | 1394 | 29.8 ms | 330.5 ms | 182x | — |
+| `dewasm-pypy` | 780 229 | 258.9 | 259.0 | 41.6 ms | 243.6 ms | 34x | — |
+| `dewasm-perl` | 132 995 | 2241 | 2242 | 15.1 ms | 313.0 ms | 294x | — |
+| `dewasm-go` | 16 777 216 | 10.5 | 10.5 | 4.8 ms | 180.3 ms | 1.37x | — |
+| `dewasm-java` | 16 218 192 | 18.1 | 18.1 | 66.5 ms | 360.5 ms | 2.37x | — |
+| `dewasm-bash` | 570 | 522034 | 522095 | 12.7 ms | 310.2 ms | 68388x | — |
+| `pywasm-cpython` | 2 814 | 101620 | 100945 | 41.9 ms | 327.8 ms | 13312x | 0.7 ms |
+| `pywasm-pypy` | 281 | 829870 | 833668 | 77.4 ms | 310.6 ms | 108715x | 4.0 ms |
+| `wardite` | 9 218 | 25694 | 25838 | 53.4 ms | 290.2 ms | 3366x | 4.1 ms |
+| `wardite-yjit` | 12 027 | 15712 | 15844 | 98.5 ms | 287.4 ms | 2058x | 9.8 ms |
+
+</details>
+
+#### `wat/eh_throw`
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="figs/wat-eh-throw-dark.svg">
+  <img alt="wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.37 ns, then wasmedge at 115 ns; wasmer is slowest at 10.3 µs, a span of 2370x. The table below carries every number." src="figs/wat-eh-throw.svg">
+</picture>
+
+<details>
+<summary>Full numbers for <code>wat/eh_throw</code></summary>
+
+| Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `wasmtime` | 1 383 163 | 220.6 | 220.9 | 5.4 ms | 310.5 ms | 1.00x | — |
+| `wasmer` | 34 772 | 10333 | 10333 | 9.6 ms | 368.9 ms | 47x | — |
+| `wasmedge` | 2 748 000 | 115.2 | 115.3 | 15.8 ms | 332.5 ms | 0.52x | — |
+| `dewasm-ruby` | 444 127 | 632.2 | 630.5 | 39.3 ms | 320.1 ms | 2.87x | — |
+| `dewasm-ruby-yjit` | 742 234 | 466.6 | 467.4 | 39.9 ms | 386.2 ms | 2.12x | — |
+| `dewasm-ruby-zjit` | 477 341 | 608.4 | 610.3 | 40.0 ms | 330.4 ms | 2.76x | — |
+| `dewasm-python` | 438 178 | 664.9 | 667.4 | 28.7 ms | 320.0 ms | 3.01x | — |
+| `dewasm-pypy` | 4 000 000 | 4.51 | 4.37 | 39.8 ms | 57.8 ms | 0.02x | — |
+| `dewasm-perl` | 253 263 | 1186 | 1190 | 10.5 ms | 310.8 ms | 5.38x | — |
+| `dewasm-go` | 1 184 751 | 198.4 | 199.7 | 5.0 ms | 240.1 ms | 0.90x | — |
+| `dewasm-java` | 392 219 | 532.1 | 533.8 | 68.1 ms | 276.8 ms | 2.41x | — |
+
+</details>
+
+#### `wat/eh_try`
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="figs/wat-eh-try-dark.svg">
+  <img alt="wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.27 ns, then dewasm-java at 1.43 ns; dewasm-perl is slowest at 515 ns, a span of 407x. The table below carries every number." src="figs/wat-eh-try.svg">
+</picture>
+
+<details>
+<summary>Full numbers for <code>wat/eh_try</code></summary>
+
+| Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `wasmtime` | 109 300 097 | 2.79 | 2.78 | 5.7 ms | 310.2 ms | 1.00x | — |
+| `wasmer` | 234 635 887 | 1.27 | 1.27 | 9.0 ms | 306.1 ms | 0.45x | — |
+| `wasmedge` | 2 539 553 | 116.8 | 116.9 | 16.0 ms | 312.7 ms | 42x | — |
+| `dewasm-ruby` | 1 902 131 | 121.5 | 122.3 | 38.5 ms | 269.6 ms | 44x | — |
+| `dewasm-ruby-yjit` | 1 832 517 | 122.8 | 122.7 | 38.9 ms | 264.0 ms | 44x | — |
+| `dewasm-ruby-zjit` | 2 704 668 | 121.7 | 122.5 | 40.2 ms | 369.4 ms | 44x | — |
+| `dewasm-python` | 1 280 336 | 198.3 | 201.1 | 28.4 ms | 282.2 ms | 71x | — |
+| `dewasm-pypy` | 105 149 754 | 2.60 | 2.59 | 40.1 ms | 313.4 ms | 0.93x | — |
+| `dewasm-perl` | 581 571 | 515.1 | 515.2 | 10.6 ms | 310.2 ms | 185x | — |
+| `dewasm-go` | 64 770 052 | 4.22 | 4.22 | 4.6 ms | 278.0 ms | 1.52x | — |
+| `dewasm-java` | 241 800 984 | 1.43 | 1.43 | 67.4 ms | 412.8 ms | 0.51x | — |
+
+</details>
+
+#### `wat/f32_alu`
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="figs/wat-f32-alu-dark.svg">
+  <img alt="wat/f32_alu: seconds per iteration for 16 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmer at 1.00 ns; dewasm-bash is slowest at 1.21 ms, a span of 1240000x. The table below carries every number." src="figs/wat-f32-alu.svg">
+</picture>
+
+<details>
+<summary>Full numbers for <code>wat/f32_alu</code></summary>
+
+| Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `wasmtime` | 299 018 404 | 1.00 | 1.00 | 5.5 ms | 304.2 ms | 1.00x | — |
+| `wasmer` | 287 193 659 | 1.00 | 1.00 | 8.9 ms | 295.0 ms | 1.00x | — |
+| `wasmedge` | 3 381 073 | 82.0 | 82.0 | 15.8 ms | 293.0 ms | 82x | — |
+| `wazero` | 307 057 865 | 0.96 | 0.97 | 5.1 ms | 300.0 ms | 0.96x | — |
+| `wasm3` | 44 854 418 | 6.65 | 6.72 | 4.2 ms | 302.7 ms | 6.66x | — |
+| `dewasm-ruby` | 409 210 | 669.5 | 677.0 | 38.6 ms | 312.6 ms | 670x | — |
+| `dewasm-ruby-yjit` | 533 556 | 547.6 | 586.8 | 40.0 ms | 332.2 ms | 548x | — |
+| `dewasm-ruby-zjit` | 414 984 | 665.7 | 680.6 | 39.7 ms | 316.0 ms | 666x | — |
+| `dewasm-python` | 356 393 | 846.8 | 849.3 | 29.3 ms | 331.1 ms | 848x | — |
+| `dewasm-pypy` | 641 667 | 374.6 | 377.4 | 40.8 ms | 281.2 ms | 375x | — |
+| `dewasm-perl` | 193 203 | 1545 | 1547 | 10.3 ms | 308.8 ms | 1546x | — |
+| `dewasm-go` | 76 794 433 | 3.48 | 3.48 | 4.0 ms | 271.0 ms | 3.48x | — |
+| `dewasm-java` | 176 997 459 | 1.64 | 1.64 | 67.3 ms | 358.2 ms | 1.64x | — |
+| `dewasm-bash` | 166 | 1204047 | 1206605 | 12.9 ms | 212.8 ms | 1205140x | — |
+| `pywasm-cpython` | 10 006 | 28709 | 28910 | 43.9 ms | 331.2 ms | 28736x | 0.6 ms |
+| `pywasm-pypy` | 19 644 | 8647 | 8775 | 78.9 ms | 248.8 ms | 8655x | 3.5 ms |
 
 </details>
 
@@ -219,7 +269,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-f64-alu-dark.svg">
-  <img alt="wat/f64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 0.97 ns, then wazero at 0.97 ns; dewasm-bash is slowest at 581 µs, a span of 599000x. The table below carries every number." src="figs/wat-f64-alu.svg">
+  <img alt="wat/f64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmtime at 0.97 ns; dewasm-bash is slowest at 578 µs, a span of 598000x. The table below carries every number." src="figs/wat-f64-alu.svg">
 </picture>
 
 <details>
@@ -227,24 +277,24 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 299 151 698 | 0.97 | 0.97 | 5.1 ms | 295.1 ms | 1.00x | — |
-| `wasmer` | 298 392 043 | 0.98 | 0.98 | 8.8 ms | 299.9 ms | 1.01x | — |
-| `wasmedge` | 3 286 381 | 82.4 | 82.3 | 15.9 ms | 286.6 ms | 85x | — |
-| `wazero` | 301 474 360 | 0.97 | 0.97 | 4.7 ms | 296.0 ms | 1.00x | — |
-| `wasm3` | 55 272 073 | 5.43 | 5.43 | 4.2 ms | 304.4 ms | 5.60x | — |
-| `dewasm-ruby` | 2 409 227 | 102.5 | 102.6 | 39.3 ms | 286.3 ms | 106x | — |
-| `dewasm-ruby-yjit` | 3 829 062 | 76.1 | 76.2 | 39.9 ms | 331.4 ms | 79x | — |
-| `dewasm-ruby-zjit` | 3 023 904 | 82.1 | 82.5 | 39.6 ms | 288.0 ms | 85x | — |
-| `dewasm-python` | 1 926 726 | 152.6 | 152.3 | 28.9 ms | 322.9 ms | 157x | — |
-| `dewasm-pypy` | 108 062 842 | 2.16 | 2.16 | 39.7 ms | 273.3 ms | 2.23x | — |
-| `dewasm-perl` | 358 753 | 835.2 | 833.8 | 14.8 ms | 314.4 ms | 862x | — |
-| `dewasm-go` | 84 199 547 | 3.51 | 3.52 | 2.7 ms | 298.5 ms | 3.62x | — |
-| `dewasm-java` | 175 111 355 | 1.64 | 1.64 | 64.6 ms | 351.9 ms | 1.69x | — |
-| `dewasm-bash` | 516 | 579817 | 580945 | 12.6 ms | 311.8 ms | 598226x | — |
-| `pywasm-cpython` | 8 316 | 29200 | 29387 | 42.9 ms | 285.7 ms | 30127x | 0.6 ms |
-| `pywasm-pypy` | 25 302 | 7573 | 7605 | 77.8 ms | 269.4 ms | 7814x | 3.3 ms |
-| `wardite` | 27 494 | 7740 | 7726 | 52.1 ms | 264.9 ms | 7986x | 4.1 ms |
-| `wardite-yjit` | 69 667 | 3606 | 3602 | 104.4 ms | 355.6 ms | 3720x | 8.9 ms |
+| `wasmtime` | 292 881 995 | 0.97 | 0.97 | 5.1 ms | 290.6 ms | 1.00x | — |
+| `wasmer` | 295 268 969 | 0.98 | 0.98 | 8.7 ms | 297.6 ms | 1.00x | — |
+| `wasmedge` | 3 057 588 | 81.9 | 81.7 | 15.6 ms | 265.9 ms | 84x | — |
+| `wazero` | 303 912 132 | 0.97 | 0.97 | 4.9 ms | 298.7 ms | 0.99x | — |
+| `wasm3` | 55 344 829 | 5.42 | 5.42 | 4.1 ms | 303.9 ms | 5.56x | — |
+| `dewasm-ruby` | 3 315 713 | 101.6 | 101.8 | 39.9 ms | 376.8 ms | 104x | — |
+| `dewasm-ruby-yjit` | 3 762 352 | 76.3 | 76.2 | 39.7 ms | 326.7 ms | 78x | — |
+| `dewasm-ruby-zjit` | 2 875 968 | 82.7 | 82.5 | 39.3 ms | 277.1 ms | 85x | — |
+| `dewasm-python` | 1 968 269 | 151.4 | 151.6 | 29.4 ms | 327.5 ms | 155x | — |
+| `dewasm-pypy` | 137 235 069 | 2.14 | 2.15 | 41.0 ms | 335.1 ms | 2.20x | — |
+| `dewasm-perl` | 351 167 | 830.0 | 831.3 | 15.0 ms | 306.5 ms | 851x | — |
+| `dewasm-go` | 85 303 177 | 3.51 | 3.52 | 2.9 ms | 302.5 ms | 3.60x | — |
+| `dewasm-java` | 177 598 704 | 1.64 | 1.63 | 66.9 ms | 357.4 ms | 1.68x | — |
+| `dewasm-bash` | 512 | 578435 | 577648 | 12.9 ms | 309.1 ms | 593320x | — |
+| `pywasm-cpython` | 7 775 | 29341 | 29362 | 42.7 ms | 270.8 ms | 30096x | 0.6 ms |
+| `pywasm-pypy` | 33 970 | 6298 | 6324 | 79.1 ms | 293.0 ms | 6460x | 3.6 ms |
+| `wardite` | 38 250 | 7699 | 7683 | 51.4 ms | 345.9 ms | 7897x | 4.1 ms |
+| `wardite-yjit` | 80 606 | 3549 | 3549 | 105.1 ms | 391.1 ms | 3640x | 9.6 ms |
 
 </details>
 
@@ -252,7 +302,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-i32-alu-dark.svg">
-  <img alt="wat/i32_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.32 ns, then wasmtime at 2.32 ns; pywasm-cpython is slowest at 53.9 µs, a span of 23200x. The table below carries every number." src="figs/wat-i32-alu.svg">
+  <img alt="wat/i32_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.32 ns, then wasmtime at 2.32 ns; pywasm-cpython is slowest at 54.1 µs, a span of 23300x. The table below carries every number." src="figs/wat-i32-alu.svg">
 </picture>
 
 <details>
@@ -260,24 +310,57 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 130 166 091 | 2.32 | 2.32 | 5.6 ms | 307.2 ms | 1.00x | — |
-| `wasmer` | 125 693 606 | 2.32 | 2.32 | 8.8 ms | 300.1 ms | 1.00x | — |
-| `wasmedge` | 1 924 220 | 157.7 | 157.7 | 16.2 ms | 319.6 ms | 68x | — |
-| `wazero` | 110 667 247 | 2.66 | 2.66 | 4.7 ms | 299.5 ms | 1.15x | — |
-| `wasm3` | 14 487 808 | 13.0 | 13.0 | 4.1 ms | 193.1 ms | 5.63x | — |
-| `dewasm-ruby` | 1 646 380 | 183.4 | 183.5 | 39.7 ms | 341.7 ms | 79x | — |
-| `dewasm-ruby-yjit` | 1 768 369 | 139.4 | 139.7 | 39.0 ms | 285.5 ms | 60x | — |
-| `dewasm-ruby-zjit` | 1 761 457 | 149.4 | 150.5 | 39.8 ms | 302.9 ms | 64x | — |
-| `dewasm-python` | 535 902 | 560.6 | 561.4 | 29.2 ms | 329.6 ms | 242x | — |
-| `dewasm-pypy` | 25 895 803 | 9.55 | 9.60 | 39.5 ms | 286.8 ms | 4.12x | — |
-| `dewasm-perl` | 434 010 | 693.0 | 695.4 | 10.8 ms | 311.6 ms | 299x | — |
-| `dewasm-go` | 97 711 828 | 3.07 | 3.07 | 2.8 ms | 303.2 ms | 1.33x | — |
-| `dewasm-java` | 124 716 710 | 2.34 | 2.35 | 64.6 ms | 356.7 ms | 1.01x | — |
-| `dewasm-bash` | 11 036 | 25061 | 25070 | 12.8 ms | 289.4 ms | 10817x | — |
-| `pywasm-cpython` | 4 780 | 53908 | 53859 | 42.4 ms | 300.1 ms | 23267x | 0.7 ms |
-| `pywasm-pypy` | 7 872 | 24386 | 24235 | 78.5 ms | 270.5 ms | 10525x | 3.7 ms |
-| `wardite` | 18 922 | 15431 | 15421 | 52.0 ms | 344.0 ms | 6660x | 3.8 ms |
-| `wardite-yjit` | 48 572 | 7022 | 7037 | 101.6 ms | 442.6 ms | 3031x | 9.2 ms |
+| `wasmtime` | 129 555 458 | 2.32 | 2.32 | 5.4 ms | 306.4 ms | 1.00x | — |
+| `wasmer` | 130 127 386 | 2.31 | 2.32 | 9.4 ms | 310.6 ms | 1.00x | — |
+| `wasmedge` | 1 905 500 | 157.4 | 157.4 | 15.9 ms | 315.8 ms | 68x | — |
+| `wazero` | 109 925 130 | 2.67 | 2.67 | 4.9 ms | 298.0 ms | 1.15x | — |
+| `wasm3` | 16 777 216 | 13.0 | 13.0 | 4.5 ms | 222.1 ms | 5.58x | — |
+| `dewasm-ruby` | 1 936 617 | 182.0 | 182.2 | 39.5 ms | 392.0 ms | 78x | — |
+| `dewasm-ruby-yjit` | 1 992 499 | 138.8 | 138.7 | 39.0 ms | 315.7 ms | 60x | — |
+| `dewasm-ruby-zjit` | 1 465 300 | 150.4 | 150.2 | 38.9 ms | 259.3 ms | 65x | — |
+| `dewasm-python` | 522 627 | 557.1 | 563.7 | 28.9 ms | 320.1 ms | 240x | — |
+| `dewasm-pypy` | 23 622 851 | 9.65 | 9.64 | 39.7 ms | 267.6 ms | 4.15x | — |
+| `dewasm-perl` | 432 693 | 693.9 | 694.3 | 10.7 ms | 311.0 ms | 299x | — |
+| `dewasm-go` | 96 745 118 | 3.07 | 3.07 | 2.7 ms | 300.1 ms | 1.32x | — |
+| `dewasm-java` | 83 776 847 | 2.37 | 2.37 | 67.5 ms | 266.4 ms | 1.02x | — |
+| `dewasm-bash` | 10 285 | 25149 | 25205 | 12.9 ms | 271.5 ms | 10825x | — |
+| `pywasm-cpython` | 4 842 | 54272 | 54089 | 42.5 ms | 305.3 ms | 23360x | 0.7 ms |
+| `pywasm-pypy` | 7 248 | 25836 | 25609 | 79.3 ms | 266.6 ms | 11120x | 3.8 ms |
+| `wardite` | 20 847 | 15205 | 15347 | 53.4 ms | 370.4 ms | 6545x | 4.2 ms |
+| `wardite-yjit` | 35 673 | 7005 | 7086 | 101.4 ms | 351.4 ms | 3015x | 9.1 ms |
+
+</details>
+
+#### `wat/i32_div`
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="figs/wat-i32-div-dark.svg">
+  <img alt="wat/i32_div: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-go is fastest at 7.63 ns, then wasmer at 7.63 ns; pywasm-pypy is slowest at 214 µs, a span of 28100x. The table below carries every number." src="figs/wat-i32-div.svg">
+</picture>
+
+<details>
+<summary>Full numbers for <code>wat/i32_div</code></summary>
+
+| Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `wasmtime` | 39 155 863 | 7.65 | 7.64 | 5.4 ms | 304.8 ms | 1.00x | — |
+| `wasmer` | 39 414 336 | 7.64 | 7.63 | 9.2 ms | 310.2 ms | 1.00x | — |
+| `wasmedge` | 1 525 586 | 188.5 | 189.0 | 15.9 ms | 303.5 ms | 25x | — |
+| `wazero` | 39 086 965 | 7.65 | 7.65 | 5.1 ms | 304.1 ms | 1.00x | — |
+| `wasm3` | 12 698 043 | 17.1 | 17.1 | 4.4 ms | 221.0 ms | 2.23x | — |
+| `dewasm-ruby` | 827 448 | 368.2 | 368.0 | 39.4 ms | 344.1 ms | 48x | — |
+| `dewasm-ruby-yjit` | 1 391 676 | 196.0 | 196.5 | 40.1 ms | 313.0 ms | 26x | — |
+| `dewasm-ruby-zjit` | 1 194 241 | 244.2 | 242.6 | 38.1 ms | 329.7 ms | 32x | — |
+| `dewasm-python` | 305 222 | 980.2 | 983.9 | 29.3 ms | 328.5 ms | 128x | — |
+| `dewasm-pypy` | 24 135 930 | 14.0 | 14.0 | 40.0 ms | 377.9 ms | 1.83x | — |
+| `dewasm-perl` | 246 870 | 1221 | 1222 | 10.7 ms | 312.1 ms | 160x | — |
+| `dewasm-go` | 34 325 805 | 7.70 | 7.63 | 3.0 ms | 267.2 ms | 1.01x | — |
+| `dewasm-java` | 24 294 063 | 7.99 | 7.99 | 66.8 ms | 260.9 ms | 1.04x | — |
+| `dewasm-bash` | 4 202 | 68674 | 68784 | 12.6 ms | 301.2 ms | 8980x | — |
+| `pywasm-cpython` | 4 672 | 60659 | 61025 | 44.5 ms | 327.9 ms | 7932x | 0.7 ms |
+| `pywasm-pypy` | 850 | 210390 | 214128 | 77.4 ms | 256.2 ms | 27512x | 3.8 ms |
+| `wardite` | 16 605 | 18345 | 18370 | 52.5 ms | 357.1 ms | 2399x | 4.4 ms |
+| `wardite-yjit` | 37 196 | 8521 | 8530 | 101.0 ms | 417.9 ms | 1114x | 9.1 ms |
 
 </details>
 
@@ -285,7 +368,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-i64-alu-dark.svg">
-  <img alt="wat/i64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.33 ns, then wasmtime at 2.33 ns; pywasm-pypy is slowest at 338 µs, a span of 145000x. The table below carries every number." src="figs/wat-i64-alu.svg">
+  <img alt="wat/i64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.32 ns, then wasmtime at 2.33 ns; pywasm-pypy is slowest at 397 µs, a span of 171000x. The table below carries every number." src="figs/wat-i64-alu.svg">
 </picture>
 
 <details>
@@ -293,24 +376,88 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 129 122 827 | 2.33 | 2.33 | 5.4 ms | 306.2 ms | 1.00x | — |
-| `wasmer` | 124 962 840 | 2.33 | 2.33 | 8.3 ms | 299.4 ms | 1.00x | — |
-| `wasmedge` | 1 734 355 | 157.8 | 157.9 | 16.5 ms | 290.1 ms | 68x | — |
-| `wazero` | 111 467 568 | 2.66 | 2.66 | 4.7 ms | 301.0 ms | 1.14x | — |
-| `wasm3` | 16 777 216 | 12.2 | 12.2 | 4.4 ms | 208.9 ms | 5.23x | — |
-| `dewasm-ruby` | 215 543 | 1345 | 1357 | 38.9 ms | 328.8 ms | 577x | — |
-| `dewasm-ruby-yjit` | 260 631 | 999.3 | 997.0 | 38.5 ms | 299.0 ms | 429x | — |
-| `dewasm-ruby-zjit` | 276 205 | 1064 | 1062 | 39.9 ms | 333.8 ms | 457x | — |
-| `dewasm-python` | 450 319 | 635.4 | 639.4 | 29.0 ms | 315.2 ms | 273x | — |
-| `dewasm-pypy` | 819 530 | 226.4 | 225.9 | 39.7 ms | 225.2 ms | 97x | — |
-| `dewasm-perl` | 289 790 | 1005 | 1011 | 10.5 ms | 301.8 ms | 431x | — |
-| `dewasm-go` | 111 926 972 | 2.63 | 2.64 | 2.7 ms | 297.2 ms | 1.13x | — |
-| `dewasm-java` | 107 783 465 | 2.36 | 2.34 | 64.2 ms | 319.1 ms | 1.02x | — |
-| `dewasm-bash` | 10 180 | 27824 | 28048 | 13.5 ms | 296.7 ms | 11943x | — |
-| `pywasm-cpython` | 5 100 | 58281 | 58240 | 43.3 ms | 340.5 ms | 25016x | 0.6 ms |
-| `pywasm-pypy` | 591 | 338965 | 337741 | 82.4 ms | 282.8 ms | 145496x | 3.7 ms |
-| `wardite` | 13 327 | 16847 | 16885 | 52.4 ms | 277.0 ms | 7231x | 4.4 ms |
-| `wardite-yjit` | 31 284 | 9330 | 9319 | 102.0 ms | 393.9 ms | 4005x | 9.5 ms |
+| `wasmtime` | 126 577 242 | 2.33 | 2.33 | 5.3 ms | 300.0 ms | 1.00x | — |
+| `wasmer` | 128 901 407 | 2.32 | 2.32 | 9.6 ms | 309.1 ms | 1.00x | — |
+| `wasmedge` | 1 725 365 | 157.9 | 157.6 | 15.6 ms | 287.9 ms | 68x | — |
+| `wazero` | 111 272 479 | 2.67 | 2.67 | 5.0 ms | 302.1 ms | 1.15x | — |
+| `wasm3` | 15 831 545 | 12.1 | 12.1 | 4.0 ms | 195.5 ms | 5.19x | — |
+| `dewasm-ruby` | 218 623 | 1332 | 1338 | 38.8 ms | 330.0 ms | 572x | — |
+| `dewasm-ruby-yjit` | 284 346 | 972.4 | 989.0 | 39.5 ms | 316.0 ms | 418x | — |
+| `dewasm-ruby-zjit` | 272 181 | 1038 | 1054 | 39.9 ms | 322.3 ms | 446x | — |
+| `dewasm-python` | 452 339 | 631.1 | 633.3 | 29.4 ms | 314.9 ms | 271x | — |
+| `dewasm-pypy` | 993 649 | 223.5 | 223.4 | 40.1 ms | 262.2 ms | 96x | — |
+| `dewasm-perl` | 300 939 | 1004 | 1006 | 10.6 ms | 312.7 ms | 431x | — |
+| `dewasm-go` | 113 960 705 | 2.64 | 2.64 | 2.9 ms | 303.9 ms | 1.13x | — |
+| `dewasm-java` | 129 434 208 | 2.36 | 2.36 | 66.5 ms | 371.9 ms | 1.01x | — |
+| `dewasm-bash` | 9 644 | 27660 | 27746 | 13.2 ms | 279.9 ms | 11876x | — |
+| `pywasm-cpython` | 4 773 | 57501 | 57232 | 44.2 ms | 318.6 ms | 24690x | 0.6 ms |
+| `pywasm-pypy` | 477 | 397386 | 397020 | 82.4 ms | 272.0 ms | 170630x | 3.8 ms |
+| `wardite` | 13 383 | 16606 | 16769 | 52.7 ms | 275.0 ms | 7130x | 4.3 ms |
+| `wardite-yjit` | 31 228 | 9317 | 9298 | 100.9 ms | 391.9 ms | 4000x | 9.8 ms |
+
+</details>
+
+#### `wat/i64_div`
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="figs/wat-i64-div-dark.svg">
+  <img alt="wat/i64_div: seconds per iteration for 16 runners on a log scale, fastest first. dewasm-go is fastest at 8.24 ns, then wasmer at 8.28 ns; pywasm-pypy is slowest at 392 µs, a span of 47600x. The table below carries every number." src="figs/wat-i64-div.svg">
+</picture>
+
+<details>
+<summary>Full numbers for <code>wat/i64_div</code></summary>
+
+| Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `wasmtime` | 36 254 517 | 8.28 | 8.29 | 5.4 ms | 305.5 ms | 1.00x | — |
+| `wasmer` | 36 133 068 | 8.27 | 8.28 | 9.3 ms | 308.2 ms | 1.00x | — |
+| `wasmedge` | 1 644 194 | 188.0 | 188.1 | 15.9 ms | 325.0 ms | 23x | — |
+| `wazero` | 36 469 103 | 8.30 | 8.31 | 5.3 ms | 308.0 ms | 1.00x | — |
+| `wasm3` | 13 930 659 | 16.2 | 16.2 | 4.1 ms | 230.0 ms | 1.96x | — |
+| `dewasm-ruby` | 162 977 | 1692 | 1695 | 39.4 ms | 315.2 ms | 204x | — |
+| `dewasm-ruby-yjit` | 200 894 | 1141 | 1150 | 39.4 ms | 268.7 ms | 138x | — |
+| `dewasm-ruby-zjit` | 152 217 | 1410 | 1409 | 38.9 ms | 253.4 ms | 170x | — |
+| `dewasm-python` | 286 489 | 1034 | 1038 | 29.2 ms | 325.4 ms | 125x | — |
+| `dewasm-pypy` | 1 043 865 | 268.2 | 266.7 | 39.6 ms | 319.6 ms | 32x | — |
+| `dewasm-perl` | 196 042 | 1509 | 1512 | 10.8 ms | 306.7 ms | 182x | — |
+| `dewasm-go` | 34 311 152 | 8.25 | 8.24 | 3.8 ms | 286.8 ms | 1.00x | — |
+| `dewasm-java` | 23 846 088 | 8.55 | 8.60 | 67.3 ms | 271.3 ms | 1.03x | — |
+| `dewasm-bash` | 3 668 | 77454 | 77444 | 12.4 ms | 296.5 ms | 9356x | — |
+| `pywasm-cpython` | 4 758 | 65436 | 65888 | 45.0 ms | 356.4 ms | 7905x | 0.7 ms |
+| `pywasm-pypy` | 503 | 394139 | 391962 | 78.5 ms | 276.8 ms | 47611x | 4.0 ms |
+
+</details>
+
+#### `wat/mem_narrow`
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="figs/wat-mem-narrow-dark.svg">
+  <img alt="wat/mem_narrow: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.58 ns; pywasm-cpython is slowest at 87.7 µs, a span of 58500x. The table below carries every number." src="figs/wat-mem-narrow.svg">
+</picture>
+
+<details>
+<summary>Full numbers for <code>wat/mem_narrow</code></summary>
+
+| Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `wasmtime` | 199 251 057 | 1.50 | 1.50 | 5.7 ms | 304.3 ms | 1.00x | — |
+| `wasmer` | 189 206 642 | 1.58 | 1.58 | 8.8 ms | 308.2 ms | 1.06x | — |
+| `wasmedge` | 1 134 465 | 268.1 | 269.3 | 16.0 ms | 320.1 ms | 179x | — |
+| `wazero` | 117 349 081 | 2.52 | 2.53 | 4.7 ms | 301.0 ms | 1.69x | — |
+| `wasm3` | 9 629 976 | 20.5 | 20.6 | 4.1 ms | 201.8 ms | 14x | — |
+| `dewasm-ruby` | 599 388 | 437.0 | 434.5 | 37.7 ms | 299.6 ms | 292x | — |
+| `dewasm-ruby-yjit` | 777 907 | 309.5 | 309.7 | 38.9 ms | 279.7 ms | 207x | — |
+| `dewasm-ruby-zjit` | 647 696 | 335.4 | 339.6 | 39.3 ms | 256.6 ms | 224x | — |
+| `dewasm-python` | 156 839 | 1893 | 1912 | 29.4 ms | 326.3 ms | 1263x | — |
+| `dewasm-pypy` | 3 304 769 | 73.0 | 72.8 | 40.5 ms | 281.8 ms | 49x | — |
+| `dewasm-perl` | 65 536 | 3232 | 3247 | 11.6 ms | 223.4 ms | 2157x | — |
+| `dewasm-go` | 103 553 741 | 2.48 | 2.48 | 4.3 ms | 260.7 ms | 1.65x | — |
+| `dewasm-java` | 45 353 611 | 4.46 | 4.51 | 66.7 ms | 269.0 ms | 2.98x | — |
+| `dewasm-bash` | 5 751 | 51298 | 51328 | 12.8 ms | 307.8 ms | 34239x | — |
+| `pywasm-cpython` | 3 353 | 87567 | 87657 | 43.7 ms | 337.3 ms | 58446x | 0.9 ms |
+| `pywasm-pypy` | 3 218 | 57676 | 57328 | 78.0 ms | 263.6 ms | 38496x | 5.1 ms |
+| `wardite` | 10 043 | 28354 | 28544 | 53.1 ms | 337.9 ms | 18925x | 3.8 ms |
+| `wardite-yjit` | 19 012 | 14780 | 14812 | 101.3 ms | 382.3 ms | 9865x | 9.1 ms |
 
 </details>
 
@@ -318,7 +465,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-mem-rw-dark.svg">
-  <img alt="wat/mem_rw: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.02 ns, then wasmer at 1.02 ns; pywasm-cpython is slowest at 39.9 µs, a span of 39200x. The table below carries every number." src="figs/wat-mem-rw.svg">
+  <img alt="wat/mem_rw: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 1.01 ns, then wasmtime at 1.01 ns; pywasm-cpython is slowest at 39.5 µs, a span of 39200x. The table below carries every number." src="figs/wat-mem-rw.svg">
 </picture>
 
 <details>
@@ -326,24 +473,123 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 291 484 765 | 1.02 | 1.02 | 5.1 ms | 301.2 ms | 1.00x | — |
-| `wasmer` | 284 120 819 | 1.01 | 1.02 | 9.0 ms | 297.1 ms | 1.00x | — |
-| `wasmedge` | 2 144 168 | 133.0 | 132.9 | 16.1 ms | 301.2 ms | 131x | — |
-| `wazero` | 192 488 785 | 1.55 | 1.56 | 4.9 ms | 304.2 ms | 1.53x | — |
-| `wasm3` | 33 554 432 | 10.3 | 10.3 | 4.5 ms | 348.8 ms | 10x | — |
-| `dewasm-ruby` | 1 543 920 | 180.8 | 181.5 | 39.4 ms | 318.5 ms | 178x | — |
-| `dewasm-ruby-yjit` | 1 862 437 | 135.2 | 135.4 | 39.3 ms | 291.0 ms | 133x | — |
-| `dewasm-ruby-zjit` | 1 943 551 | 143.5 | 143.4 | 40.1 ms | 319.0 ms | 141x | — |
-| `dewasm-python` | 385 509 | 767.7 | 772.1 | 29.0 ms | 325.0 ms | 756x | — |
-| `dewasm-pypy` | 5 382 869 | 54.6 | 54.7 | 40.5 ms | 334.6 ms | 54x | — |
-| `dewasm-perl` | 299 211 | 998.6 | 1002 | 10.7 ms | 309.5 ms | 983x | — |
-| `dewasm-go` | 197 655 147 | 1.52 | 1.52 | 2.7 ms | 302.4 ms | 1.49x | — |
-| `dewasm-java` | 150 427 483 | 1.77 | 1.77 | 65.2 ms | 331.7 ms | 1.74x | — |
-| `dewasm-bash` | 8 773 | 31962 | 32066 | 12.2 ms | 292.6 ms | 31461x | — |
-| `pywasm-cpython` | 6 280 | 40021 | 39863 | 41.8 ms | 293.1 ms | 39394x | 0.8 ms |
-| `pywasm-pypy` | 24 352 | 8991 | 8985 | 77.6 ms | 296.6 ms | 8851x | 5.0 ms |
-| `wardite` | 20 018 | 13546 | 13728 | 52.5 ms | 323.7 ms | 13334x | 3.9 ms |
-| `wardite-yjit` | 45 403 | 6530 | 6655 | 103.1 ms | 399.5 ms | 6428x | 10.8 ms |
+| `wasmtime` | 287 376 100 | 1.01 | 1.01 | 5.4 ms | 294.2 ms | 1.00x | — |
+| `wasmer` | 296 096 089 | 1.01 | 1.01 | 9.0 ms | 307.5 ms | 1.00x | — |
+| `wasmedge` | 1 971 633 | 132.6 | 131.9 | 15.6 ms | 277.1 ms | 132x | — |
+| `wazero` | 189 579 017 | 1.54 | 1.55 | 4.7 ms | 297.6 ms | 1.54x | — |
+| `wasm3` | 33 554 432 | 10.3 | 10.3 | 4.2 ms | 348.9 ms | 10x | — |
+| `dewasm-ruby` | 1 684 297 | 180.2 | 180.3 | 40.4 ms | 344.0 ms | 179x | — |
+| `dewasm-ruby-yjit` | 1 566 878 | 135.5 | 135.8 | 39.0 ms | 251.4 ms | 135x | — |
+| `dewasm-ruby-zjit` | 1 801 622 | 142.8 | 143.0 | 39.9 ms | 297.2 ms | 142x | — |
+| `dewasm-python` | 399 182 | 763.7 | 766.3 | 29.2 ms | 334.1 ms | 760x | — |
+| `dewasm-pypy` | 5 391 683 | 54.3 | 54.6 | 41.1 ms | 333.6 ms | 54x | — |
+| `dewasm-perl` | 301 672 | 1001 | 1006 | 11.1 ms | 313.2 ms | 996x | — |
+| `dewasm-go` | 198 373 798 | 1.51 | 1.51 | 3.0 ms | 303.1 ms | 1.51x | — |
+| `dewasm-java` | 145 873 518 | 1.77 | 1.77 | 66.4 ms | 324.6 ms | 1.76x | — |
+| `dewasm-bash` | 8 907 | 31710 | 31824 | 12.3 ms | 294.8 ms | 31549x | — |
+| `pywasm-cpython` | 4 788 | 39783 | 39525 | 42.8 ms | 233.2 ms | 39580x | 0.7 ms |
+| `pywasm-pypy` | 28 800 | 8266 | 8251 | 79.9 ms | 318.0 ms | 8224x | 4.5 ms |
+| `wardite` | 26 662 | 13205 | 13228 | 51.5 ms | 403.5 ms | 13138x | 4.3 ms |
+| `wardite-yjit` | 46 184 | 6226 | 6369 | 101.4 ms | 389.0 ms | 6194x | 9.4 ms |
+
+</details>
+
+#### `c/mandelbrot`
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="figs/c-mandelbrot-dark.svg">
+  <img alt="c/mandelbrot: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 96.0 ns, then wasmtime at 96.2 ns; dewasm-bash is slowest at 20.4 ms, a span of 213000x. The table below carries every number." src="figs/c-mandelbrot.svg">
+</picture>
+
+<details>
+<summary>Full numbers for <code>c/mandelbrot</code></summary>
+
+| Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `wasmtime` | 3 035 284 | 96.2 | 96.2 | 5.8 ms | 297.7 ms | 1.00x | — |
+| `wasmer` | 3 212 614 | 96.0 | 96.0 | 9.1 ms | 317.6 ms | 1.00x | — |
+| `wasmedge` | 65 536 | 3823 | 3823 | 16.2 ms | 266.8 ms | 40x | — |
+| `wazero` | 2 711 538 | 107.3 | 107.5 | 5.1 ms | 296.0 ms | 1.12x | — |
+| `wasm3` | 659 438 | 453.3 | 453.1 | 4.4 ms | 303.4 ms | 4.71x | — |
+| `dewasm-ruby` | 44 032 | 4557 | 4555 | 38.8 ms | 239.5 ms | 47x | — |
+| `dewasm-ruby-yjit` | 141 178 | 1512 | 1549 | 38.8 ms | 252.3 ms | 16x | — |
+| `dewasm-ruby-zjit` | 79 388 | 3531 | 3526 | 40.7 ms | 321.0 ms | 37x | — |
+| `dewasm-python` | 65 536 | 3568 | 3594 | 30.4 ms | 264.2 ms | 37x | — |
+| `dewasm-pypy` | 1 924 060 | 143.2 | 143.7 | 40.6 ms | 316.1 ms | 1.49x | — |
+| `dewasm-perl` | 4 827 | 56123 | 56137 | 10.6 ms | 281.5 ms | 584x | — |
+| `dewasm-go` | 1 243 649 | 235.5 | 235.4 | 2.9 ms | 295.8 ms | 2.45x | — |
+| `dewasm-java` | 2 849 764 | 97.0 | 97.1 | 67.4 ms | 344.0 ms | 1.01x | — |
+| `dewasm-bash` | 192 | 20388203 | 20403138 | 13.1 ms | 3.93 s | 211998x | — |
+| `pywasm-cpython` | 256 | 1484460 | 1486711 | 43.9 ms | 423.9 ms | 15435x | 0.9 ms |
+| `pywasm-pypy` | 150 | 1466239 | 1464171 | 79.4 ms | 299.4 ms | 15246x | 5.3 ms |
+| `wardite` | 730 | 390281 | 388762 | 51.3 ms | 336.2 ms | 4058x | 4.0 ms |
+| `wardite-yjit` | 1 816 | 183347 | 183911 | 100.8 ms | 433.8 ms | 1906x | 10.7 ms |
+
+</details>
+
+#### `c/sha256`
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="figs/c-sha256-dark.svg">
+  <img alt="c/sha256: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 293 ns, then wasmer at 294 ns; dewasm-bash is slowest at 16.0 ms, a span of 54400x. The table below carries every number." src="figs/c-sha256.svg">
+</picture>
+
+<details>
+<summary>Full numbers for <code>c/sha256</code></summary>
+
+| Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `wasmtime` | 944 658 | 292.9 | 293.1 | 5.4 ms | 282.1 ms | 1.00x | — |
+| `wasmer` | 1 021 749 | 293.3 | 293.5 | 9.0 ms | 308.7 ms | 1.00x | — |
+| `wasmedge` | 6 225 | 41969 | 41956 | 15.4 ms | 276.6 ms | 143x | — |
+| `wazero` | 780 907 | 378.5 | 377.8 | 4.9 ms | 300.5 ms | 1.29x | — |
+| `wasm3` | 50 512 | 5026 | 5030 | 4.5 ms | 258.3 ms | 17x | — |
+| `dewasm-ruby` | 3 804 | 78829 | 78919 | 40.2 ms | 340.1 ms | 269x | — |
+| `dewasm-ruby-yjit` | 8 394 | 34050 | 34180 | 39.8 ms | 325.6 ms | 116x | — |
+| `dewasm-ruby-zjit` | 5 636 | 53442 | 53679 | 40.5 ms | 341.7 ms | 182x | — |
+| `dewasm-python` | 1 090 | 268489 | 269211 | 30.8 ms | 323.5 ms | 917x | — |
+| `dewasm-pypy` | 21 514 | 13679 | 13676 | 41.7 ms | 336.0 ms | 47x | — |
+| `dewasm-perl` | 927 | 321704 | 321459 | 10.8 ms | 309.0 ms | 1098x | — |
+| `dewasm-go` | 844 607 | 349.4 | 349.0 | 2.7 ms | 297.8 ms | 1.19x | — |
+| `dewasm-java` | 444 608 | 493.1 | 503.5 | 66.8 ms | 286.0 ms | 1.68x | — |
+| `dewasm-bash` | 18 | 15958181 | 15957794 | 15.0 ms | 302.3 ms | 54484x | — |
+| `pywasm-cpython` | 18 | 14577433 | 14714340 | 45.2 ms | 307.6 ms | 49770x | 1.3 ms |
+| `pywasm-pypy` | 14 | 12908771 | 12873229 | 89.0 ms | 269.8 ms | 44073x | 7.7 ms |
+| `wardite` | 45 | 4201935 | 4211804 | 52.6 ms | 241.7 ms | 14346x | 4.6 ms |
+| `wardite-yjit` | 135 | 1944785 | 1959054 | 104.0 ms | 366.5 ms | 6640x | 10.4 ms |
+
+</details>
+
+#### `c/wordcount`
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="figs/c-wordcount-dark.svg">
+  <img alt="c/wordcount: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.51 ns, then wasmer at 1.63 ns; pywasm-cpython is slowest at 59.7 µs, a span of 39600x. The table below carries every number." src="figs/c-wordcount.svg">
+</picture>
+
+<details>
+<summary>Full numbers for <code>c/wordcount</code></summary>
+
+| Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `wasmtime` | 196 329 993 | 1.49 | 1.51 | 5.6 ms | 298.3 ms | 1.00x | — |
+| `wasmer` | 184 581 647 | 1.63 | 1.63 | 8.9 ms | 310.4 ms | 1.10x | — |
+| `wasmedge` | 1 419 129 | 204.5 | 204.5 | 16.6 ms | 306.9 ms | 137x | — |
+| `wazero` | 97 459 949 | 3.01 | 3.02 | 5.0 ms | 298.2 ms | 2.02x | — |
+| `wasm3` | 11 174 350 | 20.6 | 20.6 | 4.4 ms | 234.6 ms | 14x | — |
+| `dewasm-ruby` | 754 627 | 409.1 | 409.5 | 41.2 ms | 349.9 ms | 274x | — |
+| `dewasm-ruby-yjit` | 1 106 349 | 274.1 | 274.2 | 42.2 ms | 345.4 ms | 184x | — |
+| `dewasm-ruby-zjit` | 907 314 | 296.4 | 296.5 | 41.4 ms | 310.3 ms | 199x | — |
+| `dewasm-python` | 329 069 | 901.7 | 904.0 | 33.0 ms | 329.7 ms | 605x | — |
+| `dewasm-pypy` | 4 873 125 | 57.2 | 57.2 | 46.5 ms | 325.5 ms | 38x | — |
+| `dewasm-perl` | 200 438 | 1490 | 1492 | 18.5 ms | 317.2 ms | 1000x | — |
+| `dewasm-go` | 118 977 621 | 2.42 | 2.42 | 2.7 ms | 290.7 ms | 1.62x | — |
+| `dewasm-java` | 57 318 495 | 3.61 | 3.65 | 64.1 ms | 271.3 ms | 2.42x | — |
+| `dewasm-bash` | 7 044 | 42673 | 42840 | 124.6 ms | 425.1 ms | 28620x | — |
+| `pywasm-cpython` | 4 104 | 59835 | 59661 | 281.5 ms | 527.1 ms | 40130x | 1.3 ms |
+| `pywasm-pypy` | 10 726 | 17451 | 17488 | 195.5 ms | 382.7 ms | 11704x | 8.1 ms |
+| `wardite` | 12 922 | 20845 | 20895 | 122.7 ms | 392.0 ms | 13980x | 4.3 ms |
+| `wardite-yjit` | 29 151 | 9745 | 9774 | 143.7 ms | 427.7 ms | 6536x | 10.3 ms |
 
 </details>
 
@@ -356,7 +602,7 @@ Every runner executes the same work, so wall times compare directly.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/app-cowsay-dark.svg">
-  <img alt="app/cowsay: seconds per run for 18 runners on a log scale, fastest first. dewasm-go is fastest at 4.87 ms, then wasm3 at 7.43 ms; dewasm-bash is slowest at 1.36 s, a span of 279x. The table below carries every number." src="figs/app-cowsay.svg">
+  <img alt="app/cowsay: seconds per run for 18 runners on a log scale, fastest first. dewasm-go is fastest at 4.56 ms, then wasm3 at 7.08 ms; dewasm-bash is slowest at 1.34 s, a span of 293x. The table below carries every number." src="figs/app-cowsay.svg">
 </picture>
 
 <details>
@@ -364,24 +610,24 @@ Every runner executes the same work, so wall times compare directly.
 
 | Runner | Runs/sample | Wall time (min) | Wall time (median) | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 31 | 10.2 ms | 10.4 ms | 1.00x | — |
-| `wasmer` | 22 | 14.8 ms | 14.9 ms | 1.45x | — |
-| `wasmedge` | 11 | 28.1 ms | 28.6 ms | 2.77x | — |
-| `wazero` | 3 | 109.0 ms | 112.5 ms | 11x | — |
-| `wasm3` | 39 | 7.4 ms | 7.4 ms | 0.73x | — |
-| `dewasm-ruby` | 2 | 147.0 ms | 149.0 ms | 14x | — |
-| `dewasm-ruby-yjit` | 2 | 202.1 ms | 204.2 ms | 20x | — |
-| `dewasm-ruby-zjit` | 2 | 255.1 ms | 258.5 ms | 25x | — |
-| `dewasm-python` | 1 | 408.7 ms | 412.9 ms | 40x | — |
-| `dewasm-pypy` | 1 | 640.4 ms | 643.2 ms | 63x | — |
-| `dewasm-perl` | 3 | 111.5 ms | 114.9 ms | 11x | — |
-| `dewasm-go` | 57 | 4.8 ms | 4.9 ms | 0.48x | — |
-| `dewasm-java` | 3 | 139.1 ms | 140.9 ms | 14x | — |
-| `dewasm-bash` | 1 | 1.35 s | 1.36 s | 133x | — |
-| `pywasm-cpython` | 1 | 501.2 ms | 505.9 ms | 49x | 275.7 ms |
-| `pywasm-pypy` | 1 | 909.9 ms | 923.5 ms | 90x | 474.9 ms |
-| `wardite` | 2 | 237.1 ms | 238.6 ms | 23x | 111.5 ms |
-| `wardite-yjit` | 2 | 272.0 ms | 274.1 ms | 27x | 89.1 ms |
+| `wasmtime` | 5 | 10.1 ms | 10.1 ms | 1.00x | — |
+| `wasmer` | 5 | 14.1 ms | 14.1 ms | 1.40x | — |
+| `wasmedge` | 12 | 26.7 ms | 26.8 ms | 2.66x | — |
+| `wazero` | 3 | 106.5 ms | 106.7 ms | 11x | — |
+| `wasm3` | 45 | 7.1 ms | 7.1 ms | 0.70x | — |
+| `dewasm-ruby` | 3 | 144.6 ms | 144.7 ms | 14x | — |
+| `dewasm-ruby-yjit` | 2 | 196.8 ms | 197.6 ms | 20x | — |
+| `dewasm-ruby-zjit` | 2 | 255.4 ms | 256.9 ms | 25x | — |
+| `dewasm-python` | 1 | 422.8 ms | 424.2 ms | 42x | — |
+| `dewasm-pypy` | 1 | 628.8 ms | 630.1 ms | 62x | — |
+| `dewasm-perl` | 3 | 111.9 ms | 111.9 ms | 11x | — |
+| `dewasm-go` | 14 | 4.5 ms | 4.6 ms | 0.45x | — |
+| `dewasm-java` | 3 | 133.0 ms | 133.1 ms | 13x | — |
+| `dewasm-bash` | 1 | 1.33 s | 1.34 s | 133x | — |
+| `pywasm-cpython` | 1 | 494.6 ms | 498.2 ms | 49x | 273.4 ms |
+| `pywasm-pypy` | 1 | 921.8 ms | 925.2 ms | 92x | 482.2 ms |
+| `wardite` | 2 | 236.6 ms | 238.4 ms | 24x | 111.5 ms |
+| `wardite-yjit` | 2 | 269.7 ms | 272.4 ms | 27x | 85.7 ms |
 
 </details>
 
@@ -389,7 +635,7 @@ Every runner executes the same work, so wall times compare directly.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/app-sqlite3-query-dark.svg">
-  <img alt="app/sqlite3_query: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 76.3 ms, then wasmer at 86.4 ms; dewasm-perl is slowest at 113 s, a span of 1480x. The table below carries every number." src="figs/app-sqlite3-query.svg">
+  <img alt="app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 79.2 ms, then wasmer at 87.5 ms; dewasm-ruby is slowest at 19.3 s, a span of 244x. The table below carries every number." src="figs/app-sqlite3-query.svg">
 </picture>
 
 <details>
@@ -397,19 +643,17 @@ Every runner executes the same work, so wall times compare directly.
 
 | Runner | Runs/sample | Wall time (min) | Wall time (median) | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 4 | 76.2 ms | 76.3 ms | 1.00x | — |
-| `wasmer` | 4 | 86.3 ms | 86.4 ms | 1.13x | — |
-| `wasmedge` | 1 | 9.78 s | 9.86 s | 128x | — |
-| `wazero` | 1 | 645.3 ms | 647.4 ms | 8.47x | — |
-| `wasm3` | 1 | 1.08 s | 1.09 s | 14x | — |
-| `dewasm-ruby` | 1 | 19.18 s | 19.29 s | 252x | — |
-| `dewasm-ruby-yjit` | 1 | 9.16 s | 9.19 s | 120x | — |
-| `dewasm-ruby-zjit` | 1 | 14.08 s | 14.12 s | 185x | — |
-| `dewasm-python` | 1 | 55.33 s | 55.52 s | 727x | — |
-| `dewasm-pypy` | 1 | 11.81 s | 11.91 s | 155x | — |
-| `dewasm-perl` | 1 | 113.06 s | 113.27 s | 1485x | — |
-| `dewasm-go` | 2 | 171.0 ms | 172.1 ms | 2.25x | — |
-| `dewasm-java` | 1 | 2.34 s | 2.39 s | 31x | — |
+| `wasmtime` | 2 | 78.7 ms | 79.2 ms | 1.00x | — |
+| `wasmer` | 2 | 87.3 ms | 87.5 ms | 1.11x | — |
+| `wasmedge` | 1 | 9.68 s | 9.76 s | 123x | — |
+| `wazero` | 1 | 646.5 ms | 647.8 ms | 8.21x | — |
+| `wasm3` | 1 | 1.07 s | 1.09 s | 14x | — |
+| `dewasm-ruby` | 1 | 19.32 s | 19.34 s | 245x | — |
+| `dewasm-ruby-yjit` | 1 | 9.40 s | 9.50 s | 119x | — |
+| `dewasm-ruby-zjit` | 1 | 14.19 s | 14.25 s | 180x | — |
+| `dewasm-pypy` | 1 | 11.89 s | 11.92 s | 151x | — |
+| `dewasm-go` | 2 | 172.4 ms | 172.9 ms | 2.19x | — |
+| `dewasm-java` | 1 | 2.41 s | 2.42 s | 31x | — |
 
 </details>
 
@@ -417,7 +661,7 @@ Every runner executes the same work, so wall times compare directly.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/app-sqlite3-mod-query-dark.svg">
-  <img alt="app/sqlite3_mod_query: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 83.2 ms, then wasmer at 91.6 ms; dewasm-perl is slowest at 115 s, a span of 1380x. The table below carries every number." src="figs/app-sqlite3-mod-query.svg">
+  <img alt="app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 86.9 ms, then wasmer at 91.1 ms; dewasm-ruby is slowest at 20.4 s, a span of 235x. The table below carries every number." src="figs/app-sqlite3-mod-query.svg">
 </picture>
 
 <details>
@@ -425,19 +669,17 @@ Every runner executes the same work, so wall times compare directly.
 
 | Runner | Runs/sample | Wall time (min) | Wall time (median) | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 4 | 83.1 ms | 83.2 ms | 1.00x | — |
-| `wasmer` | 4 | 91.3 ms | 91.6 ms | 1.10x | — |
-| `wasmedge` | 1 | 10.09 s | 10.13 s | 121x | — |
-| `wazero` | 1 | 637.0 ms | 638.3 ms | 7.66x | — |
-| `wasm3` | 1 | 1.19 s | 1.21 s | 14x | — |
-| `dewasm-ruby` | 1 | 20.32 s | 20.34 s | 244x | — |
-| `dewasm-ruby-yjit` | 1 | 8.22 s | 8.26 s | 99x | — |
-| `dewasm-ruby-zjit` | 1 | 14.53 s | 14.58 s | 175x | — |
-| `dewasm-python` | 1 | 56.62 s | 57.01 s | 681x | — |
-| `dewasm-pypy` | 1 | 12.43 s | 12.80 s | 150x | — |
-| `dewasm-perl` | 1 | 114.67 s | 115.15 s | 1380x | — |
-| `dewasm-go` | 3 | 126.0 ms | 126.5 ms | 1.52x | — |
-| `dewasm-java` | 1 | 5.52 s | 5.54 s | 66x | — |
+| `wasmtime` | 2 | 86.8 ms | 86.9 ms | 1.00x | — |
+| `wasmer` | 2 | 90.9 ms | 91.1 ms | 1.05x | — |
+| `wasmedge` | 1 | 10.10 s | 10.13 s | 116x | — |
+| `wazero` | 1 | 637.0 ms | 639.4 ms | 7.34x | — |
+| `wasm3` | 1 | 1.17 s | 1.19 s | 13x | — |
+| `dewasm-ruby` | 1 | 20.34 s | 20.39 s | 234x | — |
+| `dewasm-ruby-yjit` | 1 | 8.36 s | 8.38 s | 96x | — |
+| `dewasm-ruby-zjit` | 1 | 14.67 s | 14.72 s | 169x | — |
+| `dewasm-pypy` | 1 | 12.74 s | 12.75 s | 147x | — |
+| `dewasm-go` | 2 | 126.9 ms | 127.6 ms | 1.46x | — |
+| `dewasm-java` | 1 | 5.52 s | 5.54 s | 64x | — |
 
 </details>
 
@@ -445,7 +687,7 @@ Every runner executes the same work, so wall times compare directly.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/app-minigzip-dark.svg">
-  <img alt="app/minigzip: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 46.9 ms, then wasmer at 52.7 ms; pywasm-pypy is slowest at 81.5 s, a span of 1740x. The table below carries every number." src="figs/app-minigzip.svg">
+  <img alt="app/minigzip: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 45.1 ms, then wasmer at 52.5 ms; pywasm-pypy is slowest at 81.5 s, a span of 1810x. The table below carries every number." src="figs/app-minigzip.svg">
 </picture>
 
 <details>
@@ -453,19 +695,19 @@ Every runner executes the same work, so wall times compare directly.
 
 | Runner | Runs/sample | Wall time (min) | Wall time (median) | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 7 | 46.7 ms | 46.9 ms | 1.00x | — |
-| `wasmer` | 6 | 52.4 ms | 52.7 ms | 1.12x | — |
-| `wasmedge` | 1 | 2.25 s | 2.26 s | 48x | — |
-| `wazero` | 4 | 88.2 ms | 88.5 ms | 1.89x | — |
-| `dewasm-ruby` | 1 | 5.27 s | 5.28 s | 113x | — |
-| `dewasm-ruby-yjit` | 1 | 1.64 s | 1.64 s | 35x | — |
-| `dewasm-ruby-zjit` | 1 | 3.36 s | 3.36 s | 72x | — |
-| `dewasm-python` | 1 | 15.30 s | 15.36 s | 327x | — |
-| `dewasm-pypy` | 1 | 2.86 s | 2.87 s | 61x | — |
-| `dewasm-perl` | 1 | 24.28 s | 24.39 s | 519x | — |
-| `dewasm-go` | 6 | 57.9 ms | 58.1 ms | 1.24x | — |
-| `dewasm-java` | 1 | 500.1 ms | 526.9 ms | 11x | — |
-| `pywasm-pypy` | 1 | 81.26 s | 81.45 s | 1739x | 328.9 ms |
+| `wasmtime` | 5 | 44.6 ms | 45.1 ms | 1.00x | — |
+| `wasmer` | 4 | 52.4 ms | 52.5 ms | 1.17x | — |
+| `wasmedge` | 1 | 2.25 s | 2.25 s | 50x | — |
+| `wazero` | 4 | 88.1 ms | 88.4 ms | 1.97x | — |
+| `dewasm-ruby` | 1 | 5.26 s | 5.27 s | 118x | — |
+| `dewasm-ruby-yjit` | 1 | 1.64 s | 1.65 s | 37x | — |
+| `dewasm-ruby-zjit` | 1 | 3.36 s | 3.37 s | 75x | — |
+| `dewasm-python` | 1 | 15.30 s | 15.40 s | 343x | — |
+| `dewasm-pypy` | 1 | 2.86 s | 2.86 s | 64x | — |
+| `dewasm-perl` | 1 | 24.35 s | 24.39 s | 545x | — |
+| `dewasm-go` | 5 | 58.4 ms | 58.4 ms | 1.31x | — |
+| `dewasm-java` | 1 | 537.8 ms | 572.5 ms | 12x | — |
+| `pywasm-pypy` | 1 | 81.29 s | 81.52 s | 1821x | 331.7 ms |
 
 </details>
 
@@ -476,11 +718,33 @@ A missing runner or an unbuilt module is stated here rather than left as a gap i
 
 | Workload | Runner | Reason |
 | --- | --- | --- |
+| `wat/eh_throw` | `wazero` | excluded: wazero 1.12.0 rejects the module: "tag section not supported as feature \"exception-handling\" is disabled" |
+| `wat/eh_throw` | `wasm3` | excluded: wasm3 0.5.0 fails to load it: "out of order Wasm section" (the tag section is unknown to it) |
+| `wat/eh_throw` | `dewasm-bash` | excluded: the bash backend has no exception-handling lowering and rejects the module at conversion time with "unsupported (exception-handling): tag, exnref value, or try_table/throw/throw_ref instruction" (see docs/support.md) |
+| `wat/eh_throw` | `pywasm-cpython` | excluded: pywasm 2.2.3 has no exception-handling opcodes; decoding dies with AssertionError on the throw/try_table opcode (pywasm/core.py, from_reader) |
+| `wat/eh_throw` | `pywasm-pypy` | excluded: pywasm 2.2.3 has no exception-handling opcodes; decoding dies with AssertionError on the throw/try_table opcode (pywasm/core.py, from_reader) |
+| `wat/eh_throw` | `wardite` | excluded: wardite 0.9.0 fails to load the tag section: Wardite::LoadError "unknown code: 13" |
+| `wat/eh_throw` | `wardite-yjit` | excluded: wardite 0.9.0 fails to load the tag section: Wardite::LoadError "unknown code: 13" |
+| `wat/eh_try` | `wazero` | excluded: wazero 1.12.0 rejects the module: "tag section not supported as feature \"exception-handling\" is disabled" |
+| `wat/eh_try` | `wasm3` | excluded: wasm3 0.5.0 fails to load it: "out of order Wasm section" (the tag section is unknown to it) |
+| `wat/eh_try` | `dewasm-bash` | excluded: the bash backend has no exception-handling lowering and rejects the module at conversion time with "unsupported (exception-handling): tag, exnref value, or try_table/throw/throw_ref instruction" (see docs/support.md) |
+| `wat/eh_try` | `pywasm-cpython` | excluded: pywasm 2.2.3 has no exception-handling opcodes; decoding dies with AssertionError on the throw/try_table opcode (pywasm/core.py, from_reader) |
+| `wat/eh_try` | `pywasm-pypy` | excluded: pywasm 2.2.3 has no exception-handling opcodes; decoding dies with AssertionError on the throw/try_table opcode (pywasm/core.py, from_reader) |
+| `wat/eh_try` | `wardite` | excluded: wardite 0.9.0 fails to load the tag section: Wardite::LoadError "unknown code: 13" |
+| `wat/eh_try` | `wardite-yjit` | excluded: wardite 0.9.0 fails to load the tag section: Wardite::LoadError "unknown code: 13" |
+| `wat/f32_alu` | `wardite` | excluded: wardite 0.9.0 does not re-round f32 arithmetic to single precision, so a dependent operation chain diverges from wasmtime (1232349357 vs 1232349355 at 10000 iterations) and the byte-for-byte verification would fail the whole run |
+| `wat/f32_alu` | `wardite-yjit` | excluded: wardite 0.9.0 does not re-round f32 arithmetic to single precision, so a dependent operation chain diverges from wasmtime (1232349357 vs 1232349355 at 10000 iterations) and the byte-for-byte verification would fail the whole run |
+| `wat/i64_div` | `wardite` | excluded: wardite 0.9.0 computes i64.div_s at f64 precision, wrong for operands beyond 2^53: i64.div_s(0x8000000000000000, 3) gives -3074457345618258432 where -3074457345618258602 is correct |
+| `wat/i64_div` | `wardite-yjit` | excluded: wardite 0.9.0 computes i64.div_s at f64 precision, wrong for operands beyond 2^53: i64.div_s(0x8000000000000000, 3) gives -3074457345618258432 where -3074457345618258602 is correct |
+| `app/sqlite3_query` | `dewasm-python` | excluded on cost, not capability: dewasm-python runs this program correctly but at 56 s and 57 s per run (median, sqlite3_query and sqlite3_mod_query), costing roughly 9 minutes of the roughly 65 minute full suite; dewasm-python stays measured on the other app cases and the microbenchmarks |
+| `app/sqlite3_query` | `dewasm-perl` | excluded on cost, not capability: dewasm-perl runs this program correctly but at 113 s and 115 s per run (median, sqlite3_query and sqlite3_mod_query), so one warmup plus the timed repetitions across both cases alone cost roughly 19 minutes of the roughly 65 minute full suite; dewasm-perl stays measured on the other app cases and the microbenchmarks |
 | `app/sqlite3_query` | `dewasm-bash` | excluded: bash runs ~10000x slower than wasmtime on compute, so 100k SQL inserts do not finish in a practical time |
 | `app/sqlite3_query` | `pywasm-cpython` | excluded on cost, not capability: pywasm runs this program correctly (byte-identical to wasmtime under -batch) at ~17.9 ms/row: measured 358 s at 20k rows, so the 100k-row script needs roughly half an hour per sample |
 | `app/sqlite3_query` | `pywasm-pypy` | excluded on cost, not capability: pywasm runs this program correctly (byte-identical to wasmtime under -batch) at ~17.9 ms/row: measured 358 s at 20k rows, so the 100k-row script needs roughly half an hour per sample |
 | `app/sqlite3_query` | `wardite` | excluded: wardite loads the sqlite3 shell but cannot execute a query, raising Wardite::EvalError ("maybe empty or invalid stack", convert.generated.rb:200) as soon as any SQL runs |
 | `app/sqlite3_query` | `wardite-yjit` | excluded: wardite loads the sqlite3 shell but cannot execute a query, raising Wardite::EvalError ("maybe empty or invalid stack", convert.generated.rb:200) as soon as any SQL runs |
+| `app/sqlite3_mod_query` | `dewasm-python` | excluded on cost, not capability: dewasm-python runs this program correctly but at 56 s and 57 s per run (median, sqlite3_query and sqlite3_mod_query), costing roughly 9 minutes of the roughly 65 minute full suite; dewasm-python stays measured on the other app cases and the microbenchmarks |
+| `app/sqlite3_mod_query` | `dewasm-perl` | excluded on cost, not capability: dewasm-perl runs this program correctly but at 113 s and 115 s per run (median, sqlite3_query and sqlite3_mod_query), so one warmup plus the timed repetitions across both cases alone cost roughly 19 minutes of the roughly 65 minute full suite; dewasm-perl stays measured on the other app cases and the microbenchmarks |
 | `app/sqlite3_mod_query` | `dewasm-bash` | excluded: bash runs ~10000x slower than wasmtime on compute, so 100k SQL inserts do not finish in a practical time |
 | `app/sqlite3_mod_query` | `pywasm-cpython` | excluded on cost, not capability: pywasm runs this program correctly (byte-identical to wasmtime under -batch) at ~17.9 ms/row: measured 358 s at 20k rows, so the 100k-row script needs roughly half an hour per sample |
 | `app/sqlite3_mod_query` | `pywasm-pypy` | excluded on cost, not capability: pywasm runs this program correctly (byte-identical to wasmtime under -batch) at ~17.9 ms/row: measured 358 s at 20k rows, so the 100k-row script needs roughly half an hour per sample |

--- a/records/2026-08-22T06-26-23Z-speed.json
+++ b/records/2026-08-22T06-26-23Z-speed.json
@@ -1,0 +1,10497 @@
+{
+  "schema": 1,
+  "generated_at": "2026-08-22T06:26:23Z",
+  "host": {
+    "os": "macOS 26.5.2",
+    "arch": "aarch64",
+    "kernel": "Darwin 25.5.0",
+    "cpu": "Apple M1 Pro"
+  },
+  "settings": {
+    "reps": 3,
+    "target_ms": 300,
+    "timeout_s": 900,
+    "filter": null
+  },
+  "runtimes": [
+    {
+      "runner": "wasmtime",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "wasmtime 48.0.0 (f1412a598 2026-08-20)"
+    },
+    {
+      "runner": "wasmer",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "wasmer 7.3.0"
+    },
+    {
+      "runner": "wasmedge",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "wasmedge version 0.17.1"
+    },
+    {
+      "runner": "wazero",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "1.12.0"
+    },
+    {
+      "runner": "wasm3",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "Wasm3 v0.5.0 on arm64-v8a"
+    },
+    {
+      "runner": "dewasm-ruby",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "ruby 4.0.4 (2026-05-12 revision b89eb1bcbf) +PRISM [arm64-darwin25]"
+    },
+    {
+      "runner": "dewasm-ruby-yjit",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "ruby 4.0.4 (2026-05-12 revision b89eb1bcbf) +PRISM [arm64-darwin25]"
+    },
+    {
+      "runner": "dewasm-ruby-zjit",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "ruby 4.0.4 (2026-05-12 revision b89eb1bcbf) +PRISM [arm64-darwin25]"
+    },
+    {
+      "runner": "dewasm-python",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "Python 3.14.7 (main, Aug  5 2026, 10:29:49) [Clang 21.0.0 (clang-2100.1.1.101)]"
+    },
+    {
+      "runner": "dewasm-pypy",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "Python 3.11.15 (194f9f44b505, Jul 15 2026, 12:14:56)"
+    },
+    {
+      "runner": "dewasm-perl",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "v5.44.0"
+    },
+    {
+      "runner": "dewasm-go",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "go version go1.26.2 darwin/arm64"
+    },
+    {
+      "runner": "dewasm-java",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "java version \"25.0.4.1\" 2026-08-18 LTS"
+    },
+    {
+      "runner": "dewasm-bash",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "5.3.15(1)-release"
+    },
+    {
+      "runner": "pywasm-cpython",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "pywasm 2.2.3"
+    },
+    {
+      "runner": "pywasm-pypy",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "pywasm 2.2.3"
+    },
+    {
+      "runner": "wardite",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "wardite 0.9.0"
+    },
+    {
+      "runner": "wardite-yjit",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "wardite 0.9.0"
+    }
+  ],
+  "results": [
+    {
+      "workload": "wat/br_table",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 35287220,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005894083,
+        "median_s": 0.005949042,
+        "samples_s": [
+          0.006192916,
+          0.005894083,
+          0.005949042
+        ]
+      },
+      "total": {
+        "min_s": 0.305400958,
+        "median_s": 0.306400417,
+        "samples_s": [
+          0.306400417,
+          0.307203875,
+          0.305400958
+        ]
+      },
+      "compute_s": 0.299506875,
+      "ns_per_op_min": 8.487686901943537,
+      "ns_per_op_median": 8.514452966258037,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 35089490,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.008923417,
+        "median_s": 0.009613791,
+        "samples_s": [
+          0.009613791,
+          0.008923417,
+          0.00968825
+        ]
+      },
+      "total": {
+        "min_s": 0.307606125,
+        "median_s": 0.307997542,
+        "samples_s": [
+          0.310472459,
+          0.307606125,
+          0.307997542
+        ]
+      },
+      "compute_s": 0.298682708,
+      "ns_per_op_min": 8.512027618526231,
+      "ns_per_op_median": 8.503507773980187,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1136802,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015675167,
+        "median_s": 0.016712666,
+        "samples_s": [
+          0.015675167,
+          0.016712666,
+          0.017544417
+        ]
+      },
+      "total": {
+        "min_s": 0.269414334,
+        "median_s": 0.269606083,
+        "samples_s": [
+          0.269606083,
+          0.270507042,
+          0.269414334
+        ]
+      },
+      "compute_s": 0.253739167,
+      "ns_per_op_min": 223.20436364468043,
+      "ns_per_op_median": 222.46039063970682,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 33781226,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005115917,
+        "median_s": 0.005129583,
+        "samples_s": [
+          0.005115917,
+          0.005129583,
+          0.005576166
+        ]
+      },
+      "total": {
+        "min_s": 0.304464709,
+        "median_s": 0.304996792,
+        "samples_s": [
+          0.304464709,
+          0.304996792,
+          0.305320208
+        ]
+      },
+      "compute_s": 0.299348792,
+      "ns_per_op_min": 8.861395142970832,
+      "ns_per_op_median": 8.876741448045728,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 13248133,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004369416,
+        "median_s": 0.004485041,
+        "samples_s": [
+          0.004502166,
+          0.004485041,
+          0.004369416
+        ]
+      },
+      "total": {
+        "min_s": 0.352681625,
+        "median_s": 0.353114791,
+        "samples_s": [
+          0.353114791,
+          0.352681625,
+          0.353762542
+        ]
+      },
+      "compute_s": 0.348312209,
+      "ns_per_op_min": 26.291418496477956,
+      "ns_per_op_median": 26.315387232299067,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 1202302,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.03928075,
+        "median_s": 0.039908458,
+        "samples_s": [
+          0.040873333,
+          0.03928075,
+          0.039908458
+        ]
+      },
+      "total": {
+        "min_s": 0.301197875,
+        "median_s": 0.301471417,
+        "samples_s": [
+          0.301471417,
+          0.303819292,
+          0.301197875
+        ]
+      },
+      "compute_s": 0.261917125,
+      "ns_per_op_min": 217.84636888236065,
+      "ns_per_op_median": 217.5517956386998,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 1290279,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039843042,
+        "median_s": 0.041101875,
+        "samples_s": [
+          0.041127333,
+          0.039843042,
+          0.041101875
+        ]
+      },
+      "total": {
+        "min_s": 0.32029925,
+        "median_s": 0.32246925,
+        "samples_s": [
+          0.32029925,
+          0.322814,
+          0.32246925
+        ]
+      },
+      "compute_s": 0.280456208,
+      "ns_per_op_min": 217.36090256448412,
+      "ns_per_op_median": 218.0670808406554,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 1265131,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039497792,
+        "median_s": 0.040020458,
+        "samples_s": [
+          0.039497792,
+          0.041152958,
+          0.040020458
+        ]
+      },
+      "total": {
+        "min_s": 0.315456583,
+        "median_s": 0.315988417,
+        "samples_s": [
+          0.315988417,
+          0.315456583,
+          0.316007666
+        ]
+      },
+      "compute_s": 0.27595879100000004,
+      "ns_per_op_min": 218.1266532872881,
+      "ns_per_op_median": 218.13389996767137,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 774703,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.029679708,
+        "median_s": 0.029864166,
+        "samples_s": [
+          0.030019042,
+          0.029864166,
+          0.029679708
+        ]
+      },
+      "total": {
+        "min_s": 0.336420166,
+        "median_s": 0.336700041,
+        "samples_s": [
+          0.337400959,
+          0.336700041,
+          0.336420166
+        ]
+      },
+      "compute_s": 0.30674045800000005,
+      "ns_per_op_min": 395.94587603249255,
+      "ns_per_op_median": 396.0690419425251,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 4281164,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.041325208,
+        "median_s": 0.0419765,
+        "samples_s": [
+          0.0419765,
+          0.042098875,
+          0.041325208
+        ]
+      },
+      "total": {
+        "min_s": 0.308269375,
+        "median_s": 0.30828075,
+        "samples_s": [
+          0.311118375,
+          0.30828075,
+          0.308269375
+        ]
+      },
+      "compute_s": 0.266944167,
+      "ns_per_op_min": 62.35317474406493,
+      "ns_per_op_median": 62.20370207728553,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 334562,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010641958,
+        "median_s": 0.010872209,
+        "samples_s": [
+          0.010872209,
+          0.010641958,
+          0.01140925
+        ]
+      },
+      "total": {
+        "min_s": 0.303049083,
+        "median_s": 0.303523125,
+        "samples_s": [
+          0.303049083,
+          0.303523125,
+          0.303933584
+        ]
+      },
+      "compute_s": 0.292407125,
+      "ns_per_op_min": 873.9998116940956,
+      "ns_per_op_median": 874.7284987535943,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 37149182,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004467458,
+        "median_s": 0.005641708,
+        "samples_s": [
+          0.005799,
+          0.005641708,
+          0.004467458
+        ]
+      },
+      "total": {
+        "min_s": 0.289659083,
+        "median_s": 0.289722833,
+        "samples_s": [
+          0.289659083,
+          0.290738583,
+          0.289722833
+        ]
+      },
+      "compute_s": 0.285191625,
+      "ns_per_op_min": 7.6769287948251455,
+      "ns_per_op_median": 7.647035808217796,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 26509159,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.067557042,
+        "median_s": 0.068519708,
+        "samples_s": [
+          0.068519708,
+          0.067557042,
+          0.068538
+        ]
+      },
+      "total": {
+        "min_s": 0.326013875,
+        "median_s": 0.326838834,
+        "samples_s": [
+          0.326013875,
+          0.327292709,
+          0.326838834
+        ]
+      },
+      "compute_s": 0.258456833,
+      "ns_per_op_min": 9.749718314338075,
+      "ns_per_op_median": 9.7445236191763,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 7436,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.012606542,
+        "median_s": 0.01283,
+        "samples_s": [
+          0.012606542,
+          0.013647459,
+          0.01283
+        ]
+      },
+      "total": {
+        "min_s": 0.284416292,
+        "median_s": 0.284887167,
+        "samples_s": [
+          0.284416292,
+          0.285606959,
+          0.284887167
+        ]
+      },
+      "compute_s": 0.27180975,
+      "ns_per_op_min": 36553.220817643894,
+      "ns_per_op_median": 36586.49367939753,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 4485,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.042954,
+        "median_s": 0.044383875,
+        "samples_s": [
+          0.042954,
+          0.044383875,
+          0.044407083
+        ]
+      },
+      "total": {
+        "min_s": 0.272141458,
+        "median_s": 0.273742958,
+        "samples_s": [
+          0.274939416,
+          0.272141458,
+          0.273742958
+        ]
+      },
+      "compute_s": 0.229187458,
+      "ns_per_op_min": 51100.88249721293,
+      "ns_per_op_median": 51139.14894091415,
+      "load_ms": 1.107,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 3705,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.080504042,
+        "median_s": 0.082507125,
+        "samples_s": [
+          0.080504042,
+          0.082507125,
+          0.082851083
+        ]
+      },
+      "total": {
+        "min_s": 0.267595,
+        "median_s": 0.270818417,
+        "samples_s": [
+          0.270818417,
+          0.271090792,
+          0.267595
+        ]
+      },
+      "compute_s": 0.18709095800000003,
+      "ns_per_op_min": 50496.88475033739,
+      "ns_per_op_median": 50826.259649122796,
+      "load_ms": 5.455,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 12234,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.052441042,
+        "median_s": 0.053356667,
+        "samples_s": [
+          0.053356667,
+          0.054424959,
+          0.052441042
+        ]
+      },
+      "total": {
+        "min_s": 0.311601458,
+        "median_s": 0.312315375,
+        "samples_s": [
+          0.318785125,
+          0.311601458,
+          0.312315375
+        ]
+      },
+      "compute_s": 0.259160416,
+      "ns_per_op_min": 21183.62072911558,
+      "ns_per_op_median": 21167.133235246034,
+      "load_ms": 4.339,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 24853,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.101710333,
+        "median_s": 0.102783917,
+        "samples_s": [
+          0.103500125,
+          0.102783917,
+          0.101710333
+        ]
+      },
+      "total": {
+        "min_s": 0.31974475,
+        "median_s": 0.320658458,
+        "samples_s": [
+          0.320658458,
+          0.31974475,
+          0.326225167
+        ]
+      },
+      "compute_s": 0.21803441700000004,
+      "ns_per_op_min": 8772.961694765221,
+      "ns_per_op_median": 8766.528829517561,
+      "load_ms": 10.004,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 87191798,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005441166,
+        "median_s": 0.005681625,
+        "samples_s": [
+          0.005699042,
+          0.005681625,
+          0.005441166
+        ]
+      },
+      "total": {
+        "min_s": 0.309945041,
+        "median_s": 0.310002667,
+        "samples_s": [
+          0.309945041,
+          0.310297083,
+          0.310002667
+        ]
+      },
+      "compute_s": 0.304503875,
+      "ns_per_op_min": 3.4923454038647077,
+      "ns_per_op_median": 3.490248497914907,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 86070965,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.008770541,
+        "median_s": 0.009119792,
+        "samples_s": [
+          0.009608541,
+          0.009119792,
+          0.008770541
+        ]
+      },
+      "total": {
+        "min_s": 0.309297792,
+        "median_s": 0.30933475,
+        "samples_s": [
+          0.30933475,
+          0.310215542,
+          0.309297792
+        ]
+      },
+      "compute_s": 0.300527251,
+      "ns_per_op_min": 3.491621721680476,
+      "ns_per_op_median": 3.4879934017237986,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1378333,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015780958,
+        "median_s": 0.015832833,
+        "samples_s": [
+          0.016061542,
+          0.015780958,
+          0.015832833
+        ]
+      },
+      "total": {
+        "min_s": 0.299316916,
+        "median_s": 0.300703083,
+        "samples_s": [
+          0.302066375,
+          0.299316916,
+          0.300703083
+        ]
+      },
+      "compute_s": 0.283535958,
+      "ns_per_op_min": 205.70933003853204,
+      "ns_per_op_median": 206.67737767288457,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 49810957,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005169375,
+        "median_s": 0.005394417,
+        "samples_s": [
+          0.005394417,
+          0.005592417,
+          0.005169375
+        ]
+      },
+      "total": {
+        "min_s": 0.304086292,
+        "median_s": 0.304452375,
+        "samples_s": [
+          0.304466333,
+          0.304452375,
+          0.304086292
+        ]
+      },
+      "compute_s": 0.298916917,
+      "ns_per_op_min": 6.001027384396569,
+      "ns_per_op_median": 6.003858909998457,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 5437668,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004254917,
+        "median_s": 0.004354875,
+        "samples_s": [
+          0.004254917,
+          0.004354875,
+          0.004790292
+        ]
+      },
+      "total": {
+        "min_s": 0.272250875,
+        "median_s": 0.273056791,
+        "samples_s": [
+          0.2736505,
+          0.272250875,
+          0.273056791
+        ]
+      },
+      "compute_s": 0.267995958,
+      "ns_per_op_min": 49.285090226177836,
+      "ns_per_op_median": 49.41491757128241,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 1287818,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039499375,
+        "median_s": 0.039663041,
+        "samples_s": [
+          0.039663041,
+          0.039499375,
+          0.039875459
+        ]
+      },
+      "total": {
+        "min_s": 0.30564125,
+        "median_s": 0.305713208,
+        "samples_s": [
+          0.30564125,
+          0.306122417,
+          0.305713208
+        ]
+      },
+      "compute_s": 0.26614187499999997,
+      "ns_per_op_min": 206.66109263886665,
+      "ns_per_op_median": 206.5898807129579,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 2671849,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039144667,
+        "median_s": 0.039243541,
+        "samples_s": [
+          0.039243541,
+          0.039144667,
+          0.040804458
+        ]
+      },
+      "total": {
+        "min_s": 0.329563333,
+        "median_s": 0.329935209,
+        "samples_s": [
+          0.329563333,
+          0.329935209,
+          0.333304959
+        ]
+      },
+      "compute_s": 0.290418666,
+      "ns_per_op_min": 108.69576312134406,
+      "ns_per_op_median": 108.79794030276412,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 2333855,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040146167,
+        "median_s": 0.040849,
+        "samples_s": [
+          0.040146167,
+          0.040849,
+          0.042010916
+        ]
+      },
+      "total": {
+        "min_s": 0.331388166,
+        "median_s": 0.33286,
+        "samples_s": [
+          0.334800042,
+          0.331388166,
+          0.33286
+        ]
+      },
+      "compute_s": 0.291241999,
+      "ns_per_op_min": 124.79010007048424,
+      "ns_per_op_median": 125.11959826124586,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 678642,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.02920625,
+        "median_s": 0.02970725,
+        "samples_s": [
+          0.02970725,
+          0.030636334,
+          0.02920625
+        ]
+      },
+      "total": {
+        "min_s": 0.308040667,
+        "median_s": 0.311999084,
+        "samples_s": [
+          0.312335167,
+          0.311999084,
+          0.308040667
+        ]
+      },
+      "compute_s": 0.278834417,
+      "ns_per_op_min": 410.8711470849137,
+      "ns_per_op_median": 415.9657580874746,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 2123426,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040191667,
+        "median_s": 0.04035,
+        "samples_s": [
+          0.040191667,
+          0.04035,
+          0.041096625
+        ]
+      },
+      "total": {
+        "min_s": 0.2284985,
+        "median_s": 0.228783584,
+        "samples_s": [
+          0.2284985,
+          0.228783584,
+          0.229056
+        ]
+      },
+      "compute_s": 0.188306833,
+      "ns_per_op_min": 88.68066652664137,
+      "ns_per_op_median": 88.74035827007864,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 271182,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010738375,
+        "median_s": 0.011396709,
+        "samples_s": [
+          0.010738375,
+          0.011615583,
+          0.011396709
+        ]
+      },
+      "total": {
+        "min_s": 0.308207791,
+        "median_s": 0.308554667,
+        "samples_s": [
+          0.308554667,
+          0.308207791,
+          0.309279917
+        ]
+      },
+      "compute_s": 0.297469416,
+      "ns_per_op_min": 1096.936433834104,
+      "ns_per_op_median": 1095.787913652086,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 72675219,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002664708,
+        "median_s": 0.002941792,
+        "samples_s": [
+          0.003121125,
+          0.002941792,
+          0.002664708
+        ]
+      },
+      "total": {
+        "min_s": 0.302546542,
+        "median_s": 0.303037625,
+        "samples_s": [
+          0.303037625,
+          0.303065542,
+          0.302546542
+        ]
+      },
+      "compute_s": 0.29988183399999996,
+      "ns_per_op_min": 4.126328590767645,
+      "ns_per_op_median": 4.129273184577538,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 58724210,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.065880625,
+        "median_s": 0.066582625,
+        "samples_s": [
+          0.065880625,
+          0.066582625,
+          0.067907541
+        ]
+      },
+      "total": {
+        "min_s": 0.277221041,
+        "median_s": 0.279202166,
+        "samples_s": [
+          0.279202166,
+          0.279461208,
+          0.277221041
+        ]
+      },
+      "compute_s": 0.211340416,
+      "ns_per_op_min": 3.5988635011011643,
+      "ns_per_op_median": 3.620645403318324,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 5017,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.012517708,
+        "median_s": 0.012891709,
+        "samples_s": [
+          0.012891709,
+          0.013185958,
+          0.012517708
+        ]
+      },
+      "total": {
+        "min_s": 0.291424,
+        "median_s": 0.291865667,
+        "samples_s": [
+          0.294692959,
+          0.291424,
+          0.291865667
+        ]
+      },
+      "compute_s": 0.278906292,
+      "ns_per_op_min": 55592.24476778952,
+      "ns_per_op_median": 55605.7321108232,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 6841,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.044147,
+        "median_s": 0.044358167,
+        "samples_s": [
+          0.044147,
+          0.044358167,
+          0.046351125
+        ]
+      },
+      "total": {
+        "min_s": 0.377748208,
+        "median_s": 0.378985417,
+        "samples_s": [
+          0.378985417,
+          0.385691417,
+          0.377748208
+        ]
+      },
+      "compute_s": 0.333601208,
+      "ns_per_op_min": 48764.97705013887,
+      "ns_per_op_median": 48914.96126297325,
+      "load_ms": 0.616,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 18808,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.077830375,
+        "median_s": 0.078778209,
+        "samples_s": [
+          0.080132958,
+          0.078778209,
+          0.077830375
+        ]
+      },
+      "total": {
+        "min_s": 0.281984083,
+        "median_s": 0.284027417,
+        "samples_s": [
+          0.281984083,
+          0.287148584,
+          0.284027417
+        ]
+      },
+      "compute_s": 0.204153708,
+      "ns_per_op_min": 10854.620799659719,
+      "ns_per_op_median": 10912.867290514676,
+      "load_ms": 3.951,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 13438,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.052072917,
+        "median_s": 0.05316625,
+        "samples_s": [
+          0.052072917,
+          0.05316625,
+          0.055148958
+        ]
+      },
+      "total": {
+        "min_s": 0.29378,
+        "median_s": 0.293926875,
+        "samples_s": [
+          0.29378,
+          0.293926875,
+          0.295557458
+        ]
+      },
+      "compute_s": 0.241707083,
+      "ns_per_op_min": 17986.83457359726,
+      "ns_per_op_median": 17916.40311058193,
+      "load_ms": 4.373,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 34981,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.102067542,
+        "median_s": 0.102382042,
+        "samples_s": [
+          0.104748459,
+          0.102382042,
+          0.102067542
+        ]
+      },
+      "total": {
+        "min_s": 0.3932875,
+        "median_s": 0.393464708,
+        "samples_s": [
+          0.393464708,
+          0.39475425,
+          0.3932875
+        ]
+      },
+      "compute_s": 0.291219958,
+      "ns_per_op_min": 8325.089562905578,
+      "ns_per_op_median": 8321.164803750607,
+      "load_ms": 9.128,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 33554432,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005420083,
+        "median_s": 0.005555583,
+        "samples_s": [
+          0.005555583,
+          0.005882292,
+          0.005420083
+        ]
+      },
+      "total": {
+        "min_s": 0.3561185,
+        "median_s": 0.356462084,
+        "samples_s": [
+          0.356462084,
+          0.356592833,
+          0.3561185
+        ]
+      },
+      "compute_s": 0.350698417,
+      "ns_per_op_min": 10.451627284288406,
+      "ns_per_op_median": 10.45782867074013,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 28686823,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.008907416,
+        "median_s": 0.009070834,
+        "samples_s": [
+          0.009813416,
+          0.008907416,
+          0.009070834
+        ]
+      },
+      "total": {
+        "min_s": 0.30901075,
+        "median_s": 0.309610042,
+        "samples_s": [
+          0.30901075,
+          0.310223375,
+          0.309610042
+        ]
+      },
+      "compute_s": 0.300103334,
+      "ns_per_op_min": 10.461365275618007,
+      "ns_per_op_median": 10.476559499112188,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 697957,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015788708,
+        "median_s": 0.016068542,
+        "samples_s": [
+          0.016068542,
+          0.015788708,
+          0.016634042
+        ]
+      },
+      "total": {
+        "min_s": 0.305294042,
+        "median_s": 0.306762333,
+        "samples_s": [
+          0.307053084,
+          0.305294042,
+          0.306762333
+        ]
+      },
+      "compute_s": 0.289505334,
+      "ns_per_op_min": 414.78964176876224,
+      "ns_per_op_median": 416.4924071253673,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 16777216,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004960125,
+        "median_s": 0.005202417,
+        "samples_s": [
+          0.005864375,
+          0.005202417,
+          0.004960125
+        ]
+      },
+      "total": {
+        "min_s": 0.202778416,
+        "median_s": 0.202879125,
+        "samples_s": [
+          0.202879125,
+          0.202778416,
+          0.203053833
+        ]
+      },
+      "compute_s": 0.19781829099999998,
+      "ns_per_op_min": 11.79088896512985,
+      "ns_per_op_median": 11.782449960708618,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 3823043,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004164541,
+        "median_s": 0.004706291,
+        "samples_s": [
+          0.004988542,
+          0.004706291,
+          0.004164541
+        ]
+      },
+      "total": {
+        "min_s": 0.267140833,
+        "median_s": 0.268662167,
+        "samples_s": [
+          0.267140833,
+          0.270354292,
+          0.268662167
+        ]
+      },
+      "compute_s": 0.262976292,
+      "ns_per_op_min": 68.78716561649973,
+      "ns_per_op_median": 69.04339710539485,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 337885,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.037996167,
+        "median_s": 0.039304084,
+        "samples_s": [
+          0.039455375,
+          0.039304084,
+          0.037996167
+        ]
+      },
+      "total": {
+        "min_s": 0.263754916,
+        "median_s": 0.264912959,
+        "samples_s": [
+          0.263754916,
+          0.264912959,
+          0.265276959
+        ]
+      },
+      "compute_s": 0.225758749,
+      "ns_per_op_min": 668.1526229338384,
+      "ns_per_op_median": 667.7090578155289,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 662171,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.03929675,
+        "median_s": 0.040750584,
+        "samples_s": [
+          0.03929675,
+          0.040750584,
+          0.040856042
+        ]
+      },
+      "total": {
+        "min_s": 0.311480584,
+        "median_s": 0.311636792,
+        "samples_s": [
+          0.311480584,
+          0.313197458,
+          0.311636792
+        ]
+      },
+      "compute_s": 0.272183834,
+      "ns_per_op_min": 411.047650833395,
+      "ns_per_op_median": 409.08799690714335,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 586998,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040973708,
+        "median_s": 0.041222625,
+        "samples_s": [
+          0.042023083,
+          0.041222625,
+          0.040973708
+        ]
+      },
+      "total": {
+        "min_s": 0.313349917,
+        "median_s": 0.319923708,
+        "samples_s": [
+          0.320547125,
+          0.319923708,
+          0.313349917
+        ]
+      },
+      "compute_s": 0.272376209,
+      "ns_per_op_min": 464.0155656407688,
+      "ns_per_op_median": 474.79051547024,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 363467,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.029357833,
+        "median_s": 0.029576584,
+        "samples_s": [
+          0.029357833,
+          0.03023325,
+          0.029576584
+        ]
+      },
+      "total": {
+        "min_s": 0.311578166,
+        "median_s": 0.312098666,
+        "samples_s": [
+          0.313768125,
+          0.311578166,
+          0.312098666
+        ]
+      },
+      "compute_s": 0.282220333,
+      "ns_per_op_min": 776.4675555139806,
+      "ns_per_op_median": 777.2977519279605,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 1890998,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.04059275,
+        "median_s": 0.0407705,
+        "samples_s": [
+          0.04059275,
+          0.0407705,
+          0.041287166
+        ]
+      },
+      "total": {
+        "min_s": 0.301063,
+        "median_s": 0.303117875,
+        "samples_s": [
+          0.301063,
+          0.30513925,
+          0.303117875
+        ]
+      },
+      "compute_s": 0.26047025,
+      "ns_per_op_min": 137.742213370929,
+      "ns_per_op_median": 138.73487703318565,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 131072,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010461375,
+        "median_s": 0.011350792,
+        "samples_s": [
+          0.011350792,
+          0.010461375,
+          0.011980334
+        ]
+      },
+      "total": {
+        "min_s": 0.330398459,
+        "median_s": 0.331639416,
+        "samples_s": [
+          0.335932083,
+          0.330398459,
+          0.331639416
+        ]
+      },
+      "compute_s": 0.319937084,
+      "ns_per_op_min": 2440.926239013672,
+      "ns_per_op_median": 2443.6082763671875,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 16777216,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002727208,
+        "median_s": 0.003033875,
+        "samples_s": [
+          0.002727208,
+          0.003033875,
+          0.003124792
+        ]
+      },
+      "total": {
+        "min_s": 0.183913042,
+        "median_s": 0.184192833,
+        "samples_s": [
+          0.183913042,
+          0.184386458,
+          0.184192833
+        ]
+      },
+      "compute_s": 0.181185834,
+      "ns_per_op_min": 10.799517273902893,
+      "ns_per_op_median": 10.79791533946991,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 3726232,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.065862542,
+        "median_s": 0.066032333,
+        "samples_s": [
+          0.066032333,
+          0.066517541,
+          0.065862542
+        ]
+      },
+      "total": {
+        "min_s": 0.259745417,
+        "median_s": 0.277627792,
+        "samples_s": [
+          0.282737292,
+          0.259745417,
+          0.277627792
+        ]
+      },
+      "compute_s": 0.19388287499999998,
+      "ns_per_op_min": 52.0318850248723,
+      "ns_per_op_median": 56.78536897326844,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 3514,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.011459958,
+        "median_s": 0.012448375,
+        "samples_s": [
+          0.012643042,
+          0.011459958,
+          0.012448375
+        ]
+      },
+      "total": {
+        "min_s": 0.275588334,
+        "median_s": 0.27742575,
+        "samples_s": [
+          0.27742575,
+          0.278141,
+          0.275588334
+        ]
+      },
+      "compute_s": 0.264128376,
+      "ns_per_op_min": 75164.59191804212,
+      "ns_per_op_median": 75406.19664200343,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 3121,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.042105375,
+        "median_s": 0.043983584,
+        "samples_s": [
+          0.045717167,
+          0.042105375,
+          0.043983584
+        ]
+      },
+      "total": {
+        "min_s": 0.296740458,
+        "median_s": 0.298781459,
+        "samples_s": [
+          0.296740458,
+          0.298781459,
+          0.300578792
+        ]
+      },
+      "compute_s": 0.254635083,
+      "ns_per_op_min": 81587.65876321691,
+      "ns_per_op_median": 81639.8189682794,
+      "load_ms": 0.745,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 6320,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.080130958,
+        "median_s": 0.080834542,
+        "samples_s": [
+          0.080130958,
+          0.080844125,
+          0.080834542
+        ]
+      },
+      "total": {
+        "min_s": 0.280670292,
+        "median_s": 0.2811355,
+        "samples_s": [
+          0.280670292,
+          0.2811355,
+          0.281439584
+        ]
+      },
+      "compute_s": 0.20053933399999999,
+      "ns_per_op_min": 31730.907278481012,
+      "ns_per_op_median": 31693.18955696202,
+      "load_ms": 4.2,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 7583,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.052228,
+        "median_s": 0.054591333,
+        "samples_s": [
+          0.054591333,
+          0.054610458,
+          0.052228
+        ]
+      },
+      "total": {
+        "min_s": 0.26566125,
+        "median_s": 0.266382708,
+        "samples_s": [
+          0.2691135,
+          0.266382708,
+          0.26566125
+        ]
+      },
+      "compute_s": 0.21343325000000002,
+      "ns_per_op_min": 28146.281155215616,
+      "ns_per_op_median": 27929.76064881973,
+      "load_ms": 4.193,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 14270,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.101746208,
+        "median_s": 0.102235459,
+        "samples_s": [
+          0.102235459,
+          0.104642334,
+          0.101746208
+        ]
+      },
+      "total": {
+        "min_s": 0.30493575,
+        "median_s": 0.306098209,
+        "samples_s": [
+          0.306712708,
+          0.30493575,
+          0.306098209
+        ]
+      },
+      "compute_s": 0.203189542,
+      "ns_per_op_min": 14238.930763840224,
+      "ns_per_op_median": 14286.107217939734,
+      "load_ms": 9.104,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 39213418,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005527667,
+        "median_s": 0.005659292,
+        "samples_s": [
+          0.005707708,
+          0.005527667,
+          0.005659292
+        ]
+      },
+      "total": {
+        "min_s": 0.3048605,
+        "median_s": 0.305014792,
+        "samples_s": [
+          0.3048605,
+          0.305014792,
+          0.306104708
+        ]
+      },
+      "compute_s": 0.29933283299999996,
+      "ns_per_op_min": 7.6334287666532905,
+      "ns_per_op_median": 7.634006808587816,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 39248647,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009302833,
+        "median_s": 0.009686959,
+        "samples_s": [
+          0.009716,
+          0.009302833,
+          0.009686959
+        ]
+      },
+      "total": {
+        "min_s": 0.308895542,
+        "median_s": 0.309100166,
+        "samples_s": [
+          0.309100166,
+          0.308895542,
+          0.311062584
+        ]
+      },
+      "compute_s": 0.299592709,
+      "ns_per_op_min": 7.633198387704931,
+      "ns_per_op_median": 7.6286249306886935,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1203280,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015811417,
+        "median_s": 0.01601775,
+        "samples_s": [
+          0.01601775,
+          0.015811417,
+          0.016065458
+        ]
+      },
+      "total": {
+        "min_s": 0.29809325,
+        "median_s": 0.298206667,
+        "samples_s": [
+          0.298206667,
+          0.29809325,
+          0.298757125
+        ]
+      },
+      "compute_s": 0.282281833,
+      "ns_per_op_min": 234.59363822219268,
+      "ns_per_op_median": 234.51641928728142,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 6059341,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005120458,
+        "median_s": 0.005666625,
+        "samples_s": [
+          0.005709417,
+          0.005120458,
+          0.005666625
+        ]
+      },
+      "total": {
+        "min_s": 0.350416667,
+        "median_s": 0.350430208,
+        "samples_s": [
+          0.351896458,
+          0.350430208,
+          0.350416667
+        ]
+      },
+      "compute_s": 0.345296209,
+      "ns_per_op_min": 56.985769409577706,
+      "ns_per_op_median": 56.897867771429276,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 16777216,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004368417,
+        "median_s": 0.004611791,
+        "samples_s": [
+          0.004757125,
+          0.004368417,
+          0.004611791
+        ]
+      },
+      "total": {
+        "min_s": 0.36018225,
+        "median_s": 0.360550208,
+        "samples_s": [
+          0.36018225,
+          0.360941208,
+          0.360550208
+        ]
+      },
+      "compute_s": 0.35581383299999997,
+      "ns_per_op_min": 21.20815712213516,
+      "ns_per_op_median": 21.21558290719986,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 201936,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.038261542,
+        "median_s": 0.040311292,
+        "samples_s": [
+          0.038261542,
+          0.040634917,
+          0.040311292
+        ]
+      },
+      "total": {
+        "min_s": 0.312610375,
+        "median_s": 0.314892542,
+        "samples_s": [
+          0.312610375,
+          0.316818417,
+          0.314892542
+        ]
+      },
+      "compute_s": 0.274348833,
+      "ns_per_op_min": 1358.5929849061088,
+      "ns_per_op_median": 1359.743928769511,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 295406,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040057709,
+        "median_s": 0.040287,
+        "samples_s": [
+          0.040057709,
+          0.040856875,
+          0.040287
+        ]
+      },
+      "total": {
+        "min_s": 0.2965225,
+        "median_s": 0.297250417,
+        "samples_s": [
+          0.2965225,
+          0.298030875,
+          0.297250417
+        ]
+      },
+      "compute_s": 0.256464791,
+      "ns_per_op_min": 868.1773254436268,
+      "ns_per_op_median": 869.8652600150301,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 247727,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039240625,
+        "median_s": 0.040693125,
+        "samples_s": [
+          0.039240625,
+          0.040773333,
+          0.040693125
+        ]
+      },
+      "total": {
+        "min_s": 0.282384041,
+        "median_s": 0.284325,
+        "samples_s": [
+          0.284325,
+          0.285382375,
+          0.282384041
+        ]
+      },
+      "compute_s": 0.24314341599999997,
+      "ns_per_op_min": 981.4974387127764,
+      "ns_per_op_median": 983.4692019844425,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 217040,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.029810292,
+        "median_s": 0.029839834,
+        "samples_s": [
+          0.029839834,
+          0.029810292,
+          0.031222875
+        ]
+      },
+      "total": {
+        "min_s": 0.330532125,
+        "median_s": 0.332294666,
+        "samples_s": [
+          0.330532125,
+          0.334926667,
+          0.332294666
+        ]
+      },
+      "compute_s": 0.300721833,
+      "ns_per_op_min": 1385.559495945448,
+      "ns_per_op_median": 1393.5441946185035,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 780229,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.041607959,
+        "median_s": 0.041798333,
+        "samples_s": [
+          0.042293208,
+          0.041798333,
+          0.041607959
+        ]
+      },
+      "total": {
+        "min_s": 0.243632375,
+        "median_s": 0.243864708,
+        "samples_s": [
+          0.24492375,
+          0.243632375,
+          0.243864708
+        ]
+      },
+      "compute_s": 0.202024416,
+      "ns_per_op_min": 258.92964245112654,
+      "ns_per_op_median": 258.9834202522593,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 132995,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015053709,
+        "median_s": 0.015825,
+        "samples_s": [
+          0.015053709,
+          0.015825,
+          0.016372041
+        ]
+      },
+      "total": {
+        "min_s": 0.313040709,
+        "median_s": 0.31394375,
+        "samples_s": [
+          0.316439416,
+          0.313040709,
+          0.31394375
+        ]
+      },
+      "compute_s": 0.29798699999999995,
+      "ns_per_op_min": 2240.5879920297753,
+      "ns_per_op_median": 2241.5786307755934,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 16777216,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004757791,
+        "median_s": 0.0048385,
+        "samples_s": [
+          0.005215833,
+          0.004757791,
+          0.0048385
+        ]
+      },
+      "total": {
+        "min_s": 0.180326583,
+        "median_s": 0.180342625,
+        "samples_s": [
+          0.180548542,
+          0.180342625,
+          0.180326583
+        ]
+      },
+      "compute_s": 0.175568792,
+      "ns_per_op_min": 10.464715480804443,
+      "ns_per_op_median": 10.460861027240753,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 16218192,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0665305,
+        "median_s": 0.067914542,
+        "samples_s": [
+          0.067914542,
+          0.0665305,
+          0.069185042
+        ]
+      },
+      "total": {
+        "min_s": 0.360499459,
+        "median_s": 0.360710916,
+        "samples_s": [
+          0.360499459,
+          0.360710916,
+          0.362635959
+        ]
+      },
+      "compute_s": 0.29396895900000003,
+      "ns_per_op_min": 18.125877348103906,
+      "ns_per_op_median": 18.053576748875585,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 570,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.012682958,
+        "median_s": 0.012966208,
+        "samples_s": [
+          0.012682958,
+          0.012966208,
+          0.013294166
+        ]
+      },
+      "total": {
+        "min_s": 0.310242334,
+        "median_s": 0.3105605,
+        "samples_s": [
+          0.310242334,
+          0.310701542,
+          0.3105605
+        ]
+      },
+      "compute_s": 0.297559376,
+      "ns_per_op_min": 522033.9929824561,
+      "ns_per_op_median": 522095.2491228071,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 2814,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.041886083,
+        "median_s": 0.044227458,
+        "samples_s": [
+          0.044497583,
+          0.041886083,
+          0.044227458
+        ]
+      },
+      "total": {
+        "min_s": 0.327843375,
+        "median_s": 0.328286917,
+        "samples_s": [
+          0.327843375,
+          0.328924625,
+          0.328286917
+        ]
+      },
+      "compute_s": 0.285957292,
+      "ns_per_op_min": 101619.50675195451,
+      "ns_per_op_median": 100945.08137882018,
+      "load_ms": 0.673,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 281,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.07742375,
+        "median_s": 0.078365291,
+        "samples_s": [
+          0.07742375,
+          0.08068425,
+          0.078365291
+        ]
+      },
+      "total": {
+        "min_s": 0.310617334,
+        "median_s": 0.312625916,
+        "samples_s": [
+          0.312625916,
+          0.310617334,
+          0.315189
+        ]
+      },
+      "compute_s": 0.233193584,
+      "ns_per_op_min": 829870.4056939501,
+      "ns_per_op_median": 833667.7046263345,
+      "load_ms": 4.037,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 9218,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.053392,
+        "median_s": 0.053394,
+        "samples_s": [
+          0.053394,
+          0.053392,
+          0.05358875
+        ]
+      },
+      "total": {
+        "min_s": 0.290235,
+        "median_s": 0.291572708,
+        "samples_s": [
+          0.290235,
+          0.291572708,
+          0.292046583
+        ]
+      },
+      "compute_s": 0.23684300000000003,
+      "ns_per_op_min": 25693.534389238448,
+      "ns_per_op_median": 25838.43653720981,
+      "load_ms": 4.068,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 12027,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.09845075,
+        "median_s": 0.099554166,
+        "samples_s": [
+          0.099554166,
+          0.101779,
+          0.09845075
+        ]
+      },
+      "total": {
+        "min_s": 0.287420959,
+        "median_s": 0.290105583,
+        "samples_s": [
+          0.291897875,
+          0.287420959,
+          0.290105583
+        ]
+      },
+      "compute_s": 0.18897020899999997,
+      "ns_per_op_min": 15712.165045314707,
+      "ns_per_op_median": 15843.636567722624,
+      "load_ms": 9.799,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 1383163,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005398167,
+        "median_s": 0.005725417,
+        "samples_s": [
+          0.006176709,
+          0.005725417,
+          0.005398167
+        ]
+      },
+      "total": {
+        "min_s": 0.310467959,
+        "median_s": 0.31130825,
+        "samples_s": [
+          0.310467959,
+          0.31130825,
+          0.319364042
+        ]
+      },
+      "compute_s": 0.305069792,
+      "ns_per_op_min": 220.55953781296927,
+      "ns_per_op_median": 220.9304564971735,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 34772,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009584667,
+        "median_s": 0.009652708,
+        "samples_s": [
+          0.009693875,
+          0.009584667,
+          0.009652708
+        ]
+      },
+      "total": {
+        "min_s": 0.368891459,
+        "median_s": 0.36894975,
+        "samples_s": [
+          0.368891459,
+          0.369363583,
+          0.36894975
+        ]
+      },
+      "compute_s": 0.359306792,
+      "ns_per_op_min": 10333.221902680318,
+      "ns_per_op_median": 10332.94150465892,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 2748000,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015819708,
+        "median_s": 0.01646675,
+        "samples_s": [
+          0.016584084,
+          0.015819708,
+          0.01646675
+        ]
+      },
+      "total": {
+        "min_s": 0.332512709,
+        "median_s": 0.333358959,
+        "samples_s": [
+          0.332512709,
+          0.333358959,
+          0.334095041
+        ]
+      },
+      "compute_s": 0.31669300100000003,
+      "ns_per_op_min": 115.2449057496361,
+      "ns_per_op_median": 115.3173977438137,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wazero",
+      "status": "skipped",
+      "reason": "excluded: wazero 1.12.0 rejects the module: \"tag section not supported as feature \\\"exception-handling\\\" is disabled\""
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wasm3",
+      "status": "skipped",
+      "reason": "excluded: wasm3 0.5.0 fails to load it: \"out of order Wasm section\" (the tag section is unknown to it)"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 444127,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039312416,
+        "median_s": 0.040168791,
+        "samples_s": [
+          0.040168791,
+          0.039312416,
+          0.042563625
+        ]
+      },
+      "total": {
+        "min_s": 0.320092917,
+        "median_s": 0.32019625,
+        "samples_s": [
+          0.320506167,
+          0.320092917,
+          0.32019625
+        ]
+      },
+      "compute_s": 0.28078050099999996,
+      "ns_per_op_min": 632.2076815865731,
+      "ns_per_op_median": 630.5121260360214,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 742234,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039897541,
+        "median_s": 0.040263541,
+        "samples_s": [
+          0.041268083,
+          0.040263541,
+          0.039897541
+        ]
+      },
+      "total": {
+        "min_s": 0.386224791,
+        "median_s": 0.387174792,
+        "samples_s": [
+          0.387823458,
+          0.386224791,
+          0.387174792
+        ]
+      },
+      "compute_s": 0.34632725000000003,
+      "ns_per_op_min": 466.60116620903926,
+      "ns_per_op_median": 467.38798141825896,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 477341,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040017167,
+        "median_s": 0.040925709,
+        "samples_s": [
+          0.041636166,
+          0.040017167,
+          0.040925709
+        ]
+      },
+      "total": {
+        "min_s": 0.330415084,
+        "median_s": 0.332262667,
+        "samples_s": [
+          0.333482917,
+          0.332262667,
+          0.330415084
+        ]
+      },
+      "compute_s": 0.290397917,
+      "ns_per_op_min": 608.3657532036846,
+      "ns_per_op_median": 610.3329862718687,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 438178,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.028669959,
+        "median_s": 0.029329209,
+        "samples_s": [
+          0.03013325,
+          0.028669959,
+          0.029329209
+        ]
+      },
+      "total": {
+        "min_s": 0.3200135,
+        "median_s": 0.321751542,
+        "samples_s": [
+          0.321751542,
+          0.321791542,
+          0.3200135
+        ]
+      },
+      "compute_s": 0.291343541,
+      "ns_per_op_min": 664.8976922620487,
+      "ns_per_op_median": 667.3596871590997,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 4000000,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039780083,
+        "median_s": 0.040547583,
+        "samples_s": [
+          0.046329667,
+          0.039780083,
+          0.040547583
+        ]
+      },
+      "total": {
+        "min_s": 0.057834291,
+        "median_s": 0.058007791,
+        "samples_s": [
+          0.058007791,
+          0.059621791,
+          0.057834291
+        ]
+      },
+      "compute_s": 0.018054208000000002,
+      "ns_per_op_min": 4.513552000000001,
+      "ns_per_op_median": 4.365052000000001,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 253263,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010522833,
+        "median_s": 0.010797916,
+        "samples_s": [
+          0.010797916,
+          0.011319583,
+          0.010522833
+        ]
+      },
+      "total": {
+        "min_s": 0.31076975,
+        "median_s": 0.312155875,
+        "samples_s": [
+          0.31076975,
+          0.316293041,
+          0.312155875
+        ]
+      },
+      "compute_s": 0.300246917,
+      "ns_per_op_min": 1185.5143349008738,
+      "ns_per_op_median": 1189.901244950901,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 1184751,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005037916,
+        "median_s": 0.005092375,
+        "samples_s": [
+          0.006356083,
+          0.005092375,
+          0.005037916
+        ]
+      },
+      "total": {
+        "min_s": 0.240073875,
+        "median_s": 0.24167,
+        "samples_s": [
+          0.240073875,
+          0.24167,
+          0.242598
+        ]
+      },
+      "compute_s": 0.235035959,
+      "ns_per_op_min": 198.38426724265267,
+      "ns_per_op_median": 199.68552463766648,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 392219,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.068136584,
+        "median_s": 0.069268375,
+        "samples_s": [
+          0.069471292,
+          0.068136584,
+          0.069268375
+        ]
+      },
+      "total": {
+        "min_s": 0.276847834,
+        "median_s": 0.278625833,
+        "samples_s": [
+          0.278625833,
+          0.276847834,
+          0.280454417
+        ]
+      },
+      "compute_s": 0.20871125000000001,
+      "ns_per_op_min": 532.1293716010698,
+      "ns_per_op_median": 533.7769409437075,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-bash",
+      "status": "skipped",
+      "reason": "excluded: the bash backend has no exception-handling lowering and rejects the module at conversion time with \"unsupported (exception-handling): tag, exnref value, or try_table/throw/throw_ref instruction\" (see docs/support.md)"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "pywasm-cpython",
+      "status": "skipped",
+      "reason": "excluded: pywasm 2.2.3 has no exception-handling opcodes; decoding dies with AssertionError on the throw/try_table opcode (pywasm/core.py, from_reader)"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "pywasm-pypy",
+      "status": "skipped",
+      "reason": "excluded: pywasm 2.2.3 has no exception-handling opcodes; decoding dies with AssertionError on the throw/try_table opcode (pywasm/core.py, from_reader)"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wardite",
+      "status": "skipped",
+      "reason": "excluded: wardite 0.9.0 fails to load the tag section: Wardite::LoadError \"unknown code: 13\""
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wardite-yjit",
+      "status": "skipped",
+      "reason": "excluded: wardite 0.9.0 fails to load the tag section: Wardite::LoadError \"unknown code: 13\""
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 109300097,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005729583,
+        "median_s": 0.00585775,
+        "samples_s": [
+          0.005906792,
+          0.00585775,
+          0.005729583
+        ]
+      },
+      "total": {
+        "min_s": 0.310165334,
+        "median_s": 0.310193959,
+        "samples_s": [
+          0.310165334,
+          0.310193959,
+          0.310397334
+        ]
+      },
+      "compute_s": 0.30443575100000003,
+      "ns_per_op_min": 2.7853200441350023,
+      "ns_per_op_median": 2.784409322161901,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 234635887,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0089985,
+        "median_s": 0.009293375,
+        "samples_s": [
+          0.0089985,
+          0.009293375,
+          0.009322875
+        ]
+      },
+      "total": {
+        "min_s": 0.306055666,
+        "median_s": 0.306306875,
+        "samples_s": [
+          0.306615042,
+          0.306306875,
+          0.306055666
+        ]
+      },
+      "compute_s": 0.297057166,
+      "ns_per_op_min": 1.2660346624640586,
+      "ns_per_op_median": 1.2658485613498671,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 2539553,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0160395,
+        "median_s": 0.016144916,
+        "samples_s": [
+          0.0160395,
+          0.016349541,
+          0.016144916
+        ]
+      },
+      "total": {
+        "min_s": 0.312739458,
+        "median_s": 0.313082667,
+        "samples_s": [
+          0.312739458,
+          0.314674292,
+          0.313082667
+        ]
+      },
+      "compute_s": 0.29669995800000004,
+      "ns_per_op_min": 116.83156760264505,
+      "ns_per_op_median": 116.92520337240451,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wazero",
+      "status": "skipped",
+      "reason": "excluded: wazero 1.12.0 rejects the module: \"tag section not supported as feature \\\"exception-handling\\\" is disabled\""
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wasm3",
+      "status": "skipped",
+      "reason": "excluded: wasm3 0.5.0 fails to load it: \"out of order Wasm section\" (the tag section is unknown to it)"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 1902131,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.038474958,
+        "median_s": 0.040798042,
+        "samples_s": [
+          0.040798042,
+          0.038474958,
+          0.040937792
+        ]
+      },
+      "total": {
+        "min_s": 0.269603958,
+        "median_s": 0.273498041,
+        "samples_s": [
+          0.269603958,
+          0.273901125,
+          0.273498041
+        ]
+      },
+      "compute_s": 0.23112899999999997,
+      "ns_per_op_min": 121.51055842105511,
+      "ns_per_op_median": 122.33647367084603,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 1832517,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.038946166,
+        "median_s": 0.039623209,
+        "samples_s": [
+          0.040676375,
+          0.038946166,
+          0.039623209
+        ]
+      },
+      "total": {
+        "min_s": 0.264024416,
+        "median_s": 0.264505791,
+        "samples_s": [
+          0.264505791,
+          0.264024416,
+          0.266148459
+        ]
+      },
+      "compute_s": 0.22507824999999998,
+      "ns_per_op_min": 122.8246450101145,
+      "ns_per_op_median": 122.71786946587672,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 2704668,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040162542,
+        "median_s": 0.040466,
+        "samples_s": [
+          0.040466,
+          0.041391,
+          0.040162542
+        ]
+      },
+      "total": {
+        "min_s": 0.369444417,
+        "median_s": 0.371853,
+        "samples_s": [
+          0.371853,
+          0.369444417,
+          0.372353125
+        ]
+      },
+      "compute_s": 0.329281875,
+      "ns_per_op_min": 121.74576509945028,
+      "ns_per_op_median": 122.52409537880435,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 1280336,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.028371375,
+        "median_s": 0.029251833,
+        "samples_s": [
+          0.029688084,
+          0.029251833,
+          0.028371375
+        ]
+      },
+      "total": {
+        "min_s": 0.282216,
+        "median_s": 0.286765375,
+        "samples_s": [
+          0.286765375,
+          0.290843041,
+          0.282216
+        ]
+      },
+      "compute_s": 0.25384462500000005,
+      "ns_per_op_min": 198.26406896314722,
+      "ns_per_op_median": 201.129658152235,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 105149754,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040144875,
+        "median_s": 0.040943958,
+        "samples_s": [
+          0.040943958,
+          0.040144875,
+          0.041910958
+        ]
+      },
+      "total": {
+        "min_s": 0.313358958,
+        "median_s": 0.313596958,
+        "samples_s": [
+          0.316055875,
+          0.313358958,
+          0.313596958
+        ]
+      },
+      "compute_s": 0.27321408300000005,
+      "ns_per_op_min": 2.5983330688534,
+      "ns_per_op_median": 2.5929970316430793,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 581571,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010575459,
+        "median_s": 0.010796708,
+        "samples_s": [
+          0.010796708,
+          0.011846917,
+          0.010575459
+        ]
+      },
+      "total": {
+        "min_s": 0.310161583,
+        "median_s": 0.310445,
+        "samples_s": [
+          0.310161583,
+          0.310445,
+          0.310693375
+        ]
+      },
+      "compute_s": 0.299586124,
+      "ns_per_op_min": 515.1325014486623,
+      "ns_per_op_median": 515.2393981130422,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 64770052,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004598625,
+        "median_s": 0.005143458,
+        "samples_s": [
+          0.006607375,
+          0.004598625,
+          0.005143458
+        ]
+      },
+      "total": {
+        "min_s": 0.277988166,
+        "median_s": 0.278550166,
+        "samples_s": [
+          0.277988166,
+          0.279798459,
+          0.278550166
+        ]
+      },
+      "compute_s": 0.27338954099999996,
+      "ns_per_op_min": 4.220925142996642,
+      "ns_per_op_median": 4.221190188329631,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 241800984,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.067423834,
+        "median_s": 0.068224334,
+        "samples_s": [
+          0.068224334,
+          0.067423834,
+          0.068534542
+        ]
+      },
+      "total": {
+        "min_s": 0.41282325,
+        "median_s": 0.414030542,
+        "samples_s": [
+          0.414624792,
+          0.414030542,
+          0.41282325
+        ]
+      },
+      "compute_s": 0.34539941599999996,
+      "ns_per_op_min": 1.4284450389167975,
+      "ns_per_op_median": 1.4301273811193422,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-bash",
+      "status": "skipped",
+      "reason": "excluded: the bash backend has no exception-handling lowering and rejects the module at conversion time with \"unsupported (exception-handling): tag, exnref value, or try_table/throw/throw_ref instruction\" (see docs/support.md)"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "pywasm-cpython",
+      "status": "skipped",
+      "reason": "excluded: pywasm 2.2.3 has no exception-handling opcodes; decoding dies with AssertionError on the throw/try_table opcode (pywasm/core.py, from_reader)"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "pywasm-pypy",
+      "status": "skipped",
+      "reason": "excluded: pywasm 2.2.3 has no exception-handling opcodes; decoding dies with AssertionError on the throw/try_table opcode (pywasm/core.py, from_reader)"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wardite",
+      "status": "skipped",
+      "reason": "excluded: wardite 0.9.0 fails to load the tag section: Wardite::LoadError \"unknown code: 13\""
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wardite-yjit",
+      "status": "skipped",
+      "reason": "excluded: wardite 0.9.0 fails to load the tag section: Wardite::LoadError \"unknown code: 13\""
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 299018404,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005460542,
+        "median_s": 0.0059105,
+        "samples_s": [
+          0.005985875,
+          0.005460542,
+          0.0059105
+        ]
+      },
+      "total": {
+        "min_s": 0.304207875,
+        "median_s": 0.304572584,
+        "samples_s": [
+          0.304747541,
+          0.304572584,
+          0.304207875
+        ]
+      },
+      "compute_s": 0.298747333,
+      "ns_per_op_min": 0.999093463825725,
+      "ns_per_op_median": 0.9988083676615437,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 287193659,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.008949916,
+        "median_s": 0.009206208,
+        "samples_s": [
+          0.009206208,
+          0.008949916,
+          0.009520375
+        ]
+      },
+      "total": {
+        "min_s": 0.295011875,
+        "median_s": 0.29524725,
+        "samples_s": [
+          0.295011875,
+          0.29524725,
+          0.296577459
+        ]
+      },
+      "compute_s": 0.286061959,
+      "ns_per_op_min": 0.9960594533878618,
+      "ns_per_op_median": 0.9959866209998738,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 3381073,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015789167,
+        "median_s": 0.016542417,
+        "samples_s": [
+          0.015789167,
+          0.01666325,
+          0.016542417
+        ]
+      },
+      "total": {
+        "min_s": 0.292958709,
+        "median_s": 0.293748916,
+        "samples_s": [
+          0.293748916,
+          0.318389917,
+          0.292958709
+        ]
+      },
+      "compute_s": 0.277169542,
+      "ns_per_op_min": 81.97679908123841,
+      "ns_per_op_median": 81.98772963494135,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 307057865,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005123958,
+        "median_s": 0.00544825,
+        "samples_s": [
+          0.005123958,
+          0.00544825,
+          0.006247333
+        ]
+      },
+      "total": {
+        "min_s": 0.299957583,
+        "median_s": 0.303609292,
+        "samples_s": [
+          0.299957583,
+          0.303609292,
+          0.30844475
+        ]
+      },
+      "compute_s": 0.29483362500000004,
+      "ns_per_op_min": 0.9601891324294854,
+      "ns_per_op_median": 0.9710255817743018,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 44854418,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004205667,
+        "median_s": 0.004401834,
+        "samples_s": [
+          0.004401834,
+          0.004515375,
+          0.004205667
+        ]
+      },
+      "total": {
+        "min_s": 0.302684292,
+        "median_s": 0.305744,
+        "samples_s": [
+          0.305744,
+          0.306026792,
+          0.302684292
+        ]
+      },
+      "compute_s": 0.298478625,
+      "ns_per_op_min": 6.6543863081670125,
+      "ns_per_op_median": 6.718227087463268,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 409210,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.038637875,
+        "median_s": 0.03863925,
+        "samples_s": [
+          0.038637875,
+          0.039330166,
+          0.03863925
+        ]
+      },
+      "total": {
+        "min_s": 0.312586625,
+        "median_s": 0.315664,
+        "samples_s": [
+          0.316606708,
+          0.315664,
+          0.312586625
+        ]
+      },
+      "compute_s": 0.27394875,
+      "ns_per_op_min": 669.4576134503067,
+      "ns_per_op_median": 676.9745363016544,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 533556,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040042167,
+        "median_s": 0.040509667,
+        "samples_s": [
+          0.040509667,
+          0.040042167,
+          0.041198042
+        ]
+      },
+      "total": {
+        "min_s": 0.332223,
+        "median_s": 0.353580041,
+        "samples_s": [
+          0.332223,
+          0.354792375,
+          0.353580041
+        ]
+      },
+      "compute_s": 0.292180833,
+      "ns_per_op_min": 547.6104345185885,
+      "ns_per_op_median": 586.7619781241333,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 414984,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039702375,
+        "median_s": 0.039782334,
+        "samples_s": [
+          0.039702375,
+          0.040577375,
+          0.039782334
+        ]
+      },
+      "total": {
+        "min_s": 0.315961625,
+        "median_s": 0.322229333,
+        "samples_s": [
+          0.322229333,
+          0.315961625,
+          0.328410167
+        ]
+      },
+      "compute_s": 0.27625925,
+      "ns_per_op_min": 665.7106057100997,
+      "ns_per_op_median": 680.6214191390513,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 356393,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.029268917,
+        "median_s": 0.029681791,
+        "samples_s": [
+          0.029681791,
+          0.030154334,
+          0.029268917
+        ]
+      },
+      "total": {
+        "min_s": 0.331059208,
+        "median_s": 0.332354,
+        "samples_s": [
+          0.333305375,
+          0.331059208,
+          0.332354
+        ]
+      },
+      "compute_s": 0.301790291,
+      "ns_per_op_min": 846.7907366306297,
+      "ns_per_op_median": 849.2653026294005,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 641667,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040806417,
+        "median_s": 0.041075584,
+        "samples_s": [
+          0.041075584,
+          0.040806417,
+          0.041509625
+        ]
+      },
+      "total": {
+        "min_s": 0.281177541,
+        "median_s": 0.283221208,
+        "samples_s": [
+          0.283221208,
+          0.281177541,
+          0.283373208
+        ]
+      },
+      "compute_s": 0.240371124,
+      "ns_per_op_min": 374.6041544913483,
+      "ns_per_op_median": 377.36960760020384,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 193203,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010280167,
+        "median_s": 0.010444666,
+        "samples_s": [
+          0.010280167,
+          0.010606041,
+          0.010444666
+        ]
+      },
+      "total": {
+        "min_s": 0.308793792,
+        "median_s": 0.309413083,
+        "samples_s": [
+          0.309853916,
+          0.309413083,
+          0.308793792
+        ]
+      },
+      "compute_s": 0.298513625,
+      "ns_per_op_min": 1545.0775867869547,
+      "ns_per_op_median": 1547.4315460940047,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 76794433,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004041375,
+        "median_s": 0.004050584,
+        "samples_s": [
+          0.004050584,
+          0.004041375,
+          0.004790958
+        ]
+      },
+      "total": {
+        "min_s": 0.271048125,
+        "median_s": 0.271363417,
+        "samples_s": [
+          0.271048125,
+          0.271363417,
+          0.271818833
+        ]
+      },
+      "compute_s": 0.26700674999999996,
+      "ns_per_op_min": 3.476902420778339,
+      "ns_per_op_median": 3.480888165422095,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 176997459,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.067336875,
+        "median_s": 0.06776025,
+        "samples_s": [
+          0.06776025,
+          0.068782334,
+          0.067336875
+        ]
+      },
+      "total": {
+        "min_s": 0.358229167,
+        "median_s": 0.358840041,
+        "samples_s": [
+          0.358229167,
+          0.359892458,
+          0.358840041
+        ]
+      },
+      "compute_s": 0.290892292,
+      "ns_per_op_min": 1.6434828705648254,
+      "ns_per_op_median": 1.644542202156699,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 166,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.012895416,
+        "median_s": 0.013032708,
+        "samples_s": [
+          0.012895416,
+          0.013032708,
+          0.013104167
+        ]
+      },
+      "total": {
+        "min_s": 0.21276725,
+        "median_s": 0.213329208,
+        "samples_s": [
+          0.21276725,
+          0.213329208,
+          0.213430958
+        ]
+      },
+      "compute_s": 0.199871834,
+      "ns_per_op_min": 1204047.1927710844,
+      "ns_per_op_median": 1206605.4216867469,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 10006,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.043945458,
+        "median_s": 0.043953833,
+        "samples_s": [
+          0.045035958,
+          0.043953833,
+          0.043945458
+        ]
+      },
+      "total": {
+        "min_s": 0.331212375,
+        "median_s": 0.333229083,
+        "samples_s": [
+          0.331212375,
+          0.333229083,
+          0.338203917
+        ]
+      },
+      "compute_s": 0.287266917,
+      "ns_per_op_min": 28709.46602038777,
+      "ns_per_op_median": 28910.1788926644,
+      "load_ms": 0.645,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 19644,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.078931584,
+        "median_s": 0.079227708,
+        "samples_s": [
+          0.078931584,
+          0.079554875,
+          0.079227708
+        ]
+      },
+      "total": {
+        "min_s": 0.2487905,
+        "median_s": 0.2516075,
+        "samples_s": [
+          0.253902125,
+          0.2487905,
+          0.2516075
+        ]
+      },
+      "compute_s": 0.169858916,
+      "ns_per_op_min": 8646.859906332722,
+      "ns_per_op_median": 8775.187945428628,
+      "load_ms": 3.483,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wardite",
+      "status": "skipped",
+      "reason": "excluded: wardite 0.9.0 does not re-round f32 arithmetic to single precision, so a dependent operation chain diverges from wasmtime (1232349357 vs 1232349355 at 10000 iterations) and the byte-for-byte verification would fail the whole run"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wardite-yjit",
+      "status": "skipped",
+      "reason": "excluded: wardite 0.9.0 does not re-round f32 arithmetic to single precision, so a dependent operation chain diverges from wasmtime (1232349357 vs 1232349355 at 10000 iterations) and the byte-for-byte verification would fail the whole run"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 292881995,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005058625,
+        "median_s": 0.005701,
+        "samples_s": [
+          0.005701,
+          0.005058625,
+          0.005865916
+        ]
+      },
+      "total": {
+        "min_s": 0.290592916,
+        "median_s": 0.291101208,
+        "samples_s": [
+          0.291101208,
+          0.292297,
+          0.290592916
+        ]
+      },
+      "compute_s": 0.285534291,
+      "ns_per_op_min": 0.9749124079819246,
+      "ns_per_op_median": 0.9744546024415055,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 295268969,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.008715792,
+        "median_s": 0.009055292,
+        "samples_s": [
+          0.009540375,
+          0.009055292,
+          0.008715792
+        ]
+      },
+      "total": {
+        "min_s": 0.297629375,
+        "median_s": 0.297958333,
+        "samples_s": [
+          0.297958333,
+          0.297629375,
+          0.298778625
+        ]
+      },
+      "compute_s": 0.288913583,
+      "ns_per_op_min": 0.9784759434033178,
+      "ns_per_op_median": 0.9784402403626776,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 3057588,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015599792,
+        "median_s": 0.016213292,
+        "samples_s": [
+          0.016213292,
+          0.015599792,
+          0.016320542
+        ]
+      },
+      "total": {
+        "min_s": 0.265948042,
+        "median_s": 0.266165875,
+        "samples_s": [
+          0.266812208,
+          0.266165875,
+          0.265948042
+        ]
+      },
+      "compute_s": 0.25034825,
+      "ns_per_op_min": 81.8776924817863,
+      "ns_per_op_median": 81.74828753906674,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 303912132,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004914167,
+        "median_s": 0.005154667,
+        "samples_s": [
+          0.005154667,
+          0.004914167,
+          0.005406917
+        ]
+      },
+      "total": {
+        "min_s": 0.298692875,
+        "median_s": 0.298940333,
+        "samples_s": [
+          0.298692875,
+          0.298940333,
+          0.301637042
+        ]
+      },
+      "compute_s": 0.293778708,
+      "ns_per_op_min": 0.9666567309001011,
+      "ns_per_op_median": 0.9666796256754897,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 55344829,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004117459,
+        "median_s": 0.004218584,
+        "samples_s": [
+          0.004218584,
+          0.004727583,
+          0.004117459
+        ]
+      },
+      "total": {
+        "min_s": 0.303861458,
+        "median_s": 0.30397075,
+        "samples_s": [
+          0.30397075,
+          0.303861458,
+          0.304234417
+        ]
+      },
+      "compute_s": 0.299743999,
+      "ns_per_op_min": 5.415935046072687,
+      "ns_per_op_median": 5.416082611801005,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 3315713,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.03991775,
+        "median_s": 0.04081125,
+        "samples_s": [
+          0.03991775,
+          0.041356958,
+          0.04081125
+        ]
+      },
+      "total": {
+        "min_s": 0.37683,
+        "median_s": 0.37843125,
+        "samples_s": [
+          0.378781625,
+          0.37683,
+          0.37843125
+        ]
+      },
+      "compute_s": 0.33691225,
+      "ns_per_op_min": 101.61079984908223,
+      "ns_per_op_median": 101.82425318475995,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 3762352,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039682083,
+        "median_s": 0.040234459,
+        "samples_s": [
+          0.040234459,
+          0.040643292,
+          0.039682083
+        ]
+      },
+      "total": {
+        "min_s": 0.326676,
+        "median_s": 0.3270075,
+        "samples_s": [
+          0.326676,
+          0.3270075,
+          0.327169083
+        ]
+      },
+      "compute_s": 0.28699391700000004,
+      "ns_per_op_min": 76.28045355671135,
+      "ns_per_op_median": 76.22174666272586,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 2875968,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039280042,
+        "median_s": 0.041460292,
+        "samples_s": [
+          0.041740375,
+          0.041460292,
+          0.039280042
+        ]
+      },
+      "total": {
+        "min_s": 0.277065542,
+        "median_s": 0.278766791,
+        "samples_s": [
+          0.278766791,
+          0.277065542,
+          0.279705708
+        ]
+      },
+      "compute_s": 0.23778549999999998,
+      "ns_per_op_min": 82.68016194895074,
+      "ns_per_op_median": 82.51360898313195,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 1968269,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.029399458,
+        "median_s": 0.029729334,
+        "samples_s": [
+          0.029399458,
+          0.029729334,
+          0.030006166
+        ]
+      },
+      "total": {
+        "min_s": 0.327451125,
+        "median_s": 0.328078917,
+        "samples_s": [
+          0.328078917,
+          0.327451125,
+          0.328528209
+        ]
+      },
+      "compute_s": 0.298051667,
+      "ns_per_op_min": 151.42831950307604,
+      "ns_per_op_median": 151.57967889551682,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 137235069,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.041039042,
+        "median_s": 0.041402542,
+        "samples_s": [
+          0.041039042,
+          0.042158291,
+          0.041402542
+        ]
+      },
+      "total": {
+        "min_s": 0.335135625,
+        "median_s": 0.336200667,
+        "samples_s": [
+          0.336200667,
+          0.337774542,
+          0.335135625
+        ]
+      },
+      "compute_s": 0.29409658299999997,
+      "ns_per_op_min": 2.1430133357531225,
+      "ns_per_op_median": 2.1481253089908092,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 351167,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015040541,
+        "median_s": 0.015418167,
+        "samples_s": [
+          0.015040541,
+          0.015418167,
+          0.016066875
+        ]
+      },
+      "total": {
+        "min_s": 0.306500458,
+        "median_s": 0.307345917,
+        "samples_s": [
+          0.306500458,
+          0.307495125,
+          0.307345917
+        ]
+      },
+      "compute_s": 0.29145991699999996,
+      "ns_per_op_min": 829.9752453960649,
+      "ns_per_op_median": 831.3074690959004,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 85303177,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002905708,
+        "median_s": 0.003114958,
+        "samples_s": [
+          0.003135042,
+          0.003114958,
+          0.002905708
+        ]
+      },
+      "total": {
+        "min_s": 0.302478791,
+        "median_s": 0.3034165,
+        "samples_s": [
+          0.3034165,
+          0.302478791,
+          0.303571167
+        ]
+      },
+      "compute_s": 0.299573083,
+      "ns_per_op_min": 3.511863139634295,
+      "ns_per_op_median": 3.520402786405013,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 177598704,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.066937084,
+        "median_s": 0.067850792,
+        "samples_s": [
+          0.068188459,
+          0.067850792,
+          0.066937084
+        ]
+      },
+      "total": {
+        "min_s": 0.357408208,
+        "median_s": 0.357644583,
+        "samples_s": [
+          0.357644583,
+          0.358990875,
+          0.357408208
+        ]
+      },
+      "compute_s": 0.290471124,
+      "ns_per_op_min": 1.6355475431847746,
+      "ns_per_op_median": 1.631733703417115,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 512,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.012945292,
+        "median_s": 0.01351075,
+        "samples_s": [
+          0.012945292,
+          0.01351075,
+          0.01399
+        ]
+      },
+      "total": {
+        "min_s": 0.309103792,
+        "median_s": 0.30926675,
+        "samples_s": [
+          0.309671125,
+          0.309103792,
+          0.30926675
+        ]
+      },
+      "compute_s": 0.2961585,
+      "ns_per_op_min": 578434.5703125,
+      "ns_per_op_median": 577648.4374999999,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 7775,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.042660959,
+        "median_s": 0.043787958,
+        "samples_s": [
+          0.043787958,
+          0.042660959,
+          0.044768917
+        ]
+      },
+      "total": {
+        "min_s": 0.270785042,
+        "median_s": 0.272075208,
+        "samples_s": [
+          0.274876292,
+          0.272075208,
+          0.270785042
+        ]
+      },
+      "compute_s": 0.22812408299999998,
+      "ns_per_op_min": 29340.718070739546,
+      "ns_per_op_median": 29361.70418006431,
+      "load_ms": 0.631,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 33970,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.079083959,
+        "median_s": 0.079182875,
+        "samples_s": [
+          0.079182875,
+          0.080282416,
+          0.079083959
+        ]
+      },
+      "total": {
+        "min_s": 0.293027417,
+        "median_s": 0.294022583,
+        "samples_s": [
+          0.293027417,
+          0.295271083,
+          0.294022583
+        ]
+      },
+      "compute_s": 0.21394345800000003,
+      "ns_per_op_min": 6298.011716220195,
+      "ns_per_op_median": 6324.395289961732,
+      "load_ms": 3.591,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 38250,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.051422792,
+        "median_s": 0.052085292,
+        "samples_s": [
+          0.052085292,
+          0.052527458,
+          0.051422792
+        ]
+      },
+      "total": {
+        "min_s": 0.345908167,
+        "median_s": 0.345959958,
+        "samples_s": [
+          0.345959958,
+          0.347390417,
+          0.345908167
+        ]
+      },
+      "compute_s": 0.294485375,
+      "ns_per_op_min": 7698.964052287582,
+      "ns_per_op_median": 7682.997803921568,
+      "load_ms": 4.056,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 80606,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.105071875,
+        "median_s": 0.105504542,
+        "samples_s": [
+          0.105596125,
+          0.105071875,
+          0.105504542
+        ]
+      },
+      "total": {
+        "min_s": 0.39113225,
+        "median_s": 0.391599084,
+        "samples_s": [
+          0.39113225,
+          0.392189209,
+          0.391599084
+        ]
+      },
+      "compute_s": 0.28606037500000003,
+      "ns_per_op_min": 3548.871982234574,
+      "ns_per_op_median": 3549.2958588690663,
+      "load_ms": 9.57,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 129555458,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005368708,
+        "median_s": 0.005540958,
+        "samples_s": [
+          0.006186666,
+          0.005368708,
+          0.005540958
+        ]
+      },
+      "total": {
+        "min_s": 0.30636,
+        "median_s": 0.306369834,
+        "samples_s": [
+          0.30636,
+          0.306369834,
+          0.30658375
+        ]
+      },
+      "compute_s": 0.300991292,
+      "ns_per_op_min": 2.3232621507925972,
+      "ns_per_op_median": 2.3220085100544354,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 130127386,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009382916,
+        "median_s": 0.00964825,
+        "samples_s": [
+          0.009382916,
+          0.00964825,
+          0.009648792
+        ]
+      },
+      "total": {
+        "min_s": 0.310619917,
+        "median_s": 0.31158325,
+        "samples_s": [
+          0.31158325,
+          0.311641667,
+          0.310619917
+        ]
+      },
+      "compute_s": 0.301237001,
+      "ns_per_op_min": 2.3149393087785533,
+      "ns_per_op_median": 2.3203032757455064,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1905500,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015935708,
+        "median_s": 0.01603225,
+        "samples_s": [
+          0.016505166,
+          0.01603225,
+          0.015935708
+        ]
+      },
+      "total": {
+        "min_s": 0.315791042,
+        "median_s": 0.315981791,
+        "samples_s": [
+          0.316657167,
+          0.315981791,
+          0.315791042
+        ]
+      },
+      "compute_s": 0.29985533400000003,
+      "ns_per_op_min": 157.36307215953818,
+      "ns_per_op_median": 157.41251167672527,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 109925130,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004906959,
+        "median_s": 0.004914959,
+        "samples_s": [
+          0.004914959,
+          0.005270958,
+          0.004906959
+        ]
+      },
+      "total": {
+        "min_s": 0.298045042,
+        "median_s": 0.298061875,
+        "samples_s": [
+          0.298061875,
+          0.298702125,
+          0.298045042
+        ]
+      },
+      "compute_s": 0.293138083,
+      "ns_per_op_min": 2.666706721201967,
+      "ns_per_op_median": 2.666787075894293,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 16777216,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004547,
+        "median_s": 0.004647583,
+        "samples_s": [
+          0.004647583,
+          0.004712542,
+          0.004547
+        ]
+      },
+      "total": {
+        "min_s": 0.222118042,
+        "median_s": 0.222707791,
+        "samples_s": [
+          0.222707791,
+          0.222118042,
+          0.222794625
+        ]
+      },
+      "compute_s": 0.217571042,
+      "ns_per_op_min": 12.968244671821594,
+      "ns_per_op_median": 12.997401237487791,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 1936617,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039530917,
+        "median_s": 0.040079417,
+        "samples_s": [
+          0.040079417,
+          0.040361917,
+          0.039530917
+        ]
+      },
+      "total": {
+        "min_s": 0.391958916,
+        "median_s": 0.39287975,
+        "samples_s": [
+          0.391958916,
+          0.39287975,
+          0.395666875
+        ]
+      },
+      "compute_s": 0.352427999,
+      "ns_per_op_min": 181.981258555512,
+      "ns_per_op_median": 182.17351856355697,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 1992499,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039017125,
+        "median_s": 0.040290041,
+        "samples_s": [
+          0.040290041,
+          0.0408995,
+          0.039017125
+        ]
+      },
+      "total": {
+        "min_s": 0.315650042,
+        "median_s": 0.316640083,
+        "samples_s": [
+          0.318337583,
+          0.316640083,
+          0.315650042
+        ]
+      },
+      "compute_s": 0.27663291700000003,
+      "ns_per_op_min": 138.83716729594346,
+      "ns_per_op_median": 138.69519733761473,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 1465300,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.038880291,
+        "median_s": 0.039651333,
+        "samples_s": [
+          0.039651333,
+          0.041672584,
+          0.038880291
+        ]
+      },
+      "total": {
+        "min_s": 0.25926175,
+        "median_s": 0.259686334,
+        "samples_s": [
+          0.25926175,
+          0.259686334,
+          0.260288541
+        ]
+      },
+      "compute_s": 0.220381459,
+      "ns_per_op_min": 150.40023135194158,
+      "ns_per_op_median": 150.16378966764486,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 522627,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.028885667,
+        "median_s": 0.028968875,
+        "samples_s": [
+          0.028968875,
+          0.028885667,
+          0.029055458
+        ]
+      },
+      "total": {
+        "min_s": 0.320063958,
+        "median_s": 0.323597875,
+        "samples_s": [
+          0.324629833,
+          0.320063958,
+          0.323597875
+        ]
+      },
+      "compute_s": 0.291178291,
+      "ns_per_op_min": 557.1436052863705,
+      "ns_per_op_median": 563.7462281895118,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 23622851,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039748041,
+        "median_s": 0.040787459,
+        "samples_s": [
+          0.039748041,
+          0.041077291,
+          0.040787459
+        ]
+      },
+      "total": {
+        "min_s": 0.267610583,
+        "median_s": 0.268424709,
+        "samples_s": [
+          0.267610583,
+          0.269463208,
+          0.268424709
+        ]
+      },
+      "compute_s": 0.227862542,
+      "ns_per_op_min": 9.645852738096684,
+      "ns_per_op_median": 9.636315701267387,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 432693,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010748125,
+        "median_s": 0.011269,
+        "samples_s": [
+          0.010748125,
+          0.011323459,
+          0.011269
+        ]
+      },
+      "total": {
+        "min_s": 0.3109805,
+        "median_s": 0.31167925,
+        "samples_s": [
+          0.311790708,
+          0.3109805,
+          0.31167925
+        ]
+      },
+      "compute_s": 0.300232375,
+      "ns_per_op_min": 693.8692675869496,
+      "ns_per_op_median": 694.2803558180975,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 96745118,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002718584,
+        "median_s": 0.003000916,
+        "samples_s": [
+          0.003186333,
+          0.003000916,
+          0.002718584
+        ]
+      },
+      "total": {
+        "min_s": 0.300085458,
+        "median_s": 0.30047975,
+        "samples_s": [
+          0.300085458,
+          0.30047975,
+          0.300723625
+        ]
+      },
+      "compute_s": 0.297366874,
+      "ns_per_op_min": 3.073714520664495,
+      "ns_per_op_median": 3.074871788362488,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 83776847,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.067459125,
+        "median_s": 0.068180792,
+        "samples_s": [
+          0.068180792,
+          0.068529,
+          0.067459125
+        ]
+      },
+      "total": {
+        "min_s": 0.266398208,
+        "median_s": 0.26654875,
+        "samples_s": [
+          0.26654875,
+          0.270771625,
+          0.266398208
+        ]
+      },
+      "compute_s": 0.19893908300000002,
+      "ns_per_op_min": 2.3746308213294305,
+      "ns_per_op_median": 2.367813603679785,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 10285,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.012885375,
+        "median_s": 0.013045416,
+        "samples_s": [
+          0.013591709,
+          0.012885375,
+          0.013045416
+        ]
+      },
+      "total": {
+        "min_s": 0.271547625,
+        "median_s": 0.272273791,
+        "samples_s": [
+          0.271547625,
+          0.272273791,
+          0.272518542
+        ]
+      },
+      "compute_s": 0.25866225000000004,
+      "ns_per_op_min": 25149.465240641715,
+      "ns_per_op_median": 25204.508993680116,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 4842,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.042532417,
+        "median_s": 0.043968791,
+        "samples_s": [
+          0.042532417,
+          0.04598725,
+          0.043968791
+        ]
+      },
+      "total": {
+        "min_s": 0.30531625,
+        "median_s": 0.305865917,
+        "samples_s": [
+          0.305865917,
+          0.308108375,
+          0.30531625
+        ]
+      },
+      "compute_s": 0.262783833,
+      "ns_per_op_min": 54271.75402726147,
+      "ns_per_op_median": 54088.62577447335,
+      "load_ms": 0.677,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 7248,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.079337958,
+        "median_s": 0.081198916,
+        "samples_s": [
+          0.079337958,
+          0.081198916,
+          0.083862
+        ]
+      },
+      "total": {
+        "min_s": 0.266595667,
+        "median_s": 0.266813875,
+        "samples_s": [
+          0.266813875,
+          0.266595667,
+          0.269514417
+        ]
+      },
+      "compute_s": 0.187257709,
+      "ns_per_op_min": 25835.77662803532,
+      "ns_per_op_median": 25609.12789735099,
+      "load_ms": 3.765,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 20847,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.053401833,
+        "median_s": 0.053817333,
+        "samples_s": [
+          0.053884917,
+          0.053817333,
+          0.053401833
+        ]
+      },
+      "total": {
+        "min_s": 0.370387959,
+        "median_s": 0.3737485,
+        "samples_s": [
+          0.370387959,
+          0.375842791,
+          0.3737485
+        ]
+      },
+      "compute_s": 0.316986126,
+      "ns_per_op_min": 15205.359332278025,
+      "ns_per_op_median": 15346.628627620279,
+      "load_ms": 4.226,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 35673,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.101449875,
+        "median_s": 0.101587375,
+        "samples_s": [
+          0.102467,
+          0.101449875,
+          0.101587375
+        ]
+      },
+      "total": {
+        "min_s": 0.351355917,
+        "median_s": 0.354361792,
+        "samples_s": [
+          0.354361792,
+          0.351355917,
+          0.357843291
+        ]
+      },
+      "compute_s": 0.24990604200000002,
+      "ns_per_op_min": 7005.467496425869,
+      "ns_per_op_median": 7085.874947439241,
+      "load_ms": 9.126,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 39155863,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.00536125,
+        "median_s": 0.005807542,
+        "samples_s": [
+          0.00536125,
+          0.005977875,
+          0.005807542
+        ]
+      },
+      "total": {
+        "min_s": 0.30479225,
+        "median_s": 0.304882834,
+        "samples_s": [
+          0.305220667,
+          0.304882834,
+          0.30479225
+        ]
+      },
+      "compute_s": 0.299431,
+      "ns_per_op_min": 7.64715618705684,
+      "ns_per_op_median": 7.638071774845059,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 39414336,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009186,
+        "median_s": 0.009386917,
+        "samples_s": [
+          0.009810458,
+          0.009186,
+          0.009386917
+        ]
+      },
+      "total": {
+        "min_s": 0.310167791,
+        "median_s": 0.3102695,
+        "samples_s": [
+          0.3102695,
+          0.310978208,
+          0.310167791
+        ]
+      },
+      "compute_s": 0.300981791,
+      "ns_per_op_min": 7.636353204072751,
+      "ns_per_op_median": 7.633836150379395,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1525586,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015947458,
+        "median_s": 0.016057417,
+        "samples_s": [
+          0.016057417,
+          0.016799042,
+          0.015947458
+        ]
+      },
+      "total": {
+        "min_s": 0.303468042,
+        "median_s": 0.304362209,
+        "samples_s": [
+          0.303468042,
+          0.304820666,
+          0.304362209
+        ]
+      },
+      "compute_s": 0.28752058399999997,
+      "ns_per_op_min": 188.46566761886905,
+      "ns_per_op_median": 188.97970484784207,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 39086965,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005087791,
+        "median_s": 0.00537925,
+        "samples_s": [
+          0.005511459,
+          0.005087791,
+          0.00537925
+        ]
+      },
+      "total": {
+        "min_s": 0.304050709,
+        "median_s": 0.304493667,
+        "samples_s": [
+          0.304493667,
+          0.304050709,
+          0.306432708
+        ]
+      },
+      "compute_s": 0.29896291799999997,
+      "ns_per_op_min": 7.6486603142505425,
+      "ns_per_op_median": 7.65253626112951,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 12698043,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.00435825,
+        "median_s": 0.0045375,
+        "samples_s": [
+          0.004862125,
+          0.0045375,
+          0.00435825
+        ]
+      },
+      "total": {
+        "min_s": 0.221030291,
+        "median_s": 0.221370417,
+        "samples_s": [
+          0.221772792,
+          0.221370417,
+          0.221030291
+        ]
+      },
+      "compute_s": 0.21667204099999998,
+      "ns_per_op_min": 17.063420008894283,
+      "ns_per_op_median": 17.076089362746686,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 827448,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039411791,
+        "median_s": 0.039877292,
+        "samples_s": [
+          0.039877292,
+          0.039986583,
+          0.039411791
+        ]
+      },
+      "total": {
+        "min_s": 0.344115459,
+        "median_s": 0.344367917,
+        "samples_s": [
+          0.346309208,
+          0.344115459,
+          0.344367917
+        ]
+      },
+      "compute_s": 0.30470366800000004,
+      "ns_per_op_min": 368.24509576432604,
+      "ns_per_op_median": 367.98762580851,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 1391676,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040147166,
+        "median_s": 0.040377334,
+        "samples_s": [
+          0.040147166,
+          0.040458875,
+          0.040377334
+        ]
+      },
+      "total": {
+        "min_s": 0.312954166,
+        "median_s": 0.313849542,
+        "samples_s": [
+          0.313849542,
+          0.312954166,
+          0.314861
+        ]
+      },
+      "compute_s": 0.27280699999999997,
+      "ns_per_op_min": 196.0276673593566,
+      "ns_per_op_median": 196.50565792612647,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 1194241,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.038128667,
+        "median_s": 0.040566083,
+        "samples_s": [
+          0.041245166,
+          0.038128667,
+          0.040566083
+        ]
+      },
+      "total": {
+        "min_s": 0.329724958,
+        "median_s": 0.330258667,
+        "samples_s": [
+          0.329724958,
+          0.330258667,
+          0.330598833
+        ]
+      },
+      "compute_s": 0.291596291,
+      "ns_per_op_min": 244.16871552726795,
+      "ns_per_op_median": 242.5746428066027,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 305222,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.029319958,
+        "median_s": 0.029346042,
+        "samples_s": [
+          0.029319958,
+          0.029420917,
+          0.029346042
+        ]
+      },
+      "total": {
+        "min_s": 0.328499375,
+        "median_s": 0.329645417,
+        "samples_s": [
+          0.330729875,
+          0.329645417,
+          0.328499375
+        ]
+      },
+      "compute_s": 0.299179417,
+      "ns_per_op_min": 980.202662324472,
+      "ns_per_op_median": 983.8719849814233,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 24135930,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039965042,
+        "median_s": 0.040773875,
+        "samples_s": [
+          0.041431375,
+          0.040773875,
+          0.039965042
+        ]
+      },
+      "total": {
+        "min_s": 0.377938375,
+        "median_s": 0.37957575,
+        "samples_s": [
+          0.37957575,
+          0.385146334,
+          0.377938375
+        ]
+      },
+      "compute_s": 0.337973333,
+      "ns_per_op_min": 14.002913208647854,
+      "ns_per_op_median": 14.03724136588066,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 246870,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010721125,
+        "median_s": 0.011139667,
+        "samples_s": [
+          0.011735291,
+          0.011139667,
+          0.010721125
+        ]
+      },
+      "total": {
+        "min_s": 0.312116375,
+        "median_s": 0.312736375,
+        "samples_s": [
+          0.312736375,
+          0.314606166,
+          0.312116375
+        ]
+      },
+      "compute_s": 0.30139525,
+      "ns_per_op_min": 1220.8662453923118,
+      "ns_per_op_median": 1221.6822943249483,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 34325805,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.00303575,
+        "median_s": 0.005179709,
+        "samples_s": [
+          0.00303575,
+          0.006210625,
+          0.005179709
+        ]
+      },
+      "total": {
+        "min_s": 0.267176958,
+        "median_s": 0.267177,
+        "samples_s": [
+          0.267760792,
+          0.267177,
+          0.267176958
+        ]
+      },
+      "compute_s": 0.264141208,
+      "ns_per_op_min": 7.6951205659998365,
+      "ns_per_op_median": 7.632662686279318,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 24294063,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.066829041,
+        "median_s": 0.067003375,
+        "samples_s": [
+          0.067003375,
+          0.066829041,
+          0.067530708
+        ]
+      },
+      "total": {
+        "min_s": 0.260926792,
+        "median_s": 0.261149292,
+        "samples_s": [
+          0.260926792,
+          0.261634042,
+          0.261149292
+        ]
+      },
+      "compute_s": 0.194097751,
+      "ns_per_op_min": 7.989513775443819,
+      "ns_per_op_median": 7.991496399758244,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 4202,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.012607042,
+        "median_s": 0.013001708,
+        "samples_s": [
+          0.013021958,
+          0.013001708,
+          0.012607042
+        ]
+      },
+      "total": {
+        "min_s": 0.301173375,
+        "median_s": 0.302030209,
+        "samples_s": [
+          0.302030209,
+          0.302163292,
+          0.301173375
+        ]
+      },
+      "compute_s": 0.288566333,
+      "ns_per_op_min": 68673.56806282722,
+      "ns_per_op_median": 68783.55568776773,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 4672,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.044527042,
+        "median_s": 0.045020458,
+        "samples_s": [
+          0.045020458,
+          0.04516525,
+          0.044527042
+        ]
+      },
+      "total": {
+        "min_s": 0.327926875,
+        "median_s": 0.330131,
+        "samples_s": [
+          0.332058458,
+          0.327926875,
+          0.330131
+        ]
+      },
+      "compute_s": 0.283399833,
+      "ns_per_op_min": 60659.21083047945,
+      "ns_per_op_median": 61025.37285958904,
+      "load_ms": 0.663,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 850,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.077393292,
+        "median_s": 0.077528083,
+        "samples_s": [
+          0.080340083,
+          0.077528083,
+          0.077393292
+        ]
+      },
+      "total": {
+        "min_s": 0.256224459,
+        "median_s": 0.25953675,
+        "samples_s": [
+          0.25953675,
+          0.260425834,
+          0.256224459
+        ]
+      },
+      "compute_s": 0.178831167,
+      "ns_per_op_min": 210389.60823529412,
+      "ns_per_op_median": 214127.84352941177,
+      "load_ms": 3.847,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 16605,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.052532,
+        "median_s": 0.05392525,
+        "samples_s": [
+          0.05392525,
+          0.052532,
+          0.054756833
+        ]
+      },
+      "total": {
+        "min_s": 0.357149667,
+        "median_s": 0.358961666,
+        "samples_s": [
+          0.362690209,
+          0.357149667,
+          0.358961666
+        ]
+      },
+      "compute_s": 0.304617667,
+      "ns_per_op_min": 18344.936284251733,
+      "ns_per_op_median": 18370.154531767545,
+      "load_ms": 4.399,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 37196,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.100974292,
+        "median_s": 0.102896667,
+        "samples_s": [
+          0.100974292,
+          0.104051083,
+          0.102896667
+        ]
+      },
+      "total": {
+        "min_s": 0.417921708,
+        "median_s": 0.420175167,
+        "samples_s": [
+          0.417921708,
+          0.420175167,
+          0.4225775
+        ]
+      },
+      "compute_s": 0.316947416,
+      "ns_per_op_min": 8521.008065383374,
+      "ns_per_op_median": 8529.90913001398,
+      "load_ms": 9.076,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 126577242,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005251333,
+        "median_s": 0.005727625,
+        "samples_s": [
+          0.005727625,
+          0.005811083,
+          0.005251333
+        ]
+      },
+      "total": {
+        "min_s": 0.300042125,
+        "median_s": 0.301025625,
+        "samples_s": [
+          0.301108334,
+          0.301025625,
+          0.300042125
+        ]
+      },
+      "compute_s": 0.29479079199999997,
+      "ns_per_op_min": 2.328939921127369,
+      "ns_per_op_median": 2.3329470237627707,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 128901407,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009635459,
+        "median_s": 0.009825458,
+        "samples_s": [
+          0.00986325,
+          0.009635459,
+          0.009825458
+        ]
+      },
+      "total": {
+        "min_s": 0.309101333,
+        "median_s": 0.30946825,
+        "samples_s": [
+          0.309101333,
+          0.309623833,
+          0.30946825
+        ]
+      },
+      "compute_s": 0.29946587399999997,
+      "ns_per_op_min": 2.323216487466269,
+      "ns_per_op_median": 2.3245889938191286,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1725365,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015570458,
+        "median_s": 0.016329625,
+        "samples_s": [
+          0.016329625,
+          0.015570458,
+          0.016571833
+        ]
+      },
+      "total": {
+        "min_s": 0.287925042,
+        "median_s": 0.288320791,
+        "samples_s": [
+          0.28908625,
+          0.288320791,
+          0.287925042
+        ]
+      },
+      "compute_s": 0.272354584,
+      "ns_per_op_min": 157.85331451605893,
+      "ns_per_op_median": 157.64268198323254,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 111272479,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005014584,
+        "median_s": 0.0052565,
+        "samples_s": [
+          0.005014584,
+          0.005538625,
+          0.0052565
+        ]
+      },
+      "total": {
+        "min_s": 0.3020895,
+        "median_s": 0.302173292,
+        "samples_s": [
+          0.302898875,
+          0.302173292,
+          0.3020895
+        ]
+      },
+      "compute_s": 0.297074916,
+      "ns_per_op_min": 2.6697968686399087,
+      "ns_per_op_median": 2.668375816449636,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 15831545,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.003981375,
+        "median_s": 0.004413166,
+        "samples_s": [
+          0.004413166,
+          0.004749416,
+          0.003981375
+        ]
+      },
+      "total": {
+        "min_s": 0.195524,
+        "median_s": 0.195897125,
+        "samples_s": [
+          0.195928625,
+          0.195897125,
+          0.195524
+        ]
+      },
+      "compute_s": 0.191542625,
+      "ns_per_op_min": 12.098795474478328,
+      "ns_per_op_median": 12.095089834883456,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 218623,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.038835625,
+        "median_s": 0.039402916,
+        "samples_s": [
+          0.041000583,
+          0.038835625,
+          0.039402916
+        ]
+      },
+      "total": {
+        "min_s": 0.3299805,
+        "median_s": 0.33187575,
+        "samples_s": [
+          0.33187575,
+          0.332062834,
+          0.3299805
+        ]
+      },
+      "compute_s": 0.291144875,
+      "ns_per_op_min": 1331.721159255888,
+      "ns_per_op_median": 1337.79535547495,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 284346,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039535959,
+        "median_s": 0.0400185,
+        "samples_s": [
+          0.0400185,
+          0.040983167,
+          0.039535959
+        ]
+      },
+      "total": {
+        "min_s": 0.316034042,
+        "median_s": 0.321238792,
+        "samples_s": [
+          0.316034042,
+          0.321238792,
+          0.325263291
+        ]
+      },
+      "compute_s": 0.276498083,
+      "ns_per_op_min": 972.4001146490543,
+      "ns_per_op_median": 989.0073783348456,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 272181,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039904125,
+        "median_s": 0.04053975,
+        "samples_s": [
+          0.039904125,
+          0.0411645,
+          0.04053975
+        ]
+      },
+      "total": {
+        "min_s": 0.32233475,
+        "median_s": 0.327437042,
+        "samples_s": [
+          0.32233475,
+          0.329501375,
+          0.327437042
+        ]
+      },
+      "compute_s": 0.282430625,
+      "ns_per_op_min": 1037.6573860776468,
+      "ns_per_op_median": 1054.0680356086575,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 452339,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.029383125,
+        "median_s": 0.029897584,
+        "samples_s": [
+          0.030625959,
+          0.029897584,
+          0.029383125
+        ]
+      },
+      "total": {
+        "min_s": 0.3148735,
+        "median_s": 0.316366416,
+        "samples_s": [
+          0.333164625,
+          0.3148735,
+          0.316366416
+        ]
+      },
+      "compute_s": 0.28549037499999996,
+      "ns_per_op_min": 631.1425170060506,
+      "ns_per_op_median": 633.3056225529967,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 993649,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040128584,
+        "median_s": 0.040723,
+        "samples_s": [
+          0.040128584,
+          0.041485708,
+          0.040723
+        ]
+      },
+      "total": {
+        "min_s": 0.262246541,
+        "median_s": 0.26274725,
+        "samples_s": [
+          0.262246541,
+          0.264453334,
+          0.26274725
+        ]
+      },
+      "compute_s": 0.222117957,
+      "ns_per_op_min": 223.53764458073223,
+      "ns_per_op_median": 223.44333864372626,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 300939,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010613584,
+        "median_s": 0.01068525,
+        "samples_s": [
+          0.010613584,
+          0.01068525,
+          0.011309917
+        ]
+      },
+      "total": {
+        "min_s": 0.31269675,
+        "median_s": 0.313428125,
+        "samples_s": [
+          0.31269675,
+          0.313428125,
+          0.314055709
+        ]
+      },
+      "compute_s": 0.302083166,
+      "ns_per_op_min": 1003.801986449081,
+      "ns_per_op_median": 1005.9941549616367,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 113960705,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002874916,
+        "median_s": 0.003093875,
+        "samples_s": [
+          0.003093875,
+          0.002874916,
+          0.003167667
+        ]
+      },
+      "total": {
+        "min_s": 0.303861958,
+        "median_s": 0.303918291,
+        "samples_s": [
+          0.303861958,
+          0.303918291,
+          0.30409
+        ]
+      },
+      "compute_s": 0.300987042,
+      "ns_per_op_min": 2.641147595568139,
+      "ns_per_op_median": 2.6397205598192817,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 129434208,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.066492625,
+        "median_s": 0.066568792,
+        "samples_s": [
+          0.066568792,
+          0.06831175,
+          0.066492625
+        ]
+      },
+      "total": {
+        "min_s": 0.371928667,
+        "median_s": 0.372489208,
+        "samples_s": [
+          0.372489208,
+          0.373291125,
+          0.371928667
+        ]
+      },
+      "compute_s": 0.30543604199999996,
+      "ns_per_op_min": 2.3597783516394673,
+      "ns_per_op_median": 2.363520592639621,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 9644,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.013188417,
+        "median_s": 0.01337725,
+        "samples_s": [
+          0.013560375,
+          0.01337725,
+          0.013188417
+        ]
+      },
+      "total": {
+        "min_s": 0.27993675,
+        "median_s": 0.280959083,
+        "samples_s": [
+          0.280959083,
+          0.281090667,
+          0.27993675
+        ]
+      },
+      "compute_s": 0.266748333,
+      "ns_per_op_min": 27659.51192451265,
+      "ns_per_op_median": 27745.93871837412,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 4773,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.044162208,
+        "median_s": 0.045566208,
+        "samples_s": [
+          0.045566208,
+          0.044162208,
+          0.046141208
+        ]
+      },
+      "total": {
+        "min_s": 0.318614166,
+        "median_s": 0.318736458,
+        "samples_s": [
+          0.318614166,
+          0.318736458,
+          0.3195225
+        ]
+      },
+      "compute_s": 0.274451958,
+      "ns_per_op_min": 57500.93400377121,
+      "ns_per_op_median": 57232.40100565682,
+      "load_ms": 0.643,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 477,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.082418375,
+        "median_s": 0.083553417,
+        "samples_s": [
+          0.083553417,
+          0.082418375,
+          0.084062916
+        ]
+      },
+      "total": {
+        "min_s": 0.271971666,
+        "median_s": 0.272931875,
+        "samples_s": [
+          0.271971666,
+          0.272931875,
+          0.278116375
+        ]
+      },
+      "compute_s": 0.189553291,
+      "ns_per_op_min": 397386.35429769394,
+      "ns_per_op_median": 397019.8280922431,
+      "load_ms": 3.802,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 13383,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0527485,
+        "median_s": 0.052983875,
+        "samples_s": [
+          0.053863375,
+          0.052983875,
+          0.0527485
+        ]
+      },
+      "total": {
+        "min_s": 0.274984333,
+        "median_s": 0.277407416,
+        "samples_s": [
+          0.277571625,
+          0.277407416,
+          0.274984333
+        ]
+      },
+      "compute_s": 0.22223583300000002,
+      "ns_per_op_min": 16605.830755436004,
+      "ns_per_op_median": 16769.299932750506,
+      "load_ms": 4.257,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 31228,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.10090975,
+        "median_s": 0.101905417,
+        "samples_s": [
+          0.103273334,
+          0.101905417,
+          0.10090975
+        ]
+      },
+      "total": {
+        "min_s": 0.391853709,
+        "median_s": 0.392248125,
+        "samples_s": [
+          0.392248125,
+          0.393782459,
+          0.391853709
+        ]
+      },
+      "compute_s": 0.290943959,
+      "ns_per_op_min": 9316.765691046498,
+      "ns_per_op_median": 9297.512104521584,
+      "load_ms": 9.776,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 36254517,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005351584,
+        "median_s": 0.005595834,
+        "samples_s": [
+          0.006196375,
+          0.005351584,
+          0.005595834
+        ]
+      },
+      "total": {
+        "min_s": 0.305476916,
+        "median_s": 0.306079,
+        "samples_s": [
+          0.306982959,
+          0.306079,
+          0.305476916
+        ]
+      },
+      "compute_s": 0.30012533199999997,
+      "ns_per_op_min": 8.278287971675363,
+      "ns_per_op_median": 8.288158024557324,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 36133068,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009334292,
+        "median_s": 0.00944925,
+        "samples_s": [
+          0.009334292,
+          0.00944925,
+          0.009604459
+        ]
+      },
+      "total": {
+        "min_s": 0.308215125,
+        "median_s": 0.308715,
+        "samples_s": [
+          0.308930292,
+          0.308715,
+          0.308215125
+        ]
+      },
+      "compute_s": 0.29888083299999996,
+      "ns_per_op_min": 8.271670509683815,
+      "ns_per_op_median": 8.282323272410746,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1644194,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015887208,
+        "median_s": 0.016505458,
+        "samples_s": [
+          0.016505458,
+          0.015887208,
+          0.016536458
+        ]
+      },
+      "total": {
+        "min_s": 0.324983083,
+        "median_s": 0.325800541,
+        "samples_s": [
+          0.325800541,
+          0.324983083,
+          0.32710425
+        ]
+      },
+      "compute_s": 0.309095875,
+      "ns_per_op_min": 187.9923384953357,
+      "ns_per_op_median": 188.1134969474405,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 36469103,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005314834,
+        "median_s": 0.005448042,
+        "samples_s": [
+          0.005528417,
+          0.005448042,
+          0.005314834
+        ]
+      },
+      "total": {
+        "min_s": 0.307972875,
+        "median_s": 0.308473,
+        "samples_s": [
+          0.307972875,
+          0.308473,
+          0.309500959
+        ]
+      },
+      "compute_s": 0.302658041,
+      "ns_per_op_min": 8.299026192116653,
+      "ns_per_op_median": 8.309087229263632,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 13930659,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004076625,
+        "median_s": 0.004487,
+        "samples_s": [
+          0.004768833,
+          0.004076625,
+          0.004487
+        ]
+      },
+      "total": {
+        "min_s": 0.230027041,
+        "median_s": 0.230084917,
+        "samples_s": [
+          0.230359958,
+          0.230084917,
+          0.230027041
+        ]
+      },
+      "compute_s": 0.225950416,
+      "ns_per_op_min": 16.21965019745297,
+      "ns_per_op_median": 16.19434636940004,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 162977,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039397417,
+        "median_s": 0.039709625,
+        "samples_s": [
+          0.039709625,
+          0.039397417,
+          0.0402805
+        ]
+      },
+      "total": {
+        "min_s": 0.315202958,
+        "median_s": 0.315972791,
+        "samples_s": [
+          0.316467875,
+          0.315972791,
+          0.315202958
+        ]
+      },
+      "compute_s": 0.275805541,
+      "ns_per_op_min": 1692.2973241623051,
+      "ns_per_op_median": 1695.105235708106,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 200894,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039447125,
+        "median_s": 0.039838167,
+        "samples_s": [
+          0.039447125,
+          0.039838167,
+          0.039846584
+        ]
+      },
+      "total": {
+        "min_s": 0.268673375,
+        "median_s": 0.270903459,
+        "samples_s": [
+          0.268673375,
+          0.271772875,
+          0.270903459
+        ]
+      },
+      "compute_s": 0.22922625,
+      "ns_per_op_min": 1141.0308421356535,
+      "ns_per_op_median": 1150.1851324579131,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 152217,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.038873709,
+        "median_s": 0.039429208,
+        "samples_s": [
+          0.038873709,
+          0.039429208,
+          0.040648959
+        ]
+      },
+      "total": {
+        "min_s": 0.253447834,
+        "median_s": 0.253962666,
+        "samples_s": [
+          0.254592334,
+          0.253447834,
+          0.253962666
+        ]
+      },
+      "compute_s": 0.21457412499999998,
+      "ns_per_op_min": 1409.6594007239662,
+      "ns_per_op_median": 1409.3922360840115,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 286489,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.029224708,
+        "median_s": 0.029395458,
+        "samples_s": [
+          0.029395458,
+          0.02994825,
+          0.029224708
+        ]
+      },
+      "total": {
+        "min_s": 0.325403041,
+        "median_s": 0.326657958,
+        "samples_s": [
+          0.328232209,
+          0.325403041,
+          0.326657958
+        ]
+      },
+      "compute_s": 0.296178333,
+      "ns_per_op_min": 1033.8209599670492,
+      "ns_per_op_median": 1037.6052832744017,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 1043865,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039586125,
+        "median_s": 0.041170667,
+        "samples_s": [
+          0.041170667,
+          0.039586125,
+          0.042344083
+        ]
+      },
+      "total": {
+        "min_s": 0.319578958,
+        "median_s": 0.319595291,
+        "samples_s": [
+          0.319578958,
+          0.319595291,
+          0.320255208
+        ]
+      },
+      "compute_s": 0.279992833,
+      "ns_per_op_min": 268.2270533067015,
+      "ns_per_op_median": 266.72474314207295,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 196042,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010761958,
+        "median_s": 0.011113708,
+        "samples_s": [
+          0.011113708,
+          0.011274417,
+          0.010761958
+        ]
+      },
+      "total": {
+        "min_s": 0.306675333,
+        "median_s": 0.307500833,
+        "samples_s": [
+          0.306675333,
+          0.307500833,
+          0.308605709
+        ]
+      },
+      "compute_s": 0.295913375,
+      "ns_per_op_min": 1509.4386662041807,
+      "ns_per_op_median": 1511.8552402036298,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 34311152,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.00376725,
+        "median_s": 0.004265167,
+        "samples_s": [
+          0.004265167,
+          0.00376725,
+          0.005432333
+        ]
+      },
+      "total": {
+        "min_s": 0.2868015,
+        "median_s": 0.287036875,
+        "samples_s": [
+          0.287210792,
+          0.2868015,
+          0.287036875
+        ]
+      },
+      "compute_s": 0.28303425,
+      "ns_per_op_min": 8.24904538326198,
+      "ns_per_op_median": 8.241393585385882,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 23846088,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.067343041,
+        "median_s": 0.067818208,
+        "samples_s": [
+          0.069210625,
+          0.067818208,
+          0.067343041
+        ]
+      },
+      "total": {
+        "min_s": 0.271329417,
+        "median_s": 0.2728755,
+        "samples_s": [
+          0.271329417,
+          0.273915208,
+          0.2728755
+        ]
+      },
+      "compute_s": 0.20398637600000002,
+      "ns_per_op_min": 8.554291001526122,
+      "ns_per_op_median": 8.599200506179463,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 3668,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.012412417,
+        "median_s": 0.012471417,
+        "samples_s": [
+          0.012471417,
+          0.013500417,
+          0.012412417
+        ]
+      },
+      "total": {
+        "min_s": 0.296513584,
+        "median_s": 0.29653425,
+        "samples_s": [
+          0.296513584,
+          0.29653425,
+          0.298884916
+        ]
+      },
+      "compute_s": 0.284101167,
+      "ns_per_op_min": 77453.9713740458,
+      "ns_per_op_median": 77443.52044711015,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 4758,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.045030792,
+        "median_s": 0.045213167,
+        "samples_s": [
+          0.045030792,
+          0.045344917,
+          0.045213167
+        ]
+      },
+      "total": {
+        "min_s": 0.356375375,
+        "median_s": 0.358708375,
+        "samples_s": [
+          0.356375375,
+          0.358729916,
+          0.358708375
+        ]
+      },
+      "compute_s": 0.311344583,
+      "ns_per_op_min": 65436.01996637243,
+      "ns_per_op_median": 65888.0218579235,
+      "load_ms": 0.655,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 503,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.078524333,
+        "median_s": 0.079877625,
+        "samples_s": [
+          0.079877625,
+          0.081485125,
+          0.078524333
+        ]
+      },
+      "total": {
+        "min_s": 0.27677625,
+        "median_s": 0.27703475,
+        "samples_s": [
+          0.280570292,
+          0.27677625,
+          0.27703475
+        ]
+      },
+      "compute_s": 0.198251917,
+      "ns_per_op_min": 394139.0,
+      "ns_per_op_median": 391962.47514910536,
+      "load_ms": 3.967,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wardite",
+      "status": "skipped",
+      "reason": "excluded: wardite 0.9.0 computes i64.div_s at f64 precision, wrong for operands beyond 2^53: i64.div_s(0x8000000000000000, 3) gives -3074457345618258432 where -3074457345618258602 is correct"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wardite-yjit",
+      "status": "skipped",
+      "reason": "excluded: wardite 0.9.0 computes i64.div_s at f64 precision, wrong for operands beyond 2^53: i64.div_s(0x8000000000000000, 3) gives -3074457345618258432 where -3074457345618258602 is correct"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 199251057,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005733208,
+        "median_s": 0.005944667,
+        "samples_s": [
+          0.005944667,
+          0.005733208,
+          0.005974333
+        ]
+      },
+      "total": {
+        "min_s": 0.304260792,
+        "median_s": 0.304307791,
+        "samples_s": [
+          0.3043125,
+          0.304260792,
+          0.304307791
+        ]
+      },
+      "compute_s": 0.298527584,
+      "ns_per_op_min": 1.4982484333822128,
+      "ns_per_op_median": 1.497423042528703,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 189206642,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.008810458,
+        "median_s": 0.008886667,
+        "samples_s": [
+          0.00897725,
+          0.008886667,
+          0.008810458
+        ]
+      },
+      "total": {
+        "min_s": 0.30823125,
+        "median_s": 0.30840025,
+        "samples_s": [
+          0.30840025,
+          0.30823125,
+          0.309183792
+        ]
+      },
+      "compute_s": 0.299420792,
+      "ns_per_op_min": 1.582506770560412,
+      "ns_per_op_median": 1.5829971920330366,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1134465,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015964416,
+        "median_s": 0.016000834,
+        "samples_s": [
+          0.015964416,
+          0.016287833,
+          0.016000834
+        ]
+      },
+      "total": {
+        "min_s": 0.320100541,
+        "median_s": 0.321491458,
+        "samples_s": [
+          0.320100541,
+          0.32381725,
+          0.321491458
+        ]
+      },
+      "compute_s": 0.30413612500000003,
+      "ns_per_op_min": 268.08771094745106,
+      "ns_per_op_median": 269.281664925758,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 117349081,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004715333,
+        "median_s": 0.005349584,
+        "samples_s": [
+          0.004715333,
+          0.005349584,
+          0.005458667
+        ]
+      },
+      "total": {
+        "min_s": 0.30102,
+        "median_s": 0.301963833,
+        "samples_s": [
+          0.302696541,
+          0.301963833,
+          0.30102
+        ]
+      },
+      "compute_s": 0.296304667,
+      "ns_per_op_min": 2.5249849804959275,
+      "ns_per_op_median": 2.527623109379101,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 9629976,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004071625,
+        "median_s": 0.004423834,
+        "samples_s": [
+          0.00469225,
+          0.004071625,
+          0.004423834
+        ]
+      },
+      "total": {
+        "min_s": 0.201843417,
+        "median_s": 0.202637125,
+        "samples_s": [
+          0.2041625,
+          0.202637125,
+          0.201843417
+        ]
+      },
+      "compute_s": 0.197771792,
+      "ns_per_op_min": 20.537101234727896,
+      "ns_per_op_median": 20.58294755874781,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 599388,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.037678166,
+        "median_s": 0.039624916,
+        "samples_s": [
+          0.039624916,
+          0.040815125,
+          0.037678166
+        ]
+      },
+      "total": {
+        "min_s": 0.299600125,
+        "median_s": 0.300086417,
+        "samples_s": [
+          0.300086417,
+          0.299600125,
+          0.301345709
+        ]
+      },
+      "compute_s": 0.261921959,
+      "ns_per_op_min": 436.9823203000393,
+      "ns_per_op_median": 434.5457383197528,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 777907,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.038908167,
+        "median_s": 0.039505958,
+        "samples_s": [
+          0.038908167,
+          0.039505958,
+          0.03987025
+        ]
+      },
+      "total": {
+        "min_s": 0.279663167,
+        "median_s": 0.280432875,
+        "samples_s": [
+          0.280432875,
+          0.282506916,
+          0.279663167
+        ]
+      },
+      "compute_s": 0.240755,
+      "ns_per_op_min": 309.49072318413386,
+      "ns_per_op_median": 309.71172260951505,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 647696,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039329583,
+        "median_s": 0.03994025,
+        "samples_s": [
+          0.039329583,
+          0.040189792,
+          0.03994025
+        ]
+      },
+      "total": {
+        "min_s": 0.256569459,
+        "median_s": 0.259904667,
+        "samples_s": [
+          0.260782417,
+          0.256569459,
+          0.259904667
+        ]
+      },
+      "compute_s": 0.217239876,
+      "ns_per_op_min": 335.40407228082313,
+      "ns_per_op_median": 339.6105842864553,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 156839,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.029420666,
+        "median_s": 0.030013166,
+        "samples_s": [
+          0.030013166,
+          0.029420666,
+          0.031092666
+        ]
+      },
+      "total": {
+        "min_s": 0.326280291,
+        "median_s": 0.329815292,
+        "samples_s": [
+          0.329815292,
+          0.326280291,
+          0.330450583
+        ]
+      },
+      "compute_s": 0.296859625,
+      "ns_per_op_min": 1892.7666269231504,
+      "ns_per_op_median": 1911.5279107874956,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 3304769,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040527416,
+        "median_s": 0.041554125,
+        "samples_s": [
+          0.041554125,
+          0.040527416,
+          0.042894375
+        ]
+      },
+      "total": {
+        "min_s": 0.281752541,
+        "median_s": 0.282237333,
+        "samples_s": [
+          0.281752541,
+          0.282237333,
+          0.283002
+        ]
+      },
+      "compute_s": 0.24122512500000004,
+      "ns_per_op_min": 72.99303672964737,
+      "ns_per_op_median": 72.82905643329381,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 65536,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0115715,
+        "median_s": 0.011587917,
+        "samples_s": [
+          0.0115715,
+          0.012256125,
+          0.011587917
+        ]
+      },
+      "total": {
+        "min_s": 0.223360667,
+        "median_s": 0.224400958,
+        "samples_s": [
+          0.223360667,
+          0.224400958,
+          0.226246625
+        ]
+      },
+      "compute_s": 0.211789167,
+      "ns_per_op_min": 3231.646224975586,
+      "ns_per_op_median": 3247.269302368164,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 103553741,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004283292,
+        "median_s": 0.00471975,
+        "samples_s": [
+          0.006159208,
+          0.00471975,
+          0.004283292
+        ]
+      },
+      "total": {
+        "min_s": 0.260695375,
+        "median_s": 0.261623042,
+        "samples_s": [
+          0.260695375,
+          0.261927334,
+          0.261623042
+        ]
+      },
+      "compute_s": 0.256412083,
+      "ns_per_op_min": 2.476125734559411,
+      "ns_per_op_median": 2.4808692522272078,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 45353611,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.066734125,
+        "median_s": 0.067709458,
+        "samples_s": [
+          0.067709458,
+          0.069250625,
+          0.066734125
+        ]
+      },
+      "total": {
+        "min_s": 0.269028584,
+        "median_s": 0.272044042,
+        "samples_s": [
+          0.273391084,
+          0.269028584,
+          0.272044042
+        ]
+      },
+      "compute_s": 0.202294459,
+      "ns_per_op_min": 4.4603826363462,
+      "ns_per_op_median": 4.50536527289966,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 5751,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.012817125,
+        "median_s": 0.013251792,
+        "samples_s": [
+          0.012817125,
+          0.01336625,
+          0.013251792
+        ]
+      },
+      "total": {
+        "min_s": 0.307831833,
+        "median_s": 0.308439417,
+        "samples_s": [
+          0.308439417,
+          0.309687333,
+          0.307831833
+        ]
+      },
+      "compute_s": 0.295014708,
+      "ns_per_op_min": 51297.98435054773,
+      "ns_per_op_median": 51328.05164319249,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 3353,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.043656875,
+        "median_s": 0.043991292,
+        "samples_s": [
+          0.043991292,
+          0.043656875,
+          0.045954875
+        ]
+      },
+      "total": {
+        "min_s": 0.33727,
+        "median_s": 0.337905584,
+        "samples_s": [
+          0.337905584,
+          0.33727,
+          0.339389333
+        ]
+      },
+      "compute_s": 0.29361312500000003,
+      "ns_per_op_min": 87567.29048613184,
+      "ns_per_op_median": 87657.11064718162,
+      "load_ms": 0.858,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 3218,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.078025542,
+        "median_s": 0.080318167,
+        "samples_s": [
+          0.080318167,
+          0.080989125,
+          0.078025542
+        ]
+      },
+      "total": {
+        "min_s": 0.263627083,
+        "median_s": 0.264798166,
+        "samples_s": [
+          0.263627083,
+          0.264798166,
+          0.264983541
+        ]
+      },
+      "compute_s": 0.18560154099999998,
+      "ns_per_op_min": 57676.05376009943,
+      "ns_per_op_median": 57327.53231821007,
+      "load_ms": 5.113,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 10043,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.053125917,
+        "median_s": 0.053355625,
+        "samples_s": [
+          0.054155292,
+          0.053355625,
+          0.053125917
+        ]
+      },
+      "total": {
+        "min_s": 0.337886916,
+        "median_s": 0.340021416,
+        "samples_s": [
+          0.340021416,
+          0.340614917,
+          0.337886916
+        ]
+      },
+      "compute_s": 0.28476099899999996,
+      "ns_per_op_min": 28354.1769391616,
+      "ns_per_op_median": 28543.840585482427,
+      "load_ms": 3.83,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 19012,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.101311125,
+        "median_s": 0.10196575,
+        "samples_s": [
+          0.102719792,
+          0.101311125,
+          0.10196575
+        ]
+      },
+      "total": {
+        "min_s": 0.382314041,
+        "median_s": 0.383568791,
+        "samples_s": [
+          0.3847185,
+          0.382314041,
+          0.383568791
+        ]
+      },
+      "compute_s": 0.281002916,
+      "ns_per_op_min": 14780.292236482223,
+      "ns_per_op_median": 14811.857826635809,
+      "load_ms": 9.111,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 287376100,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005388917,
+        "median_s": 0.00551075,
+        "samples_s": [
+          0.006035042,
+          0.005388917,
+          0.00551075
+        ]
+      },
+      "total": {
+        "min_s": 0.2942345,
+        "median_s": 0.295990167,
+        "samples_s": [
+          0.2942345,
+          0.295990167,
+          0.29749175
+        ]
+      },
+      "compute_s": 0.288845583,
+      "ns_per_op_min": 1.0051134488915396,
+      "ns_per_op_median": 1.0107987999002004,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 296096089,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.008982791,
+        "median_s": 0.009112458,
+        "samples_s": [
+          0.009112458,
+          0.008982791,
+          0.009617
+        ]
+      },
+      "total": {
+        "min_s": 0.307498084,
+        "median_s": 0.307670791,
+        "samples_s": [
+          0.307498084,
+          0.308990875,
+          0.307670791
+        ]
+      },
+      "compute_s": 0.298515293,
+      "ns_per_op_min": 1.0081703341917494,
+      "ns_per_op_median": 1.0083156924102432,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1971633,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015607667,
+        "median_s": 0.01706675,
+        "samples_s": [
+          0.015607667,
+          0.01706675,
+          0.0189375
+        ]
+      },
+      "total": {
+        "min_s": 0.277088625,
+        "median_s": 0.277092167,
+        "samples_s": [
+          0.278823042,
+          0.277088625,
+          0.277092167
+        ]
+      },
+      "compute_s": 0.261480958,
+      "ns_per_op_min": 132.62151627610208,
+      "ns_per_op_median": 131.8832749299692,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 189579017,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004741125,
+        "median_s": 0.005546083,
+        "samples_s": [
+          0.004741125,
+          0.005599291,
+          0.005546083
+        ]
+      },
+      "total": {
+        "min_s": 0.297590625,
+        "median_s": 0.29949025,
+        "samples_s": [
+          0.299714917,
+          0.297590625,
+          0.29949025
+        ]
+      },
+      "compute_s": 0.2928495,
+      "ns_per_op_min": 1.5447358290712099,
+      "ns_per_op_median": 1.5505100282274387,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 33554432,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004161125,
+        "median_s": 0.004390584,
+        "samples_s": [
+          0.004390584,
+          0.00481325,
+          0.004161125
+        ]
+      },
+      "total": {
+        "min_s": 0.348855459,
+        "median_s": 0.349099458,
+        "samples_s": [
+          0.349099458,
+          0.348855459,
+          0.349399208
+        ]
+      },
+      "compute_s": 0.344694334,
+      "ns_per_op_min": 10.272691667079926,
+      "ns_per_op_median": 10.273124992847443,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 1684297,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040442,
+        "median_s": 0.040621417,
+        "samples_s": [
+          0.040621417,
+          0.040442,
+          0.041104625
+        ]
+      },
+      "total": {
+        "min_s": 0.34402225,
+        "median_s": 0.344380375,
+        "samples_s": [
+          0.344380375,
+          0.345466,
+          0.34402225
+        ]
+      },
+      "compute_s": 0.30358025,
+      "ns_per_op_min": 180.24151916200051,
+      "ns_per_op_median": 180.34762158930403,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 1566878,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039047583,
+        "median_s": 0.039702417,
+        "samples_s": [
+          0.039702417,
+          0.039047583,
+          0.039728916
+        ]
+      },
+      "total": {
+        "min_s": 0.251368417,
+        "median_s": 0.252538125,
+        "samples_s": [
+          0.253009375,
+          0.251368417,
+          0.252538125
+        ]
+      },
+      "compute_s": 0.212320834,
+      "ns_per_op_min": 135.50565774744427,
+      "ns_per_op_median": 135.83425640030686,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 1801622,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039898417,
+        "median_s": 0.040701083,
+        "samples_s": [
+          0.040701083,
+          0.040853625,
+          0.039898417
+        ]
+      },
+      "total": {
+        "min_s": 0.297170416,
+        "median_s": 0.298288875,
+        "samples_s": [
+          0.298842083,
+          0.297170416,
+          0.298288875
+        ]
+      },
+      "compute_s": 0.257271999,
+      "ns_per_op_min": 142.8002094779038,
+      "ns_per_op_median": 142.97549208435512,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 399182,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.02918775,
+        "median_s": 0.029889208,
+        "samples_s": [
+          0.030241417,
+          0.02918775,
+          0.029889208
+        ]
+      },
+      "total": {
+        "min_s": 0.334057042,
+        "median_s": 0.3357935,
+        "samples_s": [
+          0.334057042,
+          0.336500875,
+          0.3357935
+        ]
+      },
+      "compute_s": 0.304869292,
+      "ns_per_op_min": 763.7350682144986,
+      "ns_per_op_median": 766.3278704951626,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 5391683,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.041069459,
+        "median_s": 0.041420333,
+        "samples_s": [
+          0.042046,
+          0.041420333,
+          0.041069459
+        ]
+      },
+      "total": {
+        "min_s": 0.333568541,
+        "median_s": 0.335798584,
+        "samples_s": [
+          0.335798584,
+          0.333568541,
+          0.336789125
+        ]
+      },
+      "compute_s": 0.29249908199999997,
+      "ns_per_op_min": 54.25005179273335,
+      "ns_per_op_median": 54.59858285437034,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 301672,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.011111042,
+        "median_s": 0.011572167,
+        "samples_s": [
+          0.011572167,
+          0.011111042,
+          0.011614667
+        ]
+      },
+      "total": {
+        "min_s": 0.31315725,
+        "median_s": 0.315178875,
+        "samples_s": [
+          0.315178875,
+          0.31315725,
+          0.316444375
+        ]
+      },
+      "compute_s": 0.302046208,
+      "ns_per_op_min": 1001.24044657774,
+      "ns_per_op_median": 1006.4132833010688,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 198373798,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002976708,
+        "median_s": 0.003033208,
+        "samples_s": [
+          0.00321225,
+          0.003033208,
+          0.002976708
+        ]
+      },
+      "total": {
+        "min_s": 0.303132666,
+        "median_s": 0.303293125,
+        "samples_s": [
+          0.303132666,
+          0.304144125,
+          0.303293125
+        ]
+      },
+      "compute_s": 0.300155958,
+      "ns_per_op_min": 1.5130826804052016,
+      "ns_per_op_median": 1.5136067365106354,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 145873518,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.066440125,
+        "median_s": 0.067683833,
+        "samples_s": [
+          0.067683833,
+          0.068357417,
+          0.066440125
+        ]
+      },
+      "total": {
+        "min_s": 0.324550708,
+        "median_s": 0.326570666,
+        "samples_s": [
+          0.324550708,
+          0.326570666,
+          0.327075333
+        ]
+      },
+      "compute_s": 0.258110583,
+      "ns_per_op_min": 1.7694135751219766,
+      "ns_per_op_median": 1.7747349659449498,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 8907,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.012318833,
+        "median_s": 0.013100125,
+        "samples_s": [
+          0.012318833,
+          0.013100125,
+          0.013176166
+        ]
+      },
+      "total": {
+        "min_s": 0.294758916,
+        "median_s": 0.296552334,
+        "samples_s": [
+          0.294758916,
+          0.298076458,
+          0.296552334
+        ]
+      },
+      "compute_s": 0.282440083,
+      "ns_per_op_min": 31709.900415403616,
+      "ns_per_op_median": 31823.533063882332,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 4788,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.042765875,
+        "median_s": 0.044022125,
+        "samples_s": [
+          0.044022125,
+          0.042765875,
+          0.044610625
+        ]
+      },
+      "total": {
+        "min_s": 0.233244542,
+        "median_s": 0.233265958,
+        "samples_s": [
+          0.233244542,
+          0.233433625,
+          0.233265958
+        ]
+      },
+      "compute_s": 0.190478667,
+      "ns_per_op_min": 39782.51190476191,
+      "ns_per_op_median": 39524.61006683375,
+      "load_ms": 0.711,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 28800,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.079948333,
+        "median_s": 0.080437083,
+        "samples_s": [
+          0.081358666,
+          0.079948333,
+          0.080437083
+        ]
+      },
+      "total": {
+        "min_s": 0.318009875,
+        "median_s": 0.318068208,
+        "samples_s": [
+          0.318068208,
+          0.318009875,
+          0.318328042
+        ]
+      },
+      "compute_s": 0.23806154200000001,
+      "ns_per_op_min": 8266.025763888889,
+      "ns_per_op_median": 8251.080729166666,
+      "load_ms": 4.527,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 26662,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.05147025,
+        "median_s": 0.05279025,
+        "samples_s": [
+          0.05279025,
+          0.055548666,
+          0.05147025
+        ]
+      },
+      "total": {
+        "min_s": 0.403549625,
+        "median_s": 0.405462208,
+        "samples_s": [
+          0.407379125,
+          0.403549625,
+          0.405462208
+        ]
+      },
+      "compute_s": 0.352079375,
+      "ns_per_op_min": 13205.287487810367,
+      "ns_per_op_median": 13227.513239816968,
+      "load_ms": 4.337,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 46184,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.101429209,
+        "median_s": 0.102121583,
+        "samples_s": [
+          0.101429209,
+          0.103254375,
+          0.102121583
+        ]
+      },
+      "total": {
+        "min_s": 0.388953083,
+        "median_s": 0.3962755,
+        "samples_s": [
+          0.388953083,
+          0.39723325,
+          0.3962755
+        ]
+      },
+      "compute_s": 0.28752387399999996,
+      "ns_per_op_min": 6225.6165338645405,
+      "ns_per_op_median": 6369.173674865754,
+      "load_ms": 9.393,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 3035284,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005774125,
+        "median_s": 0.005896625,
+        "samples_s": [
+          0.005896625,
+          0.006260542,
+          0.005774125
+        ]
+      },
+      "total": {
+        "min_s": 0.297683167,
+        "median_s": 0.297983875,
+        "samples_s": [
+          0.297983875,
+          0.2997455,
+          0.297683167
+        ]
+      },
+      "compute_s": 0.291909042,
+      "ns_per_op_min": 96.17190417766508,
+      "ns_per_op_median": 96.2306163113567,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 3212614,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009082625,
+        "median_s": 0.00965225,
+        "samples_s": [
+          0.009704875,
+          0.00965225,
+          0.009082625
+        ]
+      },
+      "total": {
+        "min_s": 0.317607417,
+        "median_s": 0.317918125,
+        "samples_s": [
+          0.317918125,
+          0.318409917,
+          0.317607417
+        ]
+      },
+      "compute_s": 0.308524792,
+      "ns_per_op_min": 96.03543780858827,
+      "ns_per_op_median": 95.95484393705561,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 65536,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.016229375,
+        "median_s": 0.016338917,
+        "samples_s": [
+          0.016338917,
+          0.016229375,
+          0.016391958
+        ]
+      },
+      "total": {
+        "min_s": 0.266760833,
+        "median_s": 0.266913958,
+        "samples_s": [
+          0.267024208,
+          0.266760833,
+          0.266913958
+        ]
+      },
+      "compute_s": 0.250531458,
+      "ns_per_op_min": 3822.8066711425777,
+      "ns_per_op_median": 3823.471694946289,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 2711538,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005112583,
+        "median_s": 0.005250125,
+        "samples_s": [
+          0.005577583,
+          0.005112583,
+          0.005250125
+        ]
+      },
+      "total": {
+        "min_s": 0.29603275,
+        "median_s": 0.296666042,
+        "samples_s": [
+          0.296666042,
+          0.297782042,
+          0.29603275
+        ]
+      },
+      "compute_s": 0.290920167,
+      "ns_per_op_min": 107.2897252408043,
+      "ns_per_op_median": 107.47255505915831,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 659438,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004408667,
+        "median_s": 0.00466575,
+        "samples_s": [
+          0.004408667,
+          0.004787209,
+          0.00466575
+        ]
+      },
+      "total": {
+        "min_s": 0.303351583,
+        "median_s": 0.303447833,
+        "samples_s": [
+          0.305264041,
+          0.303447833,
+          0.303351583
+        ]
+      },
+      "compute_s": 0.298942916,
+      "ns_per_op_min": 453.3298293395285,
+      "ns_per_op_median": 453.08593529641905,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 44032,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.038838084,
+        "median_s": 0.039541375,
+        "samples_s": [
+          0.039757459,
+          0.038838084,
+          0.039541375
+        ]
+      },
+      "total": {
+        "min_s": 0.239492417,
+        "median_s": 0.240127042,
+        "samples_s": [
+          0.240532959,
+          0.239492417,
+          0.240127042
+        ]
+      },
+      "compute_s": 0.20065433300000002,
+      "ns_per_op_min": 4557.01155977471,
+      "ns_per_op_median": 4555.452103015989,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 141178,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.038772,
+        "median_s": 0.040142333,
+        "samples_s": [
+          0.038772,
+          0.040478375,
+          0.040142333
+        ]
+      },
+      "total": {
+        "min_s": 0.252263958,
+        "median_s": 0.258859583,
+        "samples_s": [
+          0.252263958,
+          0.260892083,
+          0.258859583
+        ]
+      },
+      "compute_s": 0.213491958,
+      "ns_per_op_min": 1512.2183201348653,
+      "ns_per_op_median": 1549.2304041706216,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 79388,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040666292,
+        "median_s": 0.041156833,
+        "samples_s": [
+          0.041156833,
+          0.0414155,
+          0.040666292
+        ]
+      },
+      "total": {
+        "min_s": 0.320991542,
+        "median_s": 0.321087167,
+        "samples_s": [
+          0.320991542,
+          0.321087167,
+          0.32207925
+        ]
+      },
+      "compute_s": 0.28032525,
+      "ns_per_op_min": 3531.0783745654253,
+      "ns_per_op_median": 3526.103869602459,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 65536,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.030403083,
+        "median_s": 0.030517083,
+        "samples_s": [
+          0.030715958,
+          0.030517083,
+          0.030403083
+        ]
+      },
+      "total": {
+        "min_s": 0.264230042,
+        "median_s": 0.266074,
+        "samples_s": [
+          0.266074,
+          0.264230042,
+          0.266915625
+        ]
+      },
+      "compute_s": 0.233826959,
+      "ns_per_op_min": 3567.916244506836,
+      "ns_per_op_median": 3594.31330871582,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 1924060,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040561792,
+        "median_s": 0.040910416,
+        "samples_s": [
+          0.040910416,
+          0.041057333,
+          0.040561792
+        ]
+      },
+      "total": {
+        "min_s": 0.316050959,
+        "median_s": 0.317448833,
+        "samples_s": [
+          0.318702292,
+          0.316050959,
+          0.317448833
+        ]
+      },
+      "compute_s": 0.27548916700000003,
+      "ns_per_op_min": 143.18117262455436,
+      "ns_per_op_median": 143.72650385123126,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 4827,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010608333,
+        "median_s": 0.010900458,
+        "samples_s": [
+          0.011474667,
+          0.010900458,
+          0.010608333
+        ]
+      },
+      "total": {
+        "min_s": 0.281514417,
+        "median_s": 0.281875125,
+        "samples_s": [
+          0.281875125,
+          0.286574084,
+          0.281514417
+        ]
+      },
+      "compute_s": 0.270906084,
+      "ns_per_op_min": 56123.07520198881,
+      "ns_per_op_median": 56137.283405842136,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 1243649,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002932917,
+        "median_s": 0.003210834,
+        "samples_s": [
+          0.003363708,
+          0.002932917,
+          0.003210834
+        ]
+      },
+      "total": {
+        "min_s": 0.295824083,
+        "median_s": 0.295911167,
+        "samples_s": [
+          0.295824083,
+          0.296037542,
+          0.295911167
+        ]
+      },
+      "compute_s": 0.29289116600000004,
+      "ns_per_op_min": 235.50950951594868,
+      "ns_per_op_median": 235.3560634873666,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 2849764,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.06744225,
+        "median_s": 0.067582458,
+        "samples_s": [
+          0.067582458,
+          0.06744225,
+          0.068293042
+        ]
+      },
+      "total": {
+        "min_s": 0.343984292,
+        "median_s": 0.344195875,
+        "samples_s": [
+          0.344195875,
+          0.343984292,
+          0.345324833
+        ]
+      },
+      "compute_s": 0.27654204200000004,
+      "ns_per_op_min": 97.04033105899298,
+      "ns_per_op_median": 97.06537699262114,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 192,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.013071333,
+        "median_s": 0.013131459,
+        "samples_s": [
+          0.013559625,
+          0.013131459,
+          0.013071333
+        ]
+      },
+      "total": {
+        "min_s": 3.927606375,
+        "median_s": 3.930533875,
+        "samples_s": [
+          3.930533875,
+          3.927606375,
+          3.942566542
+        ]
+      },
+      "compute_s": 3.914535042,
+      "ns_per_op_min": 20388203.34375,
+      "ns_per_op_median": 20403137.583333336,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 256,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.043857791,
+        "median_s": 0.044416959,
+        "samples_s": [
+          0.044698042,
+          0.044416959,
+          0.043857791
+        ]
+      },
+      "total": {
+        "min_s": 0.423879667,
+        "median_s": 0.425015083,
+        "samples_s": [
+          0.423879667,
+          0.425015083,
+          0.425787542
+        ]
+      },
+      "compute_s": 0.38002187600000004,
+      "ns_per_op_min": 1484460.4531250002,
+      "ns_per_op_median": 1486711.4218750002,
+      "load_ms": 0.883,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 150,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.079414958,
+        "median_s": 0.081366833,
+        "samples_s": [
+          0.079414958,
+          0.081366833,
+          0.082049334
+        ]
+      },
+      "total": {
+        "min_s": 0.299350792,
+        "median_s": 0.300992542,
+        "samples_s": [
+          0.300992542,
+          0.299350792,
+          0.301260833
+        ]
+      },
+      "compute_s": 0.219935834,
+      "ns_per_op_min": 1466238.8933333333,
+      "ns_per_op_median": 1464171.393333333,
+      "load_ms": 5.29,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 730,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0512695,
+        "median_s": 0.053150291,
+        "samples_s": [
+          0.053150291,
+          0.0512695,
+          0.053557791
+        ]
+      },
+      "total": {
+        "min_s": 0.336174542,
+        "median_s": 0.336946333,
+        "samples_s": [
+          0.336174542,
+          0.336946333,
+          0.337570333
+        ]
+      },
+      "compute_s": 0.284905042,
+      "ns_per_op_min": 390280.8794520548,
+      "ns_per_op_median": 388761.701369863,
+      "load_ms": 3.992,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 1816,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.10083525,
+        "median_s": 0.102669042,
+        "samples_s": [
+          0.102669042,
+          0.10083525,
+          0.10458125
+        ]
+      },
+      "total": {
+        "min_s": 0.433793875,
+        "median_s": 0.436651333,
+        "samples_s": [
+          0.433793875,
+          0.436651333,
+          0.442555416
+        ]
+      },
+      "compute_s": 0.332958625,
+      "ns_per_op_min": 183347.26046255507,
+      "ns_per_op_median": 183910.9531938326,
+      "load_ms": 10.659,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 944658,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005423666,
+        "median_s": 0.005502,
+        "samples_s": [
+          0.005502,
+          0.005423666,
+          0.007325375
+        ]
+      },
+      "total": {
+        "min_s": 0.28211175,
+        "median_s": 0.282414417,
+        "samples_s": [
+          0.282414417,
+          0.282921542,
+          0.28211175
+        ]
+      },
+      "compute_s": 0.276688084,
+      "ns_per_op_min": 292.89762432541727,
+      "ns_per_op_median": 293.1350996868707,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 1021749,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.008969125,
+        "median_s": 0.009366459,
+        "samples_s": [
+          0.009603958,
+          0.009366459,
+          0.008969125
+        ]
+      },
+      "total": {
+        "min_s": 0.308659458,
+        "median_s": 0.309254916,
+        "samples_s": [
+          0.309254916,
+          0.308659458,
+          0.309304333
+        ]
+      },
+      "compute_s": 0.299690333,
+      "ns_per_op_min": 293.311109675664,
+      "ns_per_op_median": 293.5050163983522,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 6225,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015368167,
+        "median_s": 0.015746417,
+        "samples_s": [
+          0.016317833,
+          0.015368167,
+          0.015746417
+        ]
+      },
+      "total": {
+        "min_s": 0.276623958,
+        "median_s": 0.2769235,
+        "samples_s": [
+          0.277821334,
+          0.276623958,
+          0.2769235
+        ]
+      },
+      "compute_s": 0.261255791,
+      "ns_per_op_min": 41968.801767068275,
+      "ns_per_op_median": 41956.15791164658,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 780907,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0048655,
+        "median_s": 0.005593791,
+        "samples_s": [
+          0.0048655,
+          0.005793167,
+          0.005593791
+        ]
+      },
+      "total": {
+        "min_s": 0.300456166,
+        "median_s": 0.300626333,
+        "samples_s": [
+          0.300456166,
+          0.301786042,
+          0.300626333
+        ]
+      },
+      "compute_s": 0.295590666,
+      "ns_per_op_min": 378.52223888375954,
+      "ns_per_op_median": 377.8075263763803,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 50512,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004475542,
+        "median_s": 0.00453525,
+        "samples_s": [
+          0.004475542,
+          0.00453525,
+          0.004858
+        ]
+      },
+      "total": {
+        "min_s": 0.258330042,
+        "median_s": 0.258632708,
+        "samples_s": [
+          0.258330042,
+          0.258825834,
+          0.258632708
+        ]
+      },
+      "compute_s": 0.2538545,
+      "ns_per_op_min": 5025.627573645866,
+      "ns_per_op_median": 5030.437480202724,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 3804,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040210583,
+        "median_s": 0.040855625,
+        "samples_s": [
+          0.040855625,
+          0.040210583,
+          0.040947166
+        ]
+      },
+      "total": {
+        "min_s": 0.340075709,
+        "median_s": 0.341063667,
+        "samples_s": [
+          0.3414975,
+          0.341063667,
+          0.340075709
+        ]
+      },
+      "compute_s": 0.299865126,
+      "ns_per_op_min": 78828.89747634069,
+      "ns_per_op_median": 78919.0436382755,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 8394,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039795,
+        "median_s": 0.040744125,
+        "samples_s": [
+          0.039795,
+          0.041458583,
+          0.040744125
+        ]
+      },
+      "total": {
+        "min_s": 0.325610792,
+        "median_s": 0.327652792,
+        "samples_s": [
+          0.32960975,
+          0.325610792,
+          0.327652792
+        ]
+      },
+      "compute_s": 0.28581579199999996,
+      "ns_per_op_min": 34050.01096020966,
+      "ns_per_op_median": 34180.20812485109,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 5636,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040459,
+        "median_s": 0.0406625,
+        "samples_s": [
+          0.041709709,
+          0.0406625,
+          0.040459
+        ]
+      },
+      "total": {
+        "min_s": 0.341656375,
+        "median_s": 0.343195917,
+        "samples_s": [
+          0.341656375,
+          0.344493791,
+          0.343195917
+        ]
+      },
+      "compute_s": 0.301197375,
+      "ns_per_op_min": 53441.69180269695,
+      "ns_per_op_median": 53678.74680624557,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 1090,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.030803625,
+        "median_s": 0.030806417,
+        "samples_s": [
+          0.0309075,
+          0.030803625,
+          0.030806417
+        ]
+      },
+      "total": {
+        "min_s": 0.323456125,
+        "median_s": 0.3242465,
+        "samples_s": [
+          0.323456125,
+          0.3242465,
+          0.329896416
+        ]
+      },
+      "compute_s": 0.2926525,
+      "ns_per_op_min": 268488.53211009176,
+      "ns_per_op_median": 269211.0853211009,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 21514,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.041717208,
+        "median_s": 0.042070041,
+        "samples_s": [
+          0.042070041,
+          0.042154584,
+          0.041717208
+        ]
+      },
+      "total": {
+        "min_s": 0.336000208,
+        "median_s": 0.336297916,
+        "samples_s": [
+          0.339056292,
+          0.336000208,
+          0.336297916
+        ]
+      },
+      "compute_s": 0.294283,
+      "ns_per_op_min": 13678.674351585014,
+      "ns_per_op_median": 13676.112066561309,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 927,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010758125,
+        "median_s": 0.011222792,
+        "samples_s": [
+          0.011656542,
+          0.011222792,
+          0.010758125
+        ]
+      },
+      "total": {
+        "min_s": 0.308977875,
+        "median_s": 0.309215125,
+        "samples_s": [
+          0.309407083,
+          0.309215125,
+          0.308977875
+        ]
+      },
+      "compute_s": 0.29821975,
+      "ns_per_op_min": 321704.15318230854,
+      "ns_per_op_median": 321458.8274002157,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 844607,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002662167,
+        "median_s": 0.003176667,
+        "samples_s": [
+          0.003176667,
+          0.003308917,
+          0.002662167
+        ]
+      },
+      "total": {
+        "min_s": 0.297750667,
+        "median_s": 0.29795125,
+        "samples_s": [
+          0.297750667,
+          0.298297334,
+          0.29795125
+        ]
+      },
+      "compute_s": 0.29508850000000003,
+      "ns_per_op_min": 349.3796523116669,
+      "ns_per_op_median": 349.00798004278914,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 444608,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.066807709,
+        "median_s": 0.067944125,
+        "samples_s": [
+          0.066807709,
+          0.068687667,
+          0.067944125
+        ]
+      },
+      "total": {
+        "min_s": 0.286043375,
+        "median_s": 0.291817625,
+        "samples_s": [
+          0.286043375,
+          0.292477,
+          0.291817625
+        ]
+      },
+      "compute_s": 0.219235666,
+      "ns_per_op_min": 493.09878814596226,
+      "ns_per_op_median": 503.53007593205706,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 18,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015030125,
+        "median_s": 0.01510875,
+        "samples_s": [
+          0.015179958,
+          0.015030125,
+          0.01510875
+        ]
+      },
+      "total": {
+        "min_s": 0.302277375,
+        "median_s": 0.302349042,
+        "samples_s": [
+          0.302277375,
+          0.302349042,
+          0.302823042
+        ]
+      },
+      "compute_s": 0.28724725,
+      "ns_per_op_min": 15958180.555555556,
+      "ns_per_op_median": 15957794.0,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 18,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.045167458,
+        "median_s": 0.045219333,
+        "samples_s": [
+          0.045167458,
+          0.045627625,
+          0.045219333
+        ]
+      },
+      "total": {
+        "min_s": 0.30756125,
+        "median_s": 0.310077459,
+        "samples_s": [
+          0.30756125,
+          0.312172709,
+          0.310077459
+        ]
+      },
+      "compute_s": 0.262393792,
+      "ns_per_op_min": 14577432.888888888,
+      "ns_per_op_median": 14714340.333333336,
+      "load_ms": 1.256,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 14,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.089042042,
+        "median_s": 0.08988425,
+        "samples_s": [
+          0.089042042,
+          0.090912166,
+          0.08988425
+        ]
+      },
+      "total": {
+        "min_s": 0.269764833,
+        "median_s": 0.270109458,
+        "samples_s": [
+          0.269764833,
+          0.274750791,
+          0.270109458
+        ]
+      },
+      "compute_s": 0.180722791,
+      "ns_per_op_min": 12908770.785714285,
+      "ns_per_op_median": 12873229.142857146,
+      "load_ms": 7.737,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 45,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.052629625,
+        "median_s": 0.053685292,
+        "samples_s": [
+          0.053685292,
+          0.053764875,
+          0.052629625
+        ]
+      },
+      "total": {
+        "min_s": 0.241716709,
+        "median_s": 0.243216458,
+        "samples_s": [
+          0.243216458,
+          0.2438515,
+          0.241716709
+        ]
+      },
+      "compute_s": 0.18908708400000002,
+      "ns_per_op_min": 4201935.200000001,
+      "ns_per_op_median": 4211803.688888889,
+      "load_ms": 4.575,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 135,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.103980333,
+        "median_s": 0.104058416,
+        "samples_s": [
+          0.104612084,
+          0.103980333,
+          0.104058416
+        ]
+      },
+      "total": {
+        "min_s": 0.36652625,
+        "median_s": 0.368530666,
+        "samples_s": [
+          0.368530666,
+          0.36652625,
+          0.372184125
+        ]
+      },
+      "compute_s": 0.262545917,
+      "ns_per_op_min": 1944784.5703703705,
+      "ns_per_op_median": 1959053.7037037038,
+      "load_ms": 10.402,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 196329993,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005551458,
+        "median_s": 0.005698208,
+        "samples_s": [
+          0.005727417,
+          0.005698208,
+          0.005551458
+        ]
+      },
+      "total": {
+        "min_s": 0.298281042,
+        "median_s": 0.301708,
+        "samples_s": [
+          0.303695958,
+          0.301708,
+          0.298281042
+        ]
+      },
+      "compute_s": 0.292729584,
+      "ns_per_op_min": 1.4910079684055202,
+      "ns_per_op_median": 1.5077155939184492,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 184581647,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0089165,
+        "median_s": 0.009427667,
+        "samples_s": [
+          0.009589834,
+          0.009427667,
+          0.0089165
+        ]
+      },
+      "total": {
+        "min_s": 0.310444209,
+        "median_s": 0.310467125,
+        "samples_s": [
+          0.310467125,
+          0.310444209,
+          0.310985667
+        ]
+      },
+      "compute_s": 0.30152770900000003,
+      "ns_per_op_min": 1.633573618508237,
+      "ns_per_op_median": 1.630928442197723,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1419129,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.016620417,
+        "median_s": 0.016774375,
+        "samples_s": [
+          0.016620417,
+          0.017006708,
+          0.016774375
+        ]
+      },
+      "total": {
+        "min_s": 0.306868375,
+        "median_s": 0.307040333,
+        "samples_s": [
+          0.306868375,
+          0.310359416,
+          0.307040333
+        ]
+      },
+      "compute_s": 0.29024795800000003,
+      "ns_per_op_min": 204.52542228366838,
+      "ns_per_op_median": 204.5381061200215,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 97459949,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005013,
+        "median_s": 0.005461209,
+        "samples_s": [
+          0.005461209,
+          0.005991083,
+          0.005013
+        ]
+      },
+      "total": {
+        "min_s": 0.298187125,
+        "median_s": 0.299752208,
+        "samples_s": [
+          0.300304584,
+          0.299752208,
+          0.298187125
+        ]
+      },
+      "compute_s": 0.293174125,
+      "ns_per_op_min": 3.0081497887917017,
+      "ns_per_op_median": 3.0196096142016247,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 11174350,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.00436575,
+        "median_s": 0.004467833,
+        "samples_s": [
+          0.004570167,
+          0.004467833,
+          0.00436575
+        ]
+      },
+      "total": {
+        "min_s": 0.234579625,
+        "median_s": 0.234791583,
+        "samples_s": [
+          0.235092459,
+          0.234791583,
+          0.234579625
+        ]
+      },
+      "compute_s": 0.230213875,
+      "ns_per_op_min": 20.601992509631433,
+      "ns_per_op_median": 20.61182529632596,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 754627,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.041246417,
+        "median_s": 0.041989584,
+        "samples_s": [
+          0.042424,
+          0.041989584,
+          0.041246417
+        ]
+      },
+      "total": {
+        "min_s": 0.349934167,
+        "median_s": 0.351007666,
+        "samples_s": [
+          0.351007666,
+          0.351695333,
+          0.349934167
+        ]
+      },
+      "compute_s": 0.30868775000000004,
+      "ns_per_op_min": 409.06003893314187,
+      "ns_per_op_median": 409.49778102294243,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 1106349,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.042166875,
+        "median_s": 0.042287958,
+        "samples_s": [
+          0.042287958,
+          0.042166875,
+          0.042511625
+        ]
+      },
+      "total": {
+        "min_s": 0.345430625,
+        "median_s": 0.345677958,
+        "samples_s": [
+          0.345430625,
+          0.346788333,
+          0.345677958
+        ]
+      },
+      "compute_s": 0.30326375,
+      "ns_per_op_min": 274.1121924456026,
+      "ns_per_op_median": 274.2263065271447,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 907314,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.041368209,
+        "median_s": 0.041438709,
+        "samples_s": [
+          0.041368209,
+          0.043470333,
+          0.041438709
+        ]
+      },
+      "total": {
+        "min_s": 0.31030275,
+        "median_s": 0.31048875,
+        "samples_s": [
+          0.311200292,
+          0.31048875,
+          0.31030275
+        ]
+      },
+      "compute_s": 0.268934541,
+      "ns_per_op_min": 296.4073529120018,
+      "ns_per_op_median": 296.53465173027195,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 329069,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.03295825,
+        "median_s": 0.033400209,
+        "samples_s": [
+          0.033951625,
+          0.033400209,
+          0.03295825
+        ]
+      },
+      "total": {
+        "min_s": 0.329671416,
+        "median_s": 0.330881292,
+        "samples_s": [
+          0.330881292,
+          0.329671416,
+          0.331887917
+        ]
+      },
+      "compute_s": 0.296713166,
+      "ns_per_op_min": 901.6746214319793,
+      "ns_per_op_median": 904.0082262382662,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 4873125,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.046528792,
+        "median_s": 0.046996541,
+        "samples_s": [
+          0.046996541,
+          0.046528792,
+          0.047129
+        ]
+      },
+      "total": {
+        "min_s": 0.325455792,
+        "median_s": 0.325711667,
+        "samples_s": [
+          0.327365417,
+          0.325711667,
+          0.325455792
+        ]
+      },
+      "compute_s": 0.27892700000000004,
+      "ns_per_op_min": 57.237809413877144,
+      "ns_per_op_median": 57.1943313582147,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 200438,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.018515375,
+        "median_s": 0.019310833,
+        "samples_s": [
+          0.018515375,
+          0.019428375,
+          0.019310833
+        ]
+      },
+      "total": {
+        "min_s": 0.31722975,
+        "median_s": 0.318322333,
+        "samples_s": [
+          0.318322333,
+          0.31722975,
+          0.319245792
+        ]
+      },
+      "compute_s": 0.298714375,
+      "ns_per_op_min": 1490.3081002604297,
+      "ns_per_op_median": 1491.7904788513156,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 118977621,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002662542,
+        "median_s": 0.003212459,
+        "samples_s": [
+          0.003212459,
+          0.003222083,
+          0.002662542
+        ]
+      },
+      "total": {
+        "min_s": 0.290740708,
+        "median_s": 0.2913585,
+        "samples_s": [
+          0.293385542,
+          0.2913585,
+          0.290740708
+        ]
+      },
+      "compute_s": 0.288078166,
+      "ns_per_op_min": 2.4212802674882865,
+      "ns_per_op_median": 2.4218507529243674,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 57318495,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.064132292,
+        "median_s": 0.064302583,
+        "samples_s": [
+          0.064302583,
+          0.064132292,
+          0.070372625
+        ]
+      },
+      "total": {
+        "min_s": 0.271266542,
+        "median_s": 0.2734035,
+        "samples_s": [
+          0.2734035,
+          0.271266542,
+          0.276895583
+        ]
+      },
+      "compute_s": 0.20713425000000002,
+      "ns_per_op_min": 3.6137419518778366,
+      "ns_per_op_median": 3.6480531632939774,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 7044,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.124557125,
+        "median_s": 0.124681083,
+        "samples_s": [
+          0.124557125,
+          0.1254295,
+          0.124681083
+        ]
+      },
+      "total": {
+        "min_s": 0.425142541,
+        "median_s": 0.426448958,
+        "samples_s": [
+          0.426448958,
+          0.426979208,
+          0.425142541
+        ]
+      },
+      "compute_s": 0.300585416,
+      "ns_per_op_min": 42672.54628052243,
+      "ns_per_op_median": 42840.41382737081,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 4104,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.281521625,
+        "median_s": 0.283834917,
+        "samples_s": [
+          0.285013875,
+          0.281521625,
+          0.283834917
+        ]
+      },
+      "total": {
+        "min_s": 0.527082791,
+        "median_s": 0.52868325,
+        "samples_s": [
+          0.52868325,
+          0.527082791,
+          0.530321167
+        ]
+      },
+      "compute_s": 0.245561166,
+      "ns_per_op_min": 59834.59210526316,
+      "ns_per_op_median": 59660.89985380118,
+      "load_ms": 1.317,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 10726,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.195512167,
+        "median_s": 0.196092209,
+        "samples_s": [
+          0.195512167,
+          0.196092209,
+          0.198961541
+        ]
+      },
+      "total": {
+        "min_s": 0.382693375,
+        "median_s": 0.383668583,
+        "samples_s": [
+          0.384577167,
+          0.382693375,
+          0.383668583
+        ]
+      },
+      "compute_s": 0.18718120800000002,
+      "ns_per_op_min": 17451.166138355402,
+      "ns_per_op_median": 17488.008017900433,
+      "load_ms": 8.123,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 12922,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.122665166,
+        "median_s": 0.123116708,
+        "samples_s": [
+          0.123116708,
+          0.123406125,
+          0.122665166
+        ]
+      },
+      "total": {
+        "min_s": 0.392021791,
+        "median_s": 0.393124833,
+        "samples_s": [
+          0.394665292,
+          0.392021791,
+          0.393124833
+        ]
+      },
+      "compute_s": 0.269356625,
+      "ns_per_op_min": 20844.809240055718,
+      "ns_per_op_median": 20895.22713202291,
+      "load_ms": 4.283,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 29151,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.1436595,
+        "median_s": 0.144963125,
+        "samples_s": [
+          0.144963125,
+          0.1436595,
+          0.144982375
+        ]
+      },
+      "total": {
+        "min_s": 0.427743167,
+        "median_s": 0.429888667,
+        "samples_s": [
+          0.429888667,
+          0.430657291,
+          0.427743167
+        ]
+      },
+      "compute_s": 0.284083667,
+      "ns_per_op_min": 9745.246029295737,
+      "ns_per_op_median": 9774.12582758739,
+      "load_ms": 10.317,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 5,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.01006625,
+        "median_s": 0.010114316999999998,
+        "samples_s": [
+          0.0102242916,
+          0.010114316999999998,
+          0.01006625
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 5,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.0140990164,
+        "median_s": 0.0141027998,
+        "samples_s": [
+          0.0142516,
+          0.0141027998,
+          0.0140990164
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 12,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.026728885416666664,
+        "median_s": 0.02681847925,
+        "samples_s": [
+          0.026728885416666664,
+          0.026912083333333336,
+          0.02681847925
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 3,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.10645775,
+        "median_s": 0.10669359699999999,
+        "samples_s": [
+          0.10686783299999998,
+          0.10645775,
+          0.10669359699999999
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 45,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.007050984199999998,
+        "median_s": 0.007083563888888889,
+        "samples_s": [
+          0.007114258244444443,
+          0.007083563888888889,
+          0.007050984199999998
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 3,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.14457155566666668,
+        "median_s": 0.14474915266666669,
+        "samples_s": [
+          0.14457155566666668,
+          0.14474915266666669,
+          0.14514723633333335
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 2,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.1968472295,
+        "median_s": 0.1975513745,
+        "samples_s": [
+          0.1985368335,
+          0.1975513745,
+          0.1968472295
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 2,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.2553601245,
+        "median_s": 0.256907812,
+        "samples_s": [
+          0.256907812,
+          0.2553601245,
+          0.25770225
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.422824083,
+        "median_s": 0.424224792,
+        "samples_s": [
+          0.42436375,
+          0.424224792,
+          0.422824083
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.628826625,
+        "median_s": 0.630089083,
+        "samples_s": [
+          0.628826625,
+          0.63079925,
+          0.630089083
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 3,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.11193144433333334,
+        "median_s": 0.11194595866666666,
+        "samples_s": [
+          0.11203779166666668,
+          0.11193144433333334,
+          0.11194595866666666
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 14,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.004545821357142857,
+        "median_s": 0.004558118999999999,
+        "samples_s": [
+          0.004558118999999999,
+          0.004545821357142857,
+          0.004582309357142857
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 3,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.13299872199999999,
+        "median_s": 0.133090556,
+        "samples_s": [
+          0.133090556,
+          0.13299872199999999,
+          0.13355766666666666
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 1.334678625,
+        "median_s": 1.337003208,
+        "samples_s": [
+          1.337003208,
+          1.341389333,
+          1.334678625
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.494649333,
+        "median_s": 0.498247958,
+        "samples_s": [
+          0.499639167,
+          0.494649333,
+          0.498247958
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": 273.39,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.921750916,
+        "median_s": 0.925157792,
+        "samples_s": [
+          0.921750916,
+          0.927168542,
+          0.925157792
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": 482.231,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 2,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.236618354,
+        "median_s": 0.2383785,
+        "samples_s": [
+          0.2383785,
+          0.2387965625,
+          0.236618354
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": 111.496,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 2,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.269678583,
+        "median_s": 0.2724284165,
+        "samples_s": [
+          0.269678583,
+          0.27301577099999996,
+          0.2724284165
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": 85.693,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 2,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.0787134165,
+        "median_s": 0.0792190415,
+        "samples_s": [
+          0.0801031245,
+          0.0792190415,
+          0.0787134165
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 2,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.087296792,
+        "median_s": 0.0874732705,
+        "samples_s": [
+          0.08763910450000001,
+          0.0874732705,
+          0.087296792
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 9.675552,
+        "median_s": 9.764507042,
+        "samples_s": [
+          9.790654417,
+          9.675552,
+          9.764507042
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.646469292,
+        "median_s": 0.6477795,
+        "samples_s": [
+          0.6477795,
+          0.646469292,
+          0.648609542
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 1.0709535,
+        "median_s": 1.094147041,
+        "samples_s": [
+          1.103376041,
+          1.094147041,
+          1.0709535
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 19.31944475,
+        "median_s": 19.339722542,
+        "samples_s": [
+          19.339722542,
+          19.346873125,
+          19.31944475
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 9.403710333,
+        "median_s": 9.496739292,
+        "samples_s": [
+          9.403710333,
+          9.525817959,
+          9.496739292
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 14.188174417,
+        "median_s": 14.247240166,
+        "samples_s": [
+          14.285966,
+          14.247240166,
+          14.188174417
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-python",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: dewasm-python runs this program correctly but at 56 s and 57 s per run (median, sqlite3_query and sqlite3_mod_query), costing roughly 9 minutes of the roughly 65 minute full suite; dewasm-python stays measured on the other app cases and the microbenchmarks"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 11.888275667,
+        "median_s": 11.916663709,
+        "samples_s": [
+          11.964983792,
+          11.888275667,
+          11.916663709
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-perl",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: dewasm-perl runs this program correctly but at 113 s and 115 s per run (median, sqlite3_query and sqlite3_mod_query), so one warmup plus the timed repetitions across both cases alone cost roughly 19 minutes of the roughly 65 minute full suite; dewasm-perl stays measured on the other app cases and the microbenchmarks"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 2,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.1724242295,
+        "median_s": 0.1728621045,
+        "samples_s": [
+          0.1728621045,
+          0.173477333,
+          0.1724242295
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 2.414475458,
+        "median_s": 2.418014417,
+        "samples_s": [
+          2.418014417,
+          2.414475458,
+          2.421545959
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-bash",
+      "status": "skipped",
+      "reason": "excluded: bash runs ~10000x slower than wasmtime on compute, so 100k SQL inserts do not finish in a practical time"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "pywasm-cpython",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: pywasm runs this program correctly (byte-identical to wasmtime under -batch) at ~17.9 ms/row: measured 358 s at 20k rows, so the 100k-row script needs roughly half an hour per sample"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "pywasm-pypy",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: pywasm runs this program correctly (byte-identical to wasmtime under -batch) at ~17.9 ms/row: measured 358 s at 20k rows, so the 100k-row script needs roughly half an hour per sample"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wardite",
+      "status": "skipped",
+      "reason": "excluded: wardite loads the sqlite3 shell but cannot execute a query, raising Wardite::EvalError (\"maybe empty or invalid stack\", convert.generated.rb:200) as soon as any SQL runs"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wardite-yjit",
+      "status": "skipped",
+      "reason": "excluded: wardite loads the sqlite3 shell but cannot execute a query, raising Wardite::EvalError (\"maybe empty or invalid stack\", convert.generated.rb:200) as soon as any SQL runs"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 2,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.086818917,
+        "median_s": 0.0868922295,
+        "samples_s": [
+          0.0868922295,
+          0.08751147949999999,
+          0.086818917
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 2,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.090944708,
+        "median_s": 0.0911288545,
+        "samples_s": [
+          0.091452146,
+          0.090944708,
+          0.0911288545
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 10.102838,
+        "median_s": 10.128892917,
+        "samples_s": [
+          10.163178333,
+          10.102838,
+          10.128892917
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.637013833,
+        "median_s": 0.639391625,
+        "samples_s": [
+          0.639391625,
+          0.637013833,
+          0.648648458
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 1.168478416,
+        "median_s": 1.188577708,
+        "samples_s": [
+          1.194833,
+          1.168478416,
+          1.188577708
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 20.342501875,
+        "median_s": 20.38973825,
+        "samples_s": [
+          20.342501875,
+          20.429248667,
+          20.38973825
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 8.357214834,
+        "median_s": 8.383313541,
+        "samples_s": [
+          8.383313541,
+          8.385958417,
+          8.357214834
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 14.673829042,
+        "median_s": 14.723788208,
+        "samples_s": [
+          14.723788208,
+          14.842363375,
+          14.673829042
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-python",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: dewasm-python runs this program correctly but at 56 s and 57 s per run (median, sqlite3_query and sqlite3_mod_query), costing roughly 9 minutes of the roughly 65 minute full suite; dewasm-python stays measured on the other app cases and the microbenchmarks"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 12.737772542,
+        "median_s": 12.751523792,
+        "samples_s": [
+          12.737772542,
+          12.854944584,
+          12.751523792
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-perl",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: dewasm-perl runs this program correctly but at 113 s and 115 s per run (median, sqlite3_query and sqlite3_mod_query), so one warmup plus the timed repetitions across both cases alone cost roughly 19 minutes of the roughly 65 minute full suite; dewasm-perl stays measured on the other app cases and the microbenchmarks"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 2,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.1269123955,
+        "median_s": 0.1275598535,
+        "samples_s": [
+          0.1275598535,
+          0.1269123955,
+          0.128469875
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 5.524801917,
+        "median_s": 5.537317917,
+        "samples_s": [
+          5.537486458,
+          5.524801917,
+          5.537317917
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-bash",
+      "status": "skipped",
+      "reason": "excluded: bash runs ~10000x slower than wasmtime on compute, so 100k SQL inserts do not finish in a practical time"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "pywasm-cpython",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: pywasm runs this program correctly (byte-identical to wasmtime under -batch) at ~17.9 ms/row: measured 358 s at 20k rows, so the 100k-row script needs roughly half an hour per sample"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "pywasm-pypy",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: pywasm runs this program correctly (byte-identical to wasmtime under -batch) at ~17.9 ms/row: measured 358 s at 20k rows, so the 100k-row script needs roughly half an hour per sample"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wardite",
+      "status": "skipped",
+      "reason": "excluded: wardite loads the sqlite3 shell but cannot execute a query, raising Wardite::EvalError (\"maybe empty or invalid stack\", convert.generated.rb:200) as soon as any SQL runs"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wardite-yjit",
+      "status": "skipped",
+      "reason": "excluded: wardite loads the sqlite3 shell but cannot execute a query, raising Wardite::EvalError (\"maybe empty or invalid stack\", convert.generated.rb:200) as soon as any SQL runs"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 5,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.0446405414,
+        "median_s": 0.045080392000000004,
+        "samples_s": [
+          0.0446405414,
+          0.045080392000000004,
+          0.045364274999999996
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 4,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.0523989895,
+        "median_s": 0.05252881225,
+        "samples_s": [
+          0.0523989895,
+          0.05252881225,
+          0.053673875
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 2.251293042,
+        "median_s": 2.252403458,
+        "samples_s": [
+          2.251293042,
+          2.254199375,
+          2.252403458
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 4,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.088147802,
+        "median_s": 0.0884193335,
+        "samples_s": [
+          0.08853785425000002,
+          0.0884193335,
+          0.088147802
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wasm3",
+      "status": "skipped",
+      "reason": "excluded: wasm3's WASI does not provide fd_tell, which minigzip's stdio imports, so the module fails before running (\"missing imported function ('wasi_snapshot_preview1.fd_tell')\")"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 5.260884541,
+        "median_s": 5.267597791,
+        "samples_s": [
+          5.260884541,
+          5.284705291,
+          5.267597791
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 1.6404762910000001,
+        "median_s": 1.646909417,
+        "samples_s": [
+          1.651820291,
+          1.646909417,
+          1.6404762910000001
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 3.361698625,
+        "median_s": 3.367559,
+        "samples_s": [
+          3.361698625,
+          3.372883375,
+          3.367559
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 15.298107583,
+        "median_s": 15.403737875000001,
+        "samples_s": [
+          15.298107583,
+          15.447568542,
+          15.403737875000001
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 2.860056958,
+        "median_s": 2.864217375,
+        "samples_s": [
+          2.860056958,
+          2.864217375,
+          2.875869958
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 24.34545425,
+        "median_s": 24.386662792,
+        "samples_s": [
+          24.34545425,
+          24.449262709,
+          24.386662792
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 5,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.0584258082,
+        "median_s": 0.0584449666,
+        "samples_s": [
+          0.05845211659999999,
+          0.0584449666,
+          0.0584258082
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.537767042,
+        "median_s": 0.572543333,
+        "samples_s": [
+          0.537767042,
+          0.572543333,
+          0.575901417
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-bash",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: bash compresses this workload's generated text at ~0.61 ms/byte (measured 30.6 s on a 50000-byte prefix), so the full 1.2 MB input needs roughly 12 minutes per run"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "pywasm-cpython",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: pywasm under CPython compresses this workload's generated text at ~0.46 ms/byte (measured 9.2 s on a 20000-byte prefix), so the full 1.2 MB input needs roughly 9 minutes per run"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 81.290406459,
+        "median_s": 81.524857208,
+        "samples_s": [
+          81.934343917,
+          81.290406459,
+          81.524857208
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": 331.68,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wardite",
+      "status": "skipped",
+      "reason": "excluded: wardite computes the correct compressed output but its driver crashes on exit (IOError: closed stream at wardite.rb:40) because minigzip closes stdout itself and wardite's fd_close closes the real fd under it, so the driver's own trailing flush fails and the process exits 1"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wardite-yjit",
+      "status": "skipped",
+      "reason": "excluded: wardite computes the correct compressed output but its driver crashes on exit (IOError: closed stream at wardite.rb:40) because minigzip closes stdout itself and wardite's fd_close closes the real fd under it, so the driver's own trailing flush fails and the process exits 1"
+    }
+  ]
+}

--- a/records/README.md
+++ b/records/README.md
@@ -15,6 +15,7 @@ A run appends its line with a `TODO`; fill it in when committing the record.
 - `2026-08-16T09-22-02Z-speed.json`: re-baseline after the issue #164 mask elision and memory-unit rework (#224 to #245).
 - `2026-08-21T02-38-15Z-speed.json`: TODO: describe the occasion.
 - `2026-08-21T03-50-04Z-speed.json`: TODO: describe the occasion.
+- `2026-08-22T06-26-23Z-speed.json`: the first record with the shortened suite and the eight new wat cases (#266); measured 29 minutes wall.
 
 ## Size records
 


### PR DESCRIPTION
Closes #265.

## What changed

- `app/sqlite3_query` and `app/sqlite3_mod_query` exclude dewasm-perl and dewasm-python, following the existing exclusion policy: cost, not capability, with the measured numbers in the reason (113 s and 56 s per run in the 2026-08-21 full record; together roughly 28 of its 65 minutes).
- The default timed repetitions drop from 5 to 3.
  Across the 219 measured pairs of that record, the spread between the fastest and slowest of the 5 samples has a median of 0.9% and a 90th percentile of 3.1%, so a median of 3 loses little.
- The progress log prints the median instead of the minimum, the same statistic the charts and results.md publish.
- Eight new wat microbenchmarks: `eh_throw`, `eh_try`, `i32_div`, `i64_div`, `conv`, `br_table`, `mem_narrow`, `f32_alu`.
  `f32_alu` mirrors `f64_alu` and prints the accumulator's bit pattern, so a backend that skips f32 re-rounding fails verification instead of reporting a fast wrong number; `eh_throw` and `eh_try` print the same number by construction, so the pair cross-checks itself.
- Microbenchmark families run and render wat before c, so the compiled cases sit next to the app cases they resemble.

A full run now takes 29 minutes wall against the previous 65, measured by the record this PR adds (records/2026-08-22T06-26-23Z-speed.json, 341 measured pairs, 37 declared exclusions); results.md and the charts are re-rendered from it.

## Validation of the new cases

Each case was built and byte-compared against wasmtime at 10000 iterations across wasmer, wasmedge, wazero, wasm3, pywasm, wardite, and all six dewasm backends (go and java included); wasmtime calibration set each iteration cap.
The exception cases were confirmed rejected by wazero 1.12, wasm3 0.5, pywasm 2.2.3 and wardite 0.9.0, and by the bash backend at conversion time; each recorded error is quoted in its exclusion reason.
Authoring surfaced two wardite defects, recorded as exclusions with minimal reproductions: f32 arithmetic is not re-rounded to single precision, and `i64.div_s` is computed at f64 precision (wrong beyond 2^53).
The division cases use divisor `(x & 0xffff) | 3` rather than `| 1` because a divisor of 1 makes pywasm die serializing a `div_u` quotient above the signed maximum; the header comments record this.

## Notes

- `docs/benchmarks/results.md` is rendered from a record, so this PR also carries the new record and the re-rendered results.md with its charts.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` and `cargo test` pass.
