### PR TITLE
Record the f32 rounding re-baseline and render the results

### DIFF
--- a/docs/benchmarks/figs/app-cowsay-dark.svg
+++ b/docs/benchmarks/figs/app-cowsay-dark.svg
@@ -1,83 +1,83 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/cowsay: seconds per run for 18 runners on a log scale, fastest first. dewasm-go is fastest at 4.56 ms, then wasm3 at 7.08 ms; dewasm-bash is slowest at 1.34 s, a span of 293x. The table below carries every number.">
-<title>app/cowsay: seconds per run for 18 runners on a log scale, fastest first. dewasm-go is fastest at 4.56 ms, then wasm3 at 7.08 ms; dewasm-bash is slowest at 1.34 s, a span of 293x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/cowsay: seconds per run for 18 runners on a log scale, fastest first. dewasm-go is fastest at 4.43 ms, then wasm3 at 7.02 ms; dewasm-bash is slowest at 1.34 s, a span of 302x. The table below carries every number.">
+<title>app/cowsay: seconds per run for 18 runners on a log scale, fastest first. dewasm-go is fastest at 4.43 ms, then wasm3 at 7.02 ms; dewasm-bash is slowest at 1.34 s, a span of 302x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ms</text>
 <line x1="343.9" y1="68.0" x2="343.9" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="343.9" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
-<line x1="519.9" y1="68.0" x2="519.9" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="519.9" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
-<line x1="695.8" y1="68.0" x2="695.8" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="695.8" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
+<line x1="519.8" y1="68.0" x2="519.8" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="519.8" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
+<line x1="695.7" y1="68.0" x2="695.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="695.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="86.0" x2="283.9" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="283.9" cy="86.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.56 ms</text>
+<line x1="168.0" y1="86.0" x2="281.7" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="281.7" cy="86.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.43 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="110.0" x2="317.6" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="317.6" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.08 ms</text>
+<line x1="168.0" y1="110.0" x2="316.8" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="316.8" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.02 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="134.0" x2="344.8" y2="134.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="344.8" cy="134.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.1 ms</text>
+<line x1="168.0" y1="134.0" x2="344.0" y2="134.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="344.0" cy="134.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.0 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="158.0" x2="370.2" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="370.2" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.1 ms</text>
+<line x1="168.0" y1="158.0" x2="368.9" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="368.9" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.9 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="182.0" x2="419.3" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="419.3" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">26.8 ms</text>
+<line x1="168.0" y1="182.0" x2="418.4" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="418.4" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">26.5 ms</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="206.0" x2="524.8" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="524.8" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="206.0" x2="524.9" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="524.9" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">107 ms</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="230.0" x2="528.5" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="528.5" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">112 ms</text>
+<line x1="168.0" y1="230.0" x2="527.6" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="527.6" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">111 ms</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="254.0" x2="541.7" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="541.7" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">133 ms</text>
+<line x1="168.0" y1="254.0" x2="540.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="540.8" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">132 ms</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="278.0" x2="548.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="548.1" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">145 ms</text>
+<line x1="168.0" y1="278.0" x2="547.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="547.6" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">144 ms</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="302.0" x2="571.9" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="571.9" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">198 ms</text>
+<line x1="168.0" y1="302.0" x2="571.4" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="571.4" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">197 ms</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="326.0" x2="586.2" y2="326.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="586.2" cy="326.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">238 ms</text>
+<line x1="168.0" y1="326.0" x2="586.8" y2="326.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="586.8" cy="326.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">240 ms</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="350.0" x2="592.0" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="592.0" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">257 ms</text>
+<line x1="168.0" y1="350.0" x2="591.0" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="591.0" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">254 ms</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="374.0" x2="596.4" y2="374.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="596.4" cy="374.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">272 ms</text>
+<line x1="168.0" y1="374.0" x2="596.8" y2="374.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="596.8" cy="374.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">274 ms</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="398.0" x2="630.3" y2="398.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="630.3" cy="398.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">424 ms</text>
+<line x1="168.0" y1="398.0" x2="628.1" y2="398.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="628.1" cy="398.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">413 ms</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="422.0" x2="642.6" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="642.6" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">498 ms</text>
+<line x1="168.0" y1="422.0" x2="642.9" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="642.9" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">501 ms</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="660.5" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="660.5" cy="446.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">630 ms</text>
+<line x1="168.0" y1="446.0" x2="659.5" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="659.5" cy="446.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">622 ms</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="470.0" x2="689.9" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="689.9" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">925 ms</text>
+<line x1="168.0" y1="470.0" x2="688.8" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="688.8" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">914 ms</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>

--- a/docs/benchmarks/figs/app-cowsay.svg
+++ b/docs/benchmarks/figs/app-cowsay.svg
@@ -1,83 +1,83 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/cowsay: seconds per run for 18 runners on a log scale, fastest first. dewasm-go is fastest at 4.56 ms, then wasm3 at 7.08 ms; dewasm-bash is slowest at 1.34 s, a span of 293x. The table below carries every number.">
-<title>app/cowsay: seconds per run for 18 runners on a log scale, fastest first. dewasm-go is fastest at 4.56 ms, then wasm3 at 7.08 ms; dewasm-bash is slowest at 1.34 s, a span of 293x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/cowsay: seconds per run for 18 runners on a log scale, fastest first. dewasm-go is fastest at 4.43 ms, then wasm3 at 7.02 ms; dewasm-bash is slowest at 1.34 s, a span of 302x. The table below carries every number.">
+<title>app/cowsay: seconds per run for 18 runners on a log scale, fastest first. dewasm-go is fastest at 4.43 ms, then wasm3 at 7.02 ms; dewasm-bash is slowest at 1.34 s, a span of 302x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ms</text>
 <line x1="343.9" y1="68.0" x2="343.9" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="343.9" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
-<line x1="519.9" y1="68.0" x2="519.9" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="519.9" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
-<line x1="695.8" y1="68.0" x2="695.8" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="695.8" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
+<line x1="519.8" y1="68.0" x2="519.8" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="519.8" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
+<line x1="695.7" y1="68.0" x2="695.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="695.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="86.0" x2="283.9" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="283.9" cy="86.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.56 ms</text>
+<line x1="168.0" y1="86.0" x2="281.7" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="281.7" cy="86.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.43 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="110.0" x2="317.6" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="317.6" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.08 ms</text>
+<line x1="168.0" y1="110.0" x2="316.8" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="316.8" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.02 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="134.0" x2="344.8" y2="134.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="344.8" cy="134.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.1 ms</text>
+<line x1="168.0" y1="134.0" x2="344.0" y2="134.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="344.0" cy="134.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.0 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="158.0" x2="370.2" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="370.2" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.1 ms</text>
+<line x1="168.0" y1="158.0" x2="368.9" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="368.9" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.9 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="182.0" x2="419.3" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="419.3" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">26.8 ms</text>
+<line x1="168.0" y1="182.0" x2="418.4" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="418.4" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">26.5 ms</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="206.0" x2="524.8" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="524.8" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="206.0" x2="524.9" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="524.9" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">107 ms</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="230.0" x2="528.5" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="528.5" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">112 ms</text>
+<line x1="168.0" y1="230.0" x2="527.6" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="527.6" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">111 ms</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="254.0" x2="541.7" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="541.7" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">133 ms</text>
+<line x1="168.0" y1="254.0" x2="540.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="540.8" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">132 ms</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="278.0" x2="548.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="548.1" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">145 ms</text>
+<line x1="168.0" y1="278.0" x2="547.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="547.6" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">144 ms</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="302.0" x2="571.9" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="571.9" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">198 ms</text>
+<line x1="168.0" y1="302.0" x2="571.4" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="571.4" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">197 ms</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="326.0" x2="586.2" y2="326.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="586.2" cy="326.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">238 ms</text>
+<line x1="168.0" y1="326.0" x2="586.8" y2="326.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="586.8" cy="326.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">240 ms</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="350.0" x2="592.0" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="592.0" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">257 ms</text>
+<line x1="168.0" y1="350.0" x2="591.0" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="591.0" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">254 ms</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="374.0" x2="596.4" y2="374.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="596.4" cy="374.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">272 ms</text>
+<line x1="168.0" y1="374.0" x2="596.8" y2="374.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="596.8" cy="374.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">274 ms</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="398.0" x2="630.3" y2="398.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="630.3" cy="398.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">424 ms</text>
+<line x1="168.0" y1="398.0" x2="628.1" y2="398.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="628.1" cy="398.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">413 ms</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="422.0" x2="642.6" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="642.6" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">498 ms</text>
+<line x1="168.0" y1="422.0" x2="642.9" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="642.9" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">501 ms</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="660.5" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="660.5" cy="446.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">630 ms</text>
+<line x1="168.0" y1="446.0" x2="659.5" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="659.5" cy="446.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">622 ms</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="470.0" x2="689.9" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="689.9" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">925 ms</text>
+<line x1="168.0" y1="470.0" x2="688.8" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="688.8" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">914 ms</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>

--- a/docs/benchmarks/figs/app-minigzip-dark.svg
+++ b/docs/benchmarks/figs/app-minigzip-dark.svg
@@ -1,54 +1,54 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="416" viewBox="0 0 820 416" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/minigzip: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 45.1 ms, then wasmer at 52.5 ms; pywasm-pypy is slowest at 81.5 s, a span of 1810x. The table below carries every number.">
-<title>app/minigzip: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 45.1 ms, then wasmer at 52.5 ms; pywasm-pypy is slowest at 81.5 s, a span of 1810x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="416" viewBox="0 0 820 416" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/minigzip: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 44.9 ms, then wasmer at 52.2 ms; pywasm-pypy is slowest at 81.4 s, a span of 1810x. The table below carries every number.">
+<title>app/minigzip: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 44.9 ms, then wasmer at 52.2 ms; pywasm-pypy is slowest at 81.4 s, a span of 1810x. The table below carries every number.</title>
 <rect width="820" height="416" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
 <line x1="308.6" y1="68.0" x2="308.6" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="308.6" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
-<line x1="449.2" y1="68.0" x2="449.2" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="449.2" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
+<line x1="449.3" y1="68.0" x2="449.3" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="449.3" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
 <line x1="589.9" y1="68.0" x2="589.9" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="589.9" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 s</text>
 <line x1="168.0" y1="386.0" x2="726.0" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="260.0" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="260.0" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">45.1 ms</text>
+<line x1="168.0" y1="86.0" x2="259.7" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="259.7" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">44.9 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="269.3" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="269.3" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">52.5 ms</text>
+<line x1="168.0" y1="110.0" x2="269.0" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="269.0" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">52.2 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="275.8" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="275.8" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">58.4 ms</text>
+<line x1="168.0" y1="134.0" x2="275.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="275.6" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">58.2 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="301.1" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="301.1" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">88.4 ms</text>
+<line x1="168.0" y1="158.0" x2="301.2" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="301.2" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">88.5 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="415.2" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="415.2" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">573 ms</text>
+<line x1="168.0" y1="182.0" x2="415.0" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="415.0" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">571 ms</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="206.0" x2="479.7" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="479.7" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.65 s</text>
+<line x1="168.0" y1="206.0" x2="479.5" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="479.5" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.64 s</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="230.0" x2="498.8" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="498.8" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.25 s</text>
+<line x1="168.0" y1="230.0" x2="499.0" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="499.0" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.26 s</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="254.0" x2="513.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="513.5" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.86 s</text>
+<line x1="168.0" y1="254.0" x2="513.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="513.6" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.87 s</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="278.0" x2="523.4" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="523.4" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.37 s</text>
+<line x1="168.0" y1="278.0" x2="523.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="523.1" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.35 s</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="302.0" x2="550.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="550.7" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="302.0" x2="550.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="550.8" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.27 s</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
 <line x1="168.0" y1="326.0" x2="616.2" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
@@ -61,7 +61,7 @@
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
 <line x1="168.0" y1="374.0" x2="718.0" y2="374.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="374.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">81.5 s</text>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">81.4 s</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">app/minigzip: seconds per run, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/app-minigzip.svg
+++ b/docs/benchmarks/figs/app-minigzip.svg
@@ -1,54 +1,54 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="416" viewBox="0 0 820 416" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/minigzip: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 45.1 ms, then wasmer at 52.5 ms; pywasm-pypy is slowest at 81.5 s, a span of 1810x. The table below carries every number.">
-<title>app/minigzip: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 45.1 ms, then wasmer at 52.5 ms; pywasm-pypy is slowest at 81.5 s, a span of 1810x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="416" viewBox="0 0 820 416" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/minigzip: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 44.9 ms, then wasmer at 52.2 ms; pywasm-pypy is slowest at 81.4 s, a span of 1810x. The table below carries every number.">
+<title>app/minigzip: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 44.9 ms, then wasmer at 52.2 ms; pywasm-pypy is slowest at 81.4 s, a span of 1810x. The table below carries every number.</title>
 <rect width="820" height="416" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
 <line x1="308.6" y1="68.0" x2="308.6" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="308.6" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
-<line x1="449.2" y1="68.0" x2="449.2" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="449.2" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
+<line x1="449.3" y1="68.0" x2="449.3" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="449.3" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
 <line x1="589.9" y1="68.0" x2="589.9" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="589.9" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">10 s</text>
 <line x1="168.0" y1="386.0" x2="726.0" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="260.0" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="260.0" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">45.1 ms</text>
+<line x1="168.0" y1="86.0" x2="259.7" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="259.7" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">44.9 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="269.3" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="269.3" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">52.5 ms</text>
+<line x1="168.0" y1="110.0" x2="269.0" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="269.0" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">52.2 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="275.8" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="275.8" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">58.4 ms</text>
+<line x1="168.0" y1="134.0" x2="275.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="275.6" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">58.2 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="301.1" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="301.1" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">88.4 ms</text>
+<line x1="168.0" y1="158.0" x2="301.2" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="301.2" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">88.5 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="415.2" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="415.2" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">573 ms</text>
+<line x1="168.0" y1="182.0" x2="415.0" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="415.0" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">571 ms</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="206.0" x2="479.7" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="479.7" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.65 s</text>
+<line x1="168.0" y1="206.0" x2="479.5" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="479.5" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.64 s</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="230.0" x2="498.8" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="498.8" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.25 s</text>
+<line x1="168.0" y1="230.0" x2="499.0" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="499.0" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.26 s</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="254.0" x2="513.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="513.5" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.86 s</text>
+<line x1="168.0" y1="254.0" x2="513.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="513.6" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.87 s</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="278.0" x2="523.4" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="523.4" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.37 s</text>
+<line x1="168.0" y1="278.0" x2="523.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="523.1" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.35 s</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="302.0" x2="550.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="550.7" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="302.0" x2="550.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="550.8" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.27 s</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
 <line x1="168.0" y1="326.0" x2="616.2" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
@@ -61,7 +61,7 @@
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
 <line x1="168.0" y1="374.0" x2="718.0" y2="374.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="374.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">81.5 s</text>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">81.4 s</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">app/minigzip: seconds per run, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/app-sqlite3-mod-query-dark.svg
+++ b/docs/benchmarks/figs/app-sqlite3-mod-query-dark.svg
@@ -1,59 +1,59 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 86.9 ms, then wasmer at 91.1 ms; dewasm-ruby is slowest at 20.4 s, a span of 235x. The table below carries every number.">
-<title>app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 86.9 ms, then wasmer at 91.1 ms; dewasm-ruby is slowest at 20.4 s, a span of 235x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 87.2 ms, then wasmer at 90.8 ms; dewasm-ruby is slowest at 20.3 s, a span of 232x. The table below carries every number.">
+<title>app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 87.2 ms, then wasmer at 90.8 ms; dewasm-ruby is slowest at 20.3 s, a span of 232x. The table below carries every number.</title>
 <rect width="820" height="368" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
-<line x1="334.2" y1="68.0" x2="334.2" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="334.2" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
-<line x1="500.4" y1="68.0" x2="500.4" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="500.4" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
-<line x1="666.6" y1="68.0" x2="666.6" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="666.6" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 s</text>
+<line x1="334.3" y1="68.0" x2="334.3" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="334.3" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
+<line x1="500.7" y1="68.0" x2="500.7" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="500.7" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
+<line x1="667.0" y1="68.0" x2="667.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="667.0" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 s</text>
 <line x1="168.0" y1="338.0" x2="726.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="324.1" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="324.1" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">86.9 ms</text>
+<line x1="168.0" y1="86.0" x2="324.4" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="324.4" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">87.2 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="327.5" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="327.5" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">91.1 ms</text>
+<line x1="168.0" y1="110.0" x2="327.4" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="327.4" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">90.8 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="351.8" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="351.8" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">128 ms</text>
+<line x1="168.0" y1="134.0" x2="351.4" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="351.4" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">127 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
 <line x1="168.0" y1="158.0" x2="468.1" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="468.1" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">639 ms</text>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">637 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="182.0" x2="512.9" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="512.9" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="182.0" x2="513.1" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="513.1" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.19 s</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="206.0" x2="623.9" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="623.9" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.54 s</text>
+<line x1="168.0" y1="206.0" x2="624.6" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="624.6" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.56 s</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="230.0" x2="653.9" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="653.9" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.38 s</text>
+<line x1="168.0" y1="230.0" x2="653.7" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="653.7" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.32 s</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="667.5" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="667.5" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="254.0" x2="667.9" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="667.9" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.1 s</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="278.0" x2="684.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="684.1" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="278.0" x2="684.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="684.6" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.8 s</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="694.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="694.5" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.7 s</text>
+<line x1="168.0" y1="302.0" x2="693.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="693.8" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.5 s</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
 <line x1="168.0" y1="326.0" x2="718.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.4 s</text>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.3 s</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">app/sqlite3_mod_query: seconds per run, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/app-sqlite3-mod-query.svg
+++ b/docs/benchmarks/figs/app-sqlite3-mod-query.svg
@@ -1,59 +1,59 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 86.9 ms, then wasmer at 91.1 ms; dewasm-ruby is slowest at 20.4 s, a span of 235x. The table below carries every number.">
-<title>app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 86.9 ms, then wasmer at 91.1 ms; dewasm-ruby is slowest at 20.4 s, a span of 235x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 87.2 ms, then wasmer at 90.8 ms; dewasm-ruby is slowest at 20.3 s, a span of 232x. The table below carries every number.">
+<title>app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 87.2 ms, then wasmer at 90.8 ms; dewasm-ruby is slowest at 20.3 s, a span of 232x. The table below carries every number.</title>
 <rect width="820" height="368" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
-<line x1="334.2" y1="68.0" x2="334.2" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="334.2" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
-<line x1="500.4" y1="68.0" x2="500.4" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="500.4" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
-<line x1="666.6" y1="68.0" x2="666.6" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="666.6" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 s</text>
+<line x1="334.3" y1="68.0" x2="334.3" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="334.3" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
+<line x1="500.7" y1="68.0" x2="500.7" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="500.7" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
+<line x1="667.0" y1="68.0" x2="667.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="667.0" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 s</text>
 <line x1="168.0" y1="338.0" x2="726.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="324.1" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="324.1" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">86.9 ms</text>
+<line x1="168.0" y1="86.0" x2="324.4" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="324.4" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">87.2 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="327.5" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="327.5" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">91.1 ms</text>
+<line x1="168.0" y1="110.0" x2="327.4" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="327.4" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">90.8 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="351.8" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="351.8" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">128 ms</text>
+<line x1="168.0" y1="134.0" x2="351.4" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="351.4" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">127 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
 <line x1="168.0" y1="158.0" x2="468.1" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="468.1" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">639 ms</text>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">637 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="182.0" x2="512.9" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="512.9" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="182.0" x2="513.1" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="513.1" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.19 s</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="206.0" x2="623.9" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="623.9" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.54 s</text>
+<line x1="168.0" y1="206.0" x2="624.6" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="624.6" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.56 s</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="230.0" x2="653.9" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="653.9" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.38 s</text>
+<line x1="168.0" y1="230.0" x2="653.7" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="653.7" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.32 s</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="667.5" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="667.5" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="254.0" x2="667.9" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="667.9" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.1 s</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="278.0" x2="684.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="684.1" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="278.0" x2="684.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="684.6" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.8 s</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="694.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="694.5" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.7 s</text>
+<line x1="168.0" y1="302.0" x2="693.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="693.8" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.5 s</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
 <line x1="168.0" y1="326.0" x2="718.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.4 s</text>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.3 s</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">app/sqlite3_mod_query: seconds per run, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/app-sqlite3-query-dark.svg
+++ b/docs/benchmarks/figs/app-sqlite3-query-dark.svg
@@ -1,59 +1,59 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 79.2 ms, then wasmer at 87.5 ms; dewasm-ruby is slowest at 19.3 s, a span of 244x. The table below carries every number.">
-<title>app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 79.2 ms, then wasmer at 87.5 ms; dewasm-ruby is slowest at 19.3 s, a span of 244x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 79.1 ms, then wasmer at 87.9 ms; dewasm-ruby is slowest at 19.2 s, a span of 243x. The table below carries every number.">
+<title>app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 79.1 ms, then wasmer at 87.9 ms; dewasm-ruby is slowest at 19.2 s, a span of 243x. The table below carries every number.</title>
 <rect width="820" height="368" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
-<line x1="335.4" y1="68.0" x2="335.4" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="335.4" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
-<line x1="502.7" y1="68.0" x2="502.7" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="502.7" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
-<line x1="670.1" y1="68.0" x2="670.1" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="670.1" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 s</text>
+<line x1="335.5" y1="68.0" x2="335.5" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="335.5" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
+<line x1="503.0" y1="68.0" x2="503.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="503.0" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
+<line x1="670.5" y1="68.0" x2="670.5" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="670.5" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 s</text>
 <line x1="168.0" y1="338.0" x2="726.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="318.4" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="318.4" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">79.2 ms</text>
+<line x1="168.0" y1="86.0" x2="318.5" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="318.5" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">79.1 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="325.6" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="325.6" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">87.5 ms</text>
+<line x1="168.0" y1="110.0" x2="326.1" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="326.1" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">87.9 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="375.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="375.1" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="134.0" x2="375.3" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="375.3" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">173 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
 <line x1="168.0" y1="158.0" x2="471.1" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="471.1" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">648 ms</text>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">645 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="182.0" x2="509.2" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="509.2" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="182.0" x2="509.5" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="509.5" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.09 s</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="206.0" x2="566.9" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="566.9" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.42 s</text>
+<line x1="168.0" y1="206.0" x2="566.5" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="566.5" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.39 s</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="230.0" x2="666.3" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="666.3" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.50 s</text>
+<line x1="168.0" y1="230.0" x2="664.7" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="664.7" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.23 s</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="668.3" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="668.3" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="254.0" x2="668.7" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="668.7" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.76 s</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="278.0" x2="682.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="682.8" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="278.0" x2="683.0" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="683.0" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">11.9 s</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="695.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="695.8" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.2 s</text>
+<line x1="168.0" y1="302.0" x2="695.3" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="695.3" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.0 s</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
 <line x1="168.0" y1="326.0" x2="718.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">19.3 s</text>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">19.2 s</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">app/sqlite3_query: seconds per run, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/app-sqlite3-query.svg
+++ b/docs/benchmarks/figs/app-sqlite3-query.svg
@@ -1,59 +1,59 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 79.2 ms, then wasmer at 87.5 ms; dewasm-ruby is slowest at 19.3 s, a span of 244x. The table below carries every number.">
-<title>app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 79.2 ms, then wasmer at 87.5 ms; dewasm-ruby is slowest at 19.3 s, a span of 244x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 79.1 ms, then wasmer at 87.9 ms; dewasm-ruby is slowest at 19.2 s, a span of 243x. The table below carries every number.">
+<title>app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 79.1 ms, then wasmer at 87.9 ms; dewasm-ruby is slowest at 19.2 s, a span of 243x. The table below carries every number.</title>
 <rect width="820" height="368" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
-<line x1="335.4" y1="68.0" x2="335.4" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="335.4" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
-<line x1="502.7" y1="68.0" x2="502.7" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="502.7" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
-<line x1="670.1" y1="68.0" x2="670.1" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="670.1" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 s</text>
+<line x1="335.5" y1="68.0" x2="335.5" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="335.5" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
+<line x1="503.0" y1="68.0" x2="503.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="503.0" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
+<line x1="670.5" y1="68.0" x2="670.5" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="670.5" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 s</text>
 <line x1="168.0" y1="338.0" x2="726.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="318.4" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="318.4" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">79.2 ms</text>
+<line x1="168.0" y1="86.0" x2="318.5" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="318.5" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">79.1 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="325.6" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="325.6" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">87.5 ms</text>
+<line x1="168.0" y1="110.0" x2="326.1" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="326.1" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">87.9 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="375.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="375.1" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="134.0" x2="375.3" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="375.3" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">173 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
 <line x1="168.0" y1="158.0" x2="471.1" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="471.1" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">648 ms</text>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">645 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="182.0" x2="509.2" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="509.2" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="182.0" x2="509.5" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="509.5" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.09 s</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="206.0" x2="566.9" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="566.9" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.42 s</text>
+<line x1="168.0" y1="206.0" x2="566.5" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="566.5" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.39 s</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="230.0" x2="666.3" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="666.3" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.50 s</text>
+<line x1="168.0" y1="230.0" x2="664.7" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="664.7" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.23 s</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="668.3" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="668.3" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="254.0" x2="668.7" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="668.7" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.76 s</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="278.0" x2="682.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="682.8" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="278.0" x2="683.0" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="683.0" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">11.9 s</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="695.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="695.8" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.2 s</text>
+<line x1="168.0" y1="302.0" x2="695.3" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="695.3" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.0 s</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
 <line x1="168.0" y1="326.0" x2="718.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">19.3 s</text>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">19.2 s</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">app/sqlite3_query: seconds per run, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/c-mandelbrot-dark.svg
+++ b/docs/benchmarks/figs/c-mandelbrot-dark.svg
@@ -1,93 +1,93 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/mandelbrot: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 96.0 ns, then wasmtime at 96.2 ns; dewasm-bash is slowest at 20.4 ms, a span of 213000x. The table below carries every number.">
-<title>c/mandelbrot: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 96.0 ns, then wasmtime at 96.2 ns; dewasm-bash is slowest at 20.4 ms, a span of 213000x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/mandelbrot: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 96.1 ns, then wasmtime at 96.4 ns; dewasm-bash is slowest at 20.1 ms, a span of 210000x. The table below carries every number.">
+<title>c/mandelbrot: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 96.1 ns, then wasmtime at 96.4 ns; dewasm-bash is slowest at 20.1 ms, a span of 210000x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
 <line x1="255.2" y1="68.0" x2="255.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="255.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="342.3" y1="68.0" x2="342.3" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="342.3" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="429.5" y1="68.0" x2="429.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="429.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="516.7" y1="68.0" x2="516.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="516.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
-<line x1="603.8" y1="68.0" x2="603.8" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="603.8" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ms</text>
-<line x1="691.0" y1="68.0" x2="691.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="691.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
+<line x1="342.5" y1="68.0" x2="342.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="342.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="429.7" y1="68.0" x2="429.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="429.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="517.0" y1="68.0" x2="517.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="517.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="604.2" y1="68.0" x2="604.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="604.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ms</text>
+<line x1="691.5" y1="68.0" x2="691.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="691.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="86.0" x2="253.6" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="253.6" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">96.0 ns</text>
+<line x1="168.0" y1="86.0" x2="253.7" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="253.7" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">96.1 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="253.7" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="253.7" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">96.2 ns</text>
+<line x1="168.0" y1="110.0" x2="253.9" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="253.9" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">96.4 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="254.0" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="254.0" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">97.1 ns</text>
+<line x1="168.0" y1="134.0" x2="254.2" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="254.2" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">97.4 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="257.9" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="257.9" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="158.0" x2="258.0" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="258.0" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">107 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="182.0" x2="268.9" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="268.9" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">144 ns</text>
+<line x1="168.0" y1="182.0" x2="268.6" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="268.6" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">142 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="206.0" x2="287.6" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="287.6" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">235 ns</text>
+<line x1="168.0" y1="206.0" x2="287.7" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="287.7" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">236 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="230.0" x2="312.4" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="312.4" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">453 ns</text>
+<line x1="168.0" y1="230.0" x2="312.7" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="312.7" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">456 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
 <line x1="168.0" y1="254.0" x2="358.9" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="358.9" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.55 µs</text>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.54 µs</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="278.0" x2="390.0" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="390.0" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="278.0" x2="390.3" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="390.3" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.53 µs</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="302.0" x2="390.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="390.8" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.59 µs</text>
+<line x1="168.0" y1="302.0" x2="391.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="391.0" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.60 µs</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="326.0" x2="393.1" y2="326.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="393.1" cy="326.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.82 µs</text>
+<line x1="168.0" y1="326.0" x2="393.4" y2="326.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="393.4" cy="326.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.83 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="350.0" x2="399.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="399.7" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.56 µs</text>
+<line x1="168.0" y1="350.0" x2="399.8" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="399.8" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.54 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="494.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="494.8" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="374.0" x2="495.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="495.1" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">56.1 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="539.7" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="539.7" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">184 µs</text>
+<line x1="168.0" y1="398.0" x2="540.9" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="540.9" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">188 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="422.0" x2="568.1" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="568.1" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">389 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="618.3" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="618.3" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.46 ms</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="470.0" x2="618.8" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="618.8" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.49 ms</text>
+<line x1="168.0" y1="422.0" x2="568.4" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="568.4" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">388 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="446.0" x2="620.6" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="620.6" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.54 ms</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="470.0" x2="634.2" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="634.2" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.20 ms</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.4 ms</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.1 ms</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">c/mandelbrot: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/c-mandelbrot.svg
+++ b/docs/benchmarks/figs/c-mandelbrot.svg
@@ -1,93 +1,93 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/mandelbrot: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 96.0 ns, then wasmtime at 96.2 ns; dewasm-bash is slowest at 20.4 ms, a span of 213000x. The table below carries every number.">
-<title>c/mandelbrot: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 96.0 ns, then wasmtime at 96.2 ns; dewasm-bash is slowest at 20.4 ms, a span of 213000x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/mandelbrot: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 96.1 ns, then wasmtime at 96.4 ns; dewasm-bash is slowest at 20.1 ms, a span of 210000x. The table below carries every number.">
+<title>c/mandelbrot: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 96.1 ns, then wasmtime at 96.4 ns; dewasm-bash is slowest at 20.1 ms, a span of 210000x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
 <line x1="255.2" y1="68.0" x2="255.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="255.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="342.3" y1="68.0" x2="342.3" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="342.3" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="429.5" y1="68.0" x2="429.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="429.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="516.7" y1="68.0" x2="516.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="516.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
-<line x1="603.8" y1="68.0" x2="603.8" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="603.8" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ms</text>
-<line x1="691.0" y1="68.0" x2="691.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="691.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
+<line x1="342.5" y1="68.0" x2="342.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="342.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="429.7" y1="68.0" x2="429.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="429.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="517.0" y1="68.0" x2="517.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="517.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="604.2" y1="68.0" x2="604.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="604.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ms</text>
+<line x1="691.5" y1="68.0" x2="691.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="691.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="86.0" x2="253.6" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="253.6" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">96.0 ns</text>
+<line x1="168.0" y1="86.0" x2="253.7" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="253.7" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">96.1 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="253.7" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="253.7" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">96.2 ns</text>
+<line x1="168.0" y1="110.0" x2="253.9" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="253.9" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">96.4 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="254.0" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="254.0" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">97.1 ns</text>
+<line x1="168.0" y1="134.0" x2="254.2" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="254.2" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">97.4 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="257.9" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="257.9" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="158.0" x2="258.0" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="258.0" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">107 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="182.0" x2="268.9" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="268.9" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">144 ns</text>
+<line x1="168.0" y1="182.0" x2="268.6" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="268.6" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">142 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="206.0" x2="287.6" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="287.6" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">235 ns</text>
+<line x1="168.0" y1="206.0" x2="287.7" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="287.7" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">236 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="230.0" x2="312.4" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="312.4" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">453 ns</text>
+<line x1="168.0" y1="230.0" x2="312.7" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="312.7" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">456 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
 <line x1="168.0" y1="254.0" x2="358.9" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="358.9" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.55 µs</text>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.54 µs</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="278.0" x2="390.0" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="390.0" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="278.0" x2="390.3" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="390.3" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.53 µs</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="302.0" x2="390.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="390.8" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.59 µs</text>
+<line x1="168.0" y1="302.0" x2="391.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="391.0" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.60 µs</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="326.0" x2="393.1" y2="326.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="393.1" cy="326.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.82 µs</text>
+<line x1="168.0" y1="326.0" x2="393.4" y2="326.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="393.4" cy="326.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.83 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="350.0" x2="399.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="399.7" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.56 µs</text>
+<line x1="168.0" y1="350.0" x2="399.8" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="399.8" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.54 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="494.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="494.8" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="374.0" x2="495.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="495.1" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">56.1 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="539.7" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="539.7" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">184 µs</text>
+<line x1="168.0" y1="398.0" x2="540.9" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="540.9" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">188 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="422.0" x2="568.1" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="568.1" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">389 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="618.3" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="618.3" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.46 ms</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="470.0" x2="618.8" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="618.8" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.49 ms</text>
+<line x1="168.0" y1="422.0" x2="568.4" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="568.4" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">388 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="446.0" x2="620.6" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="620.6" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.54 ms</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="470.0" x2="634.2" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="634.2" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.20 ms</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.4 ms</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.1 ms</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">c/mandelbrot: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/c-sha256-dark.svg
+++ b/docs/benchmarks/figs/c-sha256-dark.svg
@@ -1,87 +1,87 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/sha256: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 293 ns, then wasmer at 294 ns; dewasm-bash is slowest at 16.0 ms, a span of 54400x. The table below carries every number.">
-<title>c/sha256: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 293 ns, then wasmer at 294 ns; dewasm-bash is slowest at 16.0 ms, a span of 54400x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/sha256: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 293 ns, then wasmtime at 294 ns; dewasm-bash is slowest at 16.0 ms, a span of 54700x. The table below carries every number.">
+<title>c/sha256: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 293 ns, then wasmtime at 294 ns; dewasm-bash is slowest at 16.0 ms, a span of 54700x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
 <line x1="273.7" y1="68.0" x2="273.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="273.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="379.4" y1="68.0" x2="379.4" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="379.4" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="485.1" y1="68.0" x2="485.1" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="485.1" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
-<line x1="590.8" y1="68.0" x2="590.8" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="590.8" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ms</text>
-<line x1="696.5" y1="68.0" x2="696.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="696.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
+<line x1="379.3" y1="68.0" x2="379.3" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="379.3" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="485.0" y1="68.0" x2="485.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="485.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="590.7" y1="68.0" x2="590.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="590.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ms</text>
+<line x1="696.3" y1="68.0" x2="696.3" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="696.3" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="217.4" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="217.4" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="86.0" x2="217.4" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="217.4" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">293 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="217.4" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="217.4" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="110.0" x2="217.5" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="217.5" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">294 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="225.4" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="225.4" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">349 ns</text>
+<line x1="168.0" y1="134.0" x2="225.5" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="225.5" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">350 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="229.0" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="229.0" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">378 ns</text>
+<line x1="168.0" y1="158.0" x2="229.2" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="229.2" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">379 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="242.2" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="242.2" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">504 ns</text>
+<line x1="168.0" y1="182.0" x2="244.4" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="244.4" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">528 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
 <line x1="168.0" y1="206.0" x2="347.9" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="347.9" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.03 µs</text>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.05 µs</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="393.8" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="393.8" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.7 µs</text>
+<line x1="168.0" y1="230.0" x2="394.2" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="394.2" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.8 µs</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="435.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="435.8" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">34.2 µs</text>
+<line x1="168.0" y1="254.0" x2="435.7" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="435.7" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">34.1 µs</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
 <line x1="168.0" y1="278.0" x2="445.3" y2="278.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="445.3" cy="278.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">42.0 µs</text>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">42.2 µs</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="456.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="456.6" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">53.7 µs</text>
+<line x1="168.0" y1="302.0" x2="456.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="456.5" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">53.8 µs</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="474.3" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="474.3" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">78.9 µs</text>
+<line x1="168.0" y1="326.0" x2="474.2" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="474.2" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">79.0 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="530.6" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="530.6" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">269 µs</text>
+<line x1="168.0" y1="350.0" x2="530.9" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="530.9" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">272 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="538.7" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="538.7" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">321 µs</text>
+<line x1="168.0" y1="374.0" x2="538.6" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="538.6" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">322 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="621.7" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="621.7" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.96 ms</text>
+<line x1="168.0" y1="398.0" x2="621.0" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="621.0" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.94 ms</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="422.0" x2="656.8" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="656.8" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.21 ms</text>
+<line x1="168.0" y1="422.0" x2="656.3" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="656.3" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.18 ms</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="708.1" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="708.1" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.9 ms</text>
+<line x1="168.0" y1="446.0" x2="682.0" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="682.0" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.32 ms</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="470.0" x2="714.3" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="714.3" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.7 ms</text>
+<line x1="168.0" y1="470.0" x2="713.7" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="713.7" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.6 ms</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>

--- a/docs/benchmarks/figs/c-sha256.svg
+++ b/docs/benchmarks/figs/c-sha256.svg
@@ -1,87 +1,87 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/sha256: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 293 ns, then wasmer at 294 ns; dewasm-bash is slowest at 16.0 ms, a span of 54400x. The table below carries every number.">
-<title>c/sha256: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 293 ns, then wasmer at 294 ns; dewasm-bash is slowest at 16.0 ms, a span of 54400x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/sha256: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 293 ns, then wasmtime at 294 ns; dewasm-bash is slowest at 16.0 ms, a span of 54700x. The table below carries every number.">
+<title>c/sha256: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 293 ns, then wasmtime at 294 ns; dewasm-bash is slowest at 16.0 ms, a span of 54700x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
 <line x1="273.7" y1="68.0" x2="273.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="273.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="379.4" y1="68.0" x2="379.4" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="379.4" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="485.1" y1="68.0" x2="485.1" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="485.1" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
-<line x1="590.8" y1="68.0" x2="590.8" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="590.8" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ms</text>
-<line x1="696.5" y1="68.0" x2="696.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="696.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
+<line x1="379.3" y1="68.0" x2="379.3" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="379.3" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="485.0" y1="68.0" x2="485.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="485.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="590.7" y1="68.0" x2="590.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="590.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ms</text>
+<line x1="696.3" y1="68.0" x2="696.3" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="696.3" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="217.4" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="217.4" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="86.0" x2="217.4" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="217.4" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">293 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="217.4" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="217.4" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="110.0" x2="217.5" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="217.5" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">294 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="225.4" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="225.4" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">349 ns</text>
+<line x1="168.0" y1="134.0" x2="225.5" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="225.5" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">350 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="229.0" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="229.0" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">378 ns</text>
+<line x1="168.0" y1="158.0" x2="229.2" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="229.2" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">379 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="242.2" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="242.2" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">504 ns</text>
+<line x1="168.0" y1="182.0" x2="244.4" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="244.4" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">528 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
 <line x1="168.0" y1="206.0" x2="347.9" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="347.9" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.03 µs</text>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.05 µs</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="393.8" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="393.8" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.7 µs</text>
+<line x1="168.0" y1="230.0" x2="394.2" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="394.2" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.8 µs</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="435.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="435.8" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">34.2 µs</text>
+<line x1="168.0" y1="254.0" x2="435.7" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="435.7" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">34.1 µs</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
 <line x1="168.0" y1="278.0" x2="445.3" y2="278.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="445.3" cy="278.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">42.0 µs</text>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">42.2 µs</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="456.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="456.6" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">53.7 µs</text>
+<line x1="168.0" y1="302.0" x2="456.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="456.5" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">53.8 µs</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="474.3" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="474.3" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">78.9 µs</text>
+<line x1="168.0" y1="326.0" x2="474.2" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="474.2" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">79.0 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="530.6" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="530.6" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">269 µs</text>
+<line x1="168.0" y1="350.0" x2="530.9" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="530.9" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">272 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="538.7" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="538.7" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">321 µs</text>
+<line x1="168.0" y1="374.0" x2="538.6" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="538.6" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">322 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="621.7" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="621.7" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.96 ms</text>
+<line x1="168.0" y1="398.0" x2="621.0" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="621.0" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.94 ms</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="422.0" x2="656.8" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="656.8" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.21 ms</text>
+<line x1="168.0" y1="422.0" x2="656.3" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="656.3" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.18 ms</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="708.1" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="708.1" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.9 ms</text>
+<line x1="168.0" y1="446.0" x2="682.0" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="682.0" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.32 ms</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="470.0" x2="714.3" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="714.3" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.7 ms</text>
+<line x1="168.0" y1="470.0" x2="713.7" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="713.7" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.6 ms</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>

--- a/docs/benchmarks/figs/c-wordcount-dark.svg
+++ b/docs/benchmarks/figs/c-wordcount-dark.svg
@@ -1,89 +1,89 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/wordcount: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.51 ns, then wasmer at 1.63 ns; pywasm-cpython is slowest at 59.7 µs, a span of 39600x. The table below carries every number.">
-<title>c/wordcount: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.51 ns, then wasmer at 1.63 ns; pywasm-cpython is slowest at 59.7 µs, a span of 39600x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/wordcount: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.47 ns, then wasmer at 1.60 ns; pywasm-cpython is slowest at 60.4 µs, a span of 41000x. The table below carries every number.">
+<title>c/wordcount: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.47 ns, then wasmer at 1.60 ns; pywasm-cpython is slowest at 60.4 µs, a span of 41000x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="283.2" y1="68.0" x2="283.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="283.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="398.3" y1="68.0" x2="398.3" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="398.3" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="513.5" y1="68.0" x2="513.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="513.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="628.7" y1="68.0" x2="628.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="628.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="283.0" y1="68.0" x2="283.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="283.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="398.1" y1="68.0" x2="398.1" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="398.1" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="513.1" y1="68.0" x2="513.1" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="513.1" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="628.2" y1="68.0" x2="628.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="628.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="188.5" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="188.5" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.51 ns</text>
+<line x1="168.0" y1="86.0" x2="187.3" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="187.3" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.47 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="192.5" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="192.5" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.63 ns</text>
+<line x1="168.0" y1="110.0" x2="191.6" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="191.6" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.60 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="212.2" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="212.2" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.42 ns</text>
+<line x1="168.0" y1="134.0" x2="211.7" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="211.7" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.40 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="223.3" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="223.3" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="158.0" x2="223.1" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="223.1" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.02 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="232.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="232.7" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.65 ns</text>
+<line x1="168.0" y1="182.0" x2="228.5" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="228.5" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.35 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="319.3" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="319.3" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="206.0" x2="319.1" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="319.1" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.6 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="370.4" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="370.4" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">57.2 ns</text>
+<line x1="168.0" y1="230.0" x2="370.8" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="370.8" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">57.9 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="434.1" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="434.1" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">205 ns</text>
+<line x1="168.0" y1="254.0" x2="433.8" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="433.8" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">204 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="448.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="448.8" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">274 ns</text>
+<line x1="168.0" y1="278.0" x2="448.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="448.6" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">275 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="452.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="452.7" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">297 ns</text>
+<line x1="168.0" y1="302.0" x2="452.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="452.0" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">294 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
 <line x1="168.0" y1="326.0" x2="468.8" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="468.8" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">409 ns</text>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">411 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="508.5" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="508.5" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">904 ns</text>
+<line x1="168.0" y1="350.0" x2="508.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="508.2" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">905 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="533.5" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="533.5" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="374.0" x2="533.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="533.0" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.49 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="627.5" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="627.5" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.77 µs</text>
+<line x1="168.0" y1="398.0" x2="627.1" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="627.1" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.79 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="422.0" x2="656.6" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="656.6" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">17.5 µs</text>
+<line x1="168.0" y1="422.0" x2="652.3" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="652.3" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">16.2 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="446.0" x2="665.5" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="665.5" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.9 µs</text>
+<line x1="168.0" y1="446.0" x2="665.2" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="665.2" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">21.0 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="470.0" x2="701.4" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="701.4" cy="470.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">42.8 µs</text>
+<line x1="168.0" y1="470.0" x2="700.6" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="700.6" cy="470.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">42.6 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">59.7 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">60.4 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">c/wordcount: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/c-wordcount.svg
+++ b/docs/benchmarks/figs/c-wordcount.svg
@@ -1,89 +1,89 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/wordcount: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.51 ns, then wasmer at 1.63 ns; pywasm-cpython is slowest at 59.7 µs, a span of 39600x. The table below carries every number.">
-<title>c/wordcount: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.51 ns, then wasmer at 1.63 ns; pywasm-cpython is slowest at 59.7 µs, a span of 39600x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/wordcount: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.47 ns, then wasmer at 1.60 ns; pywasm-cpython is slowest at 60.4 µs, a span of 41000x. The table below carries every number.">
+<title>c/wordcount: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.47 ns, then wasmer at 1.60 ns; pywasm-cpython is slowest at 60.4 µs, a span of 41000x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="283.2" y1="68.0" x2="283.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="283.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="398.3" y1="68.0" x2="398.3" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="398.3" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="513.5" y1="68.0" x2="513.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="513.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="628.7" y1="68.0" x2="628.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="628.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="283.0" y1="68.0" x2="283.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="283.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="398.1" y1="68.0" x2="398.1" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="398.1" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="513.1" y1="68.0" x2="513.1" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="513.1" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="628.2" y1="68.0" x2="628.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="628.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="188.5" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="188.5" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.51 ns</text>
+<line x1="168.0" y1="86.0" x2="187.3" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="187.3" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.47 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="192.5" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="192.5" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.63 ns</text>
+<line x1="168.0" y1="110.0" x2="191.6" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="191.6" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.60 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="212.2" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="212.2" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.42 ns</text>
+<line x1="168.0" y1="134.0" x2="211.7" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="211.7" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.40 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="223.3" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="223.3" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="158.0" x2="223.1" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="223.1" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.02 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="232.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="232.7" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.65 ns</text>
+<line x1="168.0" y1="182.0" x2="228.5" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="228.5" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.35 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="319.3" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="319.3" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="206.0" x2="319.1" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="319.1" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.6 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="370.4" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="370.4" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">57.2 ns</text>
+<line x1="168.0" y1="230.0" x2="370.8" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="370.8" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">57.9 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="434.1" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="434.1" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">205 ns</text>
+<line x1="168.0" y1="254.0" x2="433.8" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="433.8" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">204 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="448.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="448.8" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">274 ns</text>
+<line x1="168.0" y1="278.0" x2="448.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="448.6" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">275 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="452.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="452.7" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">297 ns</text>
+<line x1="168.0" y1="302.0" x2="452.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="452.0" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">294 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
 <line x1="168.0" y1="326.0" x2="468.8" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="468.8" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">409 ns</text>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">411 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="508.5" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="508.5" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">904 ns</text>
+<line x1="168.0" y1="350.0" x2="508.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="508.2" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">905 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="533.5" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="533.5" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="374.0" x2="533.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="533.0" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.49 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="627.5" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="627.5" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.77 µs</text>
+<line x1="168.0" y1="398.0" x2="627.1" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="627.1" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.79 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="422.0" x2="656.6" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="656.6" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">17.5 µs</text>
+<line x1="168.0" y1="422.0" x2="652.3" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="652.3" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">16.2 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="446.0" x2="665.5" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="665.5" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.9 µs</text>
+<line x1="168.0" y1="446.0" x2="665.2" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="665.2" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">21.0 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="470.0" x2="701.4" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="701.4" cy="470.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">42.8 µs</text>
+<line x1="168.0" y1="470.0" x2="700.6" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="700.6" cy="470.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">42.6 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">59.7 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">60.4 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">c/wordcount: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-br-table-dark.svg
+++ b/docs/benchmarks/figs/wat-br-table-dark.svg
@@ -1,89 +1,89 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/br_table: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-go is fastest at 7.65 ns, then wasmer at 8.50 ns; pywasm-cpython is slowest at 51.1 µs, a span of 6690x. The table below carries every number.">
-<title>wat/br_table: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-go is fastest at 7.65 ns, then wasmer at 8.50 ns; pywasm-cpython is slowest at 51.1 µs, a span of 6690x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/br_table: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-go is fastest at 7.85 ns, then wasmtime at 8.67 ns; pywasm-cpython is slowest at 51.8 µs, a span of 6590x. The table below carries every number.">
+<title>wat/br_table: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-go is fastest at 7.85 ns, then wasmtime at 8.67 ns; pywasm-cpython is slowest at 51.8 µs, a span of 6590x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="284.8" y1="68.0" x2="284.8" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="284.8" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="401.6" y1="68.0" x2="401.6" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="401.6" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="518.4" y1="68.0" x2="518.4" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="518.4" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="635.2" y1="68.0" x2="635.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="635.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="284.7" y1="68.0" x2="284.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="284.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="401.3" y1="68.0" x2="401.3" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="401.3" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="518.0" y1="68.0" x2="518.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="518.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="634.7" y1="68.0" x2="634.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="634.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="86.0" x2="271.2" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="271.2" cy="86.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.65 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="276.6" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="276.6" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.50 ns</text>
-<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="134.0" x2="276.6" y2="134.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="276.6" cy="134.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.51 ns</text>
+<line x1="168.0" y1="86.0" x2="272.4" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="272.4" cy="86.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.85 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="110.0" x2="277.4" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="277.4" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.67 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="134.0" x2="277.5" y2="134.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="277.5" cy="134.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.68 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="278.8" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="278.8" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.88 ns</text>
+<line x1="168.0" y1="158.0" x2="279.4" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="279.4" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.01 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="283.5" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="283.5" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.74 ns</text>
+<line x1="168.0" y1="182.0" x2="285.0" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="285.0" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.1 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="333.9" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="333.9" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">26.3 ns</text>
+<line x1="168.0" y1="206.0" x2="334.6" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="334.6" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">26.8 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="377.5" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="377.5" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">62.2 ns</text>
-<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="254.0" x2="441.0" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="441.0" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">218 ns</text>
+<line x1="168.0" y1="230.0" x2="378.6" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="378.6" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">63.8 ns</text>
+<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
+<line x1="168.0" y1="254.0" x2="441.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="441.6" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">221 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="441.2" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="441.2" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">218 ns</text>
-<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="441.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="441.2" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">218 ns</text>
+<line x1="168.0" y1="278.0" x2="441.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="441.6" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">221 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
+<line x1="168.0" y1="302.0" x2="442.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="442.0" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">223 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="326.0" x2="442.2" y2="326.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="442.2" cy="326.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">222 ns</text>
+<line x1="168.0" y1="326.0" x2="442.8" y2="326.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="442.8" cy="326.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">227 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="471.4" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="471.4" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">396 ns</text>
+<line x1="168.0" y1="350.0" x2="471.9" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="471.9" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">402 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="511.6" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="511.6" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">875 ns</text>
+<line x1="168.0" y1="374.0" x2="511.9" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="511.9" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">887 ns</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="628.5" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="628.5" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.77 µs</text>
+<line x1="168.0" y1="398.0" x2="628.7" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="628.7" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.89 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
 <line x1="168.0" y1="422.0" x2="673.3" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="673.3" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">21.2 µs</text>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">21.4 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="446.0" x2="701.0" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="701.0" cy="446.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">36.6 µs</text>
+<line x1="168.0" y1="446.0" x2="701.3" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="701.3" cy="446.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">37.2 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="470.0" x2="717.7" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="717.7" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">50.8 µs</text>
+<line x1="168.0" y1="470.0" x2="717.3" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="717.3" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">51.1 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">51.1 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">51.8 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/br_table: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-br-table.svg
+++ b/docs/benchmarks/figs/wat-br-table.svg
@@ -1,89 +1,89 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/br_table: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-go is fastest at 7.65 ns, then wasmer at 8.50 ns; pywasm-cpython is slowest at 51.1 µs, a span of 6690x. The table below carries every number.">
-<title>wat/br_table: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-go is fastest at 7.65 ns, then wasmer at 8.50 ns; pywasm-cpython is slowest at 51.1 µs, a span of 6690x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/br_table: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-go is fastest at 7.85 ns, then wasmtime at 8.67 ns; pywasm-cpython is slowest at 51.8 µs, a span of 6590x. The table below carries every number.">
+<title>wat/br_table: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-go is fastest at 7.85 ns, then wasmtime at 8.67 ns; pywasm-cpython is slowest at 51.8 µs, a span of 6590x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="284.8" y1="68.0" x2="284.8" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="284.8" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="401.6" y1="68.0" x2="401.6" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="401.6" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="518.4" y1="68.0" x2="518.4" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="518.4" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="635.2" y1="68.0" x2="635.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="635.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="284.7" y1="68.0" x2="284.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="284.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="401.3" y1="68.0" x2="401.3" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="401.3" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="518.0" y1="68.0" x2="518.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="518.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="634.7" y1="68.0" x2="634.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="634.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="86.0" x2="271.2" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="271.2" cy="86.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.65 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="276.6" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="276.6" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.50 ns</text>
-<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="134.0" x2="276.6" y2="134.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="276.6" cy="134.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.51 ns</text>
+<line x1="168.0" y1="86.0" x2="272.4" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="272.4" cy="86.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.85 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="110.0" x2="277.4" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="277.4" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.67 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="134.0" x2="277.5" y2="134.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="277.5" cy="134.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.68 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="278.8" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="278.8" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.88 ns</text>
+<line x1="168.0" y1="158.0" x2="279.4" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="279.4" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.01 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="283.5" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="283.5" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.74 ns</text>
+<line x1="168.0" y1="182.0" x2="285.0" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="285.0" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.1 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="333.9" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="333.9" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">26.3 ns</text>
+<line x1="168.0" y1="206.0" x2="334.6" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="334.6" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">26.8 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="377.5" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="377.5" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">62.2 ns</text>
-<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="254.0" x2="441.0" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="441.0" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">218 ns</text>
+<line x1="168.0" y1="230.0" x2="378.6" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="378.6" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">63.8 ns</text>
+<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
+<line x1="168.0" y1="254.0" x2="441.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="441.6" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">221 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="441.2" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="441.2" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">218 ns</text>
-<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="441.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="441.2" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">218 ns</text>
+<line x1="168.0" y1="278.0" x2="441.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="441.6" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">221 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
+<line x1="168.0" y1="302.0" x2="442.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="442.0" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">223 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="326.0" x2="442.2" y2="326.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="442.2" cy="326.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">222 ns</text>
+<line x1="168.0" y1="326.0" x2="442.8" y2="326.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="442.8" cy="326.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">227 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="471.4" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="471.4" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">396 ns</text>
+<line x1="168.0" y1="350.0" x2="471.9" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="471.9" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">402 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="511.6" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="511.6" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">875 ns</text>
+<line x1="168.0" y1="374.0" x2="511.9" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="511.9" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">887 ns</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="628.5" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="628.5" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.77 µs</text>
+<line x1="168.0" y1="398.0" x2="628.7" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="628.7" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.89 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
 <line x1="168.0" y1="422.0" x2="673.3" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="673.3" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">21.2 µs</text>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">21.4 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="446.0" x2="701.0" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="701.0" cy="446.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">36.6 µs</text>
+<line x1="168.0" y1="446.0" x2="701.3" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="701.3" cy="446.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">37.2 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="470.0" x2="717.7" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="717.7" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">50.8 µs</text>
+<line x1="168.0" y1="470.0" x2="717.3" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="717.3" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">51.1 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">51.1 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">51.8 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/br_table: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-call-direct-dark.svg
+++ b/docs/benchmarks/figs/wat-call-direct-dark.svg
@@ -1,89 +1,89 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_direct: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 3.49 ns, then wasmtime at 3.49 ns; dewasm-bash is slowest at 55.6 µs, a span of 15900x. The table below carries every number.">
-<title>wat/call_direct: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 3.49 ns, then wasmtime at 3.49 ns; dewasm-bash is slowest at 55.6 µs, a span of 15900x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_direct: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 3.53 ns, then wasmtime at 3.55 ns; dewasm-bash is slowest at 56.4 µs, a span of 16000x. The table below carries every number.">
+<title>wat/call_direct: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 3.53 ns, then wasmtime at 3.55 ns; dewasm-bash is slowest at 56.4 µs, a span of 16000x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="283.9" y1="68.0" x2="283.9" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="283.9" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="399.8" y1="68.0" x2="399.8" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="399.8" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="515.7" y1="68.0" x2="515.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="515.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="631.6" y1="68.0" x2="631.6" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="631.6" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="283.8" y1="68.0" x2="283.8" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="283.8" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="399.5" y1="68.0" x2="399.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="399.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="515.3" y1="68.0" x2="515.3" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="515.3" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="631.0" y1="68.0" x2="631.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="631.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="86.0" x2="230.9" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="230.9" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.49 ns</text>
+<line x1="168.0" y1="86.0" x2="231.4" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="231.4" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.53 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="230.9" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="230.9" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.49 ns</text>
+<line x1="168.0" y1="110.0" x2="231.6" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="231.6" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.55 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="232.8" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="232.8" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.62 ns</text>
+<line x1="168.0" y1="134.0" x2="232.3" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="232.3" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.59 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="158.0" x2="239.4" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="239.4" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="158.0" x2="239.3" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="239.3" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.13 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="182.0" x2="258.2" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="258.2" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.00 ns</text>
+<line x1="168.0" y1="182.0" x2="258.9" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="258.9" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.09 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="364.3" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="364.3" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">49.4 ns</text>
+<line x1="168.0" y1="206.0" x2="365.2" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="365.2" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">50.6 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="393.8" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="393.8" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">88.7 ns</text>
+<line x1="168.0" y1="230.0" x2="394.2" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="394.2" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">90.0 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="404.1" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="404.1" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">109 ns</text>
+<line x1="168.0" y1="254.0" x2="404.3" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="404.3" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">110 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="278.0" x2="411.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="411.1" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">125 ns</text>
+<line x1="168.0" y1="278.0" x2="412.0" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="412.0" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">128 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="302.0" x2="436.3" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="436.3" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">207 ns</text>
+<line x1="168.0" y1="302.0" x2="436.9" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="436.9" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">210 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="326.0" x2="436.4" y2="326.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="436.4" cy="326.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">207 ns</text>
+<line x1="168.0" y1="326.0" x2="437.1" y2="326.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="437.1" cy="326.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">211 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="471.6" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="471.6" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">416 ns</text>
+<line x1="168.0" y1="350.0" x2="471.8" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="471.8" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">421 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="520.3" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="520.3" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.10 µs</text>
+<line x1="168.0" y1="374.0" x2="520.9" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="520.9" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.12 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="622.4" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="622.4" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.32 µs</text>
+<line x1="168.0" y1="398.0" x2="622.1" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="622.1" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.37 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="422.0" x2="636.0" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="636.0" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.9 µs</text>
+<line x1="168.0" y1="422.0" x2="630.8" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="630.8" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.95 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
 <line x1="168.0" y1="446.0" x2="661.0" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="661.0" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">17.9 µs</text>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">18.1 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="470.0" x2="711.5" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="711.5" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">48.9 µs</text>
+<line x1="168.0" y1="470.0" x2="711.6" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="711.6" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">49.7 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">55.6 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">56.4 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/call_direct: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-call-direct.svg
+++ b/docs/benchmarks/figs/wat-call-direct.svg
@@ -1,89 +1,89 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_direct: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 3.49 ns, then wasmtime at 3.49 ns; dewasm-bash is slowest at 55.6 µs, a span of 15900x. The table below carries every number.">
-<title>wat/call_direct: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 3.49 ns, then wasmtime at 3.49 ns; dewasm-bash is slowest at 55.6 µs, a span of 15900x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_direct: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 3.53 ns, then wasmtime at 3.55 ns; dewasm-bash is slowest at 56.4 µs, a span of 16000x. The table below carries every number.">
+<title>wat/call_direct: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 3.53 ns, then wasmtime at 3.55 ns; dewasm-bash is slowest at 56.4 µs, a span of 16000x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="283.9" y1="68.0" x2="283.9" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="283.9" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="399.8" y1="68.0" x2="399.8" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="399.8" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="515.7" y1="68.0" x2="515.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="515.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="631.6" y1="68.0" x2="631.6" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="631.6" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="283.8" y1="68.0" x2="283.8" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="283.8" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="399.5" y1="68.0" x2="399.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="399.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="515.3" y1="68.0" x2="515.3" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="515.3" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="631.0" y1="68.0" x2="631.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="631.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="86.0" x2="230.9" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="230.9" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.49 ns</text>
+<line x1="168.0" y1="86.0" x2="231.4" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="231.4" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.53 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="230.9" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="230.9" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.49 ns</text>
+<line x1="168.0" y1="110.0" x2="231.6" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="231.6" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.55 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="232.8" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="232.8" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.62 ns</text>
+<line x1="168.0" y1="134.0" x2="232.3" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="232.3" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.59 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="158.0" x2="239.4" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="239.4" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="158.0" x2="239.3" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="239.3" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.13 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="182.0" x2="258.2" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="258.2" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.00 ns</text>
+<line x1="168.0" y1="182.0" x2="258.9" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="258.9" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.09 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="364.3" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="364.3" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">49.4 ns</text>
+<line x1="168.0" y1="206.0" x2="365.2" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="365.2" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">50.6 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="393.8" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="393.8" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">88.7 ns</text>
+<line x1="168.0" y1="230.0" x2="394.2" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="394.2" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">90.0 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="404.1" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="404.1" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">109 ns</text>
+<line x1="168.0" y1="254.0" x2="404.3" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="404.3" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">110 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="278.0" x2="411.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="411.1" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">125 ns</text>
+<line x1="168.0" y1="278.0" x2="412.0" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="412.0" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">128 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="302.0" x2="436.3" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="436.3" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">207 ns</text>
+<line x1="168.0" y1="302.0" x2="436.9" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="436.9" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">210 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="326.0" x2="436.4" y2="326.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="436.4" cy="326.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">207 ns</text>
+<line x1="168.0" y1="326.0" x2="437.1" y2="326.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="437.1" cy="326.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">211 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="471.6" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="471.6" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">416 ns</text>
+<line x1="168.0" y1="350.0" x2="471.8" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="471.8" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">421 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="520.3" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="520.3" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.10 µs</text>
+<line x1="168.0" y1="374.0" x2="520.9" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="520.9" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.12 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="622.4" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="622.4" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.32 µs</text>
+<line x1="168.0" y1="398.0" x2="622.1" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="622.1" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.37 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="422.0" x2="636.0" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="636.0" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.9 µs</text>
+<line x1="168.0" y1="422.0" x2="630.8" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="630.8" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.95 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
 <line x1="168.0" y1="446.0" x2="661.0" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="661.0" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">17.9 µs</text>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">18.1 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="470.0" x2="711.5" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="711.5" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">48.9 µs</text>
+<line x1="168.0" y1="470.0" x2="711.6" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="711.6" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">49.7 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">55.6 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">56.4 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/call_direct: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-call-indirect-dark.svg
+++ b/docs/benchmarks/figs/wat-call-indirect-dark.svg
@@ -1,87 +1,87 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_indirect: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 10.5 ns, then wasmer at 10.5 ns; pywasm-cpython is slowest at 81.6 µs, a span of 7810x. The table below carries every number.">
-<title>wat/call_indirect: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 10.5 ns, then wasmer at 10.5 ns; pywasm-cpython is slowest at 81.6 µs, a span of 7810x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_indirect: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 10.5 ns, then wasmtime at 10.6 ns; pywasm-cpython is slowest at 82.7 µs, a span of 7860x. The table below carries every number.">
+<title>wat/call_indirect: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 10.5 ns, then wasmtime at 10.6 ns; pywasm-cpython is slowest at 82.7 µs, a span of 7860x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="308.6" y1="68.0" x2="308.6" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="308.6" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="449.2" y1="68.0" x2="449.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="449.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="589.8" y1="68.0" x2="589.8" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="589.8" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="308.4" y1="68.0" x2="308.4" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="308.4" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="448.8" y1="68.0" x2="448.8" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="448.8" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="589.2" y1="68.0" x2="589.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="589.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="170.7" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="170.7" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="86.0" x2="171.0" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="171.0" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.5 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="170.8" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="170.8" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.5 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="110.0" x2="171.5" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="171.5" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.6 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="172.7" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="172.7" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.8 ns</text>
+<line x1="168.0" y1="134.0" x2="173.2" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="173.2" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.9 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="178.0" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="178.0" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">11.8 ns</text>
+<line x1="168.0" y1="158.0" x2="178.6" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="178.6" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">11.9 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="274.0" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="274.0" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">56.8 ns</text>
+<line x1="168.0" y1="182.0" x2="274.1" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="274.1" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">57.0 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="286.0" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="286.0" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">69.0 ns</text>
+<line x1="168.0" y1="206.0" x2="286.8" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="286.8" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">70.2 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="328.6" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="328.6" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">139 ns</text>
+<line x1="168.0" y1="230.0" x2="329.2" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="329.2" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">141 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="394.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="394.6" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">409 ns</text>
+<line x1="168.0" y1="254.0" x2="395.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="395.5" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">417 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="278.0" x2="395.7" y2="278.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="395.7" cy="278.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">416 ns</text>
+<line x1="168.0" y1="278.0" x2="396.1" y2="278.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="396.1" cy="278.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">421 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="403.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="403.7" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">475 ns</text>
+<line x1="168.0" y1="302.0" x2="404.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="404.1" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">481 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
 <line x1="168.0" y1="326.0" x2="424.5" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="424.5" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">668 ns</text>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">671 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="433.8" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="433.8" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">777 ns</text>
+<line x1="168.0" y1="350.0" x2="434.4" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="434.4" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">789 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="503.7" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="503.7" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.44 µs</text>
+<line x1="168.0" y1="374.0" x2="504.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="504.1" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.48 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
 <line x1="168.0" y1="398.0" x2="611.6" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="611.6" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.3 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="422.0" x2="652.5" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="652.5" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">27.9 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="660.2" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="660.2" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">31.7 µs</text>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.4 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="422.0" x2="650.1" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="650.1" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">27.1 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
+<line x1="168.0" y1="446.0" x2="652.9" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="652.9" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">28.4 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="470.0" x2="713.2" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="713.2" cy="470.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">75.4 µs</text>
+<line x1="168.0" y1="470.0" x2="712.7" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="712.7" cy="470.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">75.8 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">81.6 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">82.7 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/call_indirect: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-call-indirect.svg
+++ b/docs/benchmarks/figs/wat-call-indirect.svg
@@ -1,87 +1,87 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_indirect: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 10.5 ns, then wasmer at 10.5 ns; pywasm-cpython is slowest at 81.6 µs, a span of 7810x. The table below carries every number.">
-<title>wat/call_indirect: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 10.5 ns, then wasmer at 10.5 ns; pywasm-cpython is slowest at 81.6 µs, a span of 7810x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_indirect: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 10.5 ns, then wasmtime at 10.6 ns; pywasm-cpython is slowest at 82.7 µs, a span of 7860x. The table below carries every number.">
+<title>wat/call_indirect: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 10.5 ns, then wasmtime at 10.6 ns; pywasm-cpython is slowest at 82.7 µs, a span of 7860x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="308.6" y1="68.0" x2="308.6" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="308.6" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="449.2" y1="68.0" x2="449.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="449.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="589.8" y1="68.0" x2="589.8" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="589.8" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="308.4" y1="68.0" x2="308.4" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="308.4" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="448.8" y1="68.0" x2="448.8" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="448.8" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="589.2" y1="68.0" x2="589.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="589.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="170.7" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="170.7" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="86.0" x2="171.0" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="171.0" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.5 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="170.8" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="170.8" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.5 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="110.0" x2="171.5" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="171.5" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.6 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="172.7" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="172.7" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.8 ns</text>
+<line x1="168.0" y1="134.0" x2="173.2" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="173.2" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.9 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="178.0" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="178.0" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">11.8 ns</text>
+<line x1="168.0" y1="158.0" x2="178.6" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="178.6" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">11.9 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="274.0" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="274.0" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">56.8 ns</text>
+<line x1="168.0" y1="182.0" x2="274.1" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="274.1" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">57.0 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="286.0" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="286.0" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">69.0 ns</text>
+<line x1="168.0" y1="206.0" x2="286.8" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="286.8" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">70.2 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="328.6" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="328.6" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">139 ns</text>
+<line x1="168.0" y1="230.0" x2="329.2" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="329.2" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">141 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="394.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="394.6" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">409 ns</text>
+<line x1="168.0" y1="254.0" x2="395.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="395.5" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">417 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="278.0" x2="395.7" y2="278.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="395.7" cy="278.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">416 ns</text>
+<line x1="168.0" y1="278.0" x2="396.1" y2="278.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="396.1" cy="278.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">421 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="403.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="403.7" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">475 ns</text>
+<line x1="168.0" y1="302.0" x2="404.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="404.1" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">481 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
 <line x1="168.0" y1="326.0" x2="424.5" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="424.5" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">668 ns</text>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">671 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="433.8" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="433.8" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">777 ns</text>
+<line x1="168.0" y1="350.0" x2="434.4" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="434.4" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">789 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="503.7" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="503.7" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.44 µs</text>
+<line x1="168.0" y1="374.0" x2="504.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="504.1" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.48 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
 <line x1="168.0" y1="398.0" x2="611.6" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="611.6" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.3 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="422.0" x2="652.5" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="652.5" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">27.9 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="660.2" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="660.2" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">31.7 µs</text>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.4 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="422.0" x2="650.1" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="650.1" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">27.1 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
+<line x1="168.0" y1="446.0" x2="652.9" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="652.9" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">28.4 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="470.0" x2="713.2" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="713.2" cy="470.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">75.4 µs</text>
+<line x1="168.0" y1="470.0" x2="712.7" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="712.7" cy="470.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">75.8 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">81.6 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">82.7 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/call_indirect: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-conv-dark.svg
+++ b/docs/benchmarks/figs/wat-conv-dark.svg
@@ -1,91 +1,91 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/conv: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 7.63 ns, then wasmtime at 7.63 ns; pywasm-pypy is slowest at 834 µs, a span of 109000x. The table below carries every number.">
-<title>wat/conv: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 7.63 ns, then wasmtime at 7.63 ns; pywasm-pypy is slowest at 834 µs, a span of 109000x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/conv: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 7.64 ns, then wasmer at 7.65 ns; pywasm-pypy is slowest at 807 µs, a span of 106000x. The table below carries every number.">
+<title>wat/conv: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 7.64 ns, then wasmer at 7.65 ns; pywasm-pypy is slowest at 807 µs, a span of 106000x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="260.9" y1="68.0" x2="260.9" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="260.9" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="353.8" y1="68.0" x2="353.8" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="353.8" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="446.7" y1="68.0" x2="446.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="446.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="539.6" y1="68.0" x2="539.6" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="539.6" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="632.4" y1="68.0" x2="632.4" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="632.4" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="261.1" y1="68.0" x2="261.1" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="261.1" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="354.2" y1="68.0" x2="354.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="354.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="447.3" y1="68.0" x2="447.3" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="447.3" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="540.5" y1="68.0" x2="540.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="540.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="633.6" y1="68.0" x2="633.6" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="633.6" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="86.0" x2="250.0" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="250.0" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.63 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="250.0" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="250.0" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.63 ns</text>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="250.2" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="250.2" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.64 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="110.0" x2="250.3" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="250.3" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.65 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="262.7" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="262.7" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.5 ns</text>
+<line x1="168.0" y1="134.0" x2="263.3" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="263.3" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.6 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="158.0" x2="284.7" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="284.7" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">18.1 ns</text>
+<line x1="168.0" y1="158.0" x2="285.6" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="285.6" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">18.3 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="182.0" x2="291.2" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="291.2" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">21.2 ns</text>
+<line x1="168.0" y1="182.0" x2="292.0" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="292.0" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">21.5 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="206.0" x2="331.0" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="331.0" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">56.9 ns</text>
+<line x1="168.0" y1="206.0" x2="331.6" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="331.6" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">57.1 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="230.0" x2="388.2" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="388.2" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">235 ns</text>
+<line x1="168.0" y1="230.0" x2="389.1" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="389.1" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">237 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="254.0" x2="392.2" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="392.2" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">259 ns</text>
+<line x1="168.0" y1="254.0" x2="392.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="392.5" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">258 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="441.0" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="441.0" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">870 ns</text>
+<line x1="168.0" y1="278.0" x2="441.9" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="441.9" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">874 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="446.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="446.0" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">983 ns</text>
+<line x1="168.0" y1="302.0" x2="447.3" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="447.3" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">999 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="459.1" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="459.1" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.36 µs</text>
+<line x1="168.0" y1="326.0" x2="460.2" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="460.2" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.37 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="460.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="460.1" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.39 µs</text>
+<line x1="168.0" y1="350.0" x2="461.5" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="461.5" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.42 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="479.2" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="479.2" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.24 µs</text>
+<line x1="168.0" y1="374.0" x2="480.3" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="480.3" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.26 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="558.1" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="558.1" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.8 µs</text>
+<line x1="168.0" y1="398.0" x2="558.7" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="558.7" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.7 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="422.0" x2="577.9" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="577.9" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">25.8 µs</text>
+<line x1="168.0" y1="422.0" x2="579.1" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="579.1" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">26.0 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="446.0" x2="632.8" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="632.8" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">101 µs</text>
+<line x1="168.0" y1="446.0" x2="634.3" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="634.3" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">102 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="470.0" x2="699.1" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="699.1" cy="470.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">522 µs</text>
+<line x1="168.0" y1="470.0" x2="700.6" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="700.6" cy="470.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">524 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">834 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">807 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/conv: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-conv.svg
+++ b/docs/benchmarks/figs/wat-conv.svg
@@ -1,91 +1,91 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/conv: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 7.63 ns, then wasmtime at 7.63 ns; pywasm-pypy is slowest at 834 µs, a span of 109000x. The table below carries every number.">
-<title>wat/conv: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 7.63 ns, then wasmtime at 7.63 ns; pywasm-pypy is slowest at 834 µs, a span of 109000x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/conv: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 7.64 ns, then wasmer at 7.65 ns; pywasm-pypy is slowest at 807 µs, a span of 106000x. The table below carries every number.">
+<title>wat/conv: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 7.64 ns, then wasmer at 7.65 ns; pywasm-pypy is slowest at 807 µs, a span of 106000x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="260.9" y1="68.0" x2="260.9" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="260.9" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="353.8" y1="68.0" x2="353.8" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="353.8" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="446.7" y1="68.0" x2="446.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="446.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="539.6" y1="68.0" x2="539.6" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="539.6" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="632.4" y1="68.0" x2="632.4" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="632.4" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="261.1" y1="68.0" x2="261.1" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="261.1" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="354.2" y1="68.0" x2="354.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="354.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="447.3" y1="68.0" x2="447.3" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="447.3" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="540.5" y1="68.0" x2="540.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="540.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="633.6" y1="68.0" x2="633.6" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="633.6" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="86.0" x2="250.0" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="250.0" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.63 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="250.0" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="250.0" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.63 ns</text>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="250.2" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="250.2" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.64 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="110.0" x2="250.3" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="250.3" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.65 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="262.7" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="262.7" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.5 ns</text>
+<line x1="168.0" y1="134.0" x2="263.3" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="263.3" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.6 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="158.0" x2="284.7" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="284.7" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">18.1 ns</text>
+<line x1="168.0" y1="158.0" x2="285.6" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="285.6" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">18.3 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="182.0" x2="291.2" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="291.2" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">21.2 ns</text>
+<line x1="168.0" y1="182.0" x2="292.0" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="292.0" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">21.5 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="206.0" x2="331.0" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="331.0" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">56.9 ns</text>
+<line x1="168.0" y1="206.0" x2="331.6" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="331.6" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">57.1 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="230.0" x2="388.2" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="388.2" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">235 ns</text>
+<line x1="168.0" y1="230.0" x2="389.1" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="389.1" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">237 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="254.0" x2="392.2" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="392.2" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">259 ns</text>
+<line x1="168.0" y1="254.0" x2="392.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="392.5" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">258 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="441.0" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="441.0" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">870 ns</text>
+<line x1="168.0" y1="278.0" x2="441.9" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="441.9" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">874 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="446.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="446.0" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">983 ns</text>
+<line x1="168.0" y1="302.0" x2="447.3" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="447.3" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">999 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="459.1" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="459.1" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.36 µs</text>
+<line x1="168.0" y1="326.0" x2="460.2" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="460.2" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.37 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="460.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="460.1" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.39 µs</text>
+<line x1="168.0" y1="350.0" x2="461.5" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="461.5" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.42 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="479.2" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="479.2" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.24 µs</text>
+<line x1="168.0" y1="374.0" x2="480.3" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="480.3" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.26 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="558.1" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="558.1" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.8 µs</text>
+<line x1="168.0" y1="398.0" x2="558.7" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="558.7" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.7 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="422.0" x2="577.9" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="577.9" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">25.8 µs</text>
+<line x1="168.0" y1="422.0" x2="579.1" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="579.1" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">26.0 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="446.0" x2="632.8" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="632.8" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">101 µs</text>
+<line x1="168.0" y1="446.0" x2="634.3" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="634.3" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">102 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="470.0" x2="699.1" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="699.1" cy="470.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">522 µs</text>
+<line x1="168.0" y1="470.0" x2="700.6" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="700.6" cy="470.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">524 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">834 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">807 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/conv: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-eh-throw-dark.svg
+++ b/docs/benchmarks/figs/wat-eh-throw-dark.svg
@@ -1,61 +1,61 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.37 ns, then wasmedge at 115 ns; wasmer is slowest at 10.3 µs, a span of 2370x. The table below carries every number.">
-<title>wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.37 ns, then wasmedge at 115 ns; wasmer is slowest at 10.3 µs, a span of 2370x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.55 ns, then wasmedge at 116 ns; wasmer is slowest at 10.4 µs, a span of 2300x. The table below carries every number.">
+<title>wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.55 ns, then wasmedge at 116 ns; wasmer is slowest at 10.4 µs, a span of 2300x. The table below carries every number.</title>
 <rect width="820" height="368" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="305.0" y1="68.0" x2="305.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="305.0" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="442.0" y1="68.0" x2="442.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="442.0" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="579.0" y1="68.0" x2="579.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="579.0" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="716.1" y1="68.0" x2="716.1" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="716.1" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="304.9" y1="68.0" x2="304.9" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="304.9" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="441.7" y1="68.0" x2="441.7" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="441.7" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="578.6" y1="68.0" x2="578.6" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="578.6" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="715.5" y1="68.0" x2="715.5" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="715.5" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
 <line x1="168.0" y1="338.0" x2="726.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="86.0" x2="255.7" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="255.7" cy="86.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.37 ns</text>
+<line x1="168.0" y1="86.0" x2="258.0" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="258.0" cy="86.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.55 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="110.0" x2="450.5" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="450.5" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">115 ns</text>
+<line x1="168.0" y1="110.0" x2="450.8" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="450.8" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">116 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="483.2" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="483.2" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">200 ns</text>
+<line x1="168.0" y1="134.0" x2="483.8" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="483.8" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">203 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="158.0" x2="489.2" y2="158.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="489.2" cy="158.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">221 ns</text>
+<line x1="168.0" y1="158.0" x2="489.8" y2="158.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="489.8" cy="158.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">225 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="182.0" x2="533.8" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="533.8" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">467 ns</text>
+<line x1="168.0" y1="182.0" x2="534.6" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="534.6" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">477 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="206.0" x2="541.7" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="541.7" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">534 ns</text>
+<line x1="168.0" y1="206.0" x2="540.9" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="540.9" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">531 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
 <line x1="168.0" y1="230.0" x2="549.7" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="549.7" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">610 ns</text>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">615 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="254.0" x2="551.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="551.6" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">631 ns</text>
+<line x1="168.0" y1="254.0" x2="551.9" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="551.9" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">638 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="278.0" x2="555.0" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="555.0" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">667 ns</text>
+<line x1="168.0" y1="278.0" x2="554.7" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="554.7" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">669 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="302.0" x2="589.4" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="589.4" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.19 µs</text>
+<line x1="168.0" y1="302.0" x2="589.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="589.2" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.20 µs</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
 <line x1="168.0" y1="326.0" x2="718.0" y2="326.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="326.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.3 µs</text>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.4 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/eh_throw: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-eh-throw.svg
+++ b/docs/benchmarks/figs/wat-eh-throw.svg
@@ -1,61 +1,61 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.37 ns, then wasmedge at 115 ns; wasmer is slowest at 10.3 µs, a span of 2370x. The table below carries every number.">
-<title>wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.37 ns, then wasmedge at 115 ns; wasmer is slowest at 10.3 µs, a span of 2370x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.55 ns, then wasmedge at 116 ns; wasmer is slowest at 10.4 µs, a span of 2300x. The table below carries every number.">
+<title>wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.55 ns, then wasmedge at 116 ns; wasmer is slowest at 10.4 µs, a span of 2300x. The table below carries every number.</title>
 <rect width="820" height="368" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="305.0" y1="68.0" x2="305.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="305.0" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="442.0" y1="68.0" x2="442.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="442.0" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="579.0" y1="68.0" x2="579.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="579.0" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="716.1" y1="68.0" x2="716.1" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="716.1" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="304.9" y1="68.0" x2="304.9" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="304.9" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="441.7" y1="68.0" x2="441.7" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="441.7" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="578.6" y1="68.0" x2="578.6" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="578.6" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="715.5" y1="68.0" x2="715.5" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="715.5" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
 <line x1="168.0" y1="338.0" x2="726.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="86.0" x2="255.7" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="255.7" cy="86.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.37 ns</text>
+<line x1="168.0" y1="86.0" x2="258.0" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="258.0" cy="86.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.55 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="110.0" x2="450.5" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="450.5" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">115 ns</text>
+<line x1="168.0" y1="110.0" x2="450.8" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="450.8" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">116 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="483.2" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="483.2" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">200 ns</text>
+<line x1="168.0" y1="134.0" x2="483.8" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="483.8" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">203 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="158.0" x2="489.2" y2="158.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="489.2" cy="158.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">221 ns</text>
+<line x1="168.0" y1="158.0" x2="489.8" y2="158.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="489.8" cy="158.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">225 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="182.0" x2="533.8" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="533.8" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">467 ns</text>
+<line x1="168.0" y1="182.0" x2="534.6" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="534.6" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">477 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="206.0" x2="541.7" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="541.7" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">534 ns</text>
+<line x1="168.0" y1="206.0" x2="540.9" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="540.9" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">531 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
 <line x1="168.0" y1="230.0" x2="549.7" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="549.7" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">610 ns</text>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">615 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="254.0" x2="551.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="551.6" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">631 ns</text>
+<line x1="168.0" y1="254.0" x2="551.9" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="551.9" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">638 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="278.0" x2="555.0" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="555.0" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">667 ns</text>
+<line x1="168.0" y1="278.0" x2="554.7" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="554.7" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">669 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="302.0" x2="589.4" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="589.4" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.19 µs</text>
+<line x1="168.0" y1="302.0" x2="589.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="589.2" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.20 µs</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
 <line x1="168.0" y1="326.0" x2="718.0" y2="326.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="326.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.3 µs</text>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.4 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/eh_throw: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-eh-try-dark.svg
+++ b/docs/benchmarks/figs/wat-eh-try-dark.svg
@@ -1,57 +1,57 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.27 ns, then dewasm-java at 1.43 ns; dewasm-perl is slowest at 515 ns, a span of 407x. The table below carries every number.">
-<title>wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.27 ns, then dewasm-java at 1.43 ns; dewasm-perl is slowest at 515 ns, a span of 407x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.27 ns, then dewasm-java at 1.44 ns; dewasm-perl is slowest at 520 ns, a span of 411x. The table below carries every number.">
+<title>wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.27 ns, then dewasm-java at 1.44 ns; dewasm-perl is slowest at 520 ns, a span of 411x. The table below carries every number.</title>
 <rect width="820" height="368" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="370.8" y1="68.0" x2="370.8" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="370.8" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="573.6" y1="68.0" x2="573.6" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="573.6" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="370.5" y1="68.0" x2="370.5" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="370.5" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="573.0" y1="68.0" x2="573.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="573.0" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
 <line x1="168.0" y1="338.0" x2="726.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
 <line x1="168.0" y1="86.0" x2="188.8" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="188.8" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.27 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="110.0" x2="199.5" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="199.5" cy="110.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.43 ns</text>
+<line x1="168.0" y1="110.0" x2="199.9" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="199.9" cy="110.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.44 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="134.0" x2="251.9" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="251.9" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.59 ns</text>
+<line x1="168.0" y1="134.0" x2="253.4" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="253.4" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.64 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="158.0" x2="258.2" y2="158.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="258.2" cy="158.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.78 ns</text>
+<line x1="168.0" y1="158.0" x2="258.3" y2="158.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="258.3" cy="158.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.79 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="182.0" x2="294.8" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="294.8" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.22 ns</text>
+<line x1="168.0" y1="182.0" x2="296.0" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="296.0" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.29 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="206.0" x2="587.4" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="587.4" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">117 ns</text>
+<line x1="168.0" y1="206.0" x2="587.8" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="587.8" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">118 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="230.0" x2="591.4" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="591.4" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="230.0" x2="590.2" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="590.2" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">122 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="254.0" x2="591.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="591.5" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">123 ns</text>
+<line x1="168.0" y1="254.0" x2="590.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="590.6" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">122 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="591.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="591.6" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="278.0" x2="591.0" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="591.0" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">123 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="302.0" x2="635.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="635.1" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">201 ns</text>
+<line x1="168.0" y1="302.0" x2="635.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="635.2" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">203 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
 <line x1="168.0" y1="326.0" x2="718.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">515 ns</text>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">520 ns</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/eh_try: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-eh-try.svg
+++ b/docs/benchmarks/figs/wat-eh-try.svg
@@ -1,57 +1,57 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.27 ns, then dewasm-java at 1.43 ns; dewasm-perl is slowest at 515 ns, a span of 407x. The table below carries every number.">
-<title>wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.27 ns, then dewasm-java at 1.43 ns; dewasm-perl is slowest at 515 ns, a span of 407x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.27 ns, then dewasm-java at 1.44 ns; dewasm-perl is slowest at 520 ns, a span of 411x. The table below carries every number.">
+<title>wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.27 ns, then dewasm-java at 1.44 ns; dewasm-perl is slowest at 520 ns, a span of 411x. The table below carries every number.</title>
 <rect width="820" height="368" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="370.8" y1="68.0" x2="370.8" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="370.8" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="573.6" y1="68.0" x2="573.6" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="573.6" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="370.5" y1="68.0" x2="370.5" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="370.5" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="573.0" y1="68.0" x2="573.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="573.0" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
 <line x1="168.0" y1="338.0" x2="726.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
 <line x1="168.0" y1="86.0" x2="188.8" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="188.8" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.27 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="110.0" x2="199.5" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="199.5" cy="110.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.43 ns</text>
+<line x1="168.0" y1="110.0" x2="199.9" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="199.9" cy="110.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.44 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="134.0" x2="251.9" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="251.9" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.59 ns</text>
+<line x1="168.0" y1="134.0" x2="253.4" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="253.4" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.64 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="158.0" x2="258.2" y2="158.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="258.2" cy="158.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.78 ns</text>
+<line x1="168.0" y1="158.0" x2="258.3" y2="158.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="258.3" cy="158.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.79 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="182.0" x2="294.8" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="294.8" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.22 ns</text>
+<line x1="168.0" y1="182.0" x2="296.0" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="296.0" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.29 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="206.0" x2="587.4" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="587.4" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">117 ns</text>
+<line x1="168.0" y1="206.0" x2="587.8" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="587.8" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">118 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="230.0" x2="591.4" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="591.4" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="230.0" x2="590.2" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="590.2" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">122 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="254.0" x2="591.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="591.5" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">123 ns</text>
+<line x1="168.0" y1="254.0" x2="590.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="590.6" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">122 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="591.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="591.6" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="278.0" x2="591.0" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="591.0" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">123 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="302.0" x2="635.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="635.1" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">201 ns</text>
+<line x1="168.0" y1="302.0" x2="635.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="635.2" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">203 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
 <line x1="168.0" y1="326.0" x2="718.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">515 ns</text>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">520 ns</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/eh_try: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-f32-alu-dark.svg
+++ b/docs/benchmarks/figs/wat-f32-alu-dark.svg
@@ -1,87 +1,87 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="488" viewBox="0 0 820 488" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f32_alu: seconds per iteration for 16 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmer at 1.00 ns; dewasm-bash is slowest at 1.21 ms, a span of 1240000x. The table below carries every number.">
-<title>wat/f32_alu: seconds per iteration for 16 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmer at 1.00 ns; dewasm-bash is slowest at 1.21 ms, a span of 1240000x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="488" viewBox="0 0 820 488" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f32_alu: seconds per iteration for 16 runners on a log scale, fastest first. wazero is fastest at 0.96 ns, then wasmtime at 1.00 ns; dewasm-bash is slowest at 1.22 ms, a span of 1270000x. The table below carries every number.">
+<title>wat/f32_alu: seconds per iteration for 16 runners on a log scale, fastest first. wazero is fastest at 0.96 ns, then wasmtime at 1.00 ns; dewasm-bash is slowest at 1.22 ms, a span of 1270000x. The table below carries every number.</title>
 <rect width="820" height="488" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">0 ns</text>
-<line x1="245.7" y1="68.0" x2="245.7" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="245.7" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
+<line x1="245.6" y1="68.0" x2="245.6" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="245.6" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
 <line x1="323.3" y1="68.0" x2="323.3" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="323.3" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="401.0" y1="68.0" x2="401.0" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="401.0" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="478.7" y1="68.0" x2="478.7" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="478.7" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="556.3" y1="68.0" x2="556.3" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="556.3" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="634.0" y1="68.0" x2="634.0" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="634.0" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
-<line x1="711.7" y1="68.0" x2="711.7" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="711.7" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ms</text>
+<line x1="400.9" y1="68.0" x2="400.9" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="400.9" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="478.5" y1="68.0" x2="478.5" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="478.5" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="556.1" y1="68.0" x2="556.1" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="556.1" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="633.8" y1="68.0" x2="633.8" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="633.8" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="711.4" y1="68.0" x2="711.4" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="711.4" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ms</text>
 <line x1="168.0" y1="458.0" x2="726.0" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="86.0" x2="244.7" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="244.7" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.97 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="245.5" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="245.5" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="86.0" x2="244.3" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="244.3" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.96 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="110.0" x2="245.6" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="245.6" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.00 ns</text>
-<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="134.0" x2="245.6" y2="134.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="245.6" cy="134.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="134.0" x2="245.6" y2="134.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="245.6" cy="134.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.00 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="158.0" x2="262.4" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="262.4" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.64 ns</text>
+<line x1="168.0" y1="158.0" x2="262.8" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="262.8" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.66 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
 <line x1="168.0" y1="182.0" x2="287.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="287.7" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.48 ns</text>
-<text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="309.9" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="309.9" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.72 ns</text>
-<text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="230.0" x2="394.3" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="394.3" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">82.0 ns</text>
-<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="254.0" x2="445.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="445.8" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">377 ns</text>
+<text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
+<line x1="168.0" y1="206.0" x2="303.5" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="303.5" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.56 ns</text>
+<text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
+<line x1="168.0" y1="230.0" x2="310.3" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="310.3" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.80 ns</text>
+<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
+<line x1="168.0" y1="254.0" x2="394.3" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="394.3" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">82.3 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="460.7" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="460.7" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">587 ns</text>
-<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="302.0" x2="465.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="465.5" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">677 ns</text>
-<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="326.0" x2="465.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="465.7" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">681 ns</text>
+<line x1="168.0" y1="278.0" x2="428.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="428.8" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">229 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
+<line x1="168.0" y1="302.0" x2="436.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="436.1" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">284 ns</text>
+<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
+<line x1="168.0" y1="326.0" x2="444.6" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="444.6" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">366 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="473.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="473.2" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">849 ns</text>
+<line x1="168.0" y1="350.0" x2="458.0" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="458.0" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">545 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
 <line x1="168.0" y1="374.0" x2="493.4" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="493.4" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.55 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="398.0" x2="551.9" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="551.9" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.78 µs</text>
+<line x1="168.0" y1="398.0" x2="549.9" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="549.9" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.32 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="422.0" x2="592.1" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="592.1" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">28.9 µs</text>
+<line x1="168.0" y1="422.0" x2="592.2" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="592.2" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">29.2 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
 <line x1="168.0" y1="446.0" x2="718.0" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="446.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.21 ms</text>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.22 ms</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/f32_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-f32-alu.svg
+++ b/docs/benchmarks/figs/wat-f32-alu.svg
@@ -1,87 +1,87 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="488" viewBox="0 0 820 488" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f32_alu: seconds per iteration for 16 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmer at 1.00 ns; dewasm-bash is slowest at 1.21 ms, a span of 1240000x. The table below carries every number.">
-<title>wat/f32_alu: seconds per iteration for 16 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmer at 1.00 ns; dewasm-bash is slowest at 1.21 ms, a span of 1240000x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="488" viewBox="0 0 820 488" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f32_alu: seconds per iteration for 16 runners on a log scale, fastest first. wazero is fastest at 0.96 ns, then wasmtime at 1.00 ns; dewasm-bash is slowest at 1.22 ms, a span of 1270000x. The table below carries every number.">
+<title>wat/f32_alu: seconds per iteration for 16 runners on a log scale, fastest first. wazero is fastest at 0.96 ns, then wasmtime at 1.00 ns; dewasm-bash is slowest at 1.22 ms, a span of 1270000x. The table below carries every number.</title>
 <rect width="820" height="488" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">0 ns</text>
-<line x1="245.7" y1="68.0" x2="245.7" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="245.7" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
+<line x1="245.6" y1="68.0" x2="245.6" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="245.6" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
 <line x1="323.3" y1="68.0" x2="323.3" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="323.3" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="401.0" y1="68.0" x2="401.0" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="401.0" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="478.7" y1="68.0" x2="478.7" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="478.7" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="556.3" y1="68.0" x2="556.3" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="556.3" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="634.0" y1="68.0" x2="634.0" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="634.0" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
-<line x1="711.7" y1="68.0" x2="711.7" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="711.7" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">1 ms</text>
+<line x1="400.9" y1="68.0" x2="400.9" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="400.9" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="478.5" y1="68.0" x2="478.5" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="478.5" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="556.1" y1="68.0" x2="556.1" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="556.1" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="633.8" y1="68.0" x2="633.8" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="633.8" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="711.4" y1="68.0" x2="711.4" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="711.4" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">1 ms</text>
 <line x1="168.0" y1="458.0" x2="726.0" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="86.0" x2="244.7" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="244.7" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.97 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="245.5" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="245.5" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="86.0" x2="244.3" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="244.3" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.96 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="110.0" x2="245.6" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="245.6" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.00 ns</text>
-<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="134.0" x2="245.6" y2="134.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="245.6" cy="134.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="134.0" x2="245.6" y2="134.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="245.6" cy="134.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.00 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="158.0" x2="262.4" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="262.4" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.64 ns</text>
+<line x1="168.0" y1="158.0" x2="262.8" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="262.8" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.66 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
 <line x1="168.0" y1="182.0" x2="287.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="287.7" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.48 ns</text>
-<text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="309.9" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="309.9" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.72 ns</text>
-<text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="230.0" x2="394.3" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="394.3" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">82.0 ns</text>
-<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="254.0" x2="445.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="445.8" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">377 ns</text>
+<text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
+<line x1="168.0" y1="206.0" x2="303.5" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="303.5" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.56 ns</text>
+<text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
+<line x1="168.0" y1="230.0" x2="310.3" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="310.3" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.80 ns</text>
+<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
+<line x1="168.0" y1="254.0" x2="394.3" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="394.3" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">82.3 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="460.7" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="460.7" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">587 ns</text>
-<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="302.0" x2="465.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="465.5" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">677 ns</text>
-<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="326.0" x2="465.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="465.7" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">681 ns</text>
+<line x1="168.0" y1="278.0" x2="428.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="428.8" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">229 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
+<line x1="168.0" y1="302.0" x2="436.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="436.1" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">284 ns</text>
+<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
+<line x1="168.0" y1="326.0" x2="444.6" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="444.6" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">366 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="473.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="473.2" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">849 ns</text>
+<line x1="168.0" y1="350.0" x2="458.0" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="458.0" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">545 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
 <line x1="168.0" y1="374.0" x2="493.4" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="493.4" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.55 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="398.0" x2="551.9" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="551.9" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.78 µs</text>
+<line x1="168.0" y1="398.0" x2="549.9" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="549.9" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.32 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="422.0" x2="592.1" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="592.1" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">28.9 µs</text>
+<line x1="168.0" y1="422.0" x2="592.2" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="592.2" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">29.2 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
 <line x1="168.0" y1="446.0" x2="718.0" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="446.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.21 ms</text>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.22 ms</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/f32_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-f64-alu-dark.svg
+++ b/docs/benchmarks/figs/wat-f64-alu-dark.svg
@@ -1,93 +1,93 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmtime at 0.97 ns; dewasm-bash is slowest at 578 µs, a span of 598000x. The table below carries every number.">
-<title>wat/f64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmtime at 0.97 ns; dewasm-bash is slowest at 578 µs, a span of 598000x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmtime at 0.98 ns; dewasm-bash is slowest at 582 µs, a span of 599000x. The table below carries every number.">
+<title>wat/f64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmtime at 0.98 ns; dewasm-bash is slowest at 582 µs, a span of 599000x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">0 ns</text>
 <line x1="249.3" y1="68.0" x2="249.3" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="249.3" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="330.7" y1="68.0" x2="330.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="330.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="412.0" y1="68.0" x2="412.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="412.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="493.4" y1="68.0" x2="493.4" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="493.4" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="574.7" y1="68.0" x2="574.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="574.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="656.0" y1="68.0" x2="656.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="656.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="330.6" y1="68.0" x2="330.6" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="330.6" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="411.9" y1="68.0" x2="411.9" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="411.9" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="493.2" y1="68.0" x2="493.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="493.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="574.5" y1="68.0" x2="574.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="574.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="655.8" y1="68.0" x2="655.8" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="655.8" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="86.0" x2="248.1" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="248.1" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="86.0" x2="248.3" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="248.3" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.97 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="248.4" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="248.4" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.97 ns</text>
+<line x1="168.0" y1="110.0" x2="248.5" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="248.5" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.98 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
 <line x1="168.0" y1="134.0" x2="248.6" y2="134.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="248.6" cy="134.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.98 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="158.0" x2="266.6" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="266.6" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.63 ns</text>
+<line x1="168.0" y1="158.0" x2="266.7" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="266.7" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.64 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="182.0" x2="276.4" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="276.4" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.15 ns</text>
+<line x1="168.0" y1="182.0" x2="276.6" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="276.6" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.17 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="206.0" x2="293.8" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="293.8" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="206.0" x2="293.7" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="293.7" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.52 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="230.0" x2="309.0" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="309.0" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.42 ns</text>
+<line x1="168.0" y1="230.0" x2="309.1" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="309.1" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.44 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="402.4" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="402.4" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">76.2 ns</text>
+<line x1="168.0" y1="254.0" x2="402.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="402.6" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">76.8 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
 <line x1="168.0" y1="278.0" x2="404.9" y2="278.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="404.9" cy="278.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">81.7 ns</text>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">82.1 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="405.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="405.2" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">82.5 ns</text>
+<line x1="168.0" y1="302.0" x2="405.4" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="405.4" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">83.1 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="412.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="412.7" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="326.0" x2="412.8" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="412.8" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">102 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="426.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="426.7" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">152 ns</text>
+<line x1="168.0" y1="350.0" x2="426.9" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="426.9" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">153 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
 <line x1="168.0" y1="374.0" x2="486.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="486.8" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">831 ns</text>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">835 ns</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="538.1" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="538.1" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.55 µs</text>
+<line x1="168.0" y1="398.0" x2="538.3" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="538.3" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.59 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="422.0" x2="558.5" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="558.5" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.32 µs</text>
+<line x1="168.0" y1="422.0" x2="562.9" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="562.9" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.21 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
 <line x1="168.0" y1="446.0" x2="565.4" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="565.4" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.68 µs</text>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.73 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
 <line x1="168.0" y1="470.0" x2="612.8" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="612.8" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">29.4 µs</text>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">29.6 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">578 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">582 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/f64_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-f64-alu.svg
+++ b/docs/benchmarks/figs/wat-f64-alu.svg
@@ -1,93 +1,93 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmtime at 0.97 ns; dewasm-bash is slowest at 578 µs, a span of 598000x. The table below carries every number.">
-<title>wat/f64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmtime at 0.97 ns; dewasm-bash is slowest at 578 µs, a span of 598000x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmtime at 0.98 ns; dewasm-bash is slowest at 582 µs, a span of 599000x. The table below carries every number.">
+<title>wat/f64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmtime at 0.98 ns; dewasm-bash is slowest at 582 µs, a span of 599000x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">0 ns</text>
 <line x1="249.3" y1="68.0" x2="249.3" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="249.3" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="330.7" y1="68.0" x2="330.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="330.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="412.0" y1="68.0" x2="412.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="412.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="493.4" y1="68.0" x2="493.4" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="493.4" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="574.7" y1="68.0" x2="574.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="574.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="656.0" y1="68.0" x2="656.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="656.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="330.6" y1="68.0" x2="330.6" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="330.6" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="411.9" y1="68.0" x2="411.9" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="411.9" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="493.2" y1="68.0" x2="493.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="493.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="574.5" y1="68.0" x2="574.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="574.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="655.8" y1="68.0" x2="655.8" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="655.8" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="86.0" x2="248.1" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="248.1" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="86.0" x2="248.3" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="248.3" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.97 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="248.4" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="248.4" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.97 ns</text>
+<line x1="168.0" y1="110.0" x2="248.5" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="248.5" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.98 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
 <line x1="168.0" y1="134.0" x2="248.6" y2="134.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="248.6" cy="134.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.98 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="158.0" x2="266.6" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="266.6" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.63 ns</text>
+<line x1="168.0" y1="158.0" x2="266.7" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="266.7" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.64 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="182.0" x2="276.4" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="276.4" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.15 ns</text>
+<line x1="168.0" y1="182.0" x2="276.6" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="276.6" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.17 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="206.0" x2="293.8" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="293.8" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="206.0" x2="293.7" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="293.7" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.52 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="230.0" x2="309.0" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="309.0" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.42 ns</text>
+<line x1="168.0" y1="230.0" x2="309.1" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="309.1" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.44 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="402.4" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="402.4" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">76.2 ns</text>
+<line x1="168.0" y1="254.0" x2="402.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="402.6" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">76.8 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
 <line x1="168.0" y1="278.0" x2="404.9" y2="278.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="404.9" cy="278.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">81.7 ns</text>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">82.1 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="405.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="405.2" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">82.5 ns</text>
+<line x1="168.0" y1="302.0" x2="405.4" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="405.4" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">83.1 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="412.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="412.7" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="326.0" x2="412.8" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="412.8" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">102 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="426.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="426.7" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">152 ns</text>
+<line x1="168.0" y1="350.0" x2="426.9" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="426.9" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">153 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
 <line x1="168.0" y1="374.0" x2="486.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="486.8" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">831 ns</text>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">835 ns</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="538.1" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="538.1" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.55 µs</text>
+<line x1="168.0" y1="398.0" x2="538.3" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="538.3" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.59 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="422.0" x2="558.5" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="558.5" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.32 µs</text>
+<line x1="168.0" y1="422.0" x2="562.9" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="562.9" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.21 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
 <line x1="168.0" y1="446.0" x2="565.4" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="565.4" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.68 µs</text>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.73 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
 <line x1="168.0" y1="470.0" x2="612.8" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="612.8" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">29.4 µs</text>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">29.6 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">578 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">582 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/f64_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i32-alu-dark.svg
+++ b/docs/benchmarks/figs/wat-i32-alu-dark.svg
@@ -1,29 +1,29 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.32 ns, then wasmtime at 2.32 ns; pywasm-cpython is slowest at 54.1 µs, a span of 23300x. The table below carries every number.">
-<title>wat/i32_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.32 ns, then wasmtime at 2.32 ns; pywasm-cpython is slowest at 54.1 µs, a span of 23300x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 2.31 ns, then wasmer at 2.32 ns; pywasm-cpython is slowest at 54.3 µs, a span of 23500x. The table below carries every number.">
+<title>wat/i32_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 2.31 ns, then wasmer at 2.32 ns; pywasm-cpython is slowest at 54.3 µs, a span of 23500x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
 <line x1="284.2" y1="68.0" x2="284.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="284.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="400.4" y1="68.0" x2="400.4" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="400.4" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="516.6" y1="68.0" x2="516.6" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="516.6" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="632.8" y1="68.0" x2="632.8" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="632.8" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="400.3" y1="68.0" x2="400.3" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="400.3" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="516.5" y1="68.0" x2="516.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="516.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="632.7" y1="68.0" x2="632.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="632.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="86.0" x2="210.5" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="210.5" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.32 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="210.5" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="210.5" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="210.2" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="210.2" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.31 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="110.0" x2="210.5" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="210.5" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.32 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="211.5" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="211.5" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.37 ns</text>
+<line x1="168.0" y1="134.0" x2="210.9" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="210.9" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.34 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
 <line x1="168.0" y1="158.0" x2="217.5" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="217.5" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
@@ -31,59 +31,59 @@
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
 <line x1="168.0" y1="182.0" x2="224.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="224.7" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.07 ns</text>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.08 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
 <line x1="168.0" y1="206.0" x2="282.3" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="282.3" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.64 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="230.0" x2="297.4" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="297.4" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.0 ns</text>
+<line x1="168.0" y1="230.0" x2="297.8" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="297.8" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.1 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="416.9" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="416.9" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">139 ns</text>
+<line x1="168.0" y1="254.0" x2="417.2" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="417.2" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">140 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="278.0" x2="420.9" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="420.9" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">150 ns</text>
+<line x1="168.0" y1="278.0" x2="421.4" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="421.4" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">152 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="302.0" x2="423.3" y2="302.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="423.3" cy="302.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">157 ns</text>
+<line x1="168.0" y1="302.0" x2="423.6" y2="302.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="423.6" cy="302.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">158 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="430.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="430.7" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">182 ns</text>
+<line x1="168.0" y1="326.0" x2="431.6" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="431.6" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">186 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
 <line x1="168.0" y1="350.0" x2="487.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="487.7" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">564 ns</text>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">566 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="498.2" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="498.2" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">694 ns</text>
+<line x1="168.0" y1="374.0" x2="498.3" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="498.3" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">697 ns</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="615.4" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="615.4" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.09 µs</text>
+<line x1="168.0" y1="398.0" x2="616.0" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="616.0" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.18 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="422.0" x2="654.4" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="654.4" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="422.0" x2="654.2" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="654.2" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.3 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
 <line x1="168.0" y1="446.0" x2="679.5" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="679.5" cy="446.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">25.2 µs</text>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">25.3 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="470.0" x2="680.3" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="680.3" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">25.6 µs</text>
+<line x1="168.0" y1="470.0" x2="685.1" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="685.1" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">28.3 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">54.1 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">54.3 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/i32_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i32-alu.svg
+++ b/docs/benchmarks/figs/wat-i32-alu.svg
@@ -1,29 +1,29 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.32 ns, then wasmtime at 2.32 ns; pywasm-cpython is slowest at 54.1 µs, a span of 23300x. The table below carries every number.">
-<title>wat/i32_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.32 ns, then wasmtime at 2.32 ns; pywasm-cpython is slowest at 54.1 µs, a span of 23300x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 2.31 ns, then wasmer at 2.32 ns; pywasm-cpython is slowest at 54.3 µs, a span of 23500x. The table below carries every number.">
+<title>wat/i32_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 2.31 ns, then wasmer at 2.32 ns; pywasm-cpython is slowest at 54.3 µs, a span of 23500x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
 <line x1="284.2" y1="68.0" x2="284.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="284.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="400.4" y1="68.0" x2="400.4" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="400.4" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="516.6" y1="68.0" x2="516.6" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="516.6" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="632.8" y1="68.0" x2="632.8" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="632.8" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="400.3" y1="68.0" x2="400.3" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="400.3" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="516.5" y1="68.0" x2="516.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="516.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="632.7" y1="68.0" x2="632.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="632.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="86.0" x2="210.5" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="210.5" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.32 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="210.5" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="210.5" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="210.2" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="210.2" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.31 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="110.0" x2="210.5" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="210.5" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.32 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="211.5" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="211.5" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.37 ns</text>
+<line x1="168.0" y1="134.0" x2="210.9" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="210.9" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.34 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
 <line x1="168.0" y1="158.0" x2="217.5" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="217.5" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
@@ -31,59 +31,59 @@
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
 <line x1="168.0" y1="182.0" x2="224.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="224.7" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.07 ns</text>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.08 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
 <line x1="168.0" y1="206.0" x2="282.3" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="282.3" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.64 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="230.0" x2="297.4" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="297.4" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.0 ns</text>
+<line x1="168.0" y1="230.0" x2="297.8" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="297.8" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.1 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="416.9" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="416.9" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">139 ns</text>
+<line x1="168.0" y1="254.0" x2="417.2" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="417.2" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">140 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="278.0" x2="420.9" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="420.9" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">150 ns</text>
+<line x1="168.0" y1="278.0" x2="421.4" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="421.4" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">152 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="302.0" x2="423.3" y2="302.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="423.3" cy="302.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">157 ns</text>
+<line x1="168.0" y1="302.0" x2="423.6" y2="302.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="423.6" cy="302.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">158 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="430.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="430.7" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">182 ns</text>
+<line x1="168.0" y1="326.0" x2="431.6" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="431.6" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">186 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
 <line x1="168.0" y1="350.0" x2="487.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="487.7" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">564 ns</text>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">566 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="498.2" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="498.2" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">694 ns</text>
+<line x1="168.0" y1="374.0" x2="498.3" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="498.3" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">697 ns</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="615.4" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="615.4" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.09 µs</text>
+<line x1="168.0" y1="398.0" x2="616.0" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="616.0" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.18 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="422.0" x2="654.4" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="654.4" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="422.0" x2="654.2" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="654.2" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.3 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
 <line x1="168.0" y1="446.0" x2="679.5" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="679.5" cy="446.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">25.2 µs</text>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">25.3 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="470.0" x2="680.3" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="680.3" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">25.6 µs</text>
+<line x1="168.0" y1="470.0" x2="685.1" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="685.1" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">28.3 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">54.1 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">54.3 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/i32_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i32-div-dark.svg
+++ b/docs/benchmarks/figs/wat-i32-div-dark.svg
@@ -1,91 +1,89 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_div: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-go is fastest at 7.63 ns, then wasmer at 7.63 ns; pywasm-pypy is slowest at 214 µs, a span of 28100x. The table below carries every number.">
-<title>wat/i32_div: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-go is fastest at 7.63 ns, then wasmer at 7.63 ns; pywasm-pypy is slowest at 214 µs, a span of 28100x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_div: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 7.63 ns, then wasmtime at 7.65 ns; dewasm-bash is slowest at 69.0 µs, a span of 9030x. The table below carries every number.">
+<title>wat/i32_div: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 7.63 ns, then wasmtime at 7.65 ns; dewasm-bash is slowest at 69.0 µs, a span of 9030x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="271.2" y1="68.0" x2="271.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="271.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="374.4" y1="68.0" x2="374.4" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="374.4" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="477.5" y1="68.0" x2="477.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="477.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="580.7" y1="68.0" x2="580.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="580.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="683.9" y1="68.0" x2="683.9" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="683.9" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="281.7" y1="68.0" x2="281.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="281.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="395.3" y1="68.0" x2="395.3" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="395.3" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="509.0" y1="68.0" x2="509.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="509.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="622.7" y1="68.0" x2="622.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="622.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="86.0" x2="259.1" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="259.1" cy="86.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="86.0" x2="268.3" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="268.3" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.63 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="259.1" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="259.1" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.63 ns</text>
-<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="134.0" x2="259.1" y2="134.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="259.1" cy="134.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.64 ns</text>
-<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="259.2" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="259.2" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.65 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="110.0" x2="268.5" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="268.5" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.65 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
+<line x1="168.0" y1="134.0" x2="268.7" y2="134.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="268.7" cy="134.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.68 ns</text>
+<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
+<line x1="168.0" y1="158.0" x2="268.9" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="268.9" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.72 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="261.1" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="261.1" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.99 ns</text>
+<line x1="168.0" y1="182.0" x2="270.6" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="270.6" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.98 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="206.0" x2="286.4" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="286.4" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.0 ns</text>
+<line x1="168.0" y1="206.0" x2="298.8" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="298.8" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.2 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="230.0" x2="295.2" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="295.2" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">17.1 ns</text>
+<line x1="168.0" y1="230.0" x2="308.6" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="308.6" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">17.2 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="402.9" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="402.9" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">189 ns</text>
+<line x1="168.0" y1="254.0" x2="427.0" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="427.0" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">190 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="404.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="404.6" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">197 ns</text>
+<line x1="168.0" y1="278.0" x2="429.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="429.5" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">200 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="414.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="414.1" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">243 ns</text>
+<line x1="168.0" y1="302.0" x2="439.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="439.6" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">245 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="432.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="432.7" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">368 ns</text>
+<line x1="168.0" y1="326.0" x2="461.3" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="461.3" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">381 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="476.8" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="476.8" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">984 ns</text>
+<line x1="168.0" y1="350.0" x2="508.3" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="508.3" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">985 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="486.5" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="486.5" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.22 µs</text>
+<line x1="168.0" y1="374.0" x2="519.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="519.0" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.23 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="573.6" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="573.6" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.53 µs</text>
+<line x1="168.0" y1="398.0" x2="615.6" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="615.6" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.66 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="422.0" x2="608.0" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="608.0" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="422.0" x2="652.9" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="652.9" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">18.4 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="446.0" x2="661.8" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="661.8" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">61.0 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="470.0" x2="667.1" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="667.1" cy="470.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">68.8 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">214 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="446.0" x2="694.2" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="694.2" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">42.6 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="470.0" x2="712.8" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="712.8" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">62.0 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">69.0 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/i32_div: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i32-div.svg
+++ b/docs/benchmarks/figs/wat-i32-div.svg
@@ -1,91 +1,89 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_div: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-go is fastest at 7.63 ns, then wasmer at 7.63 ns; pywasm-pypy is slowest at 214 µs, a span of 28100x. The table below carries every number.">
-<title>wat/i32_div: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-go is fastest at 7.63 ns, then wasmer at 7.63 ns; pywasm-pypy is slowest at 214 µs, a span of 28100x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_div: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 7.63 ns, then wasmtime at 7.65 ns; dewasm-bash is slowest at 69.0 µs, a span of 9030x. The table below carries every number.">
+<title>wat/i32_div: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 7.63 ns, then wasmtime at 7.65 ns; dewasm-bash is slowest at 69.0 µs, a span of 9030x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="271.2" y1="68.0" x2="271.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="271.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="374.4" y1="68.0" x2="374.4" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="374.4" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="477.5" y1="68.0" x2="477.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="477.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="580.7" y1="68.0" x2="580.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="580.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="683.9" y1="68.0" x2="683.9" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="683.9" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="281.7" y1="68.0" x2="281.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="281.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="395.3" y1="68.0" x2="395.3" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="395.3" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="509.0" y1="68.0" x2="509.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="509.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="622.7" y1="68.0" x2="622.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="622.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="86.0" x2="259.1" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="259.1" cy="86.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="86.0" x2="268.3" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="268.3" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.63 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="259.1" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="259.1" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.63 ns</text>
-<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="134.0" x2="259.1" y2="134.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="259.1" cy="134.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.64 ns</text>
-<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="259.2" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="259.2" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.65 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="110.0" x2="268.5" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="268.5" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.65 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
+<line x1="168.0" y1="134.0" x2="268.7" y2="134.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="268.7" cy="134.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.68 ns</text>
+<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
+<line x1="168.0" y1="158.0" x2="268.9" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="268.9" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.72 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="261.1" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="261.1" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.99 ns</text>
+<line x1="168.0" y1="182.0" x2="270.6" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="270.6" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.98 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="206.0" x2="286.4" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="286.4" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.0 ns</text>
+<line x1="168.0" y1="206.0" x2="298.8" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="298.8" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.2 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="230.0" x2="295.2" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="295.2" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">17.1 ns</text>
+<line x1="168.0" y1="230.0" x2="308.6" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="308.6" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">17.2 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="402.9" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="402.9" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">189 ns</text>
+<line x1="168.0" y1="254.0" x2="427.0" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="427.0" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">190 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="404.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="404.6" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">197 ns</text>
+<line x1="168.0" y1="278.0" x2="429.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="429.5" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">200 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="414.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="414.1" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">243 ns</text>
+<line x1="168.0" y1="302.0" x2="439.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="439.6" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">245 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="432.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="432.7" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">368 ns</text>
+<line x1="168.0" y1="326.0" x2="461.3" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="461.3" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">381 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="476.8" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="476.8" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">984 ns</text>
+<line x1="168.0" y1="350.0" x2="508.3" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="508.3" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">985 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="486.5" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="486.5" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.22 µs</text>
+<line x1="168.0" y1="374.0" x2="519.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="519.0" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.23 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="573.6" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="573.6" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.53 µs</text>
+<line x1="168.0" y1="398.0" x2="615.6" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="615.6" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.66 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="422.0" x2="608.0" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="608.0" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="422.0" x2="652.9" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="652.9" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">18.4 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="446.0" x2="661.8" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="661.8" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">61.0 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="470.0" x2="667.1" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="667.1" cy="470.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">68.8 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">214 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="446.0" x2="694.2" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="694.2" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">42.6 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="470.0" x2="712.8" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="712.8" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">62.0 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">69.0 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/i32_div: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i64-alu-dark.svg
+++ b/docs/benchmarks/figs/wat-i64-alu-dark.svg
@@ -1,91 +1,91 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.32 ns, then wasmtime at 2.33 ns; pywasm-pypy is slowest at 397 µs, a span of 171000x. The table below carries every number.">
-<title>wat/i64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.32 ns, then wasmtime at 2.33 ns; pywasm-pypy is slowest at 397 µs, a span of 171000x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.31 ns, then wasmtime at 2.31 ns; pywasm-pypy is slowest at 329 µs, a span of 142000x. The table below carries every number.">
+<title>wat/i64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.31 ns, then wasmtime at 2.31 ns; pywasm-pypy is slowest at 329 µs, a span of 142000x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="266.2" y1="68.0" x2="266.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="266.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="364.5" y1="68.0" x2="364.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="364.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="462.7" y1="68.0" x2="462.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="462.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="560.9" y1="68.0" x2="560.9" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="560.9" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="659.2" y1="68.0" x2="659.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="659.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="267.7" y1="68.0" x2="267.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="267.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="367.4" y1="68.0" x2="367.4" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="367.4" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="467.1" y1="68.0" x2="467.1" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="467.1" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="566.8" y1="68.0" x2="566.8" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="566.8" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="666.5" y1="68.0" x2="666.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="666.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="86.0" x2="204.0" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="204.0" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.32 ns</text>
+<line x1="168.0" y1="86.0" x2="204.3" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="204.3" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.31 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="204.1" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="204.1" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.33 ns</text>
+<line x1="168.0" y1="110.0" x2="204.3" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="204.3" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.31 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="204.7" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="204.7" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="134.0" x2="205.2" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="205.2" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.36 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="158.0" x2="209.4" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="209.4" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="158.0" x2="210.1" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="210.1" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.64 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="182.0" x2="209.9" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="209.9" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="182.0" x2="210.5" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="210.5" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.67 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="274.4" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="274.4" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="206.0" x2="275.9" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="275.9" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.1 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="230.0" x2="383.9" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="383.9" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="230.0" x2="387.3" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="387.3" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">158 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="254.0" x2="398.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="398.8" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">223 ns</text>
+<line x1="168.0" y1="254.0" x2="402.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="402.6" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">225 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="278.0" x2="443.2" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="443.2" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">633 ns</text>
+<line x1="168.0" y1="278.0" x2="447.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="447.6" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">638 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="302.0" x2="462.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="462.2" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">989 ns</text>
+<line x1="168.0" y1="302.0" x2="465.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="465.2" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">958 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="326.0" x2="463.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="463.0" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="326.0" x2="467.6" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="467.6" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.01 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="350.0" x2="465.0" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="465.0" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.05 µs</text>
+<line x1="168.0" y1="350.0" x2="468.5" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="468.5" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.03 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="374.0" x2="475.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="475.1" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.34 µs</text>
+<line x1="168.0" y1="374.0" x2="477.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="477.8" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.28 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="557.8" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="557.8" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.30 µs</text>
+<line x1="168.0" y1="398.0" x2="563.4" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="563.4" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.25 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="422.0" x2="583.0" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="583.0" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">16.8 µs</text>
+<line x1="168.0" y1="422.0" x2="588.9" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="588.9" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">16.7 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="446.0" x2="604.5" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="604.5" cy="446.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="446.0" x2="610.9" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="610.9" cy="446.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">27.7 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="470.0" x2="635.4" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="635.4" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">57.2 µs</text>
+<line x1="168.0" y1="470.0" x2="642.7" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="642.7" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">57.7 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">397 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">329 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/i64_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i64-alu.svg
+++ b/docs/benchmarks/figs/wat-i64-alu.svg
@@ -1,91 +1,91 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.32 ns, then wasmtime at 2.33 ns; pywasm-pypy is slowest at 397 µs, a span of 171000x. The table below carries every number.">
-<title>wat/i64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.32 ns, then wasmtime at 2.33 ns; pywasm-pypy is slowest at 397 µs, a span of 171000x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.31 ns, then wasmtime at 2.31 ns; pywasm-pypy is slowest at 329 µs, a span of 142000x. The table below carries every number.">
+<title>wat/i64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.31 ns, then wasmtime at 2.31 ns; pywasm-pypy is slowest at 329 µs, a span of 142000x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="266.2" y1="68.0" x2="266.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="266.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="364.5" y1="68.0" x2="364.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="364.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="462.7" y1="68.0" x2="462.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="462.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="560.9" y1="68.0" x2="560.9" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="560.9" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="659.2" y1="68.0" x2="659.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="659.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="267.7" y1="68.0" x2="267.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="267.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="367.4" y1="68.0" x2="367.4" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="367.4" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="467.1" y1="68.0" x2="467.1" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="467.1" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="566.8" y1="68.0" x2="566.8" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="566.8" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="666.5" y1="68.0" x2="666.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="666.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="86.0" x2="204.0" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="204.0" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.32 ns</text>
+<line x1="168.0" y1="86.0" x2="204.3" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="204.3" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.31 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="204.1" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="204.1" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.33 ns</text>
+<line x1="168.0" y1="110.0" x2="204.3" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="204.3" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.31 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="204.7" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="204.7" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="134.0" x2="205.2" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="205.2" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.36 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="158.0" x2="209.4" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="209.4" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="158.0" x2="210.1" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="210.1" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.64 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="182.0" x2="209.9" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="209.9" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="182.0" x2="210.5" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="210.5" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.67 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="274.4" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="274.4" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="206.0" x2="275.9" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="275.9" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.1 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="230.0" x2="383.9" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="383.9" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="230.0" x2="387.3" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="387.3" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">158 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="254.0" x2="398.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="398.8" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">223 ns</text>
+<line x1="168.0" y1="254.0" x2="402.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="402.6" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">225 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="278.0" x2="443.2" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="443.2" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">633 ns</text>
+<line x1="168.0" y1="278.0" x2="447.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="447.6" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">638 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="302.0" x2="462.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="462.2" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">989 ns</text>
+<line x1="168.0" y1="302.0" x2="465.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="465.2" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">958 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="326.0" x2="463.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="463.0" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="326.0" x2="467.6" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="467.6" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.01 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="350.0" x2="465.0" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="465.0" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.05 µs</text>
+<line x1="168.0" y1="350.0" x2="468.5" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="468.5" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.03 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="374.0" x2="475.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="475.1" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.34 µs</text>
+<line x1="168.0" y1="374.0" x2="477.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="477.8" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.28 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="557.8" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="557.8" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.30 µs</text>
+<line x1="168.0" y1="398.0" x2="563.4" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="563.4" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.25 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="422.0" x2="583.0" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="583.0" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">16.8 µs</text>
+<line x1="168.0" y1="422.0" x2="588.9" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="588.9" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">16.7 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="446.0" x2="604.5" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="604.5" cy="446.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="446.0" x2="610.9" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="610.9" cy="446.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">27.7 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="470.0" x2="635.4" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="635.4" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">57.2 µs</text>
+<line x1="168.0" y1="470.0" x2="642.7" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="642.7" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">57.7 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">397 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">329 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/i64_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i64-div-dark.svg
+++ b/docs/benchmarks/figs/wat-i64-div-dark.svg
@@ -1,83 +1,83 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="488" viewBox="0 0 820 488" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_div: seconds per iteration for 16 runners on a log scale, fastest first. dewasm-go is fastest at 8.24 ns, then wasmer at 8.28 ns; pywasm-pypy is slowest at 392 µs, a span of 47600x. The table below carries every number.">
-<title>wat/i64_div: seconds per iteration for 16 runners on a log scale, fastest first. dewasm-go is fastest at 8.24 ns, then wasmer at 8.28 ns; pywasm-pypy is slowest at 392 µs, a span of 47600x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="488" viewBox="0 0 820 488" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_div: seconds per iteration for 16 runners on a log scale, fastest first. wasmtime is fastest at 8.28 ns, then wasmer at 8.30 ns; pywasm-pypy is slowest at 513 µs, a span of 62000x. The table below carries every number.">
+<title>wat/i64_div: seconds per iteration for 16 runners on a log scale, fastest first. wasmtime is fastest at 8.28 ns, then wasmer at 8.30 ns; pywasm-pypy is slowest at 513 µs, a span of 62000x. The table below carries every number.</title>
 <rect width="820" height="488" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="266.3" y1="68.0" x2="266.3" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="266.3" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="364.7" y1="68.0" x2="364.7" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="364.7" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="463.0" y1="68.0" x2="463.0" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="463.0" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="561.3" y1="68.0" x2="561.3" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="561.3" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="659.7" y1="68.0" x2="659.7" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="659.7" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="264.3" y1="68.0" x2="264.3" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="264.3" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="360.6" y1="68.0" x2="360.6" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="360.6" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="457.0" y1="68.0" x2="457.0" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="457.0" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="553.3" y1="68.0" x2="553.3" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="553.3" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="649.6" y1="68.0" x2="649.6" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="649.6" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
 <line x1="168.0" y1="458.0" x2="726.0" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="86.0" x2="258.1" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="258.1" cy="86.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.24 ns</text>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="256.4" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="256.4" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.28 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="258.3" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="258.3" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.28 ns</text>
-<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="134.0" x2="258.3" y2="134.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="258.3" cy="134.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.29 ns</text>
+<line x1="168.0" y1="110.0" x2="256.5" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="256.5" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.30 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
+<line x1="168.0" y1="134.0" x2="256.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="256.6" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.31 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="258.4" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="258.4" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="158.0" x2="256.6" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="256.6" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.31 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="259.9" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="259.9" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.60 ns</text>
+<line x1="168.0" y1="182.0" x2="257.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="257.7" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.54 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="286.9" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="286.9" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="206.0" x2="284.6" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="284.6" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">16.2 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="230.0" x2="391.7" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="391.7" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">188 ns</text>
+<line x1="168.0" y1="230.0" x2="387.2" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="387.2" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">189 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="254.0" x2="406.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="406.6" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">267 ns</text>
+<line x1="168.0" y1="254.0" x2="402.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="402.6" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">273 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="278.0" x2="464.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="464.6" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="278.0" x2="458.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="458.5" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.04 µs</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="302.0" x2="469.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="469.0" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="302.0" x2="462.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="462.8" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.15 µs</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="326.0" x2="477.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="477.7" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.41 µs</text>
+<line x1="168.0" y1="326.0" x2="471.5" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="471.5" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.42 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="350.0" x2="480.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="480.7" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.51 µs</text>
+<line x1="168.0" y1="350.0" x2="474.4" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="474.4" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.52 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="374.0" x2="485.5" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="485.5" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="374.0" x2="479.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="479.1" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.70 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="398.0" x2="641.8" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="641.8" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">65.9 µs</text>
+<line x1="168.0" y1="398.0" x2="632.5" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="632.5" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">66.5 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="422.0" x2="648.7" y2="422.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="648.7" cy="422.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">77.4 µs</text>
+<line x1="168.0" y1="422.0" x2="638.7" y2="422.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="638.7" cy="422.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">77.1 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
 <line x1="168.0" y1="446.0" x2="718.0" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">392 µs</text>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">513 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/i64_div: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i64-div.svg
+++ b/docs/benchmarks/figs/wat-i64-div.svg
@@ -1,83 +1,83 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="488" viewBox="0 0 820 488" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_div: seconds per iteration for 16 runners on a log scale, fastest first. dewasm-go is fastest at 8.24 ns, then wasmer at 8.28 ns; pywasm-pypy is slowest at 392 µs, a span of 47600x. The table below carries every number.">
-<title>wat/i64_div: seconds per iteration for 16 runners on a log scale, fastest first. dewasm-go is fastest at 8.24 ns, then wasmer at 8.28 ns; pywasm-pypy is slowest at 392 µs, a span of 47600x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="488" viewBox="0 0 820 488" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_div: seconds per iteration for 16 runners on a log scale, fastest first. wasmtime is fastest at 8.28 ns, then wasmer at 8.30 ns; pywasm-pypy is slowest at 513 µs, a span of 62000x. The table below carries every number.">
+<title>wat/i64_div: seconds per iteration for 16 runners on a log scale, fastest first. wasmtime is fastest at 8.28 ns, then wasmer at 8.30 ns; pywasm-pypy is slowest at 513 µs, a span of 62000x. The table below carries every number.</title>
 <rect width="820" height="488" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="266.3" y1="68.0" x2="266.3" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="266.3" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="364.7" y1="68.0" x2="364.7" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="364.7" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="463.0" y1="68.0" x2="463.0" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="463.0" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="561.3" y1="68.0" x2="561.3" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="561.3" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="659.7" y1="68.0" x2="659.7" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="659.7" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="264.3" y1="68.0" x2="264.3" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="264.3" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="360.6" y1="68.0" x2="360.6" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="360.6" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="457.0" y1="68.0" x2="457.0" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="457.0" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="553.3" y1="68.0" x2="553.3" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="553.3" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="649.6" y1="68.0" x2="649.6" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="649.6" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
 <line x1="168.0" y1="458.0" x2="726.0" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="86.0" x2="258.1" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="258.1" cy="86.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.24 ns</text>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="256.4" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="256.4" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.28 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="258.3" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="258.3" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.28 ns</text>
-<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="134.0" x2="258.3" y2="134.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="258.3" cy="134.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.29 ns</text>
+<line x1="168.0" y1="110.0" x2="256.5" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="256.5" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.30 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
+<line x1="168.0" y1="134.0" x2="256.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="256.6" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.31 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="258.4" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="258.4" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="158.0" x2="256.6" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="256.6" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.31 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="259.9" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="259.9" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.60 ns</text>
+<line x1="168.0" y1="182.0" x2="257.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="257.7" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.54 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="286.9" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="286.9" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="206.0" x2="284.6" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="284.6" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">16.2 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="230.0" x2="391.7" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="391.7" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">188 ns</text>
+<line x1="168.0" y1="230.0" x2="387.2" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="387.2" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">189 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="254.0" x2="406.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="406.6" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">267 ns</text>
+<line x1="168.0" y1="254.0" x2="402.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="402.6" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">273 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="278.0" x2="464.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="464.6" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="278.0" x2="458.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="458.5" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.04 µs</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="302.0" x2="469.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="469.0" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="302.0" x2="462.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="462.8" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.15 µs</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="326.0" x2="477.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="477.7" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.41 µs</text>
+<line x1="168.0" y1="326.0" x2="471.5" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="471.5" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.42 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="350.0" x2="480.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="480.7" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.51 µs</text>
+<line x1="168.0" y1="350.0" x2="474.4" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="474.4" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.52 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="374.0" x2="485.5" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="485.5" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="374.0" x2="479.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="479.1" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.70 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="398.0" x2="641.8" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="641.8" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">65.9 µs</text>
+<line x1="168.0" y1="398.0" x2="632.5" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="632.5" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">66.5 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="422.0" x2="648.7" y2="422.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="648.7" cy="422.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">77.4 µs</text>
+<line x1="168.0" y1="422.0" x2="638.7" y2="422.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="638.7" cy="422.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">77.1 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
 <line x1="168.0" y1="446.0" x2="718.0" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">392 µs</text>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">513 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/i64_div: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-mem-narrow-dark.svg
+++ b/docs/benchmarks/figs/wat-mem-narrow-dark.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_narrow: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.58 ns; pywasm-cpython is slowest at 87.7 µs, a span of 58500x. The table below carries every number.">
-<title>wat/mem_narrow: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.58 ns; pywasm-cpython is slowest at 87.7 µs, a span of 58500x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_narrow: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.59 ns; pywasm-cpython is slowest at 87.8 µs, a span of 58500x. The table below carries every number.">
+<title>wat/mem_narrow: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.59 ns; pywasm-cpython is slowest at 87.8 µs, a span of 58500x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
@@ -9,81 +9,81 @@
 <text x="390.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
 <line x1="501.8" y1="68.0" x2="501.8" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="501.8" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="613.1" y1="68.0" x2="613.1" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="613.1" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="613.0" y1="68.0" x2="613.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="613.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="187.5" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="187.5" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="86.0" x2="187.6" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="187.6" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.50 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="190.2" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="190.2" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.58 ns</text>
+<line x1="168.0" y1="110.0" x2="190.3" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="190.3" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.59 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="211.9" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="211.9" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.48 ns</text>
+<line x1="168.0" y1="134.0" x2="212.2" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="212.2" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.50 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="212.8" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="212.8" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.53 ns</text>
+<line x1="168.0" y1="158.0" x2="212.9" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="212.9" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.54 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="240.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="240.7" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.51 ns</text>
+<line x1="168.0" y1="182.0" x2="239.4" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="239.4" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.38 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="314.2" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="314.2" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.6 ns</text>
+<line x1="168.0" y1="206.0" x2="313.8" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="313.8" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.5 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="375.2" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="375.2" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">72.8 ns</text>
+<line x1="168.0" y1="230.0" x2="374.8" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="374.8" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">72.3 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="438.4" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="438.4" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">269 ns</text>
+<line x1="168.0" y1="254.0" x2="438.8" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="438.8" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">272 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="445.2" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="445.2" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">310 ns</text>
+<line x1="168.0" y1="278.0" x2="444.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="444.8" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">308 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="449.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="449.6" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">340 ns</text>
+<line x1="168.0" y1="302.0" x2="448.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="448.8" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">334 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
 <line x1="168.0" y1="326.0" x2="461.5" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="461.5" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">435 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="533.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="533.1" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.91 µs</text>
+<line x1="168.0" y1="350.0" x2="533.5" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="533.5" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.93 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="558.7" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="558.7" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.25 µs</text>
+<line x1="168.0" y1="374.0" x2="559.5" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="559.5" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.30 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="632.1" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="632.1" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.8 µs</text>
+<line x1="168.0" y1="398.0" x2="632.7" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="632.7" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.0 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="422.0" x2="663.8" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="663.8" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">28.5 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="446.0" x2="692.1" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="692.1" cy="446.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">51.3 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="470.0" x2="697.5" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="697.5" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">57.3 µs</text>
+<line x1="168.0" y1="422.0" x2="663.9" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="663.9" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">28.6 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="446.0" x2="680.1" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="680.1" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">40.0 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="470.0" x2="692.6" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="692.6" cy="470.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">51.9 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">87.7 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">87.8 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/mem_narrow: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-mem-narrow.svg
+++ b/docs/benchmarks/figs/wat-mem-narrow.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_narrow: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.58 ns; pywasm-cpython is slowest at 87.7 µs, a span of 58500x. The table below carries every number.">
-<title>wat/mem_narrow: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.58 ns; pywasm-cpython is slowest at 87.7 µs, a span of 58500x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_narrow: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.59 ns; pywasm-cpython is slowest at 87.8 µs, a span of 58500x. The table below carries every number.">
+<title>wat/mem_narrow: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.59 ns; pywasm-cpython is slowest at 87.8 µs, a span of 58500x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
@@ -9,81 +9,81 @@
 <text x="390.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
 <line x1="501.8" y1="68.0" x2="501.8" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="501.8" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="613.1" y1="68.0" x2="613.1" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="613.1" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="613.0" y1="68.0" x2="613.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="613.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="187.5" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="187.5" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="86.0" x2="187.6" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="187.6" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.50 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="190.2" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="190.2" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.58 ns</text>
+<line x1="168.0" y1="110.0" x2="190.3" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="190.3" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.59 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="211.9" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="211.9" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.48 ns</text>
+<line x1="168.0" y1="134.0" x2="212.2" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="212.2" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.50 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="212.8" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="212.8" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.53 ns</text>
+<line x1="168.0" y1="158.0" x2="212.9" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="212.9" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.54 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="240.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="240.7" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.51 ns</text>
+<line x1="168.0" y1="182.0" x2="239.4" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="239.4" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.38 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="314.2" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="314.2" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.6 ns</text>
+<line x1="168.0" y1="206.0" x2="313.8" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="313.8" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.5 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="375.2" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="375.2" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">72.8 ns</text>
+<line x1="168.0" y1="230.0" x2="374.8" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="374.8" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">72.3 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="438.4" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="438.4" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">269 ns</text>
+<line x1="168.0" y1="254.0" x2="438.8" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="438.8" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">272 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="445.2" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="445.2" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">310 ns</text>
+<line x1="168.0" y1="278.0" x2="444.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="444.8" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">308 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="449.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="449.6" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">340 ns</text>
+<line x1="168.0" y1="302.0" x2="448.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="448.8" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">334 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
 <line x1="168.0" y1="326.0" x2="461.5" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="461.5" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">435 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="533.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="533.1" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.91 µs</text>
+<line x1="168.0" y1="350.0" x2="533.5" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="533.5" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.93 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="558.7" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="558.7" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.25 µs</text>
+<line x1="168.0" y1="374.0" x2="559.5" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="559.5" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.30 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="632.1" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="632.1" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.8 µs</text>
+<line x1="168.0" y1="398.0" x2="632.7" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="632.7" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.0 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="422.0" x2="663.8" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="663.8" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">28.5 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="446.0" x2="692.1" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="692.1" cy="446.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">51.3 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="470.0" x2="697.5" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="697.5" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">57.3 µs</text>
+<line x1="168.0" y1="422.0" x2="663.9" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="663.9" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">28.6 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="446.0" x2="680.1" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="680.1" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">40.0 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="470.0" x2="692.6" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="692.6" cy="470.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">51.9 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">87.7 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">87.8 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/mem_narrow: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-mem-rw-dark.svg
+++ b/docs/benchmarks/figs/wat-mem-rw-dark.svg
@@ -1,22 +1,22 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_rw: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 1.01 ns, then wasmtime at 1.01 ns; pywasm-cpython is slowest at 39.5 µs, a span of 39200x. The table below carries every number.">
-<title>wat/mem_rw: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 1.01 ns, then wasmtime at 1.01 ns; pywasm-cpython is slowest at 39.5 µs, a span of 39200x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_rw: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.01 ns, then wasmer at 1.01 ns; pywasm-cpython is slowest at 39.8 µs, a span of 39300x. The table below carries every number.">
+<title>wat/mem_rw: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.01 ns, then wasmer at 1.01 ns; pywasm-cpython is slowest at 39.8 µs, a span of 39300x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
 <line x1="287.6" y1="68.0" x2="287.6" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="287.6" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="407.3" y1="68.0" x2="407.3" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="407.3" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="526.9" y1="68.0" x2="526.9" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="526.9" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="646.6" y1="68.0" x2="646.6" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="646.6" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="407.2" y1="68.0" x2="407.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="407.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="526.7" y1="68.0" x2="526.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="526.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="646.3" y1="68.0" x2="646.3" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="646.3" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<circle cx="168.4" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<circle cx="168.5" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.01 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<circle cx="168.6" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<circle cx="168.6" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.01 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
 <line x1="168.0" y1="134.0" x2="189.5" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
@@ -27,61 +27,61 @@
 <circle cx="190.8" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.55 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="197.8" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="197.8" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="182.0" x2="197.6" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="197.6" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.77 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="289.0" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="289.0" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.3 ns</text>
+<line x1="168.0" y1="206.0" x2="288.8" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="288.8" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.2 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="375.8" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="375.8" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">54.6 ns</text>
+<line x1="168.0" y1="230.0" x2="375.5" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="375.5" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">54.3 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="421.7" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="421.7" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">132 ns</text>
+<line x1="168.0" y1="254.0" x2="422.1" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="422.1" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">133 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="423.2" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="423.2" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="278.0" x2="422.9" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="422.9" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">136 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="425.9" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="425.9" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">143 ns</text>
+<line x1="168.0" y1="302.0" x2="426.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="426.0" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">144 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="437.9" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="437.9" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">180 ns</text>
+<line x1="168.0" y1="326.0" x2="438.2" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="438.2" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">182 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="513.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="513.1" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">766 ns</text>
+<line x1="168.0" y1="350.0" x2="513.4" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="513.4" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">774 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="527.3" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="527.3" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.01 µs</text>
+<line x1="168.0" y1="374.0" x2="527.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="527.0" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.00 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="623.1" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="623.1" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.37 µs</text>
+<line x1="168.0" y1="398.0" x2="623.2" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="623.2" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.41 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="422.0" x2="636.6" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="636.6" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.25 µs</text>
+<line x1="168.0" y1="422.0" x2="638.2" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="638.2" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.55 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="446.0" x2="661.1" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="661.1" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.2 µs</text>
+<line x1="168.0" y1="446.0" x2="661.2" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="661.2" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.3 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
 <line x1="168.0" y1="470.0" x2="706.7" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="706.7" cy="470.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">31.8 µs</text>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">32.0 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">39.5 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">39.8 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/mem_rw: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-mem-rw.svg
+++ b/docs/benchmarks/figs/wat-mem-rw.svg
@@ -1,22 +1,22 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_rw: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 1.01 ns, then wasmtime at 1.01 ns; pywasm-cpython is slowest at 39.5 µs, a span of 39200x. The table below carries every number.">
-<title>wat/mem_rw: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 1.01 ns, then wasmtime at 1.01 ns; pywasm-cpython is slowest at 39.5 µs, a span of 39200x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_rw: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.01 ns, then wasmer at 1.01 ns; pywasm-cpython is slowest at 39.8 µs, a span of 39300x. The table below carries every number.">
+<title>wat/mem_rw: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.01 ns, then wasmer at 1.01 ns; pywasm-cpython is slowest at 39.8 µs, a span of 39300x. The table below carries every number.</title>
 <rect width="820" height="536" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
 <line x1="287.6" y1="68.0" x2="287.6" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="287.6" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="407.3" y1="68.0" x2="407.3" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="407.3" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="526.9" y1="68.0" x2="526.9" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="526.9" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="646.6" y1="68.0" x2="646.6" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="646.6" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="407.2" y1="68.0" x2="407.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="407.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="526.7" y1="68.0" x2="526.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="526.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="646.3" y1="68.0" x2="646.3" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="646.3" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
 <line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<circle cx="168.4" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<circle cx="168.5" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.01 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<circle cx="168.6" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<circle cx="168.6" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.01 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
 <line x1="168.0" y1="134.0" x2="189.5" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
@@ -27,61 +27,61 @@
 <circle cx="190.8" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.55 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="197.8" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="197.8" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="182.0" x2="197.6" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="197.6" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.77 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="289.0" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="289.0" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.3 ns</text>
+<line x1="168.0" y1="206.0" x2="288.8" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="288.8" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.2 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="375.8" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="375.8" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">54.6 ns</text>
+<line x1="168.0" y1="230.0" x2="375.5" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="375.5" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">54.3 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="421.7" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="421.7" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">132 ns</text>
+<line x1="168.0" y1="254.0" x2="422.1" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="422.1" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">133 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="423.2" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="423.2" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="278.0" x2="422.9" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="422.9" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">136 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="425.9" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="425.9" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">143 ns</text>
+<line x1="168.0" y1="302.0" x2="426.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="426.0" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">144 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="437.9" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="437.9" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">180 ns</text>
+<line x1="168.0" y1="326.0" x2="438.2" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="438.2" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">182 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="513.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="513.1" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">766 ns</text>
+<line x1="168.0" y1="350.0" x2="513.4" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="513.4" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">774 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="527.3" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="527.3" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.01 µs</text>
+<line x1="168.0" y1="374.0" x2="527.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="527.0" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.00 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="623.1" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="623.1" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.37 µs</text>
+<line x1="168.0" y1="398.0" x2="623.2" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="623.2" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.41 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="422.0" x2="636.6" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="636.6" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.25 µs</text>
+<line x1="168.0" y1="422.0" x2="638.2" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="638.2" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.55 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="446.0" x2="661.1" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="661.1" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.2 µs</text>
+<line x1="168.0" y1="446.0" x2="661.2" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="661.2" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.3 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
 <line x1="168.0" y1="470.0" x2="706.7" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="706.7" cy="470.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">31.8 µs</text>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">32.0 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
 <line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">39.5 µs</text>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">39.8 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/mem_rw: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/results.md
+++ b/docs/benchmarks/results.md
@@ -7,7 +7,7 @@ How to run and read these measurements is [README.md](README.md).
 
 ## Environment
 
-Measured 2026-08-22T06:26:23Z.
+Measured 2026-08-22T08:27:05Z.
 
 | | |
 | --- | --- |
@@ -54,7 +54,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-br-table-dark.svg">
-  <img alt="wat/br_table: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-go is fastest at 7.65 ns, then wasmer at 8.50 ns; pywasm-cpython is slowest at 51.1 µs, a span of 6690x. The table below carries every number." src="figs/wat-br-table.svg">
+  <img alt="wat/br_table: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-go is fastest at 7.85 ns, then wasmtime at 8.67 ns; pywasm-cpython is slowest at 51.8 µs, a span of 6590x. The table below carries every number." src="figs/wat-br-table.svg">
 </picture>
 
 <details>
@@ -62,24 +62,24 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 35 287 220 | 8.49 | 8.51 | 5.9 ms | 305.4 ms | 1.00x | — |
-| `wasmer` | 35 089 490 | 8.51 | 8.50 | 8.9 ms | 307.6 ms | 1.00x | — |
-| `wasmedge` | 1 136 802 | 223.2 | 222.5 | 15.7 ms | 269.4 ms | 26x | — |
-| `wazero` | 33 781 226 | 8.86 | 8.88 | 5.1 ms | 304.5 ms | 1.04x | — |
-| `wasm3` | 13 248 133 | 26.3 | 26.3 | 4.4 ms | 352.7 ms | 3.10x | — |
-| `dewasm-ruby` | 1 202 302 | 217.8 | 217.6 | 39.3 ms | 301.2 ms | 26x | — |
-| `dewasm-ruby-yjit` | 1 290 279 | 217.4 | 218.1 | 39.8 ms | 320.3 ms | 26x | — |
-| `dewasm-ruby-zjit` | 1 265 131 | 218.1 | 218.1 | 39.5 ms | 315.5 ms | 26x | — |
-| `dewasm-python` | 774 703 | 395.9 | 396.1 | 29.7 ms | 336.4 ms | 47x | — |
-| `dewasm-pypy` | 4 281 164 | 62.4 | 62.2 | 41.3 ms | 308.3 ms | 7.35x | — |
-| `dewasm-perl` | 334 562 | 874.0 | 874.7 | 10.6 ms | 303.0 ms | 103x | — |
-| `dewasm-go` | 37 149 182 | 7.68 | 7.65 | 4.5 ms | 289.7 ms | 0.90x | — |
-| `dewasm-java` | 26 509 159 | 9.75 | 9.74 | 67.6 ms | 326.0 ms | 1.15x | — |
-| `dewasm-bash` | 7 436 | 36553 | 36586 | 12.6 ms | 284.4 ms | 4307x | — |
-| `pywasm-cpython` | 4 485 | 51101 | 51139 | 43.0 ms | 272.1 ms | 6021x | 1.1 ms |
-| `pywasm-pypy` | 3 705 | 50497 | 50826 | 80.5 ms | 267.6 ms | 5949x | 5.5 ms |
-| `wardite` | 12 234 | 21184 | 21167 | 52.4 ms | 311.6 ms | 2496x | 4.3 ms |
-| `wardite-yjit` | 24 853 | 8773 | 8767 | 101.7 ms | 319.7 ms | 1034x | 10.0 ms |
+| `wasmtime` | 34 606 250 | 8.67 | 8.67 | 5.5 ms | 305.5 ms | 1.00x | — |
+| `wasmer` | 34 667 768 | 8.67 | 8.68 | 9.4 ms | 309.9 ms | 1.00x | — |
+| `wasmedge` | 1 281 877 | 226.5 | 226.6 | 16.3 ms | 306.6 ms | 26x | — |
+| `wazero` | 33 554 432 | 9.02 | 9.01 | 5.0 ms | 307.8 ms | 1.04x | — |
+| `wasm3` | 10 157 780 | 26.8 | 26.8 | 4.1 ms | 276.4 ms | 3.09x | — |
+| `dewasm-ruby` | 920 025 | 223.1 | 222.9 | 39.2 ms | 244.4 ms | 26x | — |
+| `dewasm-ruby-yjit` | 1 111 242 | 221.4 | 221.2 | 40.3 ms | 286.3 ms | 26x | — |
+| `dewasm-ruby-zjit` | 949 958 | 221.6 | 221.1 | 39.7 ms | 250.2 ms | 26x | — |
+| `dewasm-python` | 747 991 | 402.8 | 402.3 | 29.9 ms | 331.2 ms | 46x | — |
+| `dewasm-pypy` | 4 173 791 | 63.5 | 63.8 | 41.2 ms | 306.1 ms | 7.32x | — |
+| `dewasm-perl` | 331 884 | 888.9 | 887.0 | 10.6 ms | 305.6 ms | 103x | — |
+| `dewasm-go` | 38 226 532 | 7.85 | 7.85 | 2.6 ms | 302.6 ms | 0.91x | — |
+| `dewasm-java` | 25 750 679 | 10.1 | 10.1 | 63.4 ms | 324.3 ms | 1.17x | — |
+| `dewasm-bash` | 7 566 | 37152 | 37194 | 12.8 ms | 293.9 ms | 4287x | — |
+| `pywasm-cpython` | 5 486 | 51706 | 51763 | 45.0 ms | 328.7 ms | 5966x | 1.0 ms |
+| `pywasm-pypy` | 3 803 | 51008 | 51082 | 81.4 ms | 275.4 ms | 5885x | 5.6 ms |
+| `wardite` | 25 798 | 21410 | 21431 | 53.7 ms | 606.1 ms | 2470x | 4.5 ms |
+| `wardite-yjit` | 24 340 | 8803 | 8889 | 103.9 ms | 318.1 ms | 1016x | 10.2 ms |
 
 </details>
 
@@ -87,7 +87,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-call-direct-dark.svg">
-  <img alt="wat/call_direct: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 3.49 ns, then wasmtime at 3.49 ns; dewasm-bash is slowest at 55.6 µs, a span of 15900x. The table below carries every number." src="figs/wat-call-direct.svg">
+  <img alt="wat/call_direct: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 3.53 ns, then wasmtime at 3.55 ns; dewasm-bash is slowest at 56.4 µs, a span of 16000x. The table below carries every number." src="figs/wat-call-direct.svg">
 </picture>
 
 <details>
@@ -95,24 +95,24 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 87 191 798 | 3.49 | 3.49 | 5.4 ms | 309.9 ms | 1.00x | — |
-| `wasmer` | 86 070 965 | 3.49 | 3.49 | 8.8 ms | 309.3 ms | 1.00x | — |
-| `wasmedge` | 1 378 333 | 205.7 | 206.7 | 15.8 ms | 299.3 ms | 59x | — |
-| `wazero` | 49 810 957 | 6.00 | 6.00 | 5.2 ms | 304.1 ms | 1.72x | — |
-| `wasm3` | 5 437 668 | 49.3 | 49.4 | 4.3 ms | 272.3 ms | 14x | — |
-| `dewasm-ruby` | 1 287 818 | 206.7 | 206.6 | 39.5 ms | 305.6 ms | 59x | — |
-| `dewasm-ruby-yjit` | 2 671 849 | 108.7 | 108.8 | 39.1 ms | 329.6 ms | 31x | — |
-| `dewasm-ruby-zjit` | 2 333 855 | 124.8 | 125.1 | 40.1 ms | 331.4 ms | 36x | — |
-| `dewasm-python` | 678 642 | 410.9 | 416.0 | 29.2 ms | 308.0 ms | 118x | — |
-| `dewasm-pypy` | 2 123 426 | 88.7 | 88.7 | 40.2 ms | 228.5 ms | 25x | — |
-| `dewasm-perl` | 271 182 | 1097 | 1096 | 10.7 ms | 308.2 ms | 314x | — |
-| `dewasm-go` | 72 675 219 | 4.13 | 4.13 | 2.7 ms | 302.5 ms | 1.18x | — |
-| `dewasm-java` | 58 724 210 | 3.60 | 3.62 | 65.9 ms | 277.2 ms | 1.03x | — |
-| `dewasm-bash` | 5 017 | 55592 | 55606 | 12.5 ms | 291.4 ms | 15918x | — |
-| `pywasm-cpython` | 6 841 | 48765 | 48915 | 44.1 ms | 377.7 ms | 13963x | 0.6 ms |
-| `pywasm-pypy` | 18 808 | 10855 | 10913 | 77.8 ms | 282.0 ms | 3108x | 4.0 ms |
-| `wardite` | 13 438 | 17987 | 17916 | 52.1 ms | 293.8 ms | 5150x | 4.4 ms |
-| `wardite-yjit` | 34 981 | 8325 | 8321 | 102.1 ms | 393.3 ms | 2384x | 9.1 ms |
+| `wasmtime` | 83 875 303 | 3.55 | 3.55 | 5.4 ms | 302.8 ms | 1.00x | — |
+| `wasmer` | 84 654 614 | 3.52 | 3.53 | 9.1 ms | 307.2 ms | 0.99x | — |
+| `wasmedge` | 1 396 909 | 210.3 | 211.0 | 16.5 ms | 310.3 ms | 59x | — |
+| `wazero` | 49 267 932 | 6.08 | 6.09 | 5.0 ms | 304.8 ms | 1.72x | — |
+| `wasm3` | 4 700 447 | 50.3 | 50.6 | 4.1 ms | 240.6 ms | 14x | — |
+| `dewasm-ruby` | 1 131 323 | 210.6 | 210.2 | 39.5 ms | 277.8 ms | 59x | — |
+| `dewasm-ruby-yjit` | 1 915 837 | 110.5 | 110.0 | 40.1 ms | 251.7 ms | 31x | — |
+| `dewasm-ruby-zjit` | 1 932 384 | 127.9 | 128.2 | 40.8 ms | 287.9 ms | 36x | — |
+| `dewasm-python` | 685 782 | 420.0 | 421.0 | 29.6 ms | 317.6 ms | 118x | — |
+| `dewasm-pypy` | 2 295 604 | 89.7 | 90.0 | 41.0 ms | 246.9 ms | 25x | — |
+| `dewasm-perl` | 266 447 | 1117 | 1118 | 10.5 ms | 308.1 ms | 315x | — |
+| `dewasm-go` | 72 189 047 | 4.13 | 4.13 | 3.0 ms | 301.0 ms | 1.16x | — |
+| `dewasm-java` | 80 051 808 | 3.62 | 3.59 | 63.7 ms | 353.6 ms | 1.02x | — |
+| `dewasm-bash` | 4 922 | 56442 | 56406 | 12.2 ms | 290.0 ms | 15915x | — |
+| `pywasm-cpython` | 5 427 | 49346 | 49701 | 44.3 ms | 312.1 ms | 13914x | 0.7 ms |
+| `pywasm-pypy` | 23 408 | 9972 | 9952 | 79.1 ms | 312.5 ms | 2812x | 3.6 ms |
+| `wardite` | 11 984 | 18072 | 18137 | 52.8 ms | 269.4 ms | 5096x | 4.2 ms |
+| `wardite-yjit` | 32 446 | 8420 | 8367 | 103.3 ms | 376.5 ms | 2374x | 9.4 ms |
 
 </details>
 
@@ -120,7 +120,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-call-indirect-dark.svg">
-  <img alt="wat/call_indirect: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 10.5 ns, then wasmer at 10.5 ns; pywasm-cpython is slowest at 81.6 µs, a span of 7810x. The table below carries every number." src="figs/wat-call-indirect.svg">
+  <img alt="wat/call_indirect: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 10.5 ns, then wasmtime at 10.6 ns; pywasm-cpython is slowest at 82.7 µs, a span of 7860x. The table below carries every number." src="figs/wat-call-indirect.svg">
 </picture>
 
 <details>
@@ -128,24 +128,24 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 33 554 432 | 10.5 | 10.5 | 5.4 ms | 356.1 ms | 1.00x | — |
-| `wasmer` | 28 686 823 | 10.5 | 10.5 | 8.9 ms | 309.0 ms | 1.00x | — |
-| `wasmedge` | 697 957 | 414.8 | 416.5 | 15.8 ms | 305.3 ms | 40x | — |
-| `wazero` | 16 777 216 | 11.8 | 11.8 | 5.0 ms | 202.8 ms | 1.13x | — |
-| `wasm3` | 3 823 043 | 68.8 | 69.0 | 4.2 ms | 267.1 ms | 6.58x | — |
-| `dewasm-ruby` | 337 885 | 668.2 | 667.7 | 38.0 ms | 263.8 ms | 64x | — |
-| `dewasm-ruby-yjit` | 662 171 | 411.0 | 409.1 | 39.3 ms | 311.5 ms | 39x | — |
-| `dewasm-ruby-zjit` | 586 998 | 464.0 | 474.8 | 41.0 ms | 313.3 ms | 44x | — |
-| `dewasm-python` | 363 467 | 776.5 | 777.3 | 29.4 ms | 311.6 ms | 74x | — |
-| `dewasm-pypy` | 1 890 998 | 137.7 | 138.7 | 40.6 ms | 301.1 ms | 13x | — |
-| `dewasm-perl` | 131 072 | 2441 | 2444 | 10.5 ms | 330.4 ms | 234x | — |
-| `dewasm-go` | 16 777 216 | 10.8 | 10.8 | 2.7 ms | 183.9 ms | 1.03x | — |
-| `dewasm-java` | 3 726 232 | 52.0 | 56.8 | 65.9 ms | 259.7 ms | 4.98x | — |
-| `dewasm-bash` | 3 514 | 75165 | 75406 | 11.5 ms | 275.6 ms | 7192x | — |
-| `pywasm-cpython` | 3 121 | 81588 | 81640 | 42.1 ms | 296.7 ms | 7806x | 0.7 ms |
-| `pywasm-pypy` | 6 320 | 31731 | 31693 | 80.1 ms | 280.7 ms | 3036x | 4.2 ms |
-| `wardite` | 7 583 | 28146 | 27930 | 52.2 ms | 265.7 ms | 2693x | 4.2 ms |
-| `wardite-yjit` | 14 270 | 14239 | 14286 | 101.7 ms | 304.9 ms | 1362x | 9.1 ms |
+| `wasmtime` | 33 554 432 | 10.5 | 10.6 | 5.8 ms | 359.6 ms | 1.00x | — |
+| `wasmer` | 28 596 734 | 10.5 | 10.5 | 9.0 ms | 308.6 ms | 0.99x | — |
+| `wasmedge` | 692 996 | 422.4 | 421.4 | 15.8 ms | 308.5 ms | 40x | — |
+| `wazero` | 25 364 682 | 11.9 | 11.9 | 5.0 ms | 306.4 ms | 1.13x | — |
+| `wasm3` | 4 143 441 | 69.7 | 70.2 | 4.4 ms | 293.2 ms | 6.61x | — |
+| `dewasm-ruby` | 427 776 | 671.4 | 671.1 | 39.7 ms | 326.9 ms | 64x | — |
+| `dewasm-ruby-yjit` | 621 208 | 411.0 | 417.3 | 39.0 ms | 294.3 ms | 39x | — |
+| `dewasm-ruby-zjit` | 579 314 | 474.7 | 480.6 | 40.9 ms | 315.9 ms | 45x | — |
+| `dewasm-python` | 386 511 | 790.3 | 789.0 | 29.2 ms | 334.6 ms | 75x | — |
+| `dewasm-pypy` | 1 768 112 | 140.3 | 140.6 | 40.5 ms | 288.6 ms | 13x | — |
+| `dewasm-perl` | 121 189 | 2477 | 2477 | 10.8 ms | 311.0 ms | 235x | — |
+| `dewasm-go` | 16 777 216 | 10.9 | 10.9 | 2.9 ms | 185.5 ms | 1.03x | — |
+| `dewasm-java` | 3 528 382 | 57.4 | 57.0 | 64.6 ms | 267.1 ms | 5.44x | — |
+| `dewasm-bash` | 3 886 | 75631 | 75849 | 13.1 ms | 307.0 ms | 7173x | — |
+| `pywasm-cpython` | 3 506 | 82845 | 82671 | 43.6 ms | 334.0 ms | 7857x | 0.8 ms |
+| `pywasm-pypy` | 8 168 | 27065 | 27131 | 77.8 ms | 298.9 ms | 2567x | 4.6 ms |
+| `wardite` | 11 110 | 28187 | 28436 | 53.9 ms | 367.1 ms | 2673x | 4.1 ms |
+| `wardite-yjit` | 13 685 | 14418 | 14446 | 102.1 ms | 299.4 ms | 1367x | 9.4 ms |
 
 </details>
 
@@ -153,7 +153,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-conv-dark.svg">
-  <img alt="wat/conv: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 7.63 ns, then wasmtime at 7.63 ns; pywasm-pypy is slowest at 834 µs, a span of 109000x. The table below carries every number." src="figs/wat-conv.svg">
+  <img alt="wat/conv: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 7.64 ns, then wasmer at 7.65 ns; pywasm-pypy is slowest at 807 µs, a span of 106000x. The table below carries every number." src="figs/wat-conv.svg">
 </picture>
 
 <details>
@@ -161,24 +161,24 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 39 213 418 | 7.63 | 7.63 | 5.5 ms | 304.9 ms | 1.00x | — |
-| `wasmer` | 39 248 647 | 7.63 | 7.63 | 9.3 ms | 308.9 ms | 1.00x | — |
-| `wasmedge` | 1 203 280 | 234.6 | 234.5 | 15.8 ms | 298.1 ms | 31x | — |
-| `wazero` | 6 059 341 | 57.0 | 56.9 | 5.1 ms | 350.4 ms | 7.47x | — |
-| `wasm3` | 16 777 216 | 21.2 | 21.2 | 4.4 ms | 360.2 ms | 2.78x | — |
-| `dewasm-ruby` | 201 936 | 1359 | 1360 | 38.3 ms | 312.6 ms | 178x | — |
-| `dewasm-ruby-yjit` | 295 406 | 868.2 | 869.9 | 40.1 ms | 296.5 ms | 114x | — |
-| `dewasm-ruby-zjit` | 247 727 | 981.5 | 983.5 | 39.2 ms | 282.4 ms | 129x | — |
-| `dewasm-python` | 217 040 | 1386 | 1394 | 29.8 ms | 330.5 ms | 182x | — |
-| `dewasm-pypy` | 780 229 | 258.9 | 259.0 | 41.6 ms | 243.6 ms | 34x | — |
-| `dewasm-perl` | 132 995 | 2241 | 2242 | 15.1 ms | 313.0 ms | 294x | — |
-| `dewasm-go` | 16 777 216 | 10.5 | 10.5 | 4.8 ms | 180.3 ms | 1.37x | — |
-| `dewasm-java` | 16 218 192 | 18.1 | 18.1 | 66.5 ms | 360.5 ms | 2.37x | — |
-| `dewasm-bash` | 570 | 522034 | 522095 | 12.7 ms | 310.2 ms | 68388x | — |
-| `pywasm-cpython` | 2 814 | 101620 | 100945 | 41.9 ms | 327.8 ms | 13312x | 0.7 ms |
-| `pywasm-pypy` | 281 | 829870 | 833668 | 77.4 ms | 310.6 ms | 108715x | 4.0 ms |
-| `wardite` | 9 218 | 25694 | 25838 | 53.4 ms | 290.2 ms | 3366x | 4.1 ms |
-| `wardite-yjit` | 12 027 | 15712 | 15844 | 98.5 ms | 287.4 ms | 2058x | 9.8 ms |
+| `wasmtime` | 39 139 572 | 7.64 | 7.64 | 5.6 ms | 304.7 ms | 1.00x | — |
+| `wasmer` | 39 113 200 | 7.63 | 7.65 | 8.8 ms | 307.4 ms | 1.00x | — |
+| `wasmedge` | 1 279 656 | 236.9 | 236.8 | 16.0 ms | 319.2 ms | 31x | — |
+| `wazero` | 5 237 294 | 56.7 | 57.1 | 5.1 ms | 301.9 ms | 7.41x | — |
+| `wasm3` | 16 777 216 | 21.4 | 21.5 | 4.5 ms | 364.4 ms | 2.81x | — |
+| `dewasm-ruby` | 212 633 | 1377 | 1374 | 39.3 ms | 332.1 ms | 180x | — |
+| `dewasm-ruby-yjit` | 240 266 | 861.7 | 874.5 | 39.4 ms | 246.5 ms | 113x | — |
+| `dewasm-ruby-zjit` | 243 150 | 998.1 | 999.2 | 39.5 ms | 282.1 ms | 131x | — |
+| `dewasm-python` | 206 442 | 1416 | 1418 | 28.4 ms | 320.8 ms | 185x | — |
+| `dewasm-pypy` | 1 248 306 | 256.9 | 257.5 | 41.0 ms | 361.7 ms | 34x | — |
+| `dewasm-perl` | 132 410 | 2259 | 2258 | 15.1 ms | 314.3 ms | 296x | — |
+| `dewasm-go` | 33 554 432 | 10.6 | 10.6 | 3.0 ms | 357.3 ms | 1.38x | — |
+| `dewasm-java` | 15 231 628 | 18.4 | 18.3 | 64.2 ms | 344.2 ms | 2.41x | — |
+| `dewasm-bash` | 569 | 524022 | 524303 | 12.6 ms | 310.8 ms | 68578x | — |
+| `pywasm-cpython` | 2 770 | 101454 | 101708 | 43.5 ms | 324.5 ms | 13277x | 0.7 ms |
+| `pywasm-pypy` | 317 | 805498 | 806549 | 78.6 ms | 334.0 ms | 105414x | 3.8 ms |
+| `wardite` | 9 686 | 26109 | 25999 | 52.7 ms | 305.6 ms | 3417x | 4.2 ms |
+| `wardite-yjit` | 13 065 | 15549 | 15697 | 101.7 ms | 304.8 ms | 2035x | 9.7 ms |
 
 </details>
 
@@ -186,7 +186,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-eh-throw-dark.svg">
-  <img alt="wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.37 ns, then wasmedge at 115 ns; wasmer is slowest at 10.3 µs, a span of 2370x. The table below carries every number." src="figs/wat-eh-throw.svg">
+  <img alt="wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.55 ns, then wasmedge at 116 ns; wasmer is slowest at 10.4 µs, a span of 2300x. The table below carries every number." src="figs/wat-eh-throw.svg">
 </picture>
 
 <details>
@@ -194,17 +194,17 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 1 383 163 | 220.6 | 220.9 | 5.4 ms | 310.5 ms | 1.00x | — |
-| `wasmer` | 34 772 | 10333 | 10333 | 9.6 ms | 368.9 ms | 47x | — |
-| `wasmedge` | 2 748 000 | 115.2 | 115.3 | 15.8 ms | 332.5 ms | 0.52x | — |
-| `dewasm-ruby` | 444 127 | 632.2 | 630.5 | 39.3 ms | 320.1 ms | 2.87x | — |
-| `dewasm-ruby-yjit` | 742 234 | 466.6 | 467.4 | 39.9 ms | 386.2 ms | 2.12x | — |
-| `dewasm-ruby-zjit` | 477 341 | 608.4 | 610.3 | 40.0 ms | 330.4 ms | 2.76x | — |
-| `dewasm-python` | 438 178 | 664.9 | 667.4 | 28.7 ms | 320.0 ms | 3.01x | — |
-| `dewasm-pypy` | 4 000 000 | 4.51 | 4.37 | 39.8 ms | 57.8 ms | 0.02x | — |
-| `dewasm-perl` | 253 263 | 1186 | 1190 | 10.5 ms | 310.8 ms | 5.38x | — |
-| `dewasm-go` | 1 184 751 | 198.4 | 199.7 | 5.0 ms | 240.1 ms | 0.90x | — |
-| `dewasm-java` | 392 219 | 532.1 | 533.8 | 68.1 ms | 276.8 ms | 2.41x | — |
+| `wasmtime` | 1 342 442 | 223.6 | 224.6 | 5.4 ms | 305.6 ms | 1.00x | — |
+| `wasmer` | 23 930 | 10444 | 10436 | 8.6 ms | 258.5 ms | 47x | — |
+| `wasmedge` | 2 477 666 | 116.5 | 116.4 | 15.9 ms | 304.6 ms | 0.52x | — |
+| `dewasm-ruby` | 458 087 | 639.5 | 637.8 | 38.7 ms | 331.7 ms | 2.86x | — |
+| `dewasm-ruby-yjit` | 480 695 | 474.8 | 477.4 | 40.8 ms | 269.0 ms | 2.12x | — |
+| `dewasm-ruby-zjit` | 460 890 | 613.8 | 614.5 | 39.8 ms | 322.7 ms | 2.75x | — |
+| `dewasm-python` | 448 340 | 666.6 | 668.9 | 29.0 ms | 327.9 ms | 2.98x | — |
+| `dewasm-pypy` | 4 000 000 | 4.58 | 4.55 | 39.9 ms | 58.2 ms | 0.02x | — |
+| `dewasm-perl` | 249 474 | 1193 | 1196 | 10.5 ms | 308.1 ms | 5.34x | — |
+| `dewasm-go` | 1 462 326 | 202.8 | 203.1 | 2.6 ms | 299.2 ms | 0.91x | — |
+| `dewasm-java` | 395 499 | 533.3 | 530.8 | 65.4 ms | 276.3 ms | 2.39x | — |
 
 </details>
 
@@ -212,7 +212,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-eh-try-dark.svg">
-  <img alt="wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.27 ns, then dewasm-java at 1.43 ns; dewasm-perl is slowest at 515 ns, a span of 407x. The table below carries every number." src="figs/wat-eh-try.svg">
+  <img alt="wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.27 ns, then dewasm-java at 1.44 ns; dewasm-perl is slowest at 520 ns, a span of 411x. The table below carries every number." src="figs/wat-eh-try.svg">
 </picture>
 
 <details>
@@ -220,17 +220,17 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 109 300 097 | 2.79 | 2.78 | 5.7 ms | 310.2 ms | 1.00x | — |
-| `wasmer` | 234 635 887 | 1.27 | 1.27 | 9.0 ms | 306.1 ms | 0.45x | — |
-| `wasmedge` | 2 539 553 | 116.8 | 116.9 | 16.0 ms | 312.7 ms | 42x | — |
-| `dewasm-ruby` | 1 902 131 | 121.5 | 122.3 | 38.5 ms | 269.6 ms | 44x | — |
-| `dewasm-ruby-yjit` | 1 832 517 | 122.8 | 122.7 | 38.9 ms | 264.0 ms | 44x | — |
-| `dewasm-ruby-zjit` | 2 704 668 | 121.7 | 122.5 | 40.2 ms | 369.4 ms | 44x | — |
-| `dewasm-python` | 1 280 336 | 198.3 | 201.1 | 28.4 ms | 282.2 ms | 71x | — |
-| `dewasm-pypy` | 105 149 754 | 2.60 | 2.59 | 40.1 ms | 313.4 ms | 0.93x | — |
-| `dewasm-perl` | 581 571 | 515.1 | 515.2 | 10.6 ms | 310.2 ms | 185x | — |
-| `dewasm-go` | 64 770 052 | 4.22 | 4.22 | 4.6 ms | 278.0 ms | 1.52x | — |
-| `dewasm-java` | 241 800 984 | 1.43 | 1.43 | 67.4 ms | 412.8 ms | 0.51x | — |
+| `wasmtime` | 106 521 348 | 2.80 | 2.79 | 5.6 ms | 303.4 ms | 1.00x | — |
+| `wasmer` | 235 678 285 | 1.27 | 1.27 | 9.2 ms | 307.6 ms | 0.45x | — |
+| `wasmedge` | 2 332 933 | 118.1 | 118.3 | 15.9 ms | 291.5 ms | 42x | — |
+| `dewasm-ruby` | 2 721 877 | 120.8 | 121.6 | 40.4 ms | 369.0 ms | 43x | — |
+| `dewasm-ruby-yjit` | 2 129 084 | 122.3 | 122.7 | 39.7 ms | 300.0 ms | 44x | — |
+| `dewasm-ruby-zjit` | 2 524 269 | 122.0 | 122.2 | 40.6 ms | 348.5 ms | 44x | — |
+| `dewasm-python` | 1 369 358 | 202.5 | 203.0 | 28.8 ms | 306.1 ms | 72x | — |
+| `dewasm-pypy` | 104 455 728 | 2.64 | 2.64 | 39.9 ms | 315.5 ms | 0.94x | — |
+| `dewasm-perl` | 562 137 | 519.8 | 520.3 | 10.3 ms | 302.5 ms | 186x | — |
+| `dewasm-go` | 70 338 454 | 4.29 | 4.29 | 2.8 ms | 304.5 ms | 1.53x | — |
+| `dewasm-java` | 232 076 204 | 1.44 | 1.44 | 63.2 ms | 397.5 ms | 0.52x | — |
 
 </details>
 
@@ -238,7 +238,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-f32-alu-dark.svg">
-  <img alt="wat/f32_alu: seconds per iteration for 16 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmer at 1.00 ns; dewasm-bash is slowest at 1.21 ms, a span of 1240000x. The table below carries every number." src="figs/wat-f32-alu.svg">
+  <img alt="wat/f32_alu: seconds per iteration for 16 runners on a log scale, fastest first. wazero is fastest at 0.96 ns, then wasmtime at 1.00 ns; dewasm-bash is slowest at 1.22 ms, a span of 1270000x. The table below carries every number." src="figs/wat-f32-alu.svg">
 </picture>
 
 <details>
@@ -246,22 +246,22 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 299 018 404 | 1.00 | 1.00 | 5.5 ms | 304.2 ms | 1.00x | — |
-| `wasmer` | 287 193 659 | 1.00 | 1.00 | 8.9 ms | 295.0 ms | 1.00x | — |
-| `wasmedge` | 3 381 073 | 82.0 | 82.0 | 15.8 ms | 293.0 ms | 82x | — |
-| `wazero` | 307 057 865 | 0.96 | 0.97 | 5.1 ms | 300.0 ms | 0.96x | — |
-| `wasm3` | 44 854 418 | 6.65 | 6.72 | 4.2 ms | 302.7 ms | 6.66x | — |
-| `dewasm-ruby` | 409 210 | 669.5 | 677.0 | 38.6 ms | 312.6 ms | 670x | — |
-| `dewasm-ruby-yjit` | 533 556 | 547.6 | 586.8 | 40.0 ms | 332.2 ms | 548x | — |
-| `dewasm-ruby-zjit` | 414 984 | 665.7 | 680.6 | 39.7 ms | 316.0 ms | 666x | — |
-| `dewasm-python` | 356 393 | 846.8 | 849.3 | 29.3 ms | 331.1 ms | 848x | — |
-| `dewasm-pypy` | 641 667 | 374.6 | 377.4 | 40.8 ms | 281.2 ms | 375x | — |
-| `dewasm-perl` | 193 203 | 1545 | 1547 | 10.3 ms | 308.8 ms | 1546x | — |
-| `dewasm-go` | 76 794 433 | 3.48 | 3.48 | 4.0 ms | 271.0 ms | 3.48x | — |
-| `dewasm-java` | 176 997 459 | 1.64 | 1.64 | 67.3 ms | 358.2 ms | 1.64x | — |
-| `dewasm-bash` | 166 | 1204047 | 1206605 | 12.9 ms | 212.8 ms | 1205140x | — |
-| `pywasm-cpython` | 10 006 | 28709 | 28910 | 43.9 ms | 331.2 ms | 28736x | 0.6 ms |
-| `pywasm-pypy` | 19 644 | 8647 | 8775 | 78.9 ms | 248.8 ms | 8655x | 3.5 ms |
+| `wasmtime` | 301 572 951 | 1.00 | 1.00 | 5.8 ms | 306.9 ms | 1.00x | — |
+| `wasmer` | 294 768 053 | 1.00 | 1.00 | 8.8 ms | 303.6 ms | 1.00x | — |
+| `wasmedge` | 4 449 864 | 82.0 | 82.3 | 16.6 ms | 381.7 ms | 82x | — |
+| `wazero` | 308 767 318 | 0.96 | 0.96 | 5.4 ms | 301.1 ms | 0.96x | — |
+| `wasm3` | 44 505 932 | 6.77 | 6.80 | 4.6 ms | 305.8 ms | 6.78x | — |
+| `dewasm-ruby` | 856 511 | 366.9 | 366.3 | 39.5 ms | 353.7 ms | 367x | — |
+| `dewasm-ruby-yjit` | 1 219 450 | 229.1 | 228.8 | 39.5 ms | 318.8 ms | 229x | — |
+| `dewasm-ruby-zjit` | 870 667 | 281.2 | 284.2 | 39.4 ms | 284.3 ms | 282x | — |
+| `dewasm-python` | 528 143 | 544.0 | 544.6 | 29.2 ms | 316.5 ms | 545x | — |
+| `dewasm-pypy` | 43 743 841 | 5.55 | 5.56 | 40.2 ms | 283.1 ms | 5.56x | — |
+| `dewasm-perl` | 193 861 | 1554 | 1554 | 10.9 ms | 312.2 ms | 1556x | — |
+| `dewasm-go` | 86 057 907 | 3.48 | 3.48 | 2.9 ms | 302.6 ms | 3.49x | — |
+| `dewasm-java` | 174 615 731 | 1.66 | 1.66 | 66.1 ms | 356.1 ms | 1.66x | — |
+| `dewasm-bash` | 186 | 1215096 | 1216863 | 13.0 ms | 239.0 ms | 1217050x | — |
+| `pywasm-cpython` | 7 694 | 29227 | 29171 | 43.0 ms | 267.9 ms | 29274x | 0.6 ms |
+| `pywasm-pypy` | 22 203 | 8233 | 8315 | 77.8 ms | 260.6 ms | 8246x | 3.3 ms |
 
 </details>
 
@@ -269,7 +269,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-f64-alu-dark.svg">
-  <img alt="wat/f64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmtime at 0.97 ns; dewasm-bash is slowest at 578 µs, a span of 598000x. The table below carries every number." src="figs/wat-f64-alu.svg">
+  <img alt="wat/f64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmtime at 0.98 ns; dewasm-bash is slowest at 582 µs, a span of 599000x. The table below carries every number." src="figs/wat-f64-alu.svg">
 </picture>
 
 <details>
@@ -277,24 +277,24 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 292 881 995 | 0.97 | 0.97 | 5.1 ms | 290.6 ms | 1.00x | — |
-| `wasmer` | 295 268 969 | 0.98 | 0.98 | 8.7 ms | 297.6 ms | 1.00x | — |
-| `wasmedge` | 3 057 588 | 81.9 | 81.7 | 15.6 ms | 265.9 ms | 84x | — |
-| `wazero` | 303 912 132 | 0.97 | 0.97 | 4.9 ms | 298.7 ms | 0.99x | — |
-| `wasm3` | 55 344 829 | 5.42 | 5.42 | 4.1 ms | 303.9 ms | 5.56x | — |
-| `dewasm-ruby` | 3 315 713 | 101.6 | 101.8 | 39.9 ms | 376.8 ms | 104x | — |
-| `dewasm-ruby-yjit` | 3 762 352 | 76.3 | 76.2 | 39.7 ms | 326.7 ms | 78x | — |
-| `dewasm-ruby-zjit` | 2 875 968 | 82.7 | 82.5 | 39.3 ms | 277.1 ms | 85x | — |
-| `dewasm-python` | 1 968 269 | 151.4 | 151.6 | 29.4 ms | 327.5 ms | 155x | — |
-| `dewasm-pypy` | 137 235 069 | 2.14 | 2.15 | 41.0 ms | 335.1 ms | 2.20x | — |
-| `dewasm-perl` | 351 167 | 830.0 | 831.3 | 15.0 ms | 306.5 ms | 851x | — |
-| `dewasm-go` | 85 303 177 | 3.51 | 3.52 | 2.9 ms | 302.5 ms | 3.60x | — |
-| `dewasm-java` | 177 598 704 | 1.64 | 1.63 | 66.9 ms | 357.4 ms | 1.68x | — |
-| `dewasm-bash` | 512 | 578435 | 577648 | 12.9 ms | 309.1 ms | 593320x | — |
-| `pywasm-cpython` | 7 775 | 29341 | 29362 | 42.7 ms | 270.8 ms | 30096x | 0.6 ms |
-| `pywasm-pypy` | 33 970 | 6298 | 6324 | 79.1 ms | 293.0 ms | 6460x | 3.6 ms |
-| `wardite` | 38 250 | 7699 | 7683 | 51.4 ms | 345.9 ms | 7897x | 4.1 ms |
-| `wardite-yjit` | 80 606 | 3549 | 3549 | 105.1 ms | 391.1 ms | 3640x | 9.6 ms |
+| `wasmtime` | 307 871 778 | 0.98 | 0.98 | 5.4 ms | 306.3 ms | 1.00x | — |
+| `wasmer` | 294 380 883 | 0.98 | 0.98 | 8.8 ms | 297.0 ms | 1.00x | — |
+| `wasmedge` | 3 635 643 | 82.2 | 82.1 | 16.1 ms | 314.9 ms | 84x | — |
+| `wazero` | 299 988 216 | 0.97 | 0.97 | 4.8 ms | 295.6 ms | 0.99x | — |
+| `wasm3` | 55 297 400 | 5.44 | 5.44 | 4.0 ms | 305.0 ms | 5.57x | — |
+| `dewasm-ruby` | 2 825 791 | 102.0 | 102.5 | 39.3 ms | 327.4 ms | 104x | — |
+| `dewasm-ruby-yjit` | 3 103 672 | 75.5 | 76.8 | 39.4 ms | 273.7 ms | 77x | — |
+| `dewasm-ruby-zjit` | 3 609 946 | 83.3 | 83.1 | 38.8 ms | 339.4 ms | 85x | — |
+| `dewasm-python` | 1 716 069 | 152.8 | 153.0 | 28.7 ms | 290.9 ms | 156x | — |
+| `dewasm-pypy` | 120 872 206 | 2.17 | 2.17 | 40.2 ms | 302.1 ms | 2.22x | — |
+| `dewasm-perl` | 358 657 | 836.8 | 835.2 | 15.3 ms | 315.4 ms | 856x | — |
+| `dewasm-go` | 85 041 822 | 3.51 | 3.52 | 2.7 ms | 301.2 ms | 3.59x | — |
+| `dewasm-java` | 177 819 719 | 1.64 | 1.64 | 66.0 ms | 357.5 ms | 1.68x | — |
+| `dewasm-bash` | 512 | 581311 | 582401 | 13.0 ms | 310.7 ms | 594860x | — |
+| `pywasm-cpython` | 8 986 | 29522 | 29559 | 43.1 ms | 308.4 ms | 30210x | 0.6 ms |
+| `pywasm-pypy` | 27 770 | 7232 | 7210 | 78.5 ms | 279.4 ms | 7400x | 3.5 ms |
+| `wardite` | 33 280 | 7735 | 7726 | 52.5 ms | 309.9 ms | 7915x | 3.9 ms |
+| `wardite-yjit` | 81 973 | 3594 | 3585 | 106.0 ms | 400.7 ms | 3678x | 9.1 ms |
 
 </details>
 
@@ -302,7 +302,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-i32-alu-dark.svg">
-  <img alt="wat/i32_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.32 ns, then wasmtime at 2.32 ns; pywasm-cpython is slowest at 54.1 µs, a span of 23300x. The table below carries every number." src="figs/wat-i32-alu.svg">
+  <img alt="wat/i32_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 2.31 ns, then wasmer at 2.32 ns; pywasm-cpython is slowest at 54.3 µs, a span of 23500x. The table below carries every number." src="figs/wat-i32-alu.svg">
 </picture>
 
 <details>
@@ -310,24 +310,24 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 129 555 458 | 2.32 | 2.32 | 5.4 ms | 306.4 ms | 1.00x | — |
-| `wasmer` | 130 127 386 | 2.31 | 2.32 | 9.4 ms | 310.6 ms | 1.00x | — |
-| `wasmedge` | 1 905 500 | 157.4 | 157.4 | 15.9 ms | 315.8 ms | 68x | — |
-| `wazero` | 109 925 130 | 2.67 | 2.67 | 4.9 ms | 298.0 ms | 1.15x | — |
-| `wasm3` | 16 777 216 | 13.0 | 13.0 | 4.5 ms | 222.1 ms | 5.58x | — |
-| `dewasm-ruby` | 1 936 617 | 182.0 | 182.2 | 39.5 ms | 392.0 ms | 78x | — |
-| `dewasm-ruby-yjit` | 1 992 499 | 138.8 | 138.7 | 39.0 ms | 315.7 ms | 60x | — |
-| `dewasm-ruby-zjit` | 1 465 300 | 150.4 | 150.2 | 38.9 ms | 259.3 ms | 65x | — |
-| `dewasm-python` | 522 627 | 557.1 | 563.7 | 28.9 ms | 320.1 ms | 240x | — |
-| `dewasm-pypy` | 23 622 851 | 9.65 | 9.64 | 39.7 ms | 267.6 ms | 4.15x | — |
-| `dewasm-perl` | 432 693 | 693.9 | 694.3 | 10.7 ms | 311.0 ms | 299x | — |
-| `dewasm-go` | 96 745 118 | 3.07 | 3.07 | 2.7 ms | 300.1 ms | 1.32x | — |
-| `dewasm-java` | 83 776 847 | 2.37 | 2.37 | 67.5 ms | 266.4 ms | 1.02x | — |
-| `dewasm-bash` | 10 285 | 25149 | 25205 | 12.9 ms | 271.5 ms | 10825x | — |
-| `pywasm-cpython` | 4 842 | 54272 | 54089 | 42.5 ms | 305.3 ms | 23360x | 0.7 ms |
-| `pywasm-pypy` | 7 248 | 25836 | 25609 | 79.3 ms | 266.6 ms | 11120x | 3.8 ms |
-| `wardite` | 20 847 | 15205 | 15347 | 53.4 ms | 370.4 ms | 6545x | 4.2 ms |
-| `wardite-yjit` | 35 673 | 7005 | 7086 | 101.4 ms | 351.4 ms | 3015x | 9.1 ms |
+| `wasmtime` | 129 197 266 | 2.31 | 2.31 | 5.5 ms | 303.4 ms | 1.00x | — |
+| `wasmer` | 131 523 254 | 2.32 | 2.32 | 9.1 ms | 314.2 ms | 1.01x | — |
+| `wasmedge` | 1 834 486 | 158.6 | 158.5 | 16.2 ms | 307.1 ms | 69x | — |
+| `wazero` | 111 068 977 | 2.66 | 2.67 | 5.2 ms | 301.2 ms | 1.16x | — |
+| `wasm3` | 16 777 216 | 13.1 | 13.1 | 4.2 ms | 223.9 ms | 5.68x | — |
+| `dewasm-ruby` | 1 557 640 | 184.5 | 185.7 | 39.6 ms | 327.1 ms | 80x | — |
+| `dewasm-ruby-yjit` | 2 085 317 | 139.6 | 139.7 | 39.5 ms | 330.6 ms | 61x | — |
+| `dewasm-ruby-zjit` | 1 656 344 | 151.2 | 151.8 | 39.7 ms | 290.1 ms | 66x | — |
+| `dewasm-python` | 537 026 | 563.0 | 565.5 | 29.5 ms | 331.8 ms | 244x | — |
+| `dewasm-pypy` | 27 501 923 | 9.62 | 9.64 | 39.8 ms | 304.3 ms | 4.17x | — |
+| `dewasm-perl` | 427 223 | 696.2 | 696.7 | 11.0 ms | 308.4 ms | 302x | — |
+| `dewasm-go` | 97 882 931 | 3.08 | 3.08 | 2.9 ms | 304.1 ms | 1.33x | — |
+| `dewasm-java` | 138 617 608 | 2.34 | 2.34 | 66.4 ms | 390.2 ms | 1.01x | — |
+| `dewasm-bash` | 11 410 | 25246 | 25278 | 12.8 ms | 300.9 ms | 10947x | — |
+| `pywasm-cpython` | 5 316 | 54158 | 54272 | 43.6 ms | 331.5 ms | 23485x | 0.7 ms |
+| `pywasm-pypy` | 6 336 | 28119 | 28262 | 81.1 ms | 259.2 ms | 12193x | 3.8 ms |
+| `wardite` | 18 480 | 15337 | 15326 | 53.9 ms | 337.3 ms | 6650x | 4.5 ms |
+| `wardite-yjit` | 45 118 | 7108 | 7182 | 101.8 ms | 422.5 ms | 3082x | 9.4 ms |
 
 </details>
 
@@ -335,7 +335,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-i32-div-dark.svg">
-  <img alt="wat/i32_div: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-go is fastest at 7.63 ns, then wasmer at 7.63 ns; pywasm-pypy is slowest at 214 µs, a span of 28100x. The table below carries every number." src="figs/wat-i32-div.svg">
+  <img alt="wat/i32_div: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 7.63 ns, then wasmtime at 7.65 ns; dewasm-bash is slowest at 69.0 µs, a span of 9030x. The table below carries every number." src="figs/wat-i32-div.svg">
 </picture>
 
 <details>
@@ -343,24 +343,24 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 39 155 863 | 7.65 | 7.64 | 5.4 ms | 304.8 ms | 1.00x | — |
-| `wasmer` | 39 414 336 | 7.64 | 7.63 | 9.2 ms | 310.2 ms | 1.00x | — |
-| `wasmedge` | 1 525 586 | 188.5 | 189.0 | 15.9 ms | 303.5 ms | 25x | — |
-| `wazero` | 39 086 965 | 7.65 | 7.65 | 5.1 ms | 304.1 ms | 1.00x | — |
-| `wasm3` | 12 698 043 | 17.1 | 17.1 | 4.4 ms | 221.0 ms | 2.23x | — |
-| `dewasm-ruby` | 827 448 | 368.2 | 368.0 | 39.4 ms | 344.1 ms | 48x | — |
-| `dewasm-ruby-yjit` | 1 391 676 | 196.0 | 196.5 | 40.1 ms | 313.0 ms | 26x | — |
-| `dewasm-ruby-zjit` | 1 194 241 | 244.2 | 242.6 | 38.1 ms | 329.7 ms | 32x | — |
-| `dewasm-python` | 305 222 | 980.2 | 983.9 | 29.3 ms | 328.5 ms | 128x | — |
-| `dewasm-pypy` | 24 135 930 | 14.0 | 14.0 | 40.0 ms | 377.9 ms | 1.83x | — |
-| `dewasm-perl` | 246 870 | 1221 | 1222 | 10.7 ms | 312.1 ms | 160x | — |
-| `dewasm-go` | 34 325 805 | 7.70 | 7.63 | 3.0 ms | 267.2 ms | 1.01x | — |
-| `dewasm-java` | 24 294 063 | 7.99 | 7.99 | 66.8 ms | 260.9 ms | 1.04x | — |
-| `dewasm-bash` | 4 202 | 68674 | 68784 | 12.6 ms | 301.2 ms | 8980x | — |
-| `pywasm-cpython` | 4 672 | 60659 | 61025 | 44.5 ms | 327.9 ms | 7932x | 0.7 ms |
-| `pywasm-pypy` | 850 | 210390 | 214128 | 77.4 ms | 256.2 ms | 27512x | 3.8 ms |
-| `wardite` | 16 605 | 18345 | 18370 | 52.5 ms | 357.1 ms | 2399x | 4.4 ms |
-| `wardite-yjit` | 37 196 | 8521 | 8530 | 101.0 ms | 417.9 ms | 1114x | 9.1 ms |
+| `wasmtime` | 39 375 587 | 7.65 | 7.65 | 5.4 ms | 306.7 ms | 1.00x | — |
+| `wasmer` | 39 144 682 | 7.65 | 7.63 | 8.7 ms | 308.1 ms | 1.00x | — |
+| `wasmedge` | 1 544 173 | 189.4 | 189.9 | 16.2 ms | 308.7 ms | 25x | — |
+| `wazero` | 38 783 852 | 7.65 | 7.68 | 5.0 ms | 301.9 ms | 1.00x | — |
+| `wasm3` | 16 777 216 | 17.1 | 17.2 | 4.3 ms | 291.6 ms | 2.24x | — |
+| `dewasm-ruby` | 561 435 | 375.3 | 380.8 | 37.9 ms | 248.6 ms | 49x | — |
+| `dewasm-ruby-yjit` | 1 148 283 | 197.1 | 200.0 | 39.9 ms | 266.3 ms | 26x | — |
+| `dewasm-ruby-zjit` | 992 813 | 244.5 | 245.1 | 39.7 ms | 282.5 ms | 32x | — |
+| `dewasm-python` | 298 266 | 982.8 | 984.9 | 29.2 ms | 322.3 ms | 128x | — |
+| `dewasm-pypy` | 17 302 629 | 14.2 | 14.2 | 40.3 ms | 285.4 ms | 1.85x | — |
+| `dewasm-perl` | 241 610 | 1223 | 1225 | 10.6 ms | 306.1 ms | 160x | — |
+| `dewasm-go` | 39 029 538 | 7.69 | 7.72 | 2.7 ms | 302.9 ms | 1.01x | — |
+| `dewasm-java` | 23 854 458 | 8.04 | 7.98 | 64.1 ms | 255.8 ms | 1.05x | — |
+| `dewasm-bash` | 4 040 | 68950 | 68959 | 12.2 ms | 290.8 ms | 9010x | — |
+| `pywasm-cpython` | 4 203 | 61780 | 62021 | 42.7 ms | 302.4 ms | 8073x | 0.7 ms |
+| `pywasm-pypy` | 4 424 | 42571 | 42589 | 78.2 ms | 266.5 ms | 5563x | 3.9 ms |
+| `wardite` | 15 431 | 18477 | 18448 | 52.4 ms | 337.5 ms | 2414x | 4.6 ms |
+| `wardite-yjit` | 24 975 | 8584 | 8656 | 101.9 ms | 316.3 ms | 1122x | 9.2 ms |
 
 </details>
 
@@ -368,7 +368,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-i64-alu-dark.svg">
-  <img alt="wat/i64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.32 ns, then wasmtime at 2.33 ns; pywasm-pypy is slowest at 397 µs, a span of 171000x. The table below carries every number." src="figs/wat-i64-alu.svg">
+  <img alt="wat/i64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.31 ns, then wasmtime at 2.31 ns; pywasm-pypy is slowest at 329 µs, a span of 142000x. The table below carries every number." src="figs/wat-i64-alu.svg">
 </picture>
 
 <details>
@@ -376,24 +376,24 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 126 577 242 | 2.33 | 2.33 | 5.3 ms | 300.0 ms | 1.00x | — |
-| `wasmer` | 128 901 407 | 2.32 | 2.32 | 9.6 ms | 309.1 ms | 1.00x | — |
-| `wasmedge` | 1 725 365 | 157.9 | 157.6 | 15.6 ms | 287.9 ms | 68x | — |
-| `wazero` | 111 272 479 | 2.67 | 2.67 | 5.0 ms | 302.1 ms | 1.15x | — |
-| `wasm3` | 15 831 545 | 12.1 | 12.1 | 4.0 ms | 195.5 ms | 5.19x | — |
-| `dewasm-ruby` | 218 623 | 1332 | 1338 | 38.8 ms | 330.0 ms | 572x | — |
-| `dewasm-ruby-yjit` | 284 346 | 972.4 | 989.0 | 39.5 ms | 316.0 ms | 418x | — |
-| `dewasm-ruby-zjit` | 272 181 | 1038 | 1054 | 39.9 ms | 322.3 ms | 446x | — |
-| `dewasm-python` | 452 339 | 631.1 | 633.3 | 29.4 ms | 314.9 ms | 271x | — |
-| `dewasm-pypy` | 993 649 | 223.5 | 223.4 | 40.1 ms | 262.2 ms | 96x | — |
-| `dewasm-perl` | 300 939 | 1004 | 1006 | 10.6 ms | 312.7 ms | 431x | — |
-| `dewasm-go` | 113 960 705 | 2.64 | 2.64 | 2.9 ms | 303.9 ms | 1.13x | — |
-| `dewasm-java` | 129 434 208 | 2.36 | 2.36 | 66.5 ms | 371.9 ms | 1.01x | — |
-| `dewasm-bash` | 9 644 | 27660 | 27746 | 13.2 ms | 279.9 ms | 11876x | — |
-| `pywasm-cpython` | 4 773 | 57501 | 57232 | 44.2 ms | 318.6 ms | 24690x | 0.6 ms |
-| `pywasm-pypy` | 477 | 397386 | 397020 | 82.4 ms | 272.0 ms | 170630x | 3.8 ms |
-| `wardite` | 13 383 | 16606 | 16769 | 52.7 ms | 275.0 ms | 7130x | 4.3 ms |
-| `wardite-yjit` | 31 228 | 9317 | 9298 | 100.9 ms | 391.9 ms | 4000x | 9.8 ms |
+| `wasmtime` | 128 506 609 | 2.31 | 2.31 | 5.4 ms | 302.4 ms | 1.00x | — |
+| `wasmer` | 128 498 545 | 2.31 | 2.31 | 8.5 ms | 305.7 ms | 1.00x | — |
+| `wasmedge` | 1 885 958 | 157.3 | 158.2 | 16.2 ms | 312.8 ms | 68x | — |
+| `wazero` | 110 343 753 | 2.67 | 2.67 | 4.7 ms | 299.0 ms | 1.15x | — |
+| `wasm3` | 28 117 002 | 12.1 | 12.1 | 4.0 ms | 344.1 ms | 5.24x | — |
+| `dewasm-ruby` | 231 266 | 1268 | 1280 | 39.5 ms | 332.6 ms | 549x | — |
+| `dewasm-ruby-yjit` | 294 857 | 960.3 | 957.8 | 40.2 ms | 323.3 ms | 416x | — |
+| `dewasm-ruby-zjit` | 284 005 | 1029 | 1032 | 40.7 ms | 333.1 ms | 446x | — |
+| `dewasm-python` | 480 602 | 637.7 | 637.8 | 29.2 ms | 335.7 ms | 276x | — |
+| `dewasm-pypy` | 991 696 | 225.1 | 225.3 | 39.9 ms | 263.1 ms | 97x | — |
+| `dewasm-perl` | 295 624 | 1010 | 1011 | 10.6 ms | 309.4 ms | 437x | — |
+| `dewasm-go` | 113 601 995 | 2.64 | 2.64 | 2.9 ms | 303.0 ms | 1.14x | — |
+| `dewasm-java` | 136 744 570 | 2.36 | 2.36 | 64.9 ms | 387.7 ms | 1.02x | — |
+| `dewasm-bash` | 10 405 | 27649 | 27692 | 13.4 ms | 301.1 ms | 11966x | — |
+| `pywasm-cpython` | 5 410 | 57358 | 57662 | 44.7 ms | 355.0 ms | 24824x | 0.6 ms |
+| `pywasm-pypy` | 607 | 330284 | 328533 | 83.1 ms | 283.6 ms | 142942x | 3.7 ms |
+| `wardite` | 14 456 | 16714 | 16674 | 53.1 ms | 294.7 ms | 7234x | 4.0 ms |
+| `wardite-yjit` | 33 244 | 9241 | 9245 | 102.1 ms | 409.3 ms | 3999x | 9.6 ms |
 
 </details>
 
@@ -401,7 +401,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-i64-div-dark.svg">
-  <img alt="wat/i64_div: seconds per iteration for 16 runners on a log scale, fastest first. dewasm-go is fastest at 8.24 ns, then wasmer at 8.28 ns; pywasm-pypy is slowest at 392 µs, a span of 47600x. The table below carries every number." src="figs/wat-i64-div.svg">
+  <img alt="wat/i64_div: seconds per iteration for 16 runners on a log scale, fastest first. wasmtime is fastest at 8.28 ns, then wasmer at 8.30 ns; pywasm-pypy is slowest at 513 µs, a span of 62000x. The table below carries every number." src="figs/wat-i64-div.svg">
 </picture>
 
 <details>
@@ -409,22 +409,22 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 36 254 517 | 8.28 | 8.29 | 5.4 ms | 305.5 ms | 1.00x | — |
-| `wasmer` | 36 133 068 | 8.27 | 8.28 | 9.3 ms | 308.2 ms | 1.00x | — |
-| `wasmedge` | 1 644 194 | 188.0 | 188.1 | 15.9 ms | 325.0 ms | 23x | — |
-| `wazero` | 36 469 103 | 8.30 | 8.31 | 5.3 ms | 308.0 ms | 1.00x | — |
-| `wasm3` | 13 930 659 | 16.2 | 16.2 | 4.1 ms | 230.0 ms | 1.96x | — |
-| `dewasm-ruby` | 162 977 | 1692 | 1695 | 39.4 ms | 315.2 ms | 204x | — |
-| `dewasm-ruby-yjit` | 200 894 | 1141 | 1150 | 39.4 ms | 268.7 ms | 138x | — |
-| `dewasm-ruby-zjit` | 152 217 | 1410 | 1409 | 38.9 ms | 253.4 ms | 170x | — |
-| `dewasm-python` | 286 489 | 1034 | 1038 | 29.2 ms | 325.4 ms | 125x | — |
-| `dewasm-pypy` | 1 043 865 | 268.2 | 266.7 | 39.6 ms | 319.6 ms | 32x | — |
-| `dewasm-perl` | 196 042 | 1509 | 1512 | 10.8 ms | 306.7 ms | 182x | — |
-| `dewasm-go` | 34 311 152 | 8.25 | 8.24 | 3.8 ms | 286.8 ms | 1.00x | — |
-| `dewasm-java` | 23 846 088 | 8.55 | 8.60 | 67.3 ms | 271.3 ms | 1.03x | — |
-| `dewasm-bash` | 3 668 | 77454 | 77444 | 12.4 ms | 296.5 ms | 9356x | — |
-| `pywasm-cpython` | 4 758 | 65436 | 65888 | 45.0 ms | 356.4 ms | 7905x | 0.7 ms |
-| `pywasm-pypy` | 503 | 394139 | 391962 | 78.5 ms | 276.8 ms | 47611x | 4.0 ms |
+| `wasmtime` | 36 355 097 | 8.29 | 8.28 | 5.6 ms | 306.8 ms | 1.00x | — |
+| `wasmer` | 36 040 778 | 8.29 | 8.30 | 8.7 ms | 307.7 ms | 1.00x | — |
+| `wasmedge` | 1 574 932 | 188.5 | 188.6 | 15.9 ms | 312.9 ms | 23x | — |
+| `wazero` | 36 094 987 | 8.30 | 8.31 | 5.1 ms | 304.8 ms | 1.00x | — |
+| `wasm3` | 16 777 216 | 16.2 | 16.2 | 4.1 ms | 276.3 ms | 1.96x | — |
+| `dewasm-ruby` | 164 920 | 1693 | 1698 | 39.6 ms | 318.7 ms | 204x | — |
+| `dewasm-ruby-yjit` | 205 691 | 1149 | 1149 | 39.4 ms | 275.7 ms | 139x | — |
+| `dewasm-ruby-zjit` | 188 582 | 1413 | 1416 | 39.9 ms | 306.4 ms | 171x | — |
+| `dewasm-python` | 284 095 | 1036 | 1039 | 28.8 ms | 323.1 ms | 125x | — |
+| `dewasm-pypy` | 681 767 | 272.5 | 272.8 | 39.7 ms | 225.4 ms | 33x | — |
+| `dewasm-perl` | 195 767 | 1511 | 1516 | 10.9 ms | 306.8 ms | 182x | — |
+| `dewasm-go` | 36 049 078 | 8.26 | 8.31 | 2.5 ms | 300.4 ms | 1.00x | — |
+| `dewasm-java` | 33 155 187 | 8.66 | 8.54 | 61.7 ms | 348.9 ms | 1.05x | — |
+| `dewasm-bash` | 3 867 | 76976 | 77132 | 12.5 ms | 310.2 ms | 9291x | — |
+| `pywasm-cpython` | 4 231 | 66304 | 66508 | 43.8 ms | 324.3 ms | 8003x | 0.7 ms |
+| `pywasm-pypy` | 368 | 511172 | 513225 | 78.2 ms | 266.3 ms | 61698x | 4.0 ms |
 
 </details>
 
@@ -432,7 +432,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-mem-narrow-dark.svg">
-  <img alt="wat/mem_narrow: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.58 ns; pywasm-cpython is slowest at 87.7 µs, a span of 58500x. The table below carries every number." src="figs/wat-mem-narrow.svg">
+  <img alt="wat/mem_narrow: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.59 ns; pywasm-cpython is slowest at 87.8 µs, a span of 58500x. The table below carries every number." src="figs/wat-mem-narrow.svg">
 </picture>
 
 <details>
@@ -440,24 +440,24 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 199 251 057 | 1.50 | 1.50 | 5.7 ms | 304.3 ms | 1.00x | — |
-| `wasmer` | 189 206 642 | 1.58 | 1.58 | 8.8 ms | 308.2 ms | 1.06x | — |
-| `wasmedge` | 1 134 465 | 268.1 | 269.3 | 16.0 ms | 320.1 ms | 179x | — |
-| `wazero` | 117 349 081 | 2.52 | 2.53 | 4.7 ms | 301.0 ms | 1.69x | — |
-| `wasm3` | 9 629 976 | 20.5 | 20.6 | 4.1 ms | 201.8 ms | 14x | — |
-| `dewasm-ruby` | 599 388 | 437.0 | 434.5 | 37.7 ms | 299.6 ms | 292x | — |
-| `dewasm-ruby-yjit` | 777 907 | 309.5 | 309.7 | 38.9 ms | 279.7 ms | 207x | — |
-| `dewasm-ruby-zjit` | 647 696 | 335.4 | 339.6 | 39.3 ms | 256.6 ms | 224x | — |
-| `dewasm-python` | 156 839 | 1893 | 1912 | 29.4 ms | 326.3 ms | 1263x | — |
-| `dewasm-pypy` | 3 304 769 | 73.0 | 72.8 | 40.5 ms | 281.8 ms | 49x | — |
-| `dewasm-perl` | 65 536 | 3232 | 3247 | 11.6 ms | 223.4 ms | 2157x | — |
-| `dewasm-go` | 103 553 741 | 2.48 | 2.48 | 4.3 ms | 260.7 ms | 1.65x | — |
-| `dewasm-java` | 45 353 611 | 4.46 | 4.51 | 66.7 ms | 269.0 ms | 2.98x | — |
-| `dewasm-bash` | 5 751 | 51298 | 51328 | 12.8 ms | 307.8 ms | 34239x | — |
-| `pywasm-cpython` | 3 353 | 87567 | 87657 | 43.7 ms | 337.3 ms | 58446x | 0.9 ms |
-| `pywasm-pypy` | 3 218 | 57676 | 57328 | 78.0 ms | 263.6 ms | 38496x | 5.1 ms |
-| `wardite` | 10 043 | 28354 | 28544 | 53.1 ms | 337.9 ms | 18925x | 3.8 ms |
-| `wardite-yjit` | 19 012 | 14780 | 14812 | 101.3 ms | 382.3 ms | 9865x | 9.1 ms |
+| `wasmtime` | 198 644 235 | 1.50 | 1.50 | 5.2 ms | 303.7 ms | 1.00x | — |
+| `wasmer` | 192 199 667 | 1.59 | 1.59 | 9.0 ms | 314.4 ms | 1.06x | — |
+| `wasmedge` | 1 071 781 | 271.3 | 271.7 | 15.7 ms | 306.4 ms | 181x | — |
+| `wazero` | 119 457 327 | 2.53 | 2.54 | 4.7 ms | 306.5 ms | 1.68x | — |
+| `wasm3` | 16 161 788 | 20.5 | 20.5 | 4.1 ms | 334.8 ms | 14x | — |
+| `dewasm-ruby` | 676 523 | 435.2 | 434.9 | 39.2 ms | 333.6 ms | 290x | — |
+| `dewasm-ruby-yjit` | 867 515 | 307.6 | 307.5 | 39.5 ms | 306.3 ms | 205x | — |
+| `dewasm-ruby-zjit` | 834 428 | 333.9 | 333.9 | 39.9 ms | 318.6 ms | 222x | — |
+| `dewasm-python` | 158 914 | 1910 | 1926 | 29.2 ms | 332.7 ms | 1271x | — |
+| `dewasm-pypy` | 3 771 346 | 72.2 | 72.3 | 41.6 ms | 313.7 ms | 48x | — |
+| `dewasm-perl` | 65 536 | 3274 | 3299 | 10.6 ms | 225.2 ms | 2179x | — |
+| `dewasm-go` | 118 793 803 | 2.50 | 2.50 | 2.6 ms | 299.1 ms | 1.66x | — |
+| `dewasm-java` | 53 453 830 | 4.37 | 4.38 | 65.5 ms | 298.9 ms | 2.91x | — |
+| `dewasm-bash` | 5 911 | 51898 | 51867 | 12.1 ms | 318.9 ms | 34538x | — |
+| `pywasm-cpython` | 3 337 | 87016 | 87773 | 43.9 ms | 334.2 ms | 57909x | 0.8 ms |
+| `pywasm-pypy` | 5 072 | 39972 | 40045 | 80.0 ms | 282.8 ms | 26601x | 5.2 ms |
+| `wardite` | 8 642 | 28434 | 28635 | 53.3 ms | 299.0 ms | 18923x | 4.2 ms |
+| `wardite-yjit` | 19 185 | 15052 | 15010 | 101.2 ms | 389.9 ms | 10017x | 9.7 ms |
 
 </details>
 
@@ -465,7 +465,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-mem-rw-dark.svg">
-  <img alt="wat/mem_rw: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 1.01 ns, then wasmtime at 1.01 ns; pywasm-cpython is slowest at 39.5 µs, a span of 39200x. The table below carries every number." src="figs/wat-mem-rw.svg">
+  <img alt="wat/mem_rw: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.01 ns, then wasmer at 1.01 ns; pywasm-cpython is slowest at 39.8 µs, a span of 39300x. The table below carries every number." src="figs/wat-mem-rw.svg">
 </picture>
 
 <details>
@@ -473,24 +473,24 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 287 376 100 | 1.01 | 1.01 | 5.4 ms | 294.2 ms | 1.00x | — |
-| `wasmer` | 296 096 089 | 1.01 | 1.01 | 9.0 ms | 307.5 ms | 1.00x | — |
-| `wasmedge` | 1 971 633 | 132.6 | 131.9 | 15.6 ms | 277.1 ms | 132x | — |
-| `wazero` | 189 579 017 | 1.54 | 1.55 | 4.7 ms | 297.6 ms | 1.54x | — |
-| `wasm3` | 33 554 432 | 10.3 | 10.3 | 4.2 ms | 348.9 ms | 10x | — |
-| `dewasm-ruby` | 1 684 297 | 180.2 | 180.3 | 40.4 ms | 344.0 ms | 179x | — |
-| `dewasm-ruby-yjit` | 1 566 878 | 135.5 | 135.8 | 39.0 ms | 251.4 ms | 135x | — |
-| `dewasm-ruby-zjit` | 1 801 622 | 142.8 | 143.0 | 39.9 ms | 297.2 ms | 142x | — |
-| `dewasm-python` | 399 182 | 763.7 | 766.3 | 29.2 ms | 334.1 ms | 760x | — |
-| `dewasm-pypy` | 5 391 683 | 54.3 | 54.6 | 41.1 ms | 333.6 ms | 54x | — |
-| `dewasm-perl` | 301 672 | 1001 | 1006 | 11.1 ms | 313.2 ms | 996x | — |
-| `dewasm-go` | 198 373 798 | 1.51 | 1.51 | 3.0 ms | 303.1 ms | 1.51x | — |
-| `dewasm-java` | 145 873 518 | 1.77 | 1.77 | 66.4 ms | 324.6 ms | 1.76x | — |
-| `dewasm-bash` | 8 907 | 31710 | 31824 | 12.3 ms | 294.8 ms | 31549x | — |
-| `pywasm-cpython` | 4 788 | 39783 | 39525 | 42.8 ms | 233.2 ms | 39580x | 0.7 ms |
-| `pywasm-pypy` | 28 800 | 8266 | 8251 | 79.9 ms | 318.0 ms | 8224x | 4.5 ms |
-| `wardite` | 26 662 | 13205 | 13228 | 51.5 ms | 403.5 ms | 13138x | 4.3 ms |
-| `wardite-yjit` | 46 184 | 6226 | 6369 | 101.4 ms | 389.0 ms | 6194x | 9.4 ms |
+| `wasmtime` | 292 550 018 | 1.01 | 1.01 | 5.5 ms | 300.7 ms | 1.00x | — |
+| `wasmer` | 283 198 272 | 1.01 | 1.01 | 8.8 ms | 295.4 ms | 1.00x | — |
+| `wasmedge` | 2 149 768 | 133.0 | 133.4 | 15.9 ms | 301.8 ms | 132x | — |
+| `wazero` | 189 109 192 | 1.55 | 1.55 | 4.8 ms | 298.3 ms | 1.54x | — |
+| `wasm3` | 33 554 432 | 10.2 | 10.2 | 4.6 ms | 347.9 ms | 10x | — |
+| `dewasm-ruby` | 1 715 994 | 182.1 | 181.8 | 39.0 ms | 351.5 ms | 181x | — |
+| `dewasm-ruby-yjit` | 2 010 049 | 135.5 | 135.5 | 39.4 ms | 311.7 ms | 134x | — |
+| `dewasm-ruby-zjit` | 1 791 961 | 143.0 | 143.7 | 39.8 ms | 296.1 ms | 142x | — |
+| `dewasm-python` | 382 114 | 765.8 | 774.2 | 28.8 ms | 321.5 ms | 759x | — |
+| `dewasm-pypy` | 4 842 165 | 54.7 | 54.3 | 39.9 ms | 304.8 ms | 54x | — |
+| `dewasm-perl` | 294 146 | 998.5 | 1004 | 11.0 ms | 304.7 ms | 990x | — |
+| `dewasm-go` | 198 361 421 | 1.51 | 1.51 | 2.8 ms | 302.0 ms | 1.49x | — |
+| `dewasm-java` | 138 922 196 | 1.77 | 1.77 | 64.9 ms | 311.1 ms | 1.76x | — |
+| `dewasm-bash` | 9 806 | 31988 | 32000 | 13.0 ms | 326.7 ms | 31706x | — |
+| `pywasm-cpython` | 8 011 | 39636 | 39761 | 44.1 ms | 361.6 ms | 39286x | 0.7 ms |
+| `pywasm-pypy` | 26 496 | 8586 | 8551 | 78.6 ms | 306.1 ms | 8510x | 4.7 ms |
+| `wardite` | 26 635 | 13273 | 13315 | 53.4 ms | 406.9 ms | 13156x | 4.1 ms |
+| `wardite-yjit` | 37 693 | 6366 | 6408 | 101.6 ms | 341.5 ms | 6310x | 8.9 ms |
 
 </details>
 
@@ -498,7 +498,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/c-mandelbrot-dark.svg">
-  <img alt="c/mandelbrot: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 96.0 ns, then wasmtime at 96.2 ns; dewasm-bash is slowest at 20.4 ms, a span of 213000x. The table below carries every number." src="figs/c-mandelbrot.svg">
+  <img alt="c/mandelbrot: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 96.1 ns, then wasmtime at 96.4 ns; dewasm-bash is slowest at 20.1 ms, a span of 210000x. The table below carries every number." src="figs/c-mandelbrot.svg">
 </picture>
 
 <details>
@@ -506,24 +506,24 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 3 035 284 | 96.2 | 96.2 | 5.8 ms | 297.7 ms | 1.00x | — |
-| `wasmer` | 3 212 614 | 96.0 | 96.0 | 9.1 ms | 317.6 ms | 1.00x | — |
-| `wasmedge` | 65 536 | 3823 | 3823 | 16.2 ms | 266.8 ms | 40x | — |
-| `wazero` | 2 711 538 | 107.3 | 107.5 | 5.1 ms | 296.0 ms | 1.12x | — |
-| `wasm3` | 659 438 | 453.3 | 453.1 | 4.4 ms | 303.4 ms | 4.71x | — |
-| `dewasm-ruby` | 44 032 | 4557 | 4555 | 38.8 ms | 239.5 ms | 47x | — |
-| `dewasm-ruby-yjit` | 141 178 | 1512 | 1549 | 38.8 ms | 252.3 ms | 16x | — |
-| `dewasm-ruby-zjit` | 79 388 | 3531 | 3526 | 40.7 ms | 321.0 ms | 37x | — |
-| `dewasm-python` | 65 536 | 3568 | 3594 | 30.4 ms | 264.2 ms | 37x | — |
-| `dewasm-pypy` | 1 924 060 | 143.2 | 143.7 | 40.6 ms | 316.1 ms | 1.49x | — |
-| `dewasm-perl` | 4 827 | 56123 | 56137 | 10.6 ms | 281.5 ms | 584x | — |
-| `dewasm-go` | 1 243 649 | 235.5 | 235.4 | 2.9 ms | 295.8 ms | 2.45x | — |
-| `dewasm-java` | 2 849 764 | 97.0 | 97.1 | 67.4 ms | 344.0 ms | 1.01x | — |
-| `dewasm-bash` | 192 | 20388203 | 20403138 | 13.1 ms | 3.93 s | 211998x | — |
-| `pywasm-cpython` | 256 | 1484460 | 1486711 | 43.9 ms | 423.9 ms | 15435x | 0.9 ms |
-| `pywasm-pypy` | 150 | 1466239 | 1464171 | 79.4 ms | 299.4 ms | 15246x | 5.3 ms |
-| `wardite` | 730 | 390281 | 388762 | 51.3 ms | 336.2 ms | 4058x | 4.0 ms |
-| `wardite-yjit` | 1 816 | 183347 | 183911 | 100.8 ms | 433.8 ms | 1906x | 10.7 ms |
+| `wasmtime` | 2 957 048 | 96.5 | 96.4 | 5.3 ms | 290.6 ms | 1.00x | — |
+| `wasmer` | 2 808 902 | 96.1 | 96.1 | 8.8 ms | 278.6 ms | 1.00x | — |
+| `wasmedge` | 89 740 | 3832 | 3829 | 15.4 ms | 359.3 ms | 40x | — |
+| `wazero` | 2 501 652 | 107.6 | 107.4 | 4.6 ms | 273.8 ms | 1.12x | — |
+| `wasm3` | 653 872 | 454.9 | 455.9 | 4.0 ms | 301.5 ms | 4.72x | — |
+| `dewasm-ruby` | 65 536 | 4539 | 4540 | 39.4 ms | 336.8 ms | 47x | — |
+| `dewasm-ruby-yjit` | 162 747 | 1498 | 1540 | 39.9 ms | 283.8 ms | 16x | — |
+| `dewasm-ruby-zjit` | 81 838 | 3512 | 3531 | 40.7 ms | 328.1 ms | 36x | — |
+| `dewasm-python` | 97 952 | 3586 | 3599 | 29.3 ms | 380.6 ms | 37x | — |
+| `dewasm-pypy` | 2 022 040 | 141.5 | 142.3 | 40.0 ms | 326.1 ms | 1.47x | — |
+| `dewasm-perl` | 5 054 | 56127 | 56125 | 10.9 ms | 294.6 ms | 582x | — |
+| `dewasm-go` | 1 238 225 | 235.5 | 235.6 | 2.7 ms | 294.4 ms | 2.44x | — |
+| `dewasm-java` | 2 825 122 | 97.0 | 97.4 | 66.3 ms | 340.2 ms | 1.01x | — |
+| `dewasm-bash` | 156 | 20072047 | 20138204 | 12.6 ms | 3.14 s | 208068x | — |
+| `pywasm-cpython` | 193 | 1540812 | 1538407 | 43.0 ms | 340.4 ms | 15972x | 0.8 ms |
+| `pywasm-pypy` | 83 | 2209863 | 2203721 | 79.5 ms | 262.9 ms | 22908x | 5.3 ms |
+| `wardite` | 771 | 384673 | 388149 | 52.9 ms | 349.5 ms | 3988x | 4.5 ms |
+| `wardite-yjit` | 1 277 | 188649 | 187951 | 101.4 ms | 342.3 ms | 1956x | 9.9 ms |
 
 </details>
 
@@ -531,7 +531,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/c-sha256-dark.svg">
-  <img alt="c/sha256: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 293 ns, then wasmer at 294 ns; dewasm-bash is slowest at 16.0 ms, a span of 54400x. The table below carries every number." src="figs/c-sha256.svg">
+  <img alt="c/sha256: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 293 ns, then wasmtime at 294 ns; dewasm-bash is slowest at 16.0 ms, a span of 54700x. The table below carries every number." src="figs/c-sha256.svg">
 </picture>
 
 <details>
@@ -539,24 +539,24 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 944 658 | 292.9 | 293.1 | 5.4 ms | 282.1 ms | 1.00x | — |
-| `wasmer` | 1 021 749 | 293.3 | 293.5 | 9.0 ms | 308.7 ms | 1.00x | — |
-| `wasmedge` | 6 225 | 41969 | 41956 | 15.4 ms | 276.6 ms | 143x | — |
-| `wazero` | 780 907 | 378.5 | 377.8 | 4.9 ms | 300.5 ms | 1.29x | — |
-| `wasm3` | 50 512 | 5026 | 5030 | 4.5 ms | 258.3 ms | 17x | — |
-| `dewasm-ruby` | 3 804 | 78829 | 78919 | 40.2 ms | 340.1 ms | 269x | — |
-| `dewasm-ruby-yjit` | 8 394 | 34050 | 34180 | 39.8 ms | 325.6 ms | 116x | — |
-| `dewasm-ruby-zjit` | 5 636 | 53442 | 53679 | 40.5 ms | 341.7 ms | 182x | — |
-| `dewasm-python` | 1 090 | 268489 | 269211 | 30.8 ms | 323.5 ms | 917x | — |
-| `dewasm-pypy` | 21 514 | 13679 | 13676 | 41.7 ms | 336.0 ms | 47x | — |
-| `dewasm-perl` | 927 | 321704 | 321459 | 10.8 ms | 309.0 ms | 1098x | — |
-| `dewasm-go` | 844 607 | 349.4 | 349.0 | 2.7 ms | 297.8 ms | 1.19x | — |
-| `dewasm-java` | 444 608 | 493.1 | 503.5 | 66.8 ms | 286.0 ms | 1.68x | — |
-| `dewasm-bash` | 18 | 15958181 | 15957794 | 15.0 ms | 302.3 ms | 54484x | — |
-| `pywasm-cpython` | 18 | 14577433 | 14714340 | 45.2 ms | 307.6 ms | 49770x | 1.3 ms |
-| `pywasm-pypy` | 14 | 12908771 | 12873229 | 89.0 ms | 269.8 ms | 44073x | 7.7 ms |
-| `wardite` | 45 | 4201935 | 4211804 | 52.6 ms | 241.7 ms | 14346x | 4.6 ms |
-| `wardite-yjit` | 135 | 1944785 | 1959054 | 104.0 ms | 366.5 ms | 6640x | 10.4 ms |
+| `wasmtime` | 987 301 | 294.4 | 293.8 | 5.0 ms | 295.7 ms | 1.00x | — |
+| `wasmer` | 989 668 | 293.4 | 293.5 | 8.9 ms | 299.2 ms | 1.00x | — |
+| `wasmedge` | 7 045 | 41977 | 42154 | 15.8 ms | 311.6 ms | 143x | — |
+| `wazero` | 803 791 | 377.8 | 379.1 | 5.5 ms | 309.1 ms | 1.28x | — |
+| `wasm3` | 48 739 | 5046 | 5046 | 4.2 ms | 250.1 ms | 17x | — |
+| `dewasm-ruby` | 3 625 | 78904 | 78978 | 40.0 ms | 326.0 ms | 268x | — |
+| `dewasm-ruby-yjit` | 8 271 | 33997 | 34124 | 38.8 ms | 320.0 ms | 115x | — |
+| `dewasm-ruby-zjit` | 5 852 | 53711 | 53768 | 39.9 ms | 354.2 ms | 182x | — |
+| `dewasm-python` | 1 100 | 269974 | 272212 | 29.8 ms | 326.7 ms | 917x | — |
+| `dewasm-pypy` | 19 373 | 13801 | 13825 | 41.6 ms | 309.0 ms | 47x | — |
+| `dewasm-perl` | 921 | 321719 | 321673 | 10.8 ms | 307.1 ms | 1093x | — |
+| `dewasm-go` | 860 893 | 349.6 | 349.8 | 2.8 ms | 303.8 ms | 1.19x | — |
+| `dewasm-java` | 492 277 | 502.8 | 528.1 | 65.6 ms | 313.1 ms | 1.71x | — |
+| `dewasm-bash` | 18 | 15997521 | 16040873 | 14.9 ms | 302.9 ms | 54331x | — |
+| `pywasm-cpython` | 21 | 14588792 | 14592746 | 44.7 ms | 351.1 ms | 49546x | 1.3 ms |
+| `pywasm-pypy` | 28 | 7282637 | 7319546 | 89.0 ms | 292.9 ms | 24733x | 8.0 ms |
+| `wardite` | 78 | 4177134 | 4179952 | 52.8 ms | 378.6 ms | 14186x | 4.1 ms |
+| `wardite-yjit` | 127 | 1948599 | 1937999 | 103.4 ms | 350.8 ms | 6618x | 9.4 ms |
 
 </details>
 
@@ -564,7 +564,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/c-wordcount-dark.svg">
-  <img alt="c/wordcount: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.51 ns, then wasmer at 1.63 ns; pywasm-cpython is slowest at 59.7 µs, a span of 39600x. The table below carries every number." src="figs/c-wordcount.svg">
+  <img alt="c/wordcount: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.47 ns, then wasmer at 1.60 ns; pywasm-cpython is slowest at 60.4 µs, a span of 41000x. The table below carries every number." src="figs/c-wordcount.svg">
 </picture>
 
 <details>
@@ -572,24 +572,24 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 196 329 993 | 1.49 | 1.51 | 5.6 ms | 298.3 ms | 1.00x | — |
-| `wasmer` | 184 581 647 | 1.63 | 1.63 | 8.9 ms | 310.4 ms | 1.10x | — |
-| `wasmedge` | 1 419 129 | 204.5 | 204.5 | 16.6 ms | 306.9 ms | 137x | — |
-| `wazero` | 97 459 949 | 3.01 | 3.02 | 5.0 ms | 298.2 ms | 2.02x | — |
-| `wasm3` | 11 174 350 | 20.6 | 20.6 | 4.4 ms | 234.6 ms | 14x | — |
-| `dewasm-ruby` | 754 627 | 409.1 | 409.5 | 41.2 ms | 349.9 ms | 274x | — |
-| `dewasm-ruby-yjit` | 1 106 349 | 274.1 | 274.2 | 42.2 ms | 345.4 ms | 184x | — |
-| `dewasm-ruby-zjit` | 907 314 | 296.4 | 296.5 | 41.4 ms | 310.3 ms | 199x | — |
-| `dewasm-python` | 329 069 | 901.7 | 904.0 | 33.0 ms | 329.7 ms | 605x | — |
-| `dewasm-pypy` | 4 873 125 | 57.2 | 57.2 | 46.5 ms | 325.5 ms | 38x | — |
-| `dewasm-perl` | 200 438 | 1490 | 1492 | 18.5 ms | 317.2 ms | 1000x | — |
-| `dewasm-go` | 118 977 621 | 2.42 | 2.42 | 2.7 ms | 290.7 ms | 1.62x | — |
-| `dewasm-java` | 57 318 495 | 3.61 | 3.65 | 64.1 ms | 271.3 ms | 2.42x | — |
-| `dewasm-bash` | 7 044 | 42673 | 42840 | 124.6 ms | 425.1 ms | 28620x | — |
-| `pywasm-cpython` | 4 104 | 59835 | 59661 | 281.5 ms | 527.1 ms | 40130x | 1.3 ms |
-| `pywasm-pypy` | 10 726 | 17451 | 17488 | 195.5 ms | 382.7 ms | 11704x | 8.1 ms |
-| `wardite` | 12 922 | 20845 | 20895 | 122.7 ms | 392.0 ms | 13980x | 4.3 ms |
-| `wardite-yjit` | 29 151 | 9745 | 9774 | 143.7 ms | 427.7 ms | 6536x | 10.3 ms |
+| `wasmtime` | 192 369 542 | 1.45 | 1.47 | 5.5 ms | 285.3 ms | 1.00x | — |
+| `wasmer` | 175 759 196 | 1.60 | 1.60 | 9.0 ms | 290.6 ms | 1.10x | — |
+| `wasmedge` | 1 438 586 | 204.5 | 204.4 | 16.6 ms | 310.7 ms | 141x | — |
+| `wazero` | 98 152 235 | 3.02 | 3.02 | 5.2 ms | 301.3 ms | 2.07x | — |
+| `wasm3` | 11 456 227 | 20.6 | 20.6 | 4.1 ms | 240.4 ms | 14x | — |
+| `dewasm-ruby` | 734 318 | 411.5 | 411.5 | 40.6 ms | 342.8 ms | 283x | — |
+| `dewasm-ruby-yjit` | 1 031 431 | 274.4 | 274.7 | 41.6 ms | 324.6 ms | 189x | — |
+| `dewasm-ruby-zjit` | 1 001 900 | 295.6 | 294.5 | 42.4 ms | 338.5 ms | 203x | — |
+| `dewasm-python` | 332 108 | 897.7 | 905.1 | 33.5 ms | 331.6 ms | 617x | — |
+| `dewasm-pypy` | 3 966 877 | 57.8 | 57.9 | 45.0 ms | 274.2 ms | 40x | — |
+| `dewasm-perl` | 201 170 | 1483 | 1488 | 18.8 ms | 317.1 ms | 1019x | — |
+| `dewasm-go` | 120 124 698 | 2.40 | 2.40 | 2.9 ms | 290.7 ms | 1.65x | — |
+| `dewasm-java` | 75 044 080 | 3.36 | 3.35 | 66.6 ms | 318.6 ms | 2.31x | — |
+| `dewasm-bash` | 6 470 | 42627 | 42580 | 124.3 ms | 400.1 ms | 29309x | — |
+| `pywasm-cpython` | 4 509 | 59775 | 60360 | 282.3 ms | 551.8 ms | 41099x | 1.3 ms |
+| `pywasm-pypy` | 12 340 | 16175 | 16210 | 195.4 ms | 395.0 ms | 11122x | 8.2 ms |
+| `wardite` | 11 079 | 21098 | 20967 | 121.3 ms | 355.0 ms | 14506x | 4.5 ms |
+| `wardite-yjit` | 30 193 | 9789 | 9790 | 144.0 ms | 439.5 ms | 6731x | 10.4 ms |
 
 </details>
 
@@ -602,7 +602,7 @@ Every runner executes the same work, so wall times compare directly.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/app-cowsay-dark.svg">
-  <img alt="app/cowsay: seconds per run for 18 runners on a log scale, fastest first. dewasm-go is fastest at 4.56 ms, then wasm3 at 7.08 ms; dewasm-bash is slowest at 1.34 s, a span of 293x. The table below carries every number." src="figs/app-cowsay.svg">
+  <img alt="app/cowsay: seconds per run for 18 runners on a log scale, fastest first. dewasm-go is fastest at 4.43 ms, then wasm3 at 7.02 ms; dewasm-bash is slowest at 1.34 s, a span of 302x. The table below carries every number." src="figs/app-cowsay.svg">
 </picture>
 
 <details>
@@ -610,24 +610,24 @@ Every runner executes the same work, so wall times compare directly.
 
 | Runner | Runs/sample | Wall time (min) | Wall time (median) | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 5 | 10.1 ms | 10.1 ms | 1.00x | — |
-| `wasmer` | 5 | 14.1 ms | 14.1 ms | 1.40x | — |
-| `wasmedge` | 12 | 26.7 ms | 26.8 ms | 2.66x | — |
-| `wazero` | 3 | 106.5 ms | 106.7 ms | 11x | — |
-| `wasm3` | 45 | 7.1 ms | 7.1 ms | 0.70x | — |
-| `dewasm-ruby` | 3 | 144.6 ms | 144.7 ms | 14x | — |
-| `dewasm-ruby-yjit` | 2 | 196.8 ms | 197.6 ms | 20x | — |
-| `dewasm-ruby-zjit` | 2 | 255.4 ms | 256.9 ms | 25x | — |
-| `dewasm-python` | 1 | 422.8 ms | 424.2 ms | 42x | — |
-| `dewasm-pypy` | 1 | 628.8 ms | 630.1 ms | 62x | — |
-| `dewasm-perl` | 3 | 111.9 ms | 111.9 ms | 11x | — |
-| `dewasm-go` | 14 | 4.5 ms | 4.6 ms | 0.45x | — |
-| `dewasm-java` | 3 | 133.0 ms | 133.1 ms | 13x | — |
-| `dewasm-bash` | 1 | 1.33 s | 1.34 s | 133x | — |
-| `pywasm-cpython` | 1 | 494.6 ms | 498.2 ms | 49x | 273.4 ms |
-| `pywasm-pypy` | 1 | 921.8 ms | 925.2 ms | 92x | 482.2 ms |
-| `wardite` | 2 | 236.6 ms | 238.4 ms | 24x | 111.5 ms |
-| `wardite-yjit` | 2 | 269.7 ms | 272.4 ms | 27x | 85.7 ms |
+| `wasmtime` | 23 | 10.0 ms | 10.0 ms | 1.00x | — |
+| `wasmer` | 18 | 13.9 ms | 13.9 ms | 1.39x | — |
+| `wasmedge` | 12 | 26.5 ms | 26.5 ms | 2.66x | — |
+| `wazero` | 3 | 106.3 ms | 106.9 ms | 11x | — |
+| `wasm3` | 43 | 7.0 ms | 7.0 ms | 0.70x | — |
+| `dewasm-ruby` | 3 | 142.9 ms | 143.9 ms | 14x | — |
+| `dewasm-ruby-yjit` | 2 | 196.2 ms | 196.5 ms | 20x | — |
+| `dewasm-ruby-zjit` | 2 | 253.6 ms | 254.2 ms | 25x | — |
+| `dewasm-python` | 1 | 409.3 ms | 413.0 ms | 41x | — |
+| `dewasm-pypy` | 1 | 621.8 ms | 622.5 ms | 62x | — |
+| `dewasm-perl` | 3 | 110.5 ms | 110.7 ms | 11x | — |
+| `dewasm-go` | 21 | 4.4 ms | 4.4 ms | 0.44x | — |
+| `dewasm-java` | 3 | 131.4 ms | 131.7 ms | 13x | — |
+| `dewasm-bash` | 1 | 1.34 s | 1.34 s | 134x | — |
+| `pywasm-cpython` | 1 | 499.8 ms | 500.9 ms | 50x | 276.7 ms |
+| `pywasm-pypy` | 1 | 909.0 ms | 914.1 ms | 91x | 476.6 ms |
+| `wardite` | 2 | 238.7 ms | 240.4 ms | 24x | 112.9 ms |
+| `wardite-yjit` | 2 | 274.0 ms | 274.1 ms | 28x | 89.4 ms |
 
 </details>
 
@@ -635,7 +635,7 @@ Every runner executes the same work, so wall times compare directly.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/app-sqlite3-query-dark.svg">
-  <img alt="app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 79.2 ms, then wasmer at 87.5 ms; dewasm-ruby is slowest at 19.3 s, a span of 244x. The table below carries every number." src="figs/app-sqlite3-query.svg">
+  <img alt="app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 79.1 ms, then wasmer at 87.9 ms; dewasm-ruby is slowest at 19.2 s, a span of 243x. The table below carries every number." src="figs/app-sqlite3-query.svg">
 </picture>
 
 <details>
@@ -643,17 +643,17 @@ Every runner executes the same work, so wall times compare directly.
 
 | Runner | Runs/sample | Wall time (min) | Wall time (median) | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 2 | 78.7 ms | 79.2 ms | 1.00x | — |
-| `wasmer` | 2 | 87.3 ms | 87.5 ms | 1.11x | — |
-| `wasmedge` | 1 | 9.68 s | 9.76 s | 123x | — |
-| `wazero` | 1 | 646.5 ms | 647.8 ms | 8.21x | — |
-| `wasm3` | 1 | 1.07 s | 1.09 s | 14x | — |
-| `dewasm-ruby` | 1 | 19.32 s | 19.34 s | 245x | — |
-| `dewasm-ruby-yjit` | 1 | 9.40 s | 9.50 s | 119x | — |
-| `dewasm-ruby-zjit` | 1 | 14.19 s | 14.25 s | 180x | — |
-| `dewasm-pypy` | 1 | 11.89 s | 11.92 s | 151x | — |
-| `dewasm-go` | 2 | 172.4 ms | 172.9 ms | 2.19x | — |
-| `dewasm-java` | 1 | 2.41 s | 2.42 s | 31x | — |
+| `wasmtime` | 4 | 79.0 ms | 79.1 ms | 1.00x | — |
+| `wasmer` | 4 | 87.6 ms | 87.9 ms | 1.11x | — |
+| `wasmedge` | 1 | 9.69 s | 9.76 s | 123x | — |
+| `wazero` | 1 | 644.4 ms | 644.8 ms | 8.16x | — |
+| `wasm3` | 1 | 1.09 s | 1.09 s | 14x | — |
+| `dewasm-ruby` | 1 | 19.17 s | 19.20 s | 243x | — |
+| `dewasm-ruby-yjit` | 1 | 9.22 s | 9.23 s | 117x | — |
+| `dewasm-ruby-zjit` | 1 | 14.02 s | 14.05 s | 177x | — |
+| `dewasm-pypy` | 1 | 11.81 s | 11.86 s | 149x | — |
+| `dewasm-go` | 2 | 172.3 ms | 172.8 ms | 2.18x | — |
+| `dewasm-java` | 1 | 2.38 s | 2.39 s | 30x | — |
 
 </details>
 
@@ -661,7 +661,7 @@ Every runner executes the same work, so wall times compare directly.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/app-sqlite3-mod-query-dark.svg">
-  <img alt="app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 86.9 ms, then wasmer at 91.1 ms; dewasm-ruby is slowest at 20.4 s, a span of 235x. The table below carries every number." src="figs/app-sqlite3-mod-query.svg">
+  <img alt="app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 87.2 ms, then wasmer at 90.8 ms; dewasm-ruby is slowest at 20.3 s, a span of 232x. The table below carries every number." src="figs/app-sqlite3-mod-query.svg">
 </picture>
 
 <details>
@@ -669,17 +669,17 @@ Every runner executes the same work, so wall times compare directly.
 
 | Runner | Runs/sample | Wall time (min) | Wall time (median) | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 2 | 86.8 ms | 86.9 ms | 1.00x | — |
-| `wasmer` | 2 | 90.9 ms | 91.1 ms | 1.05x | — |
-| `wasmedge` | 1 | 10.10 s | 10.13 s | 116x | — |
-| `wazero` | 1 | 637.0 ms | 639.4 ms | 7.34x | — |
-| `wasm3` | 1 | 1.17 s | 1.19 s | 13x | — |
-| `dewasm-ruby` | 1 | 20.34 s | 20.39 s | 234x | — |
-| `dewasm-ruby-yjit` | 1 | 8.36 s | 8.38 s | 96x | — |
-| `dewasm-ruby-zjit` | 1 | 14.67 s | 14.72 s | 169x | — |
-| `dewasm-pypy` | 1 | 12.74 s | 12.75 s | 147x | — |
-| `dewasm-go` | 2 | 126.9 ms | 127.6 ms | 1.46x | — |
-| `dewasm-java` | 1 | 5.52 s | 5.54 s | 64x | — |
+| `wasmtime` | 4 | 87.0 ms | 87.2 ms | 1.00x | — |
+| `wasmer` | 3 | 90.5 ms | 90.8 ms | 1.04x | — |
+| `wasmedge` | 1 | 10.12 s | 10.13 s | 116x | — |
+| `wazero` | 1 | 636.4 ms | 637.0 ms | 7.32x | — |
+| `wasm3` | 1 | 1.01 s | 1.19 s | 12x | — |
+| `dewasm-ruby` | 1 | 20.25 s | 20.25 s | 233x | — |
+| `dewasm-ruby-yjit` | 1 | 8.29 s | 8.32 s | 95x | — |
+| `dewasm-ruby-zjit` | 1 | 14.39 s | 14.49 s | 166x | — |
+| `dewasm-pypy` | 1 | 12.71 s | 12.76 s | 146x | — |
+| `dewasm-go` | 3 | 126.6 ms | 126.7 ms | 1.46x | — |
+| `dewasm-java` | 1 | 5.53 s | 5.56 s | 64x | — |
 
 </details>
 
@@ -687,7 +687,7 @@ Every runner executes the same work, so wall times compare directly.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/app-minigzip-dark.svg">
-  <img alt="app/minigzip: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 45.1 ms, then wasmer at 52.5 ms; pywasm-pypy is slowest at 81.5 s, a span of 1810x. The table below carries every number." src="figs/app-minigzip.svg">
+  <img alt="app/minigzip: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 44.9 ms, then wasmer at 52.2 ms; pywasm-pypy is slowest at 81.4 s, a span of 1810x. The table below carries every number." src="figs/app-minigzip.svg">
 </picture>
 
 <details>
@@ -695,19 +695,19 @@ Every runner executes the same work, so wall times compare directly.
 
 | Runner | Runs/sample | Wall time (min) | Wall time (median) | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 5 | 44.6 ms | 45.1 ms | 1.00x | — |
-| `wasmer` | 4 | 52.4 ms | 52.5 ms | 1.17x | — |
-| `wasmedge` | 1 | 2.25 s | 2.25 s | 50x | — |
-| `wazero` | 4 | 88.1 ms | 88.4 ms | 1.97x | — |
-| `dewasm-ruby` | 1 | 5.26 s | 5.27 s | 118x | — |
-| `dewasm-ruby-yjit` | 1 | 1.64 s | 1.65 s | 37x | — |
-| `dewasm-ruby-zjit` | 1 | 3.36 s | 3.37 s | 75x | — |
-| `dewasm-python` | 1 | 15.30 s | 15.40 s | 343x | — |
-| `dewasm-pypy` | 1 | 2.86 s | 2.86 s | 64x | — |
-| `dewasm-perl` | 1 | 24.35 s | 24.39 s | 545x | — |
-| `dewasm-go` | 5 | 58.4 ms | 58.4 ms | 1.31x | — |
-| `dewasm-java` | 1 | 537.8 ms | 572.5 ms | 12x | — |
-| `pywasm-pypy` | 1 | 81.29 s | 81.52 s | 1821x | 331.7 ms |
+| `wasmtime` | 7 | 44.8 ms | 44.9 ms | 1.00x | — |
+| `wasmer` | 6 | 52.2 ms | 52.2 ms | 1.17x | — |
+| `wasmedge` | 1 | 2.26 s | 2.26 s | 50x | — |
+| `wazero` | 4 | 88.4 ms | 88.5 ms | 1.97x | — |
+| `dewasm-ruby` | 1 | 5.26 s | 5.27 s | 117x | — |
+| `dewasm-ruby-yjit` | 1 | 1.64 s | 1.64 s | 37x | — |
+| `dewasm-ruby-zjit` | 1 | 3.35 s | 3.35 s | 75x | — |
+| `dewasm-python` | 1 | 15.27 s | 15.39 s | 341x | — |
+| `dewasm-pypy` | 1 | 2.86 s | 2.87 s | 64x | — |
+| `dewasm-perl` | 1 | 24.36 s | 24.36 s | 544x | — |
+| `dewasm-go` | 5 | 58.0 ms | 58.2 ms | 1.29x | — |
+| `dewasm-java` | 1 | 540.1 ms | 570.6 ms | 12x | — |
+| `pywasm-pypy` | 1 | 81.18 s | 81.40 s | 1813x | 330.3 ms |
 
 </details>
 

--- a/records/2026-08-22T08-27-05Z-speed.json
+++ b/records/2026-08-22T08-27-05Z-speed.json
@@ -1,0 +1,10497 @@
+{
+  "schema": 1,
+  "generated_at": "2026-08-22T08:27:05Z",
+  "host": {
+    "os": "macOS 26.5.2",
+    "arch": "aarch64",
+    "kernel": "Darwin 25.5.0",
+    "cpu": "Apple M1 Pro"
+  },
+  "settings": {
+    "reps": 3,
+    "target_ms": 300,
+    "timeout_s": 900,
+    "filter": null
+  },
+  "runtimes": [
+    {
+      "runner": "wasmtime",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "wasmtime 48.0.0 (f1412a598 2026-08-20)"
+    },
+    {
+      "runner": "wasmer",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "wasmer 7.3.0"
+    },
+    {
+      "runner": "wasmedge",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "wasmedge version 0.17.1"
+    },
+    {
+      "runner": "wazero",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "1.12.0"
+    },
+    {
+      "runner": "wasm3",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "Wasm3 v0.5.0 on arm64-v8a"
+    },
+    {
+      "runner": "dewasm-ruby",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "ruby 4.0.4 (2026-05-12 revision b89eb1bcbf) +PRISM [arm64-darwin25]"
+    },
+    {
+      "runner": "dewasm-ruby-yjit",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "ruby 4.0.4 (2026-05-12 revision b89eb1bcbf) +PRISM [arm64-darwin25]"
+    },
+    {
+      "runner": "dewasm-ruby-zjit",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "ruby 4.0.4 (2026-05-12 revision b89eb1bcbf) +PRISM [arm64-darwin25]"
+    },
+    {
+      "runner": "dewasm-python",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "Python 3.14.7 (main, Aug  5 2026, 10:29:49) [Clang 21.0.0 (clang-2100.1.1.101)]"
+    },
+    {
+      "runner": "dewasm-pypy",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "Python 3.11.15 (194f9f44b505, Jul 15 2026, 12:14:56)"
+    },
+    {
+      "runner": "dewasm-perl",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "v5.44.0"
+    },
+    {
+      "runner": "dewasm-go",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "go version go1.26.2 darwin/arm64"
+    },
+    {
+      "runner": "dewasm-java",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "java version \"25.0.4.1\" 2026-08-18 LTS"
+    },
+    {
+      "runner": "dewasm-bash",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "5.3.15(1)-release"
+    },
+    {
+      "runner": "pywasm-cpython",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "pywasm 2.2.3"
+    },
+    {
+      "runner": "pywasm-pypy",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "pywasm 2.2.3"
+    },
+    {
+      "runner": "wardite",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "wardite 0.9.0"
+    },
+    {
+      "runner": "wardite-yjit",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "wardite 0.9.0"
+    }
+  ],
+  "results": [
+    {
+      "workload": "wat/br_table",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 34606250,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005533791,
+        "median_s": 0.005655958,
+        "samples_s": [
+          0.006042875,
+          0.005533791,
+          0.005655958
+        ]
+      },
+      "total": {
+        "min_s": 0.3054705,
+        "median_s": 0.305597583,
+        "samples_s": [
+          0.3054705,
+          0.305597583,
+          0.30583475
+        ]
+      },
+      "compute_s": 0.29993670899999997,
+      "ns_per_op_min": 8.66712541809644,
+      "ns_per_op_median": 8.667267473361026,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 34667768,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009421625,
+        "median_s": 0.009502375,
+        "samples_s": [
+          0.009502375,
+          0.00974575,
+          0.009421625
+        ]
+      },
+      "total": {
+        "min_s": 0.309896042,
+        "median_s": 0.310272458,
+        "samples_s": [
+          0.309896042,
+          0.310842875,
+          0.310272458
+        ]
+      },
+      "compute_s": 0.300474417,
+      "ns_per_op_min": 8.667255907562321,
+      "ns_per_op_median": 8.675784463539733,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1281877,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.016329959,
+        "median_s": 0.016516375,
+        "samples_s": [
+          0.016516375,
+          0.016762,
+          0.016329959
+        ]
+      },
+      "total": {
+        "min_s": 0.306623833,
+        "median_s": 0.306998958,
+        "samples_s": [
+          0.306623833,
+          0.306998958,
+          0.30702875
+        ]
+      },
+      "compute_s": 0.290293874,
+      "ns_per_op_min": 226.46000669330988,
+      "ns_per_op_median": 226.60721972544943,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 33554432,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0050455,
+        "median_s": 0.005403792,
+        "samples_s": [
+          0.005403792,
+          0.005548916,
+          0.0050455
+        ]
+      },
+      "total": {
+        "min_s": 0.307773167,
+        "median_s": 0.3077925,
+        "samples_s": [
+          0.308007333,
+          0.3077925,
+          0.307773167
+        ]
+      },
+      "compute_s": 0.30272766700000003,
+      "ns_per_op_min": 9.021987527608873,
+      "ns_per_op_median": 9.01188576221466,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 10157780,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004131334,
+        "median_s": 0.004458917,
+        "samples_s": [
+          0.004502875,
+          0.004131334,
+          0.004458917
+        ]
+      },
+      "total": {
+        "min_s": 0.276422041,
+        "median_s": 0.276650792,
+        "samples_s": [
+          0.276422041,
+          0.276650792,
+          0.276753708
+        ]
+      },
+      "compute_s": 0.272290707,
+      "ns_per_op_min": 26.806123680568,
+      "ns_per_op_median": 26.796393995538395,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 920025,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039195042,
+        "median_s": 0.040240083,
+        "samples_s": [
+          0.039195042,
+          0.041480709,
+          0.040240083
+        ]
+      },
+      "total": {
+        "min_s": 0.24443,
+        "median_s": 0.245314875,
+        "samples_s": [
+          0.24443,
+          0.245843417,
+          0.245314875
+        ]
+      },
+      "compute_s": 0.20523495800000002,
+      "ns_per_op_min": 223.07541425504746,
+      "ns_per_op_median": 222.901325507459,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 1111242,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040272625,
+        "median_s": 0.041257667,
+        "samples_s": [
+          0.040272625,
+          0.041257667,
+          0.041539292
+        ]
+      },
+      "total": {
+        "min_s": 0.286280125,
+        "median_s": 0.287057917,
+        "samples_s": [
+          0.289096333,
+          0.286280125,
+          0.287057917
+        ]
+      },
+      "compute_s": 0.2460075,
+      "ns_per_op_min": 221.38067135691415,
+      "ns_per_op_median": 221.1941683269711,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 949958,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039659459,
+        "median_s": 0.041308708,
+        "samples_s": [
+          0.039659459,
+          0.041308708,
+          0.041849708
+        ]
+      },
+      "total": {
+        "min_s": 0.250150833,
+        "median_s": 0.251363583,
+        "samples_s": [
+          0.250150833,
+          0.252601084,
+          0.251363583
+        ]
+      },
+      "compute_s": 0.210491374,
+      "ns_per_op_min": 221.57966352196624,
+      "ns_per_op_median": 221.1201705759623,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 747991,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.02994625,
+        "median_s": 0.03038125,
+        "samples_s": [
+          0.030881292,
+          0.03038125,
+          0.02994625
+        ]
+      },
+      "total": {
+        "min_s": 0.3312035,
+        "median_s": 0.331320417,
+        "samples_s": [
+          0.332550459,
+          0.331320417,
+          0.3312035
+        ]
+      },
+      "compute_s": 0.30125725,
+      "ns_per_op_min": 402.75518020938756,
+      "ns_per_op_median": 402.3299304403395,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 4173791,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.041199834,
+        "median_s": 0.041717792,
+        "samples_s": [
+          0.041199834,
+          0.042092833,
+          0.041717792
+        ]
+      },
+      "total": {
+        "min_s": 0.30610975,
+        "median_s": 0.308051083,
+        "samples_s": [
+          0.308051083,
+          0.30610975,
+          0.30891575
+        ]
+      },
+      "compute_s": 0.264909916,
+      "ns_per_op_min": 63.46985654049281,
+      "ns_per_op_median": 63.81088343906056,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 331884,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010615333,
+        "median_s": 0.011729584,
+        "samples_s": [
+          0.012150125,
+          0.010615333,
+          0.011729584
+        ]
+      },
+      "total": {
+        "min_s": 0.305636583,
+        "median_s": 0.306104458,
+        "samples_s": [
+          0.306378584,
+          0.306104458,
+          0.305636583
+        ]
+      },
+      "compute_s": 0.29502125,
+      "ns_per_op_min": 888.9288124766484,
+      "ns_per_op_median": 886.9812163285967,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 38226532,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002614417,
+        "median_s": 0.002921166,
+        "samples_s": [
+          0.003225458,
+          0.002921166,
+          0.002614417
+        ]
+      },
+      "total": {
+        "min_s": 0.3025875,
+        "median_s": 0.303111292,
+        "samples_s": [
+          0.303111292,
+          0.303344834,
+          0.3025875
+        ]
+      },
+      "compute_s": 0.29997308300000003,
+      "ns_per_op_min": 7.847248162611246,
+      "ns_per_op_median": 7.852925972986511,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 25750679,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.063434542,
+        "median_s": 0.06563425,
+        "samples_s": [
+          0.063434542,
+          0.06563425,
+          0.067837333
+        ]
+      },
+      "total": {
+        "min_s": 0.324264041,
+        "median_s": 0.324611625,
+        "samples_s": [
+          0.324264041,
+          0.324611625,
+          0.326055917
+        ]
+      },
+      "compute_s": 0.260829499,
+      "ns_per_op_min": 10.129033840233884,
+      "ns_per_op_median": 10.057108591194819,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 7566,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.012763791,
+        "median_s": 0.012862667,
+        "samples_s": [
+          0.013496708,
+          0.012862667,
+          0.012763791
+        ]
+      },
+      "total": {
+        "min_s": 0.293859334,
+        "median_s": 0.294273834,
+        "samples_s": [
+          0.294423959,
+          0.293859334,
+          0.294273834
+        ]
+      },
+      "compute_s": 0.281095543,
+      "ns_per_op_min": 37152.464049696006,
+      "ns_per_op_median": 37194.18014803066,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 5486,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.045026708,
+        "median_s": 0.045552292,
+        "samples_s": [
+          0.045552292,
+          0.045026708,
+          0.046472916
+        ]
+      },
+      "total": {
+        "min_s": 0.328687125,
+        "median_s": 0.329521792,
+        "samples_s": [
+          0.329521792,
+          0.330670792,
+          0.328687125
+        ]
+      },
+      "compute_s": 0.283660417,
+      "ns_per_op_min": 51706.23714910682,
+      "ns_per_op_median": 51762.57746992344,
+      "load_ms": 1.034,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 3803,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.081391,
+        "median_s": 0.082206709,
+        "samples_s": [
+          0.081391,
+          0.082206709,
+          0.082760084
+        ]
+      },
+      "total": {
+        "min_s": 0.2753735,
+        "median_s": 0.276472458,
+        "samples_s": [
+          0.276472458,
+          0.276724542,
+          0.2753735
+        ]
+      },
+      "compute_s": 0.1939825,
+      "ns_per_op_min": 51007.75703392059,
+      "ns_per_op_median": 51082.237444123064,
+      "load_ms": 5.621,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 25798,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.053747417,
+        "median_s": 0.05377275,
+        "samples_s": [
+          0.053747417,
+          0.054658709,
+          0.05377275
+        ]
+      },
+      "total": {
+        "min_s": 0.606087666,
+        "median_s": 0.60666125,
+        "samples_s": [
+          0.608476625,
+          0.606087666,
+          0.60666125
+        ]
+      },
+      "compute_s": 0.552340249,
+      "ns_per_op_min": 21410.196488099853,
+      "ns_per_op_median": 21431.448174277077,
+      "load_ms": 4.532,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 24340,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.103853292,
+        "median_s": 0.104865166,
+        "samples_s": [
+          0.104865166,
+          0.103853292,
+          0.105802375
+        ]
+      },
+      "total": {
+        "min_s": 0.318126375,
+        "median_s": 0.321217834,
+        "samples_s": [
+          0.321217834,
+          0.318126375,
+          0.323508791
+        ]
+      },
+      "compute_s": 0.21427308300000003,
+      "ns_per_op_min": 8803.33126540674,
+      "ns_per_op_median": 8888.770254724732,
+      "load_ms": 10.238,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 83875303,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0053725,
+        "median_s": 0.005776958,
+        "samples_s": [
+          0.0053725,
+          0.006219,
+          0.005776958
+        ]
+      },
+      "total": {
+        "min_s": 0.302833708,
+        "median_s": 0.303246291,
+        "samples_s": [
+          0.302833708,
+          0.303572,
+          0.303246291
+        ]
+      },
+      "compute_s": 0.297461208,
+      "ns_per_op_min": 3.546469548968425,
+      "ns_per_op_median": 3.5465664189612527,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 84654614,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009104125,
+        "median_s": 0.009466209,
+        "samples_s": [
+          0.009466209,
+          0.009521833,
+          0.009104125
+        ]
+      },
+      "total": {
+        "min_s": 0.307226625,
+        "median_s": 0.308004084,
+        "samples_s": [
+          0.308004084,
+          0.308218666,
+          0.307226625
+        ]
+      },
+      "compute_s": 0.29812249999999996,
+      "ns_per_op_min": 3.521633209502319,
+      "ns_per_op_median": 3.5265399119296674,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1396909,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.016472417,
+        "median_s": 0.016822417,
+        "samples_s": [
+          0.016472417,
+          0.016822417,
+          0.016903959
+        ]
+      },
+      "total": {
+        "min_s": 0.310253416,
+        "median_s": 0.311581041,
+        "samples_s": [
+          0.313414958,
+          0.310253416,
+          0.311581041
+        ]
+      },
+      "compute_s": 0.293780999,
+      "ns_per_op_min": 210.30790051463623,
+      "ns_per_op_median": 211.00774925209873,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 49267932,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005001708,
+        "median_s": 0.005209125,
+        "samples_s": [
+          0.005209125,
+          0.005001708,
+          0.00566525
+        ]
+      },
+      "total": {
+        "min_s": 0.304780458,
+        "median_s": 0.305486959,
+        "samples_s": [
+          0.305491709,
+          0.304780458,
+          0.305486959
+        ]
+      },
+      "compute_s": 0.29977875,
+      "ns_per_op_min": 6.084662737620081,
+      "ns_per_op_median": 6.09479273455196,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 4700447,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004084166,
+        "median_s": 0.004325209,
+        "samples_s": [
+          0.004779209,
+          0.004084166,
+          0.004325209
+        ]
+      },
+      "total": {
+        "min_s": 0.24063625,
+        "median_s": 0.241962125,
+        "samples_s": [
+          0.243077,
+          0.24063625,
+          0.241962125
+        ]
+      },
+      "compute_s": 0.236552084,
+      "ns_per_op_min": 50.3254443673123,
+      "ns_per_op_median": 50.55623773653868,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 1131323,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039497,
+        "median_s": 0.040071459,
+        "samples_s": [
+          0.040071459,
+          0.04120425,
+          0.039497
+        ]
+      },
+      "total": {
+        "min_s": 0.2777875,
+        "median_s": 0.277871625,
+        "samples_s": [
+          0.2777875,
+          0.279252833,
+          0.277871625
+        ]
+      },
+      "compute_s": 0.23829050000000002,
+      "ns_per_op_min": 210.62994387986458,
+      "ns_per_op_median": 210.19652742850627,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 1915837,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040103208,
+        "median_s": 0.04121,
+        "samples_s": [
+          0.04121,
+          0.040103208,
+          0.041405083
+        ]
+      },
+      "total": {
+        "min_s": 0.251734291,
+        "median_s": 0.251935042,
+        "samples_s": [
+          0.252643292,
+          0.251935042,
+          0.251734291
+        ]
+      },
+      "compute_s": 0.211631083,
+      "ns_per_op_min": 110.46403373564661,
+      "ns_per_op_median": 109.99111197873306,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 1932384,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040816834,
+        "median_s": 0.0414195,
+        "samples_s": [
+          0.0414195,
+          0.040816834,
+          0.041434917
+        ]
+      },
+      "total": {
+        "min_s": 0.287941459,
+        "median_s": 0.289164292,
+        "samples_s": [
+          0.289164292,
+          0.289211667,
+          0.287941459
+        ]
+      },
+      "compute_s": 0.24712462500000001,
+      "ns_per_op_min": 127.88587827264146,
+      "ns_per_op_median": 128.20681189660027,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 685782,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.029588625,
+        "median_s": 0.030037833,
+        "samples_s": [
+          0.030943958,
+          0.029588625,
+          0.030037833
+        ]
+      },
+      "total": {
+        "min_s": 0.317638916,
+        "median_s": 0.31876425,
+        "samples_s": [
+          0.321477584,
+          0.31876425,
+          0.317638916
+        ]
+      },
+      "compute_s": 0.288050291,
+      "ns_per_op_min": 420.0318628952058,
+      "ns_per_op_median": 421.01778261896635,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 2295604,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.041023542,
+        "median_s": 0.04128575,
+        "samples_s": [
+          0.041894375,
+          0.041023542,
+          0.04128575
+        ]
+      },
+      "total": {
+        "min_s": 0.246909667,
+        "median_s": 0.247820542,
+        "samples_s": [
+          0.248974458,
+          0.246909667,
+          0.247820542
+        ]
+      },
+      "compute_s": 0.205886125,
+      "ns_per_op_min": 89.68712591544535,
+      "ns_per_op_median": 89.96969512163248,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 266447,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010484708,
+        "median_s": 0.010833084,
+        "samples_s": [
+          0.010484708,
+          0.011095792,
+          0.010833084
+        ]
+      },
+      "total": {
+        "min_s": 0.308077541,
+        "median_s": 0.308741334,
+        "samples_s": [
+          0.309219333,
+          0.308077541,
+          0.308741334
+        ]
+      },
+      "compute_s": 0.297592833,
+      "ns_per_op_min": 1116.8931644942522,
+      "ns_per_op_median": 1118.0769533903554,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 72189047,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.003002709,
+        "median_s": 0.003054125,
+        "samples_s": [
+          0.003054125,
+          0.003067959,
+          0.003002709
+        ]
+      },
+      "total": {
+        "min_s": 0.300950917,
+        "median_s": 0.301233417,
+        "samples_s": [
+          0.301233417,
+          0.302143875,
+          0.300950917
+        ]
+      },
+      "compute_s": 0.297948208,
+      "ns_per_op_min": 4.127332613214855,
+      "ns_per_op_median": 4.130533708250782,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 80051808,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.063669834,
+        "median_s": 0.066345416,
+        "samples_s": [
+          0.066345416,
+          0.063669834,
+          0.066808083
+        ]
+      },
+      "total": {
+        "min_s": 0.353636916,
+        "median_s": 0.353776917,
+        "samples_s": [
+          0.353905083,
+          0.353776917,
+          0.353636916
+        ]
+      },
+      "compute_s": 0.28996708200000004,
+      "ns_per_op_min": 3.622242760588244,
+      "ns_per_op_median": 3.590568510332709,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 4922,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0121625,
+        "median_s": 0.012779917,
+        "samples_s": [
+          0.012779917,
+          0.012906625,
+          0.0121625
+        ]
+      },
+      "total": {
+        "min_s": 0.289970875,
+        "median_s": 0.29040875,
+        "samples_s": [
+          0.290638666,
+          0.289970875,
+          0.29040875
+        ]
+      },
+      "compute_s": 0.277808375,
+      "ns_per_op_min": 56442.17289719626,
+      "ns_per_op_median": 56405.695449004466,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 5427,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.04432525,
+        "median_s": 0.044355208,
+        "samples_s": [
+          0.04432525,
+          0.044355208,
+          0.044962083
+        ]
+      },
+      "total": {
+        "min_s": 0.312125084,
+        "median_s": 0.314082125,
+        "samples_s": [
+          0.314342583,
+          0.312125084,
+          0.314082125
+        ]
+      },
+      "compute_s": 0.267799834,
+      "ns_per_op_min": 49345.832688409806,
+      "ns_per_op_median": 49700.924451815,
+      "load_ms": 0.708,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 23408,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.079097333,
+        "median_s": 0.080272083,
+        "samples_s": [
+          0.080272083,
+          0.079097333,
+          0.080914458
+        ]
+      },
+      "total": {
+        "min_s": 0.312519542,
+        "median_s": 0.313220541,
+        "samples_s": [
+          0.312519542,
+          0.313449167,
+          0.313220541
+        ]
+      },
+      "compute_s": 0.233422209,
+      "ns_per_op_min": 9971.898880724539,
+      "ns_per_op_median": 9951.660030758716,
+      "load_ms": 3.585,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 11984,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.052835333,
+        "median_s": 0.054477209,
+        "samples_s": [
+          0.054832875,
+          0.052835333,
+          0.054477209
+        ]
+      },
+      "total": {
+        "min_s": 0.269414583,
+        "median_s": 0.2718305,
+        "samples_s": [
+          0.2726425,
+          0.2718305,
+          0.269414583
+        ]
+      },
+      "compute_s": 0.21657925,
+      "ns_per_op_min": 18072.367323097464,
+      "ns_per_op_median": 18136.956859145525,
+      "load_ms": 4.211,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 32446,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.103266625,
+        "median_s": 0.105277875,
+        "samples_s": [
+          0.105277875,
+          0.105668,
+          0.103266625
+        ]
+      },
+      "total": {
+        "min_s": 0.376460417,
+        "median_s": 0.376765125,
+        "samples_s": [
+          0.376765125,
+          0.37940025,
+          0.376460417
+        ]
+      },
+      "compute_s": 0.273193792,
+      "ns_per_op_min": 8419.952906367504,
+      "ns_per_op_median": 8367.356530851259,
+      "load_ms": 9.45,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 33554432,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.00575275,
+        "median_s": 0.005844166,
+        "samples_s": [
+          0.00575275,
+          0.006021083,
+          0.005844166
+        ]
+      },
+      "total": {
+        "min_s": 0.359566791,
+        "median_s": 0.361056125,
+        "samples_s": [
+          0.361625292,
+          0.361056125,
+          0.359566791
+        ]
+      },
+      "compute_s": 0.353814041,
+      "ns_per_op_min": 10.544480115175247,
+      "ns_per_op_median": 10.58614131808281,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 28596734,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009018167,
+        "median_s": 0.009119625,
+        "samples_s": [
+          0.009018167,
+          0.009119625,
+          0.009863042
+        ]
+      },
+      "total": {
+        "min_s": 0.308587167,
+        "median_s": 0.309727583,
+        "samples_s": [
+          0.309727583,
+          0.310200208,
+          0.308587167
+        ]
+      },
+      "compute_s": 0.299569,
+      "ns_per_op_min": 10.47563683321319,
+      "ns_per_op_median": 10.511968184898315,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 692996,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015836209,
+        "median_s": 0.016700333,
+        "samples_s": [
+          0.015836209,
+          0.016834417,
+          0.016700333
+        ]
+      },
+      "total": {
+        "min_s": 0.308544875,
+        "median_s": 0.308721708,
+        "samples_s": [
+          0.311084666,
+          0.308721708,
+          0.308544875
+        ]
+      },
+      "compute_s": 0.292708666,
+      "ns_per_op_min": 422.38146540528373,
+      "ns_per_op_median": 421.38969777603336,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 25364682,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005041708,
+        "median_s": 0.005165916,
+        "samples_s": [
+          0.005165916,
+          0.005644666,
+          0.005041708
+        ]
+      },
+      "total": {
+        "min_s": 0.306399,
+        "median_s": 0.307210792,
+        "samples_s": [
+          0.306399,
+          0.308225542,
+          0.307210792
+        ]
+      },
+      "compute_s": 0.301357292,
+      "ns_per_op_min": 11.880980490904637,
+      "ns_per_op_median": 11.908088419953382,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 4143441,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004403042,
+        "median_s": 0.004450083,
+        "samples_s": [
+          0.004450083,
+          0.004482125,
+          0.004403042
+        ]
+      },
+      "total": {
+        "min_s": 0.293167,
+        "median_s": 0.295175375,
+        "samples_s": [
+          0.293167,
+          0.295175375,
+          0.295244625
+        ]
+      },
+      "compute_s": 0.288763958,
+      "ns_per_op_min": 69.69182329373098,
+      "ns_per_op_median": 70.16518203107032,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 427776,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.03967625,
+        "median_s": 0.0403205,
+        "samples_s": [
+          0.0403205,
+          0.040839083,
+          0.03967625
+        ]
+      },
+      "total": {
+        "min_s": 0.326883084,
+        "median_s": 0.327407167,
+        "samples_s": [
+          0.328630875,
+          0.327407167,
+          0.326883084
+        ]
+      },
+      "compute_s": 0.28720683399999997,
+      "ns_per_op_min": 671.3953891756432,
+      "ns_per_op_median": 671.1144781380909,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 621208,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.038951834,
+        "median_s": 0.038999,
+        "samples_s": [
+          0.03962525,
+          0.038951834,
+          0.038999
+        ]
+      },
+      "total": {
+        "min_s": 0.294254708,
+        "median_s": 0.298231583,
+        "samples_s": [
+          0.298231583,
+          0.29904025,
+          0.294254708
+        ]
+      },
+      "compute_s": 0.25530287399999996,
+      "ns_per_op_min": 410.978084635098,
+      "ns_per_op_median": 417.30399962653416,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 579314,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040889875,
+        "median_s": 0.040987042,
+        "samples_s": [
+          0.040987042,
+          0.041566542,
+          0.040889875
+        ]
+      },
+      "total": {
+        "min_s": 0.315902959,
+        "median_s": 0.319407875,
+        "samples_s": [
+          0.320077541,
+          0.319407875,
+          0.315902959
+        ]
+      },
+      "compute_s": 0.27501308399999996,
+      "ns_per_op_min": 474.7219711589914,
+      "ns_per_op_median": 480.6043579129798,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 386511,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.02919075,
+        "median_s": 0.029892458,
+        "samples_s": [
+          0.02919075,
+          0.030072959,
+          0.029892458
+        ]
+      },
+      "total": {
+        "min_s": 0.334642208,
+        "median_s": 0.334854708,
+        "samples_s": [
+          0.334854708,
+          0.334642208,
+          0.335560667
+        ]
+      },
+      "compute_s": 0.305451458,
+      "ns_per_op_min": 790.2788225949585,
+      "ns_per_op_median": 789.0131199370782,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 1768112,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040544292,
+        "median_s": 0.040711167,
+        "samples_s": [
+          0.041087708,
+          0.040711167,
+          0.040544292
+        ]
+      },
+      "total": {
+        "min_s": 0.28859,
+        "median_s": 0.289349542,
+        "samples_s": [
+          0.290221166,
+          0.289349542,
+          0.28859
+        ]
+      },
+      "compute_s": 0.248045708,
+      "ns_per_op_min": 140.28845910213832,
+      "ns_per_op_median": 140.62365675930033,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 121189,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0108015,
+        "median_s": 0.010940208,
+        "samples_s": [
+          0.010940208,
+          0.011297583,
+          0.0108015
+        ]
+      },
+      "total": {
+        "min_s": 0.311004,
+        "median_s": 0.311173792,
+        "samples_s": [
+          0.312299083,
+          0.311004,
+          0.311173792
+        ]
+      },
+      "compute_s": 0.3002025,
+      "ns_per_op_min": 2477.1431400539655,
+      "ns_per_op_median": 2477.3996319798002,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 16777216,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002863584,
+        "median_s": 0.002932375,
+        "samples_s": [
+          0.002932375,
+          0.002863584,
+          0.002986541
+        ]
+      },
+      "total": {
+        "min_s": 0.18545175,
+        "median_s": 0.185501,
+        "samples_s": [
+          0.185501,
+          0.186420417,
+          0.18545175
+        ]
+      },
+      "compute_s": 0.182588166,
+      "ns_per_op_min": 10.883102774620056,
+      "ns_per_op_median": 10.8819380402565,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 3528382,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.064575875,
+        "median_s": 0.066628083,
+        "samples_s": [
+          0.066628083,
+          0.064575875,
+          0.066931167
+        ]
+      },
+      "total": {
+        "min_s": 0.267140417,
+        "median_s": 0.267710583,
+        "samples_s": [
+          0.267140417,
+          0.267710583,
+          0.268630209
+        ]
+      },
+      "compute_s": 0.20256454200000001,
+      "ns_per_op_min": 57.41003723519732,
+      "ns_per_op_median": 56.990002783145364,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 3886,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.013105583,
+        "median_s": 0.013142,
+        "samples_s": [
+          0.013491917,
+          0.013142,
+          0.013105583
+        ]
+      },
+      "total": {
+        "min_s": 0.307005791,
+        "median_s": 0.307891,
+        "samples_s": [
+          0.307891,
+          0.307005791,
+          0.309160875
+        ]
+      },
+      "compute_s": 0.293900208,
+      "ns_per_op_min": 75630.52187339166,
+      "ns_per_op_median": 75848.94493051984,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 3506,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.043586291,
+        "median_s": 0.044342458,
+        "samples_s": [
+          0.043586291,
+          0.045431875,
+          0.044342458
+        ]
+      },
+      "total": {
+        "min_s": 0.334041042,
+        "median_s": 0.334187,
+        "samples_s": [
+          0.334187,
+          0.334041042,
+          0.33476875
+        ]
+      },
+      "compute_s": 0.290454751,
+      "ns_per_op_min": 82845.05162578437,
+      "ns_per_op_median": 82671.00456360525,
+      "load_ms": 0.841,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 8168,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.077843791,
+        "median_s": 0.080833333,
+        "samples_s": [
+          0.081886833,
+          0.077843791,
+          0.080833333
+        ]
+      },
+      "total": {
+        "min_s": 0.298908375,
+        "median_s": 0.302436833,
+        "samples_s": [
+          0.298908375,
+          0.302436833,
+          0.302878459
+        ]
+      },
+      "compute_s": 0.221064584,
+      "ns_per_op_min": 27064.71400587659,
+      "ns_per_op_median": 27130.69294809011,
+      "load_ms": 4.589,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 11110,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.05394525,
+        "median_s": 0.054486792,
+        "samples_s": [
+          0.054545834,
+          0.054486792,
+          0.05394525
+        ]
+      },
+      "total": {
+        "min_s": 0.367099,
+        "median_s": 0.370406375,
+        "samples_s": [
+          0.370406375,
+          0.367099,
+          0.370547375
+        ]
+      },
+      "compute_s": 0.31315375,
+      "ns_per_op_min": 28186.65616561656,
+      "ns_per_op_median": 28435.60603060306,
+      "load_ms": 4.11,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 13685,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.102113666,
+        "median_s": 0.103605083,
+        "samples_s": [
+          0.103605083,
+          0.104244334,
+          0.102113666
+        ]
+      },
+      "total": {
+        "min_s": 0.29942575,
+        "median_s": 0.301298375,
+        "samples_s": [
+          0.301298375,
+          0.303572375,
+          0.29942575
+        ]
+      },
+      "compute_s": 0.197312084,
+      "ns_per_op_min": 14418.128169528682,
+      "ns_per_op_median": 14445.984070149801,
+      "load_ms": 9.378,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 39139572,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005585083,
+        "median_s": 0.005782875,
+        "samples_s": [
+          0.005782875,
+          0.005585083,
+          0.005865917
+        ]
+      },
+      "total": {
+        "min_s": 0.304662584,
+        "median_s": 0.304956333,
+        "samples_s": [
+          0.304956333,
+          0.304662584,
+          0.305527125
+        ]
+      },
+      "compute_s": 0.299077501,
+      "ns_per_op_min": 7.6413073960032065,
+      "ns_per_op_median": 7.6437590579682375,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 39113200,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.008842084,
+        "median_s": 0.009009083,
+        "samples_s": [
+          0.009009083,
+          0.008842084,
+          0.009399916
+        ]
+      },
+      "total": {
+        "min_s": 0.307421834,
+        "median_s": 0.308068792,
+        "samples_s": [
+          0.307421834,
+          0.308068792,
+          0.308163458
+        ]
+      },
+      "compute_s": 0.29857975000000003,
+      "ns_per_op_min": 7.63373362445415,
+      "ns_per_op_median": 7.646004648047207,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1279656,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015983542,
+        "median_s": 0.016332291,
+        "samples_s": [
+          0.016559292,
+          0.016332291,
+          0.015983542
+        ]
+      },
+      "total": {
+        "min_s": 0.319163083,
+        "median_s": 0.319372,
+        "samples_s": [
+          0.319372,
+          0.319163083,
+          0.319668625
+        ]
+      },
+      "compute_s": 0.303179541,
+      "ns_per_op_min": 236.92268937902062,
+      "ns_per_op_median": 236.81341626187037,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 5237294,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005135084,
+        "median_s": 0.005155125,
+        "samples_s": [
+          0.005135084,
+          0.005155125,
+          0.005161416
+        ]
+      },
+      "total": {
+        "min_s": 0.301874833,
+        "median_s": 0.30433175,
+        "samples_s": [
+          0.301874833,
+          0.30433175,
+          0.30744625
+        ]
+      },
+      "compute_s": 0.296739749,
+      "ns_per_op_min": 56.658982482174956,
+      "ns_per_op_median": 57.124275436895466,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 16777216,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004527375,
+        "median_s": 0.004553791,
+        "samples_s": [
+          0.004527375,
+          0.004553791,
+          0.005142042
+        ]
+      },
+      "total": {
+        "min_s": 0.364390542,
+        "median_s": 0.364873084,
+        "samples_s": [
+          0.364873084,
+          0.3660695,
+          0.364390542
+        ]
+      },
+      "compute_s": 0.359863167,
+      "ns_per_op_min": 21.449516236782074,
+      "ns_per_op_median": 21.476703464984897,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 212633,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.03933475,
+        "median_s": 0.040234292,
+        "samples_s": [
+          0.040234292,
+          0.041375167,
+          0.03933475
+        ]
+      },
+      "total": {
+        "min_s": 0.3320605,
+        "median_s": 0.332364416,
+        "samples_s": [
+          0.3320605,
+          0.332364416,
+          0.332708709
+        ]
+      },
+      "compute_s": 0.29272575,
+      "ns_per_op_min": 1376.6713068996817,
+      "ns_per_op_median": 1373.870114234385,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 240266,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0394345,
+        "median_s": 0.040735417,
+        "samples_s": [
+          0.040735417,
+          0.0394345,
+          0.041226916
+        ]
+      },
+      "total": {
+        "min_s": 0.246475916,
+        "median_s": 0.250837958,
+        "samples_s": [
+          0.252262167,
+          0.246475916,
+          0.250837958
+        ]
+      },
+      "compute_s": 0.20704141599999998,
+      "ns_per_op_min": 861.7174964414439,
+      "ns_per_op_median": 874.4580631466793,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 243150,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0394545,
+        "median_s": 0.039688833,
+        "samples_s": [
+          0.0394545,
+          0.040768875,
+          0.039688833
+        ]
+      },
+      "total": {
+        "min_s": 0.282141833,
+        "median_s": 0.282642084,
+        "samples_s": [
+          0.282642084,
+          0.282141833,
+          0.283367833
+        ]
+      },
+      "compute_s": 0.242687333,
+      "ns_per_op_min": 998.0971951470286,
+      "ns_per_op_median": 999.1908328192474,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 206442,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.028385584,
+        "median_s": 0.028463708,
+        "samples_s": [
+          0.0302465,
+          0.028463708,
+          0.028385584
+        ]
+      },
+      "total": {
+        "min_s": 0.3207545,
+        "median_s": 0.321185625,
+        "samples_s": [
+          0.3207545,
+          0.322345458,
+          0.321185625
+        ]
+      },
+      "compute_s": 0.292368916,
+      "ns_per_op_min": 1416.2278799856617,
+      "ns_per_op_median": 1417.9378081979442,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 1248306,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040964209,
+        "median_s": 0.04096475,
+        "samples_s": [
+          0.04096475,
+          0.041053958,
+          0.040964209
+        ]
+      },
+      "total": {
+        "min_s": 0.361697625,
+        "median_s": 0.362441042,
+        "samples_s": [
+          0.362441042,
+          0.362611792,
+          0.361697625
+        ]
+      },
+      "compute_s": 0.32073341600000005,
+      "ns_per_op_min": 256.93493101851635,
+      "ns_per_op_median": 257.5300383079149,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 132410,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015127333,
+        "median_s": 0.015832541,
+        "samples_s": [
+          0.015127333,
+          0.015832541,
+          0.015986791
+        ]
+      },
+      "total": {
+        "min_s": 0.314263,
+        "median_s": 0.314850125,
+        "samples_s": [
+          0.314850125,
+          0.316141125,
+          0.314263
+        ]
+      },
+      "compute_s": 0.299135667,
+      "ns_per_op_min": 2259.162200740125,
+      "ns_per_op_median": 2258.270402537573,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 33554432,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.003004792,
+        "median_s": 0.00301825,
+        "samples_s": [
+          0.003004792,
+          0.003043,
+          0.00301825
+        ]
+      },
+      "total": {
+        "min_s": 0.357291584,
+        "median_s": 0.357391334,
+        "samples_s": [
+          0.357291584,
+          0.357848083,
+          0.357391334
+        ]
+      },
+      "compute_s": 0.354286792,
+      "ns_per_op_min": 10.558569192886353,
+      "ns_per_op_median": 10.561140894889832,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 15231628,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.064214625,
+        "median_s": 0.066698083,
+        "samples_s": [
+          0.067270375,
+          0.066698083,
+          0.064214625
+        ]
+      },
+      "total": {
+        "min_s": 0.344194208,
+        "median_s": 0.345552042,
+        "samples_s": [
+          0.344194208,
+          0.345552042,
+          0.346837875
+        ]
+      },
+      "compute_s": 0.27997958300000003,
+      "ns_per_op_min": 18.381461456385363,
+      "ns_per_op_median": 18.307561017115177,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 569,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.012601875,
+        "median_s": 0.012778625,
+        "samples_s": [
+          0.012853458,
+          0.012778625,
+          0.012601875
+        ]
+      },
+      "total": {
+        "min_s": 0.3107705,
+        "median_s": 0.311107166,
+        "samples_s": [
+          0.311107166,
+          0.313352125,
+          0.3107705
+        ]
+      },
+      "compute_s": 0.298168625,
+      "ns_per_op_min": 524022.18804920913,
+      "ns_per_op_median": 524303.2355008788,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 2770,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.043508542,
+        "median_s": 0.043690917,
+        "samples_s": [
+          0.043508542,
+          0.044514709,
+          0.043690917
+        ]
+      },
+      "total": {
+        "min_s": 0.32453625,
+        "median_s": 0.325423,
+        "samples_s": [
+          0.32453625,
+          0.325423,
+          0.325970417
+        ]
+      },
+      "compute_s": 0.28102770800000004,
+      "ns_per_op_min": 101454.0462093863,
+      "ns_per_op_median": 101708.3332129964,
+      "load_ms": 0.665,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 317,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.078627625,
+        "median_s": 0.080662416,
+        "samples_s": [
+          0.080662416,
+          0.080693583,
+          0.078627625
+        ]
+      },
+      "total": {
+        "min_s": 0.333970417,
+        "median_s": 0.336338416,
+        "samples_s": [
+          0.333970417,
+          0.336338416,
+          0.33675475
+        ]
+      },
+      "compute_s": 0.255342792,
+      "ns_per_op_min": 805497.7665615142,
+      "ns_per_op_median": 806548.8958990535,
+      "load_ms": 3.832,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 9686,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.052710875,
+        "median_s": 0.054220542,
+        "samples_s": [
+          0.054446792,
+          0.054220542,
+          0.052710875
+        ]
+      },
+      "total": {
+        "min_s": 0.305600292,
+        "median_s": 0.3060445,
+        "samples_s": [
+          0.305600292,
+          0.310441333,
+          0.3060445
+        ]
+      },
+      "compute_s": 0.252889417,
+      "ns_per_op_min": 26108.7566590956,
+      "ns_per_op_median": 25998.756762337394,
+      "load_ms": 4.208,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 13065,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.101652542,
+        "median_s": 0.101893083,
+        "samples_s": [
+          0.101893083,
+          0.102568125,
+          0.101652542
+        ]
+      },
+      "total": {
+        "min_s": 0.304803583,
+        "median_s": 0.306980416,
+        "samples_s": [
+          0.306980416,
+          0.304803583,
+          0.309788625
+        ]
+      },
+      "compute_s": 0.20315104099999998,
+      "ns_per_op_min": 15549.256869498658,
+      "ns_per_op_median": 15697.461385380786,
+      "load_ms": 9.671,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 1342442,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005410333,
+        "median_s": 0.00580475,
+        "samples_s": [
+          0.005867125,
+          0.005410333,
+          0.00580475
+        ]
+      },
+      "total": {
+        "min_s": 0.305596375,
+        "median_s": 0.307306167,
+        "samples_s": [
+          0.305596375,
+          0.309183667,
+          0.307306167
+        ]
+      },
+      "compute_s": 0.300186042,
+      "ns_per_op_min": 223.61192662327312,
+      "ns_per_op_median": 224.5917641134589,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 23930,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.008596417,
+        "median_s": 0.009194167,
+        "samples_s": [
+          0.009576041,
+          0.009194167,
+          0.008596417
+        ]
+      },
+      "total": {
+        "min_s": 0.258525458,
+        "median_s": 0.258936958,
+        "samples_s": [
+          0.258525458,
+          0.258936958,
+          0.25893925
+        ]
+      },
+      "compute_s": 0.249929041,
+      "ns_per_op_min": 10444.172210614292,
+      "ns_per_op_median": 10436.389093188467,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 2477666,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015850458,
+        "median_s": 0.016346792,
+        "samples_s": [
+          0.016346792,
+          0.017039917,
+          0.015850458
+        ]
+      },
+      "total": {
+        "min_s": 0.304612958,
+        "median_s": 0.304758583,
+        "samples_s": [
+          0.306018042,
+          0.304612958,
+          0.304758583
+        ]
+      },
+      "compute_s": 0.2887625,
+      "ns_per_op_min": 116.5461769261878,
+      "ns_per_op_median": 116.4046287917742,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wazero",
+      "status": "skipped",
+      "reason": "excluded: wazero 1.12.0 rejects the module: \"tag section not supported as feature \\\"exception-handling\\\" is disabled\""
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wasm3",
+      "status": "skipped",
+      "reason": "excluded: wasm3 0.5.0 fails to load it: \"out of order Wasm section\" (the tag section is unknown to it)"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 458087,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.038703292,
+        "median_s": 0.039567083,
+        "samples_s": [
+          0.039852834,
+          0.039567083,
+          0.038703292
+        ]
+      },
+      "total": {
+        "min_s": 0.331667916,
+        "median_s": 0.331752042,
+        "samples_s": [
+          0.331667916,
+          0.331752042,
+          0.333983209
+        ]
+      },
+      "compute_s": 0.292964624,
+      "ns_per_op_min": 639.5392665585358,
+      "ns_per_op_median": 637.8372645370857,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 480695,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040791625,
+        "median_s": 0.041032792,
+        "samples_s": [
+          0.041032792,
+          0.041064209,
+          0.040791625
+        ]
+      },
+      "total": {
+        "min_s": 0.269041375,
+        "median_s": 0.27052325,
+        "samples_s": [
+          0.27052325,
+          0.270560125,
+          0.269041375
+        ]
+      },
+      "compute_s": 0.22824975000000003,
+      "ns_per_op_min": 474.832794183422,
+      "ns_per_op_median": 477.4138653408086,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 460890,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039760542,
+        "median_s": 0.039779125,
+        "samples_s": [
+          0.041322833,
+          0.039760542,
+          0.039779125
+        ]
+      },
+      "total": {
+        "min_s": 0.322663792,
+        "median_s": 0.323013708,
+        "samples_s": [
+          0.323032125,
+          0.323013708,
+          0.322663792
+        ]
+      },
+      "compute_s": 0.28290325,
+      "ns_per_op_min": 613.8194580051639,
+      "ns_per_op_median": 614.5383562238279,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 448340,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.02902125,
+        "median_s": 0.03014475,
+        "samples_s": [
+          0.03014475,
+          0.02902125,
+          0.030672875
+        ]
+      },
+      "total": {
+        "min_s": 0.327876167,
+        "median_s": 0.330017917,
+        "samples_s": [
+          0.327876167,
+          0.330017917,
+          0.332253875
+        ]
+      },
+      "compute_s": 0.298854917,
+      "ns_per_op_min": 666.5809809519561,
+      "ns_per_op_median": 668.8521367712004,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 4000000,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039921458,
+        "median_s": 0.041048959,
+        "samples_s": [
+          0.039921458,
+          0.041048959,
+          0.0412345
+        ]
+      },
+      "total": {
+        "min_s": 0.058221667,
+        "median_s": 0.059231041,
+        "samples_s": [
+          0.058221667,
+          0.059246875,
+          0.059231041
+        ]
+      },
+      "compute_s": 0.018300208999999998,
+      "ns_per_op_min": 4.575052249999999,
+      "ns_per_op_median": 4.545520499999999,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 249474,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010455375,
+        "median_s": 0.010712084,
+        "samples_s": [
+          0.010835167,
+          0.010455375,
+          0.010712084
+        ]
+      },
+      "total": {
+        "min_s": 0.3080725,
+        "median_s": 0.309071792,
+        "samples_s": [
+          0.309874458,
+          0.309071792,
+          0.3080725
+        ]
+      },
+      "compute_s": 0.29761712500000004,
+      "ns_per_op_min": 1192.9785268204305,
+      "ns_per_op_median": 1195.9551215757954,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 1462326,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002629042,
+        "median_s": 0.003010458,
+        "samples_s": [
+          0.003302708,
+          0.002629042,
+          0.003010458
+        ]
+      },
+      "total": {
+        "min_s": 0.299152917,
+        "median_s": 0.299955,
+        "samples_s": [
+          0.3007545,
+          0.299955,
+          0.299152917
+        ]
+      },
+      "compute_s": 0.296523875,
+      "ns_per_op_min": 202.775492605616,
+      "ns_per_op_median": 203.06316238649936,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 395499,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.06538375,
+        "median_s": 0.066830833,
+        "samples_s": [
+          0.066830833,
+          0.067251458,
+          0.06538375
+        ]
+      },
+      "total": {
+        "min_s": 0.276320625,
+        "median_s": 0.276749458,
+        "samples_s": [
+          0.276749458,
+          0.27749025,
+          0.276320625
+        ]
+      },
+      "compute_s": 0.21093687499999997,
+      "ns_per_op_min": 533.3436367727857,
+      "ns_per_op_median": 530.7690411353758,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-bash",
+      "status": "skipped",
+      "reason": "excluded: the bash backend has no exception-handling lowering and rejects the module at conversion time with \"unsupported (exception-handling): tag, exnref value, or try_table/throw/throw_ref instruction\" (see docs/support.md)"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "pywasm-cpython",
+      "status": "skipped",
+      "reason": "excluded: pywasm 2.2.3 has no exception-handling opcodes; decoding dies with AssertionError on the throw/try_table opcode (pywasm/core.py, from_reader)"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "pywasm-pypy",
+      "status": "skipped",
+      "reason": "excluded: pywasm 2.2.3 has no exception-handling opcodes; decoding dies with AssertionError on the throw/try_table opcode (pywasm/core.py, from_reader)"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wardite",
+      "status": "skipped",
+      "reason": "excluded: wardite 0.9.0 fails to load the tag section: Wardite::LoadError \"unknown code: 13\""
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wardite-yjit",
+      "status": "skipped",
+      "reason": "excluded: wardite 0.9.0 fails to load the tag section: Wardite::LoadError \"unknown code: 13\""
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 106521348,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005624375,
+        "median_s": 0.005855042,
+        "samples_s": [
+          0.005855042,
+          0.005624375,
+          0.006126791
+        ]
+      },
+      "total": {
+        "min_s": 0.303396042,
+        "median_s": 0.303424,
+        "samples_s": [
+          0.303424,
+          0.303396042,
+          0.304096458
+        ]
+      },
+      "compute_s": 0.29777166699999996,
+      "ns_per_op_min": 2.7954177504400333,
+      "ns_per_op_median": 2.793514761003588,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 235678285,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009181584,
+        "median_s": 0.009205042,
+        "samples_s": [
+          0.009205042,
+          0.009181584,
+          0.009391417
+        ]
+      },
+      "total": {
+        "min_s": 0.307613042,
+        "median_s": 0.307623084,
+        "samples_s": [
+          0.308503625,
+          0.307623084,
+          0.307613042
+        ]
+      },
+      "compute_s": 0.298431458,
+      "ns_per_op_min": 1.2662662493491923,
+      "ns_per_op_median": 1.2662093242913746,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 2332933,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015850167,
+        "median_s": 0.015927042,
+        "samples_s": [
+          0.015927042,
+          0.016071208,
+          0.015850167
+        ]
+      },
+      "total": {
+        "min_s": 0.291459459,
+        "median_s": 0.291997916,
+        "samples_s": [
+          0.292200084,
+          0.291997916,
+          0.291459459
+        ]
+      },
+      "compute_s": 0.27560929199999995,
+      "ns_per_op_min": 118.1385371975963,
+      "ns_per_op_median": 118.33639200097045,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wazero",
+      "status": "skipped",
+      "reason": "excluded: wazero 1.12.0 rejects the module: \"tag section not supported as feature \\\"exception-handling\\\" is disabled\""
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wasm3",
+      "status": "skipped",
+      "reason": "excluded: wasm3 0.5.0 fails to load it: \"out of order Wasm section\" (the tag section is unknown to it)"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 2721877,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040362084,
+        "median_s": 0.040398709,
+        "samples_s": [
+          0.040645417,
+          0.040362084,
+          0.040398709
+        ]
+      },
+      "total": {
+        "min_s": 0.369030458,
+        "median_s": 0.371356208,
+        "samples_s": [
+          0.369030458,
+          0.37144525,
+          0.371356208
+        ]
+      },
+      "compute_s": 0.328668374,
+      "ns_per_op_min": 120.75063421308164,
+      "ns_per_op_median": 121.59164392806878,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 2129084,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.03972125,
+        "median_s": 0.040308583,
+        "samples_s": [
+          0.04059775,
+          0.03972125,
+          0.040308583
+        ]
+      },
+      "total": {
+        "min_s": 0.30003,
+        "median_s": 0.301516208,
+        "samples_s": [
+          0.301516208,
+          0.30277775,
+          0.30003
+        ]
+      },
+      "compute_s": 0.26030875000000003,
+      "ns_per_op_min": 122.26325969290082,
+      "ns_per_op_median": 122.68544829607474,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 2524269,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040616958,
+        "median_s": 0.040755,
+        "samples_s": [
+          0.040616958,
+          0.040755,
+          0.041193333
+        ]
+      },
+      "total": {
+        "min_s": 0.348470375,
+        "median_s": 0.34920525,
+        "samples_s": [
+          0.348470375,
+          0.353061792,
+          0.34920525
+        ]
+      },
+      "compute_s": 0.307853417,
+      "ns_per_op_min": 121.95745263282161,
+      "ns_per_op_median": 122.19389058773056,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 1369358,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.028845208,
+        "median_s": 0.029016625,
+        "samples_s": [
+          0.028845208,
+          0.029016625,
+          0.029144209
+        ]
+      },
+      "total": {
+        "min_s": 0.306106375,
+        "median_s": 0.306929916,
+        "samples_s": [
+          0.306106375,
+          0.306929916,
+          0.309211167
+        ]
+      },
+      "compute_s": 0.277261167,
+      "ns_per_op_min": 202.47529645279027,
+      "ns_per_op_median": 202.95152253829897,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 104455728,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039940959,
+        "median_s": 0.040061875,
+        "samples_s": [
+          0.040061875,
+          0.039940959,
+          0.0405505
+        ]
+      },
+      "total": {
+        "min_s": 0.315484042,
+        "median_s": 0.315795833,
+        "samples_s": [
+          0.315842042,
+          0.315795833,
+          0.315484042
+        ]
+      },
+      "compute_s": 0.275543083,
+      "ns_per_op_min": 2.6378934719597185,
+      "ns_per_op_median": 2.6397208011417046,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 562137,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010323625,
+        "median_s": 0.010433333,
+        "samples_s": [
+          0.010323625,
+          0.010433333,
+          0.011149708
+        ]
+      },
+      "total": {
+        "min_s": 0.302511625,
+        "median_s": 0.302894666,
+        "samples_s": [
+          0.304147333,
+          0.302511625,
+          0.302894666
+        ]
+      },
+      "compute_s": 0.292188,
+      "ns_per_op_min": 519.7807651871341,
+      "ns_per_op_median": 520.2670043067793,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 70338454,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002846,
+        "median_s": 0.003007375,
+        "samples_s": [
+          0.003007375,
+          0.003073583,
+          0.002846
+        ]
+      },
+      "total": {
+        "min_s": 0.304541125,
+        "median_s": 0.304663667,
+        "samples_s": [
+          0.304663667,
+          0.304541125,
+          0.305054083
+        ]
+      },
+      "compute_s": 0.301695125,
+      "ns_per_op_min": 4.2891918693578335,
+      "ns_per_op_median": 4.288639781590879,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 232076204,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.063232,
+        "median_s": 0.066432041,
+        "samples_s": [
+          0.067022125,
+          0.066432041,
+          0.063232
+        ]
+      },
+      "total": {
+        "min_s": 0.397515875,
+        "median_s": 0.399843166,
+        "samples_s": [
+          0.399843166,
+          0.401103167,
+          0.397515875
+        ]
+      },
+      "compute_s": 0.334283875,
+      "ns_per_op_min": 1.4404056479655278,
+      "ns_per_op_median": 1.4366450297506592,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-bash",
+      "status": "skipped",
+      "reason": "excluded: the bash backend has no exception-handling lowering and rejects the module at conversion time with \"unsupported (exception-handling): tag, exnref value, or try_table/throw/throw_ref instruction\" (see docs/support.md)"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "pywasm-cpython",
+      "status": "skipped",
+      "reason": "excluded: pywasm 2.2.3 has no exception-handling opcodes; decoding dies with AssertionError on the throw/try_table opcode (pywasm/core.py, from_reader)"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "pywasm-pypy",
+      "status": "skipped",
+      "reason": "excluded: pywasm 2.2.3 has no exception-handling opcodes; decoding dies with AssertionError on the throw/try_table opcode (pywasm/core.py, from_reader)"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wardite",
+      "status": "skipped",
+      "reason": "excluded: wardite 0.9.0 fails to load the tag section: Wardite::LoadError \"unknown code: 13\""
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wardite-yjit",
+      "status": "skipped",
+      "reason": "excluded: wardite 0.9.0 fails to load the tag section: Wardite::LoadError \"unknown code: 13\""
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 301572951,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005772958,
+        "median_s": 0.005993334,
+        "samples_s": [
+          0.005772958,
+          0.005993334,
+          0.006027417
+        ]
+      },
+      "total": {
+        "min_s": 0.306861833,
+        "median_s": 0.307183208,
+        "samples_s": [
+          0.307386541,
+          0.306861833,
+          0.307183208
+        ]
+      },
+      "compute_s": 0.301088875,
+      "ns_per_op_min": 0.9983948295150649,
+      "ns_per_op_median": 0.9987297368721904,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 294768053,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.008806166,
+        "median_s": 0.009434583,
+        "samples_s": [
+          0.009434583,
+          0.010078083,
+          0.008806166
+        ]
+      },
+      "total": {
+        "min_s": 0.303648333,
+        "median_s": 0.303970584,
+        "samples_s": [
+          0.303648333,
+          0.304336916,
+          0.303970584
+        ]
+      },
+      "compute_s": 0.294842167,
+      "ns_per_op_min": 1.000251431589162,
+      "ns_per_op_median": 0.9992127640779308,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 4449864,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.01659175,
+        "median_s": 0.016841708,
+        "samples_s": [
+          0.01659175,
+          0.016841708,
+          0.017212625
+        ]
+      },
+      "total": {
+        "min_s": 0.381664667,
+        "median_s": 0.383001375,
+        "samples_s": [
+          0.381664667,
+          0.383001375,
+          0.383725875
+        ]
+      },
+      "compute_s": 0.365072917,
+      "ns_per_op_min": 82.04136508441606,
+      "ns_per_op_median": 82.28558603139331,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 308767318,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0054325,
+        "median_s": 0.00544875,
+        "samples_s": [
+          0.00559225,
+          0.00544875,
+          0.0054325
+        ]
+      },
+      "total": {
+        "min_s": 0.301121458,
+        "median_s": 0.302123541,
+        "samples_s": [
+          0.302123541,
+          0.301121458,
+          0.302442125
+        ]
+      },
+      "compute_s": 0.295688958,
+      "ns_per_op_min": 0.9576433150868642,
+      "ns_per_op_median": 0.9608361173769046,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 44505932,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004576625,
+        "median_s": 0.004602041,
+        "samples_s": [
+          0.004602041,
+          0.004693709,
+          0.004576625
+        ]
+      },
+      "total": {
+        "min_s": 0.305807584,
+        "median_s": 0.307374417,
+        "samples_s": [
+          0.305807584,
+          0.315775375,
+          0.307374417
+        ]
+      },
+      "compute_s": 0.301230959,
+      "ns_per_op_min": 6.768332792132069,
+      "ns_per_op_median": 6.802966759577128,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 856511,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039453334,
+        "median_s": 0.040259708,
+        "samples_s": [
+          0.039453334,
+          0.040259708,
+          0.040623166
+        ]
+      },
+      "total": {
+        "min_s": 0.353667292,
+        "median_s": 0.3540125,
+        "samples_s": [
+          0.353667292,
+          0.354825416,
+          0.3540125
+        ]
+      },
+      "compute_s": 0.314213958,
+      "ns_per_op_min": 366.8533830855646,
+      "ns_per_op_median": 366.31495917740693,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 1219450,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039486375,
+        "median_s": 0.040179917,
+        "samples_s": [
+          0.040179917,
+          0.039486375,
+          0.041514167
+        ]
+      },
+      "total": {
+        "min_s": 0.318825,
+        "median_s": 0.319214042,
+        "samples_s": [
+          0.318825,
+          0.319214042,
+          0.319752958
+        ]
+      },
+      "compute_s": 0.279338625,
+      "ns_per_op_min": 229.0693550371069,
+      "ns_per_op_median": 228.81965230226737,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 870667,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.03943175,
+        "median_s": 0.039520125,
+        "samples_s": [
+          0.040230583,
+          0.039520125,
+          0.03943175
+        ]
+      },
+      "total": {
+        "min_s": 0.284284125,
+        "median_s": 0.28694,
+        "samples_s": [
+          0.284284125,
+          0.28694,
+          0.287348166
+        ]
+      },
+      "compute_s": 0.244852375,
+      "ns_per_op_min": 281.2239064992701,
+      "ns_per_op_median": 284.17279510995587,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 528143,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.029178084,
+        "median_s": 0.0296,
+        "samples_s": [
+          0.029178084,
+          0.0296,
+          0.030129792
+        ]
+      },
+      "total": {
+        "min_s": 0.316513458,
+        "median_s": 0.317239458,
+        "samples_s": [
+          0.317239458,
+          0.319474542,
+          0.316513458
+        ]
+      },
+      "compute_s": 0.28733537400000003,
+      "ns_per_op_min": 544.0484376390486,
+      "ns_per_op_median": 544.624198370517,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 43743841,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040229417,
+        "median_s": 0.0412945,
+        "samples_s": [
+          0.040229417,
+          0.04205025,
+          0.0412945
+        ]
+      },
+      "total": {
+        "min_s": 0.283058833,
+        "median_s": 0.284447666,
+        "samples_s": [
+          0.283058833,
+          0.287719208,
+          0.284447666
+        ]
+      },
+      "compute_s": 0.24282941600000002,
+      "ns_per_op_min": 5.551168129017295,
+      "ns_per_op_median": 5.558569170914826,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 193861,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010897375,
+        "median_s": 0.011055292,
+        "samples_s": [
+          0.010897375,
+          0.011495791,
+          0.011055292
+        ]
+      },
+      "total": {
+        "min_s": 0.312153041,
+        "median_s": 0.3122455,
+        "samples_s": [
+          0.313868417,
+          0.312153041,
+          0.3122455
+        ]
+      },
+      "compute_s": 0.30125566600000003,
+      "ns_per_op_min": 1553.9776747257058,
+      "ns_per_op_median": 1553.640020427007,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 86057907,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002910209,
+        "median_s": 0.002953875,
+        "samples_s": [
+          0.002910209,
+          0.002953875,
+          0.003087291
+        ]
+      },
+      "total": {
+        "min_s": 0.302605917,
+        "median_s": 0.302745541,
+        "samples_s": [
+          0.302745541,
+          0.304806833,
+          0.302605917
+        ]
+      },
+      "compute_s": 0.299695708,
+      "ns_per_op_min": 3.482488924579586,
+      "ns_per_op_median": 3.4836039644794057,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 174615731,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.06613075,
+        "median_s": 0.066307875,
+        "samples_s": [
+          0.06613075,
+          0.066307875,
+          0.067274333
+        ]
+      },
+      "total": {
+        "min_s": 0.356089041,
+        "median_s": 0.356529708,
+        "samples_s": [
+          0.356089041,
+          0.356529708,
+          0.35697775
+        ]
+      },
+      "compute_s": 0.289958291,
+      "ns_per_op_min": 1.6605507953919685,
+      "ns_per_op_median": 1.6620600637636709,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 186,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.012955,
+        "median_s": 0.0133475,
+        "samples_s": [
+          0.013671083,
+          0.012955,
+          0.0133475
+        ]
+      },
+      "total": {
+        "min_s": 0.238962917,
+        "median_s": 0.239684042,
+        "samples_s": [
+          0.240203291,
+          0.238962917,
+          0.239684042
+        ]
+      },
+      "compute_s": 0.226007917,
+      "ns_per_op_min": 1215096.3279569892,
+      "ns_per_op_median": 1216863.1290322582,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 7694,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.042993917,
+        "median_s": 0.044756,
+        "samples_s": [
+          0.044756,
+          0.042993917,
+          0.045770792
+        ]
+      },
+      "total": {
+        "min_s": 0.26786675,
+        "median_s": 0.269195917,
+        "samples_s": [
+          0.27021375,
+          0.26786675,
+          0.269195917
+        ]
+      },
+      "compute_s": 0.224872833,
+      "ns_per_op_min": 29227.038341564858,
+      "ns_per_op_median": 29170.771640239152,
+      "load_ms": 0.616,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 22203,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.077804959,
+        "median_s": 0.078468834,
+        "samples_s": [
+          0.077804959,
+          0.079594292,
+          0.078468834
+        ]
+      },
+      "total": {
+        "min_s": 0.2605915,
+        "median_s": 0.263088458,
+        "samples_s": [
+          0.263598667,
+          0.263088458,
+          0.2605915
+        ]
+      },
+      "compute_s": 0.18278654099999997,
+      "ns_per_op_min": 8232.515470882312,
+      "ns_per_op_median": 8315.075620411657,
+      "load_ms": 3.329,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wardite",
+      "status": "skipped",
+      "reason": "excluded: wardite 0.9.0 does not re-round f32 arithmetic to single precision, so a dependent operation chain diverges from wasmtime (1232349357 vs 1232349355 at 10000 iterations) and the byte-for-byte verification would fail the whole run"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wardite-yjit",
+      "status": "skipped",
+      "reason": "excluded: wardite 0.9.0 does not re-round f32 arithmetic to single precision, so a dependent operation chain diverges from wasmtime (1232349357 vs 1232349355 at 10000 iterations) and the byte-for-byte verification would fail the whole run"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 307871778,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005393417,
+        "median_s": 0.005733208,
+        "samples_s": [
+          0.005785084,
+          0.005393417,
+          0.005733208
+        ]
+      },
+      "total": {
+        "min_s": 0.306253,
+        "median_s": 0.306824084,
+        "samples_s": [
+          0.306824084,
+          0.306253,
+          0.307135542
+        ]
+      },
+      "compute_s": 0.300859583,
+      "ns_per_op_min": 0.9772236512045609,
+      "ns_per_op_median": 0.9779749152583904,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 294380883,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.008816584,
+        "median_s": 0.008949209,
+        "samples_s": [
+          0.008816584,
+          0.008992542,
+          0.008949209
+        ]
+      },
+      "total": {
+        "min_s": 0.296990584,
+        "median_s": 0.297221875,
+        "samples_s": [
+          0.296990584,
+          0.297221875,
+          0.297232875
+        ]
+      },
+      "compute_s": 0.288174,
+      "ns_per_op_min": 0.9789154685020766,
+      "ns_per_op_median": 0.979250632929177,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 3635643,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.016077167,
+        "median_s": 0.016538875,
+        "samples_s": [
+          0.016538875,
+          0.016563167,
+          0.016077167
+        ]
+      },
+      "total": {
+        "min_s": 0.314867792,
+        "median_s": 0.314919375,
+        "samples_s": [
+          0.314919375,
+          0.314867792,
+          0.315503833
+        ]
+      },
+      "compute_s": 0.298790625,
+      "ns_per_op_min": 82.18370863145805,
+      "ns_per_op_median": 82.07090190098423,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 299988216,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004841083,
+        "median_s": 0.004953291,
+        "samples_s": [
+          0.004953291,
+          0.005394958,
+          0.004841083
+        ]
+      },
+      "total": {
+        "min_s": 0.295550792,
+        "median_s": 0.296403292,
+        "samples_s": [
+          0.295550792,
+          0.2972645,
+          0.296403292
+        ]
+      },
+      "compute_s": 0.290709709,
+      "ns_per_op_min": 0.9690704284197617,
+      "ns_per_op_median": 0.9715381653524682,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 55297400,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004011542,
+        "median_s": 0.0046065,
+        "samples_s": [
+          0.004898666,
+          0.0046065,
+          0.004011542
+        ]
+      },
+      "total": {
+        "min_s": 0.305045958,
+        "median_s": 0.305418584,
+        "samples_s": [
+          0.305045958,
+          0.305505959,
+          0.305418584
+        ]
+      },
+      "compute_s": 0.301034416,
+      "ns_per_op_min": 5.44391627816136,
+      "ns_per_op_median": 5.439895618962193,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 2825791,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.03925775,
+        "median_s": 0.039868584,
+        "samples_s": [
+          0.039886417,
+          0.03925775,
+          0.039868584
+        ]
+      },
+      "total": {
+        "min_s": 0.327439208,
+        "median_s": 0.329400542,
+        "samples_s": [
+          0.327439208,
+          0.330849916,
+          0.329400542
+        ]
+      },
+      "compute_s": 0.288181458,
+      "ns_per_op_min": 101.98258045269448,
+      "ns_per_op_median": 102.46049973264125,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 3103672,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039353709,
+        "median_s": 0.039358583,
+        "samples_s": [
+          0.040191583,
+          0.039353709,
+          0.039358583
+        ]
+      },
+      "total": {
+        "min_s": 0.273652,
+        "median_s": 0.277604375,
+        "samples_s": [
+          0.273652,
+          0.277715625,
+          0.277604375
+        ]
+      },
+      "compute_s": 0.234298291,
+      "ns_per_op_min": 75.49067395008235,
+      "ns_per_op_median": 76.7625548060491,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 3609946,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.038792459,
+        "median_s": 0.039990208,
+        "samples_s": [
+          0.038792459,
+          0.039990208,
+          0.040282541
+        ]
+      },
+      "total": {
+        "min_s": 0.339429583,
+        "median_s": 0.339947042,
+        "samples_s": [
+          0.339947042,
+          0.340016083,
+          0.339429583
+        ]
+      },
+      "compute_s": 0.300637124,
+      "ns_per_op_min": 83.28022746046616,
+      "ns_per_op_median": 83.0917786581849,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 1716069,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.028748291,
+        "median_s": 0.029511208,
+        "samples_s": [
+          0.029511208,
+          0.0297155,
+          0.028748291
+        ]
+      },
+      "total": {
+        "min_s": 0.290914958,
+        "median_s": 0.291999208,
+        "samples_s": [
+          0.290914958,
+          0.291999208,
+          0.292088667
+        ]
+      },
+      "compute_s": 0.262166667,
+      "ns_per_op_min": 152.77163505663236,
+      "ns_per_op_median": 152.95888452037767,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 120872206,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040204791,
+        "median_s": 0.040586667,
+        "samples_s": [
+          0.040204791,
+          0.040586667,
+          0.041493125
+        ]
+      },
+      "total": {
+        "min_s": 0.302097666,
+        "median_s": 0.302443334,
+        "samples_s": [
+          0.302544417,
+          0.302097666,
+          0.302443334
+        ]
+      },
+      "compute_s": 0.26189287499999997,
+      "ns_per_op_min": 2.1666922749800723,
+      "ns_per_op_median": 2.1663927189349055,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 358657,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015272625,
+        "median_s": 0.016028333,
+        "samples_s": [
+          0.016028333,
+          0.018686959,
+          0.015272625
+        ]
+      },
+      "total": {
+        "min_s": 0.31538275,
+        "median_s": 0.315582583,
+        "samples_s": [
+          0.315582583,
+          0.31538275,
+          0.317535542
+        ]
+      },
+      "compute_s": 0.300110125,
+      "ns_per_op_min": 836.7608188324779,
+      "ns_per_op_median": 835.2109397000477,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 85041822,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002700917,
+        "median_s": 0.002945041,
+        "samples_s": [
+          0.003276167,
+          0.002945041,
+          0.002700917
+        ]
+      },
+      "total": {
+        "min_s": 0.301176,
+        "median_s": 0.302155833,
+        "samples_s": [
+          0.301176,
+          0.302169584,
+          0.302155833
+        ]
+      },
+      "compute_s": 0.298475083,
+      "ns_per_op_min": 3.5097446877372875,
+      "ns_per_op_median": 3.518395831171162,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 177819719,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.066003959,
+        "median_s": 0.066365208,
+        "samples_s": [
+          0.066906292,
+          0.066003959,
+          0.066365208
+        ]
+      },
+      "total": {
+        "min_s": 0.357496708,
+        "median_s": 0.3575535,
+        "samples_s": [
+          0.358549417,
+          0.3575535,
+          0.357496708
+        ]
+      },
+      "compute_s": 0.291492749,
+      "ns_per_op_min": 1.639259979935071,
+      "ns_per_op_median": 1.637547813243367,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 512,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.013033791,
+        "median_s": 0.013225875,
+        "samples_s": [
+          0.013225875,
+          0.013033791,
+          0.013324833
+        ]
+      },
+      "total": {
+        "min_s": 0.310664917,
+        "median_s": 0.311415167,
+        "samples_s": [
+          0.311745542,
+          0.311415167,
+          0.310664917
+        ]
+      },
+      "compute_s": 0.29763112599999997,
+      "ns_per_op_min": 581310.7929687499,
+      "ns_per_op_median": 582400.9609375,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 8986,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.043067792,
+        "median_s": 0.04336525,
+        "samples_s": [
+          0.043067792,
+          0.04336525,
+          0.044441834
+        ]
+      },
+      "total": {
+        "min_s": 0.308353,
+        "median_s": 0.30898,
+        "samples_s": [
+          0.30898,
+          0.308353,
+          0.310797209
+        ]
+      },
+      "compute_s": 0.265285208,
+      "ns_per_op_min": 29522.057422657468,
+      "ns_per_op_median": 29558.73024705096,
+      "load_ms": 0.605,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 27770,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.078537875,
+        "median_s": 0.079611208,
+        "samples_s": [
+          0.078537875,
+          0.08030825,
+          0.079611208
+        ]
+      },
+      "total": {
+        "min_s": 0.2793645,
+        "median_s": 0.279828667,
+        "samples_s": [
+          0.279828667,
+          0.284056292,
+          0.2793645
+        ]
+      },
+      "compute_s": 0.20082662500000004,
+      "ns_per_op_min": 7231.78339935182,
+      "ns_per_op_median": 7209.847281238747,
+      "load_ms": 3.518,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 33280,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.052459125,
+        "median_s": 0.052994791,
+        "samples_s": [
+          0.054468917,
+          0.052994791,
+          0.052459125
+        ]
+      },
+      "total": {
+        "min_s": 0.309868709,
+        "median_s": 0.310124834,
+        "samples_s": [
+          0.310207166,
+          0.309868709,
+          0.310124834
+        ]
+      },
+      "compute_s": 0.257409584,
+      "ns_per_op_min": 7734.662980769232,
+      "ns_per_op_median": 7726.2633112980775,
+      "load_ms": 3.892,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 81973,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.106036375,
+        "median_s": 0.107094666,
+        "samples_s": [
+          0.106036375,
+          0.107094666,
+          0.107630625
+        ]
+      },
+      "total": {
+        "min_s": 0.400674,
+        "median_s": 0.400977875,
+        "samples_s": [
+          0.400977875,
+          0.400674,
+          0.40821525
+        ]
+      },
+      "compute_s": 0.29463762499999996,
+      "ns_per_op_min": 3594.325265636245,
+      "ns_per_op_median": 3585.1220401839632,
+      "load_ms": 9.142,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 129197266,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005504042,
+        "median_s": 0.0056445,
+        "samples_s": [
+          0.005666042,
+          0.0056445,
+          0.005504042
+        ]
+      },
+      "total": {
+        "min_s": 0.303449084,
+        "median_s": 0.303829083,
+        "samples_s": [
+          0.30855025,
+          0.303449084,
+          0.303829083
+        ]
+      },
+      "compute_s": 0.297945042,
+      "ns_per_op_min": 2.306124976359794,
+      "ns_per_op_median": 2.3079790481015285,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 131523254,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009081333,
+        "median_s": 0.00912725,
+        "samples_s": [
+          0.009081333,
+          0.00912725,
+          0.009186209
+        ]
+      },
+      "total": {
+        "min_s": 0.314233,
+        "median_s": 0.314750208,
+        "samples_s": [
+          0.314233,
+          0.314750208,
+          0.314943
+        ]
+      },
+      "compute_s": 0.30515166699999996,
+      "ns_per_op_min": 2.320134711691363,
+      "ns_per_op_median": 2.3237180400053057,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1834486,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0161915,
+        "median_s": 0.016502709,
+        "samples_s": [
+          0.01660575,
+          0.016502709,
+          0.0161915
+        ]
+      },
+      "total": {
+        "min_s": 0.307139541,
+        "median_s": 0.307251,
+        "samples_s": [
+          0.307251,
+          0.307442458,
+          0.307139541
+        ]
+      },
+      "compute_s": 0.290948041,
+      "ns_per_op_min": 158.59921580213748,
+      "ns_per_op_median": 158.4903297163347,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 111068977,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005240542,
+        "median_s": 0.00524225,
+        "samples_s": [
+          0.00524225,
+          0.005240542,
+          0.005282792
+        ]
+      },
+      "total": {
+        "min_s": 0.301181666,
+        "median_s": 0.301424333,
+        "samples_s": [
+          0.301181666,
+          0.301495292,
+          0.301424333
+        ]
+      },
+      "compute_s": 0.295941124,
+      "ns_per_op_min": 2.6644805056591094,
+      "ns_per_op_median": 2.666649959331128,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 16777216,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004166,
+        "median_s": 0.00450375,
+        "samples_s": [
+          0.004166,
+          0.00450375,
+          0.004869458
+        ]
+      },
+      "total": {
+        "min_s": 0.223940709,
+        "median_s": 0.224180708,
+        "samples_s": [
+          0.223940709,
+          0.22506975,
+          0.224180708
+        ]
+      },
+      "compute_s": 0.21977470899999998,
+      "ns_per_op_min": 13.099593460559843,
+      "ns_per_op_median": 13.093767046928406,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 1557640,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039599125,
+        "median_s": 0.039978792,
+        "samples_s": [
+          0.039978792,
+          0.040723417,
+          0.039599125
+        ]
+      },
+      "total": {
+        "min_s": 0.327051917,
+        "median_s": 0.329233833,
+        "samples_s": [
+          0.329233833,
+          0.327051917,
+          0.33325475
+        ]
+      },
+      "compute_s": 0.287452792,
+      "ns_per_op_min": 184.54379189029558,
+      "ns_per_op_median": 185.7008301019491,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 2085317,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.03948725,
+        "median_s": 0.039528042,
+        "samples_s": [
+          0.041339166,
+          0.03948725,
+          0.039528042
+        ]
+      },
+      "total": {
+        "min_s": 0.330595333,
+        "median_s": 0.330755458,
+        "samples_s": [
+          0.330595333,
+          0.330755458,
+          0.330987125
+        ]
+      },
+      "compute_s": 0.291108083,
+      "ns_per_op_min": 139.59895929491776,
+      "ns_per_op_median": 139.6561846472263,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 1656344,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039692709,
+        "median_s": 0.040047458,
+        "samples_s": [
+          0.04080675,
+          0.040047458,
+          0.039692709
+        ]
+      },
+      "total": {
+        "min_s": 0.290105,
+        "median_s": 0.291446084,
+        "samples_s": [
+          0.290105,
+          0.291446084,
+          0.291920208
+        ]
+      },
+      "compute_s": 0.250412291,
+      "ns_per_op_min": 151.18374625077882,
+      "ns_per_op_median": 151.7792354728245,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 537026,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0294845,
+        "median_s": 0.029543458,
+        "samples_s": [
+          0.0294845,
+          0.030333542,
+          0.029543458
+        ]
+      },
+      "total": {
+        "min_s": 0.331823125,
+        "median_s": 0.333254209,
+        "samples_s": [
+          0.333925375,
+          0.331823125,
+          0.333254209
+        ]
+      },
+      "compute_s": 0.30233862499999997,
+      "ns_per_op_min": 562.9869410419607,
+      "ns_per_op_median": 565.5419867939355,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 27501923,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039800708,
+        "median_s": 0.04067475,
+        "samples_s": [
+          0.041422209,
+          0.04067475,
+          0.039800708
+        ]
+      },
+      "total": {
+        "min_s": 0.30426475,
+        "median_s": 0.305809708,
+        "samples_s": [
+          0.30426475,
+          0.305809708,
+          0.306641291
+        ]
+      },
+      "compute_s": 0.26446404199999995,
+      "ns_per_op_min": 9.616201819778201,
+      "ns_per_op_median": 9.640597059340179,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 427223,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010952125,
+        "median_s": 0.010967458,
+        "samples_s": [
+          0.010967458,
+          0.011351167,
+          0.010952125
+        ]
+      },
+      "total": {
+        "min_s": 0.308379667,
+        "median_s": 0.308634,
+        "samples_s": [
+          0.308940625,
+          0.308634,
+          0.308379667
+        ]
+      },
+      "compute_s": 0.29742754200000004,
+      "ns_per_op_min": 696.1880376290603,
+      "ns_per_op_median": 696.7474644389465,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 97882931,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002929833,
+        "median_s": 0.003004708,
+        "samples_s": [
+          0.002929833,
+          0.003133875,
+          0.003004708
+        ]
+      },
+      "total": {
+        "min_s": 0.30409975,
+        "median_s": 0.304216208,
+        "samples_s": [
+          0.30409975,
+          0.304461708,
+          0.304216208
+        ]
+      },
+      "compute_s": 0.301169917,
+      "ns_per_op_min": 3.0768379524720197,
+      "ns_per_op_median": 3.0772627762852744,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 138617608,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.066393875,
+        "median_s": 0.067031042,
+        "samples_s": [
+          0.067031042,
+          0.066393875,
+          0.067611208
+        ]
+      },
+      "total": {
+        "min_s": 0.390185833,
+        "median_s": 0.391732917,
+        "samples_s": [
+          0.390185833,
+          0.391732917,
+          0.392144
+        ]
+      },
+      "compute_s": 0.323791958,
+      "ns_per_op_min": 2.335864560583097,
+      "ns_per_op_median": 2.34242878437204,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 11410,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.012844042,
+        "median_s": 0.012866875,
+        "samples_s": [
+          0.013522709,
+          0.012866875,
+          0.012844042
+        ]
+      },
+      "total": {
+        "min_s": 0.300899542,
+        "median_s": 0.301283667,
+        "samples_s": [
+          0.301283667,
+          0.301317792,
+          0.300899542
+        ]
+      },
+      "compute_s": 0.2880555,
+      "ns_per_op_min": 25245.880806310255,
+      "ns_per_op_median": 25277.545311130587,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 5316,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.043620458,
+        "median_s": 0.044303209,
+        "samples_s": [
+          0.043620458,
+          0.044512375,
+          0.044303209
+        ]
+      },
+      "total": {
+        "min_s": 0.331526,
+        "median_s": 0.332813208,
+        "samples_s": [
+          0.331526,
+          0.332813208,
+          0.333966167
+        ]
+      },
+      "compute_s": 0.28790554199999996,
+      "ns_per_op_min": 54158.303611738134,
+      "ns_per_op_median": 54272.00884123401,
+      "load_ms": 0.73,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 6336,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.081059584,
+        "median_s": 0.08111,
+        "samples_s": [
+          0.08168725,
+          0.081059584,
+          0.08111
+        ]
+      },
+      "total": {
+        "min_s": 0.259223208,
+        "median_s": 0.260175125,
+        "samples_s": [
+          0.259223208,
+          0.260175125,
+          0.261733417
+        ]
+      },
+      "compute_s": 0.17816362399999996,
+      "ns_per_op_min": 28119.258838383834,
+      "ns_per_op_median": 28261.54119318182,
+      "load_ms": 3.76,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 18480,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.053864375,
+        "median_s": 0.054202708,
+        "samples_s": [
+          0.0543355,
+          0.053864375,
+          0.054202708
+        ]
+      },
+      "total": {
+        "min_s": 0.337288834,
+        "median_s": 0.337429167,
+        "samples_s": [
+          0.337288834,
+          0.339943208,
+          0.337429167
+        ]
+      },
+      "compute_s": 0.28342445899999996,
+      "ns_per_op_min": 15336.821374458872,
+      "ns_per_op_median": 15326.10708874459,
+      "load_ms": 4.51,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 45118,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.101759417,
+        "median_s": 0.102007334,
+        "samples_s": [
+          0.104199459,
+          0.101759417,
+          0.102007334
+        ]
+      },
+      "total": {
+        "min_s": 0.422467916,
+        "median_s": 0.426023292,
+        "samples_s": [
+          0.426023292,
+          0.42705725,
+          0.422467916
+        ]
+      },
+      "compute_s": 0.320708499,
+      "ns_per_op_min": 7108.216210824948,
+      "ns_per_op_median": 7181.523072831243,
+      "load_ms": 9.441,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 39375587,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005413416,
+        "median_s": 0.005541083,
+        "samples_s": [
+          0.005413416,
+          0.005541083,
+          0.005899666
+        ]
+      },
+      "total": {
+        "min_s": 0.30673975,
+        "median_s": 0.306906375,
+        "samples_s": [
+          0.30673975,
+          0.306906375,
+          0.309453
+        ]
+      },
+      "compute_s": 0.301326334,
+      "ns_per_op_min": 7.652618207317138,
+      "ns_per_op_median": 7.653607602091113,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 39144682,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.008712084,
+        "median_s": 0.009386375,
+        "samples_s": [
+          0.008712084,
+          0.009386375,
+          0.009613625
+        ]
+      },
+      "total": {
+        "min_s": 0.308138375,
+        "median_s": 0.308252916,
+        "samples_s": [
+          0.309617167,
+          0.308138375,
+          0.308252916
+        ]
+      },
+      "compute_s": 0.299426291,
+      "ns_per_op_min": 7.6492201673780365,
+      "ns_per_op_median": 7.634920651545975,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1544173,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.016222542,
+        "median_s": 0.01634125,
+        "samples_s": [
+          0.016364125,
+          0.01634125,
+          0.016222542
+        ]
+      },
+      "total": {
+        "min_s": 0.3087105,
+        "median_s": 0.309646291,
+        "samples_s": [
+          0.309646291,
+          0.310075708,
+          0.3087105
+        ]
+      },
+      "compute_s": 0.292487958,
+      "ns_per_op_min": 189.41398275970374,
+      "ns_per_op_median": 189.94312230559657,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 38783852,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004984791,
+        "median_s": 0.005126791,
+        "samples_s": [
+          0.005359416,
+          0.004984791,
+          0.005126791
+        ]
+      },
+      "total": {
+        "min_s": 0.301868042,
+        "median_s": 0.303057458,
+        "samples_s": [
+          0.301868042,
+          0.303057458,
+          0.30610125
+        ]
+      },
+      "compute_s": 0.296883251,
+      "ns_per_op_min": 7.654816004351502,
+      "ns_per_op_median": 7.681822501797913,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 16777216,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004306084,
+        "median_s": 0.004572625,
+        "samples_s": [
+          0.004572625,
+          0.004696833,
+          0.004306084
+        ]
+      },
+      "total": {
+        "min_s": 0.291632042,
+        "median_s": 0.293845208,
+        "samples_s": [
+          0.291632042,
+          0.296443208,
+          0.293845208
+        ]
+      },
+      "compute_s": 0.287325958,
+      "ns_per_op_min": 17.125961661338806,
+      "ns_per_op_median": 17.2419895529747,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 561435,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.03788325,
+        "median_s": 0.038250959,
+        "samples_s": [
+          0.039425167,
+          0.038250959,
+          0.03788325
+        ]
+      },
+      "total": {
+        "min_s": 0.248579916,
+        "median_s": 0.252044791,
+        "samples_s": [
+          0.252044791,
+          0.2521215,
+          0.248579916
+        ]
+      },
+      "compute_s": 0.210696666,
+      "ns_per_op_min": 375.28238531619866,
+      "ns_per_op_median": 380.7989028115454,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 1148283,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039895833,
+        "median_s": 0.040687292,
+        "samples_s": [
+          0.042227125,
+          0.040687292,
+          0.039895833
+        ]
+      },
+      "total": {
+        "min_s": 0.266271292,
+        "median_s": 0.270288375,
+        "samples_s": [
+          0.270288375,
+          0.266271292,
+          0.286660875
+        ]
+      },
+      "compute_s": 0.226375459,
+      "ns_per_op_min": 197.14256764229725,
+      "ns_per_op_median": 199.9516521624025,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 992813,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039748792,
+        "median_s": 0.040632458,
+        "samples_s": [
+          0.040632458,
+          0.039748792,
+          0.041591083
+        ]
+      },
+      "total": {
+        "min_s": 0.282495167,
+        "median_s": 0.284019333,
+        "samples_s": [
+          0.284019333,
+          0.2856405,
+          0.282495167
+        ]
+      },
+      "compute_s": 0.242746375,
+      "ns_per_op_min": 244.5036225351602,
+      "ns_per_op_median": 245.1487591318808,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 298266,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.029155792,
+        "median_s": 0.02936375,
+        "samples_s": [
+          0.03005825,
+          0.029155792,
+          0.02936375
+        ]
+      },
+      "total": {
+        "min_s": 0.322296834,
+        "median_s": 0.32312025,
+        "samples_s": [
+          0.32312025,
+          0.322296834,
+          0.325567625
+        ]
+      },
+      "compute_s": 0.29314104199999996,
+      "ns_per_op_min": 982.8174917690918,
+      "ns_per_op_median": 984.8809451965695,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 17302629,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040254541,
+        "median_s": 0.040779667,
+        "samples_s": [
+          0.040845167,
+          0.040254541,
+          0.040779667
+        ]
+      },
+      "total": {
+        "min_s": 0.285402792,
+        "median_s": 0.285782833,
+        "samples_s": [
+          0.285402792,
+          0.285988625,
+          0.285782833
+        ]
+      },
+      "compute_s": 0.245148251,
+      "ns_per_op_min": 14.168266047893647,
+      "ns_per_op_median": 14.159880905959437,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 241610,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010552875,
+        "median_s": 0.010567333,
+        "samples_s": [
+          0.011660542,
+          0.010567333,
+          0.010552875
+        ]
+      },
+      "total": {
+        "min_s": 0.306093708,
+        "median_s": 0.306621125,
+        "samples_s": [
+          0.307924167,
+          0.306621125,
+          0.306093708
+        ]
+      },
+      "compute_s": 0.295540833,
+      "ns_per_op_min": 1223.2144075162453,
+      "ns_per_op_median": 1225.3374943090105,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 39029538,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002723291,
+        "median_s": 0.002833542,
+        "samples_s": [
+          0.003154292,
+          0.002723291,
+          0.002833542
+        ]
+      },
+      "total": {
+        "min_s": 0.30290575,
+        "median_s": 0.304037333,
+        "samples_s": [
+          0.30423575,
+          0.30290575,
+          0.304037333
+        ]
+      },
+      "compute_s": 0.30018245899999996,
+      "ns_per_op_min": 7.691160961218653,
+      "ns_per_op_median": 7.717329141841239,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 23854458,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.06409925,
+        "median_s": 0.065370792,
+        "samples_s": [
+          0.065656083,
+          0.06409925,
+          0.065370792
+        ]
+      },
+      "total": {
+        "min_s": 0.255805083,
+        "median_s": 0.255842875,
+        "samples_s": [
+          0.256285708,
+          0.255805083,
+          0.255842875
+        ]
+      },
+      "compute_s": 0.191705833,
+      "ns_per_op_min": 8.03647825492409,
+      "ns_per_op_median": 7.984758362566863,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 4040,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.012209291,
+        "median_s": 0.012726333,
+        "samples_s": [
+          0.013167208,
+          0.012726333,
+          0.012209291
+        ]
+      },
+      "total": {
+        "min_s": 0.2907665,
+        "median_s": 0.291319208,
+        "samples_s": [
+          0.29179975,
+          0.291319208,
+          0.2907665
+        ]
+      },
+      "compute_s": 0.278557209,
+      "ns_per_op_min": 68949.8042079208,
+      "ns_per_op_median": 68958.63242574257,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 4203,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.042742167,
+        "median_s": 0.04341575,
+        "samples_s": [
+          0.04341575,
+          0.042742167,
+          0.043971333
+        ]
+      },
+      "total": {
+        "min_s": 0.302401792,
+        "median_s": 0.304089541,
+        "samples_s": [
+          0.302401792,
+          0.30428825,
+          0.304089541
+        ]
+      },
+      "compute_s": 0.259659625,
+      "ns_per_op_min": 61779.59195812515,
+      "ns_per_op_median": 62020.88769926243,
+      "load_ms": 0.654,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 4424,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.078199917,
+        "median_s": 0.078550083,
+        "samples_s": [
+          0.078199917,
+          0.080317875,
+          0.078550083
+        ]
+      },
+      "total": {
+        "min_s": 0.266535375,
+        "median_s": 0.2669655,
+        "samples_s": [
+          0.268981292,
+          0.266535375,
+          0.2669655
+        ]
+      },
+      "compute_s": 0.188335458,
+      "ns_per_op_min": 42571.30605786618,
+      "ns_per_op_median": 42589.379972875235,
+      "load_ms": 3.9,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 15431,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.052427125,
+        "median_s": 0.053020083,
+        "samples_s": [
+          0.052427125,
+          0.0533285,
+          0.053020083
+        ]
+      },
+      "total": {
+        "min_s": 0.337547792,
+        "median_s": 0.337685959,
+        "samples_s": [
+          0.337812458,
+          0.337547792,
+          0.337685959
+        ]
+      },
+      "compute_s": 0.285120667,
+      "ns_per_op_min": 18477.134793597303,
+      "ns_per_op_median": 18447.66223835137,
+      "load_ms": 4.565,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 24975,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.101880542,
+        "median_s": 0.102044792,
+        "samples_s": [
+          0.102044792,
+          0.102885041,
+          0.101880542
+        ]
+      },
+      "total": {
+        "min_s": 0.316266167,
+        "median_s": 0.318222375,
+        "samples_s": [
+          0.335644709,
+          0.318222375,
+          0.316266167
+        ]
+      },
+      "compute_s": 0.21438562499999997,
+      "ns_per_op_min": 8584.009009009007,
+      "ns_per_op_median": 8655.759079079078,
+      "load_ms": 9.17,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 128506609,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.00544025,
+        "median_s": 0.005445208,
+        "samples_s": [
+          0.00544025,
+          0.005445208,
+          0.005523875
+        ]
+      },
+      "total": {
+        "min_s": 0.302369958,
+        "median_s": 0.302789375,
+        "samples_s": [
+          0.302977125,
+          0.302789375,
+          0.302369958
+        ]
+      },
+      "compute_s": 0.296929708,
+      "ns_per_op_min": 2.3106181877384997,
+      "ns_per_op_median": 2.3138433837282255,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 128498545,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.008497917,
+        "median_s": 0.008819583,
+        "samples_s": [
+          0.009295583,
+          0.008497917,
+          0.008819583
+        ]
+      },
+      "total": {
+        "min_s": 0.305714,
+        "median_s": 0.306061709,
+        "samples_s": [
+          0.306061709,
+          0.305714,
+          0.311043125
+        ]
+      },
+      "compute_s": 0.29721608299999996,
+      "ns_per_op_min": 2.3129918163664804,
+      "ns_per_op_median": 2.313194487922023,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1885958,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.016212792,
+        "median_s": 0.016474916,
+        "samples_s": [
+          0.016582667,
+          0.016474916,
+          0.016212792
+        ]
+      },
+      "total": {
+        "min_s": 0.312839167,
+        "median_s": 0.314924083,
+        "samples_s": [
+          0.312839167,
+          0.314924083,
+          0.31761075
+        ]
+      },
+      "compute_s": 0.296626375,
+      "ns_per_op_min": 157.28153808303261,
+      "ns_per_op_median": 158.2480452905102,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 110343753,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004745625,
+        "median_s": 0.005146,
+        "samples_s": [
+          0.005146,
+          0.004745625,
+          0.005166084
+        ]
+      },
+      "total": {
+        "min_s": 0.299025875,
+        "median_s": 0.299368375,
+        "samples_s": [
+          0.299025875,
+          0.299368375,
+          0.29961625
+        ]
+      },
+      "compute_s": 0.29428025,
+      "ns_per_op_min": 2.666940737460688,
+      "ns_per_op_median": 2.6664162401654043,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 28117002,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.003956209,
+        "median_s": 0.004449833,
+        "samples_s": [
+          0.003956209,
+          0.004574459,
+          0.004449833
+        ]
+      },
+      "total": {
+        "min_s": 0.344127333,
+        "median_s": 0.344288,
+        "samples_s": [
+          0.344127333,
+          0.345548,
+          0.344288
+        ]
+      },
+      "compute_s": 0.340171124,
+      "ns_per_op_min": 12.0984137640279,
+      "ns_per_op_median": 12.086571925413667,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 231266,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039464209,
+        "median_s": 0.039482167,
+        "samples_s": [
+          0.039464209,
+          0.039482167,
+          0.039820916
+        ]
+      },
+      "total": {
+        "min_s": 0.33262175,
+        "median_s": 0.335402583,
+        "samples_s": [
+          0.335402583,
+          0.33262175,
+          0.337233375
+        ]
+      },
+      "compute_s": 0.293157541,
+      "ns_per_op_min": 1267.620579765292,
+      "ns_per_op_median": 1279.5673207475372,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 294857,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040181958,
+        "median_s": 0.040940375,
+        "samples_s": [
+          0.04120075,
+          0.040940375,
+          0.040181958
+        ]
+      },
+      "total": {
+        "min_s": 0.323326208,
+        "median_s": 0.323357833,
+        "samples_s": [
+          0.323357833,
+          0.323718291,
+          0.323326208
+        ]
+      },
+      "compute_s": 0.28314425,
+      "ns_per_op_min": 960.2765069169122,
+      "ns_per_op_median": 957.8116103738421,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 284005,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040713375,
+        "median_s": 0.040728958,
+        "samples_s": [
+          0.040728958,
+          0.0410285,
+          0.040713375
+        ]
+      },
+      "total": {
+        "min_s": 0.333084458,
+        "median_s": 0.333929958,
+        "samples_s": [
+          0.333939125,
+          0.333084458,
+          0.333929958
+        ]
+      },
+      "compute_s": 0.29237108300000003,
+      "ns_per_op_min": 1029.4575201140826,
+      "ns_per_op_median": 1032.3797116247956,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 480602,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.029211541,
+        "median_s": 0.029253583,
+        "samples_s": [
+          0.029211541,
+          0.029329416,
+          0.029253583
+        ]
+      },
+      "total": {
+        "min_s": 0.33567,
+        "median_s": 0.3357945,
+        "samples_s": [
+          0.3357945,
+          0.336541209,
+          0.33567
+        ]
+      },
+      "compute_s": 0.306458459,
+      "ns_per_op_min": 637.6553967732136,
+      "ns_per_op_median": 637.8269690929292,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 991696,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039869333,
+        "median_s": 0.04002025,
+        "samples_s": [
+          0.04002025,
+          0.040515291,
+          0.039869333
+        ]
+      },
+      "total": {
+        "min_s": 0.263073709,
+        "median_s": 0.263492083,
+        "samples_s": [
+          0.265071958,
+          0.263073709,
+          0.263492083
+        ]
+      },
+      "compute_s": 0.22320437599999998,
+      "ns_per_op_min": 225.0733853922976,
+      "ns_per_op_median": 225.34308195253382,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 295624,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010646667,
+        "median_s": 0.010982709,
+        "samples_s": [
+          0.010646667,
+          0.011384792,
+          0.010982709
+        ]
+      },
+      "total": {
+        "min_s": 0.309372041,
+        "median_s": 0.309780459,
+        "samples_s": [
+          0.310566333,
+          0.309372041,
+          0.309780459
+        ]
+      },
+      "compute_s": 0.298725374,
+      "ns_per_op_min": 1010.4909411955728,
+      "ns_per_op_median": 1010.7357657023787,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 113601995,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002941042,
+        "median_s": 0.002977125,
+        "samples_s": [
+          0.002988417,
+          0.002941042,
+          0.002977125
+        ]
+      },
+      "total": {
+        "min_s": 0.303033167,
+        "median_s": 0.303122291,
+        "samples_s": [
+          0.303122291,
+          0.303577084,
+          0.303033167
+        ]
+      },
+      "compute_s": 0.300092125,
+      "ns_per_op_min": 2.6416096389856536,
+      "ns_per_op_median": 2.642076540997365,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 136744570,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.06493675,
+        "median_s": 0.065607375,
+        "samples_s": [
+          0.065607375,
+          0.06493675,
+          0.068772
+        ]
+      },
+      "total": {
+        "min_s": 0.387704292,
+        "median_s": 0.388806917,
+        "samples_s": [
+          0.387704292,
+          0.388806917,
+          0.389445
+        ]
+      },
+      "compute_s": 0.322767542,
+      "ns_per_op_min": 2.3603682544762106,
+      "ns_per_op_median": 2.363527429279276,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 10405,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.013410292,
+        "median_s": 0.013759375,
+        "samples_s": [
+          0.014054,
+          0.013759375,
+          0.013410292
+        ]
+      },
+      "total": {
+        "min_s": 0.301096333,
+        "median_s": 0.301892834,
+        "samples_s": [
+          0.3031135,
+          0.301096333,
+          0.301892834
+        ]
+      },
+      "compute_s": 0.287686041,
+      "ns_per_op_min": 27648.826621816435,
+      "ns_per_op_median": 27691.826910139356,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 5410,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.04470025,
+        "median_s": 0.044787625,
+        "samples_s": [
+          0.04470025,
+          0.045204333,
+          0.044787625
+        ]
+      },
+      "total": {
+        "min_s": 0.355008292,
+        "median_s": 0.356737084,
+        "samples_s": [
+          0.358931541,
+          0.356737084,
+          0.355008292
+        ]
+      },
+      "compute_s": 0.310308042,
+      "ns_per_op_min": 57358.23327171904,
+      "ns_per_op_median": 57661.63752310536,
+      "load_ms": 0.636,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 607,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.083114042,
+        "median_s": 0.084322667,
+        "samples_s": [
+          0.0844795,
+          0.083114042,
+          0.084322667
+        ]
+      },
+      "total": {
+        "min_s": 0.283596375,
+        "median_s": 0.283742333,
+        "samples_s": [
+          0.284145166,
+          0.283596375,
+          0.283742333
+        ]
+      },
+      "compute_s": 0.200482333,
+      "ns_per_op_min": 330283.9093904448,
+      "ns_per_op_median": 328533.22240527184,
+      "load_ms": 3.728,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 14456,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.053069625,
+        "median_s": 0.053929791,
+        "samples_s": [
+          0.054168875,
+          0.053069625,
+          0.053929791
+        ]
+      },
+      "total": {
+        "min_s": 0.29469225,
+        "median_s": 0.294968334,
+        "samples_s": [
+          0.294968334,
+          0.295476083,
+          0.29469225
+        ]
+      },
+      "compute_s": 0.24162262499999998,
+      "ns_per_op_min": 16714.34871333702,
+      "ns_per_op_median": 16673.94459048146,
+      "load_ms": 4.041,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 33244,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.102078416,
+        "median_s": 0.103046791,
+        "samples_s": [
+          0.103046791,
+          0.105417167,
+          0.102078416
+        ]
+      },
+      "total": {
+        "min_s": 0.409278917,
+        "median_s": 0.410402708,
+        "samples_s": [
+          0.409278917,
+          0.410402708,
+          0.412972875
+        ]
+      },
+      "compute_s": 0.307200501,
+      "ns_per_op_min": 9240.78032126098,
+      "ns_per_op_median": 9245.455330285164,
+      "load_ms": 9.63,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 36355097,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005564125,
+        "median_s": 0.005920875,
+        "samples_s": [
+          0.005564125,
+          0.005920875,
+          0.00611825
+        ]
+      },
+      "total": {
+        "min_s": 0.306769083,
+        "median_s": 0.30697725,
+        "samples_s": [
+          0.306769083,
+          0.307398208,
+          0.30697725
+        ]
+      },
+      "compute_s": 0.301204958,
+      "ns_per_op_min": 8.285081951507378,
+      "ns_per_op_median": 8.280994959248767,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 36040778,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.008727541,
+        "median_s": 0.009186667,
+        "samples_s": [
+          0.009530917,
+          0.008727541,
+          0.009186667
+        ]
+      },
+      "total": {
+        "min_s": 0.307678416,
+        "median_s": 0.308213667,
+        "samples_s": [
+          0.30857425,
+          0.308213667,
+          0.307678416
+        ]
+      },
+      "compute_s": 0.298950875,
+      "ns_per_op_min": 8.294795273287386,
+      "ns_per_op_median": 8.296907464095256,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1574932,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0159445,
+        "median_s": 0.016204458,
+        "samples_s": [
+          0.016256458,
+          0.016204458,
+          0.0159445
+        ]
+      },
+      "total": {
+        "min_s": 0.312885,
+        "median_s": 0.313210292,
+        "samples_s": [
+          0.313210292,
+          0.313941625,
+          0.312885
+        ]
+      },
+      "compute_s": 0.29694050000000005,
+      "ns_per_op_min": 188.54179101065955,
+      "ns_per_op_median": 188.58327470646353,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 36094987,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005108542,
+        "median_s": 0.005300833,
+        "samples_s": [
+          0.005348375,
+          0.005108542,
+          0.005300833
+        ]
+      },
+      "total": {
+        "min_s": 0.304848917,
+        "median_s": 0.305331375,
+        "samples_s": [
+          0.305331375,
+          0.304848917,
+          0.305369291
+        ]
+      },
+      "compute_s": 0.299740375,
+      "ns_per_op_min": 8.304210637338642,
+      "ns_per_op_median": 8.312249620702177,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 16777216,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004132542,
+        "median_s": 0.004149583,
+        "samples_s": [
+          0.004546166,
+          0.004149583,
+          0.004132542
+        ]
+      },
+      "total": {
+        "min_s": 0.276339708,
+        "median_s": 0.276586792,
+        "samples_s": [
+          0.276339708,
+          0.277836292,
+          0.276586792
+        ]
+      },
+      "compute_s": 0.272207166,
+      "ns_per_op_min": 16.22481143474579,
+      "ns_per_op_median": 16.238523066043854,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 164920,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039585875,
+        "median_s": 0.039803959,
+        "samples_s": [
+          0.040393167,
+          0.039585875,
+          0.039803959
+        ]
+      },
+      "total": {
+        "min_s": 0.318744291,
+        "median_s": 0.3198945,
+        "samples_s": [
+          0.3198945,
+          0.318744291,
+          0.32043
+        ]
+      },
+      "compute_s": 0.279158416,
+      "ns_per_op_min": 1692.689886005336,
+      "ns_per_op_median": 1698.3418687848655,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 205691,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039357834,
+        "median_s": 0.039512833,
+        "samples_s": [
+          0.039574209,
+          0.039357834,
+          0.039512833
+        ]
+      },
+      "total": {
+        "min_s": 0.275674125,
+        "median_s": 0.27581975,
+        "samples_s": [
+          0.277542584,
+          0.275674125,
+          0.27581975
+        ]
+      },
+      "compute_s": 0.23631629099999998,
+      "ns_per_op_min": 1148.8897958588366,
+      "ns_per_op_median": 1148.8442226446464,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 188582,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0398765,
+        "median_s": 0.039951708,
+        "samples_s": [
+          0.039951708,
+          0.0398765,
+          0.04050625
+        ]
+      },
+      "total": {
+        "min_s": 0.306426042,
+        "median_s": 0.306941084,
+        "samples_s": [
+          0.306941084,
+          0.306426042,
+          0.3077485
+        ]
+      },
+      "compute_s": 0.26654954200000003,
+      "ns_per_op_min": 1413.4410601223872,
+      "ns_per_op_median": 1415.7733824012894,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 284095,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.028812875,
+        "median_s": 0.029345041,
+        "samples_s": [
+          0.029347834,
+          0.029345041,
+          0.028812875
+        ]
+      },
+      "total": {
+        "min_s": 0.3231115,
+        "median_s": 0.324473666,
+        "samples_s": [
+          0.344584417,
+          0.324473666,
+          0.3231115
+        ]
+      },
+      "compute_s": 0.294298625,
+      "ns_per_op_min": 1035.9162428061036,
+      "ns_per_op_median": 1038.8378007356694,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 681767,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039656083,
+        "median_s": 0.040744917,
+        "samples_s": [
+          0.039656083,
+          0.041461542,
+          0.040744917
+        ]
+      },
+      "total": {
+        "min_s": 0.22542325,
+        "median_s": 0.22671075,
+        "samples_s": [
+          0.227346708,
+          0.22671075,
+          0.22542325
+        ]
+      },
+      "compute_s": 0.18576716699999998,
+      "ns_per_op_min": 272.4789656876909,
+      "ns_per_op_median": 272.7703643620181,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 195767,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010937416,
+        "median_s": 0.011357875,
+        "samples_s": [
+          0.012191125,
+          0.011357875,
+          0.010937416
+        ]
+      },
+      "total": {
+        "min_s": 0.3067525,
+        "median_s": 0.308105542,
+        "samples_s": [
+          0.308105542,
+          0.3067525,
+          0.309928083
+        ]
+      },
+      "compute_s": 0.295815084,
+      "ns_per_op_min": 1511.0569401380212,
+      "ns_per_op_median": 1515.8206796855445,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 36049078,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002528083,
+        "median_s": 0.002689791,
+        "samples_s": [
+          0.003111125,
+          0.002689791,
+          0.002528083
+        ]
+      },
+      "total": {
+        "min_s": 0.30035,
+        "median_s": 0.302297208,
+        "samples_s": [
+          0.302894583,
+          0.30035,
+          0.302297208
+        ]
+      },
+      "compute_s": 0.297821917,
+      "ns_per_op_min": 8.2615682154201,
+      "ns_per_op_median": 8.311097914903677,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 33155187,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.061700417,
+        "median_s": 0.065857375,
+        "samples_s": [
+          0.061700417,
+          0.065857375,
+          0.066537917
+        ]
+      },
+      "total": {
+        "min_s": 0.348888625,
+        "median_s": 0.348918042,
+        "samples_s": [
+          0.348918042,
+          0.349050291,
+          0.348888625
+        ]
+      },
+      "compute_s": 0.287188208,
+      "ns_per_op_min": 8.661939020280597,
+      "ns_per_op_median": 8.537447458824467,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 3867,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.012490458,
+        "median_s": 0.012549167,
+        "samples_s": [
+          0.0128335,
+          0.012549167,
+          0.012490458
+        ]
+      },
+      "total": {
+        "min_s": 0.310155167,
+        "median_s": 0.310819833,
+        "samples_s": [
+          0.310819833,
+          0.310155167,
+          0.310887917
+        ]
+      },
+      "compute_s": 0.297664709,
+      "ns_per_op_min": 76975.61649857771,
+      "ns_per_op_median": 77132.31600724073,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 4231,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.043804166,
+        "median_s": 0.0442885,
+        "samples_s": [
+          0.0442885,
+          0.043804166,
+          0.044686125
+        ]
+      },
+      "total": {
+        "min_s": 0.324334709,
+        "median_s": 0.325682375,
+        "samples_s": [
+          0.329959125,
+          0.324334709,
+          0.325682375
+        ]
+      },
+      "compute_s": 0.280530543,
+      "ns_per_op_min": 66303.60269439849,
+      "ns_per_op_median": 66507.65185535334,
+      "load_ms": 0.689,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 368,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.078158208,
+        "median_s": 0.079081541,
+        "samples_s": [
+          0.079081541,
+          0.079867959,
+          0.078158208
+        ]
+      },
+      "total": {
+        "min_s": 0.266269459,
+        "median_s": 0.2679485,
+        "samples_s": [
+          0.269147625,
+          0.266269459,
+          0.2679485
+        ]
+      },
+      "compute_s": 0.18811125099999998,
+      "ns_per_op_min": 511171.87771739124,
+      "ns_per_op_median": 513225.4320652173,
+      "load_ms": 3.981,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wardite",
+      "status": "skipped",
+      "reason": "excluded: wardite 0.9.0 computes i64.div_s at f64 precision, wrong for operands beyond 2^53: i64.div_s(0x8000000000000000, 3) gives -3074457345618258432 where -3074457345618258602 is correct"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wardite-yjit",
+      "status": "skipped",
+      "reason": "excluded: wardite 0.9.0 computes i64.div_s at f64 precision, wrong for operands beyond 2^53: i64.div_s(0x8000000000000000, 3) gives -3074457345618258432 where -3074457345618258602 is correct"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 198644235,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005183167,
+        "median_s": 0.005646583,
+        "samples_s": [
+          0.005904333,
+          0.005646583,
+          0.005183167
+        ]
+      },
+      "total": {
+        "min_s": 0.303670416,
+        "median_s": 0.303686,
+        "samples_s": [
+          0.303785958,
+          0.303686,
+          0.303670416
+        ]
+      },
+      "compute_s": 0.298487249,
+      "ns_per_op_min": 1.5026222583303261,
+      "ns_per_op_median": 1.5003678158593428,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 192199667,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009023208,
+        "median_s": 0.0094865,
+        "samples_s": [
+          0.0094865,
+          0.009023208,
+          0.009500125
+        ]
+      },
+      "total": {
+        "min_s": 0.314424583,
+        "median_s": 0.314586417,
+        "samples_s": [
+          0.314586417,
+          0.314424583,
+          0.315698584
+        ]
+      },
+      "compute_s": 0.305401375,
+      "ns_per_op_min": 1.5889797301261714,
+      "ns_per_op_median": 1.5874112674711345,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1071781,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.01566,
+        "median_s": 0.015903166,
+        "samples_s": [
+          0.01566,
+          0.016190167,
+          0.015903166
+        ]
+      },
+      "total": {
+        "min_s": 0.306389083,
+        "median_s": 0.307150209,
+        "samples_s": [
+          0.307344583,
+          0.306389083,
+          0.307150209
+        ]
+      },
+      "compute_s": 0.290729083,
+      "ns_per_op_min": 271.25791836205343,
+      "ns_per_op_median": 271.7411887316532,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 119457327,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004747084,
+        "median_s": 0.005092958,
+        "samples_s": [
+          0.00532675,
+          0.005092958,
+          0.004747084
+        ]
+      },
+      "total": {
+        "min_s": 0.306483,
+        "median_s": 0.307922208,
+        "samples_s": [
+          0.307922208,
+          0.308088125,
+          0.306483
+        ]
+      },
+      "compute_s": 0.301735916,
+      "ns_per_op_min": 2.525888730123687,
+      "ns_per_op_median": 2.5350412369431305,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 16161788,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004138834,
+        "median_s": 0.004404791,
+        "samples_s": [
+          0.004138834,
+          0.004404791,
+          0.005031042
+        ]
+      },
+      "total": {
+        "min_s": 0.334794334,
+        "median_s": 0.334917125,
+        "samples_s": [
+          0.335129125,
+          0.334794334,
+          0.334917125
+        ]
+      },
+      "compute_s": 0.33065550000000005,
+      "ns_per_op_min": 20.4590915312093,
+      "ns_per_op_median": 20.450233229145187,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 676523,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039200375,
+        "median_s": 0.03976025,
+        "samples_s": [
+          0.039200375,
+          0.03976025,
+          0.040137833
+        ]
+      },
+      "total": {
+        "min_s": 0.333609625,
+        "median_s": 0.333982083,
+        "samples_s": [
+          0.333609625,
+          0.333982083,
+          0.334822666
+        ]
+      },
+      "compute_s": 0.29440925,
+      "ns_per_op_min": 435.1799569268155,
+      "ns_per_op_median": 434.90292717320773,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 867515,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039474208,
+        "median_s": 0.040297292,
+        "samples_s": [
+          0.041192,
+          0.040297292,
+          0.039474208
+        ]
+      },
+      "total": {
+        "min_s": 0.306346792,
+        "median_s": 0.307076,
+        "samples_s": [
+          0.30874925,
+          0.307076,
+          0.306346792
+        ]
+      },
+      "compute_s": 0.26687258399999997,
+      "ns_per_op_min": 307.62878336397637,
+      "ns_per_op_median": 307.5205708258647,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 834428,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039932083,
+        "median_s": 0.040366042,
+        "samples_s": [
+          0.040792083,
+          0.040366042,
+          0.039932083
+        ]
+      },
+      "total": {
+        "min_s": 0.318558041,
+        "median_s": 0.319012375,
+        "samples_s": [
+          0.318558041,
+          0.320414584,
+          0.319012375
+        ]
+      },
+      "compute_s": 0.278625958,
+      "ns_per_op_min": 333.912522110955,
+      "ns_per_op_median": 333.93694003556925,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 158914,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.029174125,
+        "median_s": 0.029466459,
+        "samples_s": [
+          0.029466459,
+          0.029174125,
+          0.0297975
+        ]
+      },
+      "total": {
+        "min_s": 0.332689,
+        "median_s": 0.335566708,
+        "samples_s": [
+          0.332689,
+          0.335566708,
+          0.33559
+        ]
+      },
+      "compute_s": 0.303514875,
+      "ns_per_op_min": 1909.931629686497,
+      "ns_per_op_median": 1926.200643115144,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 3771346,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.041569291,
+        "median_s": 0.041769166,
+        "samples_s": [
+          0.041569291,
+          0.043079542,
+          0.041769166
+        ]
+      },
+      "total": {
+        "min_s": 0.313701042,
+        "median_s": 0.3142805,
+        "samples_s": [
+          0.313701042,
+          0.316010791,
+          0.3142805
+        ]
+      },
+      "compute_s": 0.272131751,
+      "ns_per_op_min": 72.15772591536285,
+      "ns_per_op_median": 72.25837512654633,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 65536,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010616375,
+        "median_s": 0.010620917,
+        "samples_s": [
+          0.010616375,
+          0.0115405,
+          0.010620917
+        ]
+      },
+      "total": {
+        "min_s": 0.225195667,
+        "median_s": 0.226808333,
+        "samples_s": [
+          0.225195667,
+          0.227605584,
+          0.226808333
+        ]
+      },
+      "compute_s": 0.21457929199999998,
+      "ns_per_op_min": 3274.2201538085933,
+      "ns_per_op_median": 3298.7581787109375,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 118793803,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002637125,
+        "median_s": 0.002696792,
+        "samples_s": [
+          0.002970583,
+          0.002696792,
+          0.002637125
+        ]
+      },
+      "total": {
+        "min_s": 0.299099459,
+        "median_s": 0.299270084,
+        "samples_s": [
+          0.299099459,
+          0.29938425,
+          0.299270084
+        ]
+      },
+      "compute_s": 0.296462334,
+      "ns_per_op_min": 2.4956043708778313,
+      "ns_per_op_median": 2.4965384094993577,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 53453830,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.065496,
+        "median_s": 0.0663375,
+        "samples_s": [
+          0.065496,
+          0.0663375,
+          0.066610792
+        ]
+      },
+      "total": {
+        "min_s": 0.298925084,
+        "median_s": 0.30066675,
+        "samples_s": [
+          0.30066675,
+          0.298925084,
+          0.305998792
+        ]
+      },
+      "compute_s": 0.233429084,
+      "ns_per_op_min": 4.366929067571023,
+      "ns_per_op_median": 4.383769133100472,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 5911,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.012112,
+        "median_s": 0.012322625,
+        "samples_s": [
+          0.012623791,
+          0.012112,
+          0.012322625
+        ]
+      },
+      "total": {
+        "min_s": 0.318878708,
+        "median_s": 0.318906125,
+        "samples_s": [
+          0.320912875,
+          0.318878708,
+          0.318906125
+        ]
+      },
+      "compute_s": 0.306766708,
+      "ns_per_op_min": 51897.59905261377,
+      "ns_per_op_median": 51866.60463542548,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 3337,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.043867208,
+        "median_s": 0.043883416,
+        "samples_s": [
+          0.043883416,
+          0.045209542,
+          0.043867208
+        ]
+      },
+      "total": {
+        "min_s": 0.334239584,
+        "median_s": 0.336780709,
+        "samples_s": [
+          0.334239584,
+          0.336780709,
+          0.340838209
+        ]
+      },
+      "compute_s": 0.290372376,
+      "ns_per_op_min": 87015.9952052742,
+      "ns_per_op_median": 87772.63799820197,
+      "load_ms": 0.757,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 5072,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.080018542,
+        "median_s": 0.0805255,
+        "samples_s": [
+          0.081184792,
+          0.0805255,
+          0.080018542
+        ]
+      },
+      "total": {
+        "min_s": 0.282755834,
+        "median_s": 0.283634083,
+        "samples_s": [
+          0.283634083,
+          0.282755834,
+          0.283807084
+        ]
+      },
+      "compute_s": 0.20273729199999999,
+      "ns_per_op_min": 39971.86356466877,
+      "ns_per_op_median": 40045.06762618296,
+      "load_ms": 5.161,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 8642,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.053260792,
+        "median_s": 0.053436917,
+        "samples_s": [
+          0.053436917,
+          0.053260792,
+          0.054143958
+        ]
+      },
+      "total": {
+        "min_s": 0.2989875,
+        "median_s": 0.300900917,
+        "samples_s": [
+          0.300900917,
+          0.2989875,
+          0.301479542
+        ]
+      },
+      "compute_s": 0.24572670800000002,
+      "ns_per_op_min": 28434.009257116413,
+      "ns_per_op_median": 28635.038185605183,
+      "load_ms": 4.163,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 19185,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.101167334,
+        "median_s": 0.102649291,
+        "samples_s": [
+          0.103638,
+          0.102649291,
+          0.101167334
+        ]
+      },
+      "total": {
+        "min_s": 0.38993475,
+        "median_s": 0.390617666,
+        "samples_s": [
+          0.392954584,
+          0.38993475,
+          0.390617666
+        ]
+      },
+      "compute_s": 0.288767416,
+      "ns_per_op_min": 15051.728746416471,
+      "ns_per_op_median": 15010.079489184256,
+      "load_ms": 9.662,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 292550018,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.00550725,
+        "median_s": 0.005732833,
+        "samples_s": [
+          0.005732833,
+          0.00550725,
+          0.005821542
+        ]
+      },
+      "total": {
+        "min_s": 0.300664417,
+        "median_s": 0.301341834,
+        "samples_s": [
+          0.301341834,
+          0.302245041,
+          0.300664417
+        ]
+      },
+      "compute_s": 0.295157167,
+      "ns_per_op_min": 1.0089118059804734,
+      "ns_per_op_median": 1.0104562734978195,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 283198272,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.008784584,
+        "median_s": 0.008810708,
+        "samples_s": [
+          0.008883875,
+          0.008810708,
+          0.008784584
+        ]
+      },
+      "total": {
+        "min_s": 0.295352875,
+        "median_s": 0.295412333,
+        "samples_s": [
+          0.295412333,
+          0.295412417,
+          0.295352875
+        ]
+      },
+      "compute_s": 0.28656829100000003,
+      "ns_per_op_min": 1.0118998572138183,
+      "ns_per_op_median": 1.0120175627342811,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 2149768,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.01591275,
+        "median_s": 0.016408708,
+        "samples_s": [
+          0.016408708,
+          0.016591375,
+          0.01591275
+        ]
+      },
+      "total": {
+        "min_s": 0.301790375,
+        "median_s": 0.303174208,
+        "samples_s": [
+          0.303617959,
+          0.301790375,
+          0.303174208
+        ]
+      },
+      "compute_s": 0.285877625,
+      "ns_per_op_min": 132.98068675317523,
+      "ns_per_op_median": 133.39369643608055,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 189109192,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004777292,
+        "median_s": 0.004998,
+        "samples_s": [
+          0.004998,
+          0.005193541,
+          0.004777292
+        ]
+      },
+      "total": {
+        "min_s": 0.298256666,
+        "median_s": 0.298386167,
+        "samples_s": [
+          0.299185208,
+          0.298256666,
+          0.298386167
+        ]
+      },
+      "compute_s": 0.293479374,
+      "ns_per_op_min": 1.5519043304885993,
+      "ns_per_op_median": 1.55142203240972,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 33554432,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004607,
+        "median_s": 0.004764167,
+        "samples_s": [
+          0.004607,
+          0.004787166,
+          0.004764167
+        ]
+      },
+      "total": {
+        "min_s": 0.347871583,
+        "median_s": 0.348565834,
+        "samples_s": [
+          0.348943167,
+          0.348565834,
+          0.347871583
+        ]
+      },
+      "compute_s": 0.34326458299999996,
+      "ns_per_op_min": 10.230081766843794,
+      "ns_per_op_median": 10.24608811736107,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 1715994,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.038974334,
+        "median_s": 0.039560959,
+        "samples_s": [
+          0.04117375,
+          0.039560959,
+          0.038974334
+        ]
+      },
+      "total": {
+        "min_s": 0.351501416,
+        "median_s": 0.351538666,
+        "samples_s": [
+          0.351501416,
+          0.351941875,
+          0.351538666
+        ]
+      },
+      "compute_s": 0.312527082,
+      "ns_per_op_min": 182.12597596495092,
+      "ns_per_op_median": 181.8058262441477,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 2010049,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039387542,
+        "median_s": 0.039808709,
+        "samples_s": [
+          0.039387542,
+          0.039808709,
+          0.04057375
+        ]
+      },
+      "total": {
+        "min_s": 0.311718916,
+        "median_s": 0.312186,
+        "samples_s": [
+          0.313114833,
+          0.311718916,
+          0.312186
+        ]
+      },
+      "compute_s": 0.272331374,
+      "ns_per_op_min": 135.48494290437696,
+      "ns_per_op_median": 135.5077866260972,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 1791961,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039812875,
+        "median_s": 0.040246291,
+        "samples_s": [
+          0.040246291,
+          0.041567375,
+          0.039812875
+        ]
+      },
+      "total": {
+        "min_s": 0.296087166,
+        "median_s": 0.29766275,
+        "samples_s": [
+          0.29766275,
+          0.297924625,
+          0.296087166
+        ]
+      },
+      "compute_s": 0.256274291,
+      "ns_per_op_min": 143.0133194863058,
+      "ns_per_op_median": 143.65070389366733,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 382114,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.028839834,
+        "median_s": 0.02928575,
+        "samples_s": [
+          0.029899625,
+          0.02928575,
+          0.028839834
+        ]
+      },
+      "total": {
+        "min_s": 0.321456042,
+        "median_s": 0.325110084,
+        "samples_s": [
+          0.325110084,
+          0.325895542,
+          0.321456042
+        ]
+      },
+      "compute_s": 0.292616208,
+      "ns_per_op_min": 765.7824837613906,
+      "ns_per_op_median": 774.1782138314744,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 4842165,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.03985425,
+        "median_s": 0.042062416,
+        "samples_s": [
+          0.03985425,
+          0.042861167,
+          0.042062416
+        ]
+      },
+      "total": {
+        "min_s": 0.304759417,
+        "median_s": 0.305116416,
+        "samples_s": [
+          0.305116416,
+          0.304759417,
+          0.306205084
+        ]
+      },
+      "compute_s": 0.264905167,
+      "ns_per_op_min": 54.70800086325022,
+      "ns_per_op_median": 54.32569935142648,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 294146,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.011032375,
+        "median_s": 0.01138475,
+        "samples_s": [
+          0.011032375,
+          0.011477375,
+          0.01138475
+        ]
+      },
+      "total": {
+        "min_s": 0.30473225,
+        "median_s": 0.306807875,
+        "samples_s": [
+          0.30473225,
+          0.307867625,
+          0.306807875
+        ]
+      },
+      "compute_s": 0.293699875,
+      "ns_per_op_min": 998.4833212078356,
+      "ns_per_op_median": 1004.3418064498583,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 198361421,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002785875,
+        "median_s": 0.002801083,
+        "samples_s": [
+          0.003256584,
+          0.002785875,
+          0.002801083
+        ]
+      },
+      "total": {
+        "min_s": 0.301971667,
+        "median_s": 0.303166208,
+        "samples_s": [
+          0.303960083,
+          0.301971667,
+          0.303166208
+        ]
+      },
+      "compute_s": 0.299185792,
+      "ns_per_op_min": 1.5082861903877973,
+      "ns_per_op_median": 1.5142315652195293,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 138922196,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.064874167,
+        "median_s": 0.065406166,
+        "samples_s": [
+          0.064874167,
+          0.065774167,
+          0.065406166
+        ]
+      },
+      "total": {
+        "min_s": 0.311141625,
+        "median_s": 0.311247916,
+        "samples_s": [
+          0.311247916,
+          0.31170475,
+          0.311141625
+        ]
+      },
+      "compute_s": 0.246267458,
+      "ns_per_op_min": 1.7727005841456753,
+      "ns_per_op_median": 1.7696362214141794,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 9806,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.013047667,
+        "median_s": 0.013590083,
+        "samples_s": [
+          0.013047667,
+          0.013687334,
+          0.013590083
+        ]
+      },
+      "total": {
+        "min_s": 0.326724833,
+        "median_s": 0.32738275,
+        "samples_s": [
+          0.32738275,
+          0.326724833,
+          0.349215417
+        ]
+      },
+      "compute_s": 0.313677166,
+      "ns_per_op_min": 31988.289414644096,
+      "ns_per_op_median": 32000.06801957985,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 8011,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.044114167,
+        "median_s": 0.044244583,
+        "samples_s": [
+          0.045003166,
+          0.044114167,
+          0.044244583
+        ]
+      },
+      "total": {
+        "min_s": 0.361635292,
+        "median_s": 0.362770833,
+        "samples_s": [
+          0.361635292,
+          0.379687083,
+          0.362770833
+        ]
+      },
+      "compute_s": 0.317521125,
+      "ns_per_op_min": 39635.64161777556,
+      "ns_per_op_median": 39761.109724129325,
+      "load_ms": 0.678,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 26496,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.078606667,
+        "median_s": 0.080596083,
+        "samples_s": [
+          0.080596083,
+          0.078606667,
+          0.080609458
+        ]
+      },
+      "total": {
+        "min_s": 0.306097333,
+        "median_s": 0.307172292,
+        "samples_s": [
+          0.307172292,
+          0.306097333,
+          0.310225541
+        ]
+      },
+      "compute_s": 0.227490666,
+      "ns_per_op_min": 8585.849411231884,
+      "ns_per_op_median": 8551.336390398552,
+      "load_ms": 4.671,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 26635,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.053386125,
+        "median_s": 0.053391041,
+        "samples_s": [
+          0.05472725,
+          0.053386125,
+          0.053391041
+        ]
+      },
+      "total": {
+        "min_s": 0.406912,
+        "median_s": 0.408038,
+        "samples_s": [
+          0.406912,
+          0.409219958,
+          0.408038
+        ]
+      },
+      "compute_s": 0.353525875,
+      "ns_per_op_min": 13272.981978599588,
+      "ns_per_op_median": 13315.07261122583,
+      "load_ms": 4.117,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 37693,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.101555917,
+        "median_s": 0.102426792,
+        "samples_s": [
+          0.103400208,
+          0.102426792,
+          0.101555917
+        ]
+      },
+      "total": {
+        "min_s": 0.341521,
+        "median_s": 0.343944833,
+        "samples_s": [
+          0.345058,
+          0.341521,
+          0.343944833
+        ]
+      },
+      "compute_s": 0.23996508300000002,
+      "ns_per_op_min": 6366.3036372801325,
+      "ns_per_op_median": 6407.503807072932,
+      "load_ms": 8.882,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 2957048,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005313292,
+        "median_s": 0.005517541,
+        "samples_s": [
+          0.005313292,
+          0.005983583,
+          0.005517541
+        ]
+      },
+      "total": {
+        "min_s": 0.290575542,
+        "median_s": 0.2906265,
+        "samples_s": [
+          0.290793042,
+          0.2906265,
+          0.290575542
+        ]
+      },
+      "compute_s": 0.28526225,
+      "ns_per_op_min": 96.46858962045933,
+      "ns_per_op_median": 96.41675042136617,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 2808902,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.008752875,
+        "median_s": 0.008922958,
+        "samples_s": [
+          0.008752875,
+          0.009232541,
+          0.008922958
+        ]
+      },
+      "total": {
+        "min_s": 0.27862025,
+        "median_s": 0.278876958,
+        "samples_s": [
+          0.278876958,
+          0.27898375,
+          0.27862025
+        ]
+      },
+      "compute_s": 0.269867375,
+      "ns_per_op_min": 96.07575308786137,
+      "ns_per_op_median": 96.10659254043038,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 89740,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015424583,
+        "median_s": 0.01586175,
+        "samples_s": [
+          0.01619825,
+          0.01586175,
+          0.015424583
+        ]
+      },
+      "total": {
+        "min_s": 0.359297333,
+        "median_s": 0.359444958,
+        "samples_s": [
+          0.359444958,
+          0.359297333,
+          0.359609917
+        ]
+      },
+      "compute_s": 0.34387275,
+      "ns_per_op_min": 3831.8782036995767,
+      "ns_per_op_median": 3828.6517494985515,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 2501652,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004580291,
+        "median_s": 0.00513325,
+        "samples_s": [
+          0.004580291,
+          0.00513325,
+          0.005361292
+        ]
+      },
+      "total": {
+        "min_s": 0.27375775,
+        "median_s": 0.273817791,
+        "samples_s": [
+          0.274434,
+          0.273817791,
+          0.27375775
+        ]
+      },
+      "compute_s": 0.269177459,
+      "ns_per_op_min": 107.59988159823989,
+      "ns_per_op_median": 107.40284460028813,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 653872,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004015792,
+        "median_s": 0.004533375,
+        "samples_s": [
+          0.004533375,
+          0.004609792,
+          0.004015792
+        ]
+      },
+      "total": {
+        "min_s": 0.301489666,
+        "median_s": 0.302601375,
+        "samples_s": [
+          0.303272583,
+          0.301489666,
+          0.302601375
+        ]
+      },
+      "compute_s": 0.29747387399999997,
+      "ns_per_op_min": 454.94205899625615,
+      "ns_per_op_median": 455.8506863728681,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 65536,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039369917,
+        "median_s": 0.039986708,
+        "samples_s": [
+          0.039369917,
+          0.039986708,
+          0.041064167
+        ]
+      },
+      "total": {
+        "min_s": 0.336814917,
+        "median_s": 0.337518625,
+        "samples_s": [
+          0.336814917,
+          0.33811975,
+          0.337518625
+        ]
+      },
+      "compute_s": 0.297445,
+      "ns_per_op_min": 4538.6505126953125,
+      "ns_per_op_median": 4539.976760864259,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 162747,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039887417,
+        "median_s": 0.040420625,
+        "samples_s": [
+          0.039887417,
+          0.040420625,
+          0.041096916
+        ]
+      },
+      "total": {
+        "min_s": 0.283756875,
+        "median_s": 0.291077792,
+        "samples_s": [
+          0.283756875,
+          0.291077792,
+          0.292721833
+        ]
+      },
+      "compute_s": 0.243869458,
+      "ns_per_op_min": 1498.4574707982329,
+      "ns_per_op_median": 1540.1645928957216,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 81838,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0406995,
+        "median_s": 0.040975959,
+        "samples_s": [
+          0.041139459,
+          0.040975959,
+          0.0406995
+        ]
+      },
+      "total": {
+        "min_s": 0.328120375,
+        "median_s": 0.329983125,
+        "samples_s": [
+          0.328120375,
+          0.331034292,
+          0.329983125
+        ]
+      },
+      "compute_s": 0.287420875,
+      "ns_per_op_min": 3512.071103888169,
+      "ns_per_op_median": 3531.4544099318164,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 97952,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.029332541,
+        "median_s": 0.030094917,
+        "samples_s": [
+          0.030094917,
+          0.030144875,
+          0.029332541
+        ]
+      },
+      "total": {
+        "min_s": 0.380607,
+        "median_s": 0.3825785,
+        "samples_s": [
+          0.3825785,
+          0.380607,
+          0.384354958
+        ]
+      },
+      "compute_s": 0.351274459,
+      "ns_per_op_min": 3586.1897562071217,
+      "ns_per_op_median": 3598.5338022705,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 2022040,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040028459,
+        "median_s": 0.040979542,
+        "samples_s": [
+          0.040028459,
+          0.041118583,
+          0.040979542
+        ]
+      },
+      "total": {
+        "min_s": 0.326098916,
+        "median_s": 0.328773334,
+        "samples_s": [
+          0.329714625,
+          0.328773334,
+          0.326098916
+        ]
+      },
+      "compute_s": 0.286070457,
+      "ns_per_op_min": 141.47616120353703,
+      "ns_per_op_median": 142.32843662835552,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 5054,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010901917,
+        "median_s": 0.01109625,
+        "samples_s": [
+          0.01109625,
+          0.010901917,
+          0.011367708
+        ]
+      },
+      "total": {
+        "min_s": 0.294565708,
+        "median_s": 0.294753,
+        "samples_s": [
+          0.294753,
+          0.29664175,
+          0.294565708
+        ]
+      },
+      "compute_s": 0.283663791,
+      "ns_per_op_min": 56126.591017016224,
+      "ns_per_op_median": 56125.19786307875,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 1238225,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002718333,
+        "median_s": 0.003025625,
+        "samples_s": [
+          0.003073875,
+          0.003025625,
+          0.002718333
+        ]
+      },
+      "total": {
+        "min_s": 0.294356042,
+        "median_s": 0.294739083,
+        "samples_s": [
+          0.295166417,
+          0.294356042,
+          0.294739083
+        ]
+      },
+      "compute_s": 0.29163770899999997,
+      "ns_per_op_min": 235.52884895717656,
+      "ns_per_op_median": 235.59002443013188,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 2825122,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.066252125,
+        "median_s": 0.066486208,
+        "samples_s": [
+          0.066252125,
+          0.066486208,
+          0.067054708
+        ]
+      },
+      "total": {
+        "min_s": 0.340168375,
+        "median_s": 0.341574583,
+        "samples_s": [
+          0.343531125,
+          0.341574583,
+          0.340168375
+        ]
+      },
+      "compute_s": 0.27391625000000003,
+      "ns_per_op_min": 96.9573172415209,
+      "ns_per_op_median": 97.37221082841732,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 156,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.01259475,
+        "median_s": 0.012672209,
+        "samples_s": [
+          0.01259475,
+          0.012672209,
+          0.012897875
+        ]
+      },
+      "total": {
+        "min_s": 3.143834083,
+        "median_s": 3.154231958,
+        "samples_s": [
+          3.154231958,
+          3.143834083,
+          3.162963042
+        ]
+      },
+      "compute_s": 3.131239333,
+      "ns_per_op_min": 20072047.006410256,
+      "ns_per_op_median": 20138203.519230768,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 193,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.042975375,
+        "median_s": 0.043879875,
+        "samples_s": [
+          0.043879875,
+          0.042975375,
+          0.043890167
+        ]
+      },
+      "total": {
+        "min_s": 0.340352041,
+        "median_s": 0.3407925,
+        "samples_s": [
+          0.340352041,
+          0.340869166,
+          0.3407925
+        ]
+      },
+      "compute_s": 0.297376666,
+      "ns_per_op_min": 1540811.7409326425,
+      "ns_per_op_median": 1538407.383419689,
+      "load_ms": 0.849,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 83,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.079456333,
+        "median_s": 0.080973916,
+        "samples_s": [
+          0.081921959,
+          0.079456333,
+          0.080973916
+        ]
+      },
+      "total": {
+        "min_s": 0.262874958,
+        "median_s": 0.263882791,
+        "samples_s": [
+          0.262874958,
+          0.263882791,
+          0.264688042
+        ]
+      },
+      "compute_s": 0.183418625,
+      "ns_per_op_min": 2209862.951807229,
+      "ns_per_op_median": 2203721.3855421687,
+      "load_ms": 5.333,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 771,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.052912584,
+        "median_s": 0.053066833,
+        "samples_s": [
+          0.05371975,
+          0.052912584,
+          0.053066833
+        ]
+      },
+      "total": {
+        "min_s": 0.349495417,
+        "median_s": 0.352330041,
+        "samples_s": [
+          0.349495417,
+          0.354843,
+          0.352330041
+        ]
+      },
+      "compute_s": 0.296582833,
+      "ns_per_op_min": 384672.93514915695,
+      "ns_per_op_median": 388149.42671854736,
+      "load_ms": 4.49,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 1277,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.101439125,
+        "median_s": 0.103622709,
+        "samples_s": [
+          0.104255959,
+          0.101439125,
+          0.103622709
+        ]
+      },
+      "total": {
+        "min_s": 0.342343959,
+        "median_s": 0.343636167,
+        "samples_s": [
+          0.346728542,
+          0.343636167,
+          0.342343959
+        ]
+      },
+      "compute_s": 0.24090483399999996,
+      "ns_per_op_min": 188649.0477682067,
+      "ns_per_op_median": 187951.02427564605,
+      "load_ms": 9.9,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 987301,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005008167,
+        "median_s": 0.005650083,
+        "samples_s": [
+          0.005008167,
+          0.005650083,
+          0.00572725
+        ]
+      },
+      "total": {
+        "min_s": 0.295716042,
+        "median_s": 0.295737917,
+        "samples_s": [
+          0.295716042,
+          0.295737917,
+          0.297291041
+        ]
+      },
+      "compute_s": 0.290707875,
+      "ns_per_op_min": 294.44705819198,
+      "ns_per_op_median": 293.81904201454273,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 989668,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.008856417,
+        "median_s": 0.009279167,
+        "samples_s": [
+          0.0095265,
+          0.009279167,
+          0.008856417
+        ]
+      },
+      "total": {
+        "min_s": 0.299201125,
+        "median_s": 0.299706292,
+        "samples_s": [
+          0.299706292,
+          0.299201125,
+          0.299837292
+        ]
+      },
+      "compute_s": 0.290344708,
+      "ns_per_op_min": 293.37586746262383,
+      "ns_per_op_median": 293.45914488495134,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 7045,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015837875,
+        "median_s": 0.01605225,
+        "samples_s": [
+          0.015837875,
+          0.01605225,
+          0.016278833
+        ]
+      },
+      "total": {
+        "min_s": 0.31156575,
+        "median_s": 0.313030208,
+        "samples_s": [
+          0.313178125,
+          0.313030208,
+          0.31156575
+        ]
+      },
+      "compute_s": 0.295727875,
+      "ns_per_op_min": 41976.98722498226,
+      "ns_per_op_median": 42154.429808374734,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 803791,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.00546625,
+        "median_s": 0.0054705,
+        "samples_s": [
+          0.0054705,
+          0.00546625,
+          0.005525791
+        ]
+      },
+      "total": {
+        "min_s": 0.309128333,
+        "median_s": 0.310214,
+        "samples_s": [
+          0.310214,
+          0.310443667,
+          0.309128333
+        ]
+      },
+      "compute_s": 0.30366208299999997,
+      "ns_per_op_min": 377.78736387941643,
+      "ns_per_op_median": 379.1327596352783,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 48739,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004193833,
+        "median_s": 0.004256584,
+        "samples_s": [
+          0.004256584,
+          0.004193833,
+          0.00430075
+        ]
+      },
+      "total": {
+        "min_s": 0.250149834,
+        "median_s": 0.250192583,
+        "samples_s": [
+          0.250344916,
+          0.250192583,
+          0.250149834
+        ]
+      },
+      "compute_s": 0.245956001,
+      "ns_per_op_min": 5046.389975173885,
+      "ns_per_op_median": 5045.97958513716,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 3625,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040002792,
+        "median_s": 0.040304125,
+        "samples_s": [
+          0.040304125,
+          0.041204125,
+          0.040002792
+        ]
+      },
+      "total": {
+        "min_s": 0.32602975,
+        "median_s": 0.326598958,
+        "samples_s": [
+          0.327027834,
+          0.326598958,
+          0.32602975
+        ]
+      },
+      "compute_s": 0.286026958,
+      "ns_per_op_min": 78903.98841379311,
+      "ns_per_op_median": 78977.88496551724,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 8271,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.038846666,
+        "median_s": 0.04039625,
+        "samples_s": [
+          0.040856333,
+          0.04039625,
+          0.038846666
+        ]
+      },
+      "total": {
+        "min_s": 0.320036167,
+        "median_s": 0.322639208,
+        "samples_s": [
+          0.320036167,
+          0.322639208,
+          0.32288125
+        ]
+      },
+      "compute_s": 0.28118950099999995,
+      "ns_per_op_min": 33997.03796397049,
+      "ns_per_op_median": 34124.40551323903,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 5852,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039853917,
+        "median_s": 0.040303875,
+        "samples_s": [
+          0.041154292,
+          0.040303875,
+          0.039853917
+        ]
+      },
+      "total": {
+        "min_s": 0.354168167,
+        "median_s": 0.354956958,
+        "samples_s": [
+          0.355489125,
+          0.354168167,
+          0.354956958
+        ]
+      },
+      "compute_s": 0.31431424999999996,
+      "ns_per_op_min": 53710.56903622692,
+      "ns_per_op_median": 53768.46941216678,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 1100,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.029754917,
+        "median_s": 0.030272583,
+        "samples_s": [
+          0.030272583,
+          0.029754917,
+          0.031150375
+        ]
+      },
+      "total": {
+        "min_s": 0.326726041,
+        "median_s": 0.329705375,
+        "samples_s": [
+          0.330759958,
+          0.329705375,
+          0.326726041
+        ]
+      },
+      "compute_s": 0.29697112400000003,
+      "ns_per_op_min": 269973.74909090914,
+      "ns_per_op_median": 272211.6290909091,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 19373,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.041618042,
+        "median_s": 0.042196042,
+        "samples_s": [
+          0.041618042,
+          0.04331775,
+          0.042196042
+        ]
+      },
+      "total": {
+        "min_s": 0.308985334,
+        "median_s": 0.310026,
+        "samples_s": [
+          0.310026,
+          0.308985334,
+          0.310413084
+        ]
+      },
+      "compute_s": 0.267367292,
+      "ns_per_op_min": 13801.026789862177,
+      "ns_per_op_median": 13824.908790584836,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 921,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010834875,
+        "median_s": 0.011475791,
+        "samples_s": [
+          0.010834875,
+          0.011612916,
+          0.011475791
+        ]
+      },
+      "total": {
+        "min_s": 0.307138208,
+        "median_s": 0.307736292,
+        "samples_s": [
+          0.307986708,
+          0.307736292,
+          0.307138208
+        ]
+      },
+      "compute_s": 0.296303333,
+      "ns_per_op_min": 321719.1454940282,
+      "ns_per_op_median": 321672.6395222584,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 860893,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002809167,
+        "median_s": 0.002859834,
+        "samples_s": [
+          0.00314225,
+          0.002809167,
+          0.002859834
+        ]
+      },
+      "total": {
+        "min_s": 0.303769458,
+        "median_s": 0.304003792,
+        "samples_s": [
+          0.304003792,
+          0.304332167,
+          0.303769458
+        ]
+      },
+      "compute_s": 0.300960291,
+      "ns_per_op_min": 349.5908213912763,
+      "ns_per_op_median": 349.8041661391137,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 492277,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.06555725,
+        "median_s": 0.065903958,
+        "samples_s": [
+          0.06555725,
+          0.065903958,
+          0.066449542
+        ]
+      },
+      "total": {
+        "min_s": 0.31305925,
+        "median_s": 0.325855375,
+        "samples_s": [
+          0.31305925,
+          0.325855375,
+          0.344605958
+        ]
+      },
+      "compute_s": 0.247502,
+      "ns_per_op_min": 502.7697820535999,
+      "ns_per_op_median": 528.0592369743051,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 18,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.014919583,
+        "median_s": 0.015096333,
+        "samples_s": [
+          0.014919583,
+          0.01533125,
+          0.015096333
+        ]
+      },
+      "total": {
+        "min_s": 0.302874958,
+        "median_s": 0.303832041,
+        "samples_s": [
+          0.306811042,
+          0.302874958,
+          0.303832041
+        ]
+      },
+      "compute_s": 0.287955375,
+      "ns_per_op_min": 15997520.833333334,
+      "ns_per_op_median": 16040872.666666666,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 21,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.044710584,
+        "median_s": 0.045498875,
+        "samples_s": [
+          0.045498875,
+          0.046180875,
+          0.044710584
+        ]
+      },
+      "total": {
+        "min_s": 0.351075208,
+        "median_s": 0.351946542,
+        "samples_s": [
+          0.351075208,
+          0.355090333,
+          0.351946542
+        ]
+      },
+      "compute_s": 0.30636462400000003,
+      "ns_per_op_min": 14588791.619047621,
+      "ns_per_op_median": 14592746.047619049,
+      "load_ms": 1.256,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 28,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.088983625,
+        "median_s": 0.089133416,
+        "samples_s": [
+          0.08920325,
+          0.088983625,
+          0.089133416
+        ]
+      },
+      "total": {
+        "min_s": 0.292897459,
+        "median_s": 0.294080708,
+        "samples_s": [
+          0.292897459,
+          0.294457334,
+          0.294080708
+        ]
+      },
+      "compute_s": 0.20391383400000002,
+      "ns_per_op_min": 7282636.92857143,
+      "ns_per_op_median": 7319546.142857144,
+      "load_ms": 7.963,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 78,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.052797958,
+        "median_s": 0.053269042,
+        "samples_s": [
+          0.053269042,
+          0.053490417,
+          0.052797958
+        ]
+      },
+      "total": {
+        "min_s": 0.378614375,
+        "median_s": 0.379305292,
+        "samples_s": [
+          0.380492375,
+          0.378614375,
+          0.379305292
+        ]
+      },
+      "compute_s": 0.325816417,
+      "ns_per_op_min": 4177133.5512820515,
+      "ns_per_op_median": 4179951.923076923,
+      "load_ms": 4.085,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 127,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.103359,
+        "median_s": 0.105113458,
+        "samples_s": [
+          0.103359,
+          0.105113458,
+          0.105418459
+        ]
+      },
+      "total": {
+        "min_s": 0.350831042,
+        "median_s": 0.351239375,
+        "samples_s": [
+          0.353511,
+          0.351239375,
+          0.350831042
+        ]
+      },
+      "compute_s": 0.24747204199999998,
+      "ns_per_op_min": 1948598.7559055116,
+      "ns_per_op_median": 1937999.3464566933,
+      "load_ms": 9.36,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 192369542,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005490708,
+        "median_s": 0.005702667,
+        "samples_s": [
+          0.005490708,
+          0.005702667,
+          0.005942584
+        ]
+      },
+      "total": {
+        "min_s": 0.285277334,
+        "median_s": 0.288802583,
+        "samples_s": [
+          0.285277334,
+          0.292427208,
+          0.288802583
+        ]
+      },
+      "compute_s": 0.279786626,
+      "ns_per_op_min": 1.454422686102772,
+      "ns_per_op_median": 1.471646254686202,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 175759196,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.008978,
+        "median_s": 0.009145,
+        "samples_s": [
+          0.008978,
+          0.009145,
+          0.009246
+        ]
+      },
+      "total": {
+        "min_s": 0.290596,
+        "median_s": 0.290937333,
+        "samples_s": [
+          0.292189959,
+          0.290596,
+          0.290937333
+        ]
+      },
+      "compute_s": 0.28161800000000003,
+      "ns_per_op_min": 1.602294539399236,
+      "ns_per_op_median": 1.6032864249105918,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1438586,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.016600333,
+        "median_s": 0.016795666,
+        "samples_s": [
+          0.0170625,
+          0.016795666,
+          0.016600333
+        ]
+      },
+      "total": {
+        "min_s": 0.310747666,
+        "median_s": 0.310843583,
+        "samples_s": [
+          0.310843583,
+          0.310747666,
+          0.311279833
+        ]
+      },
+      "compute_s": 0.29414733299999996,
+      "ns_per_op_min": 204.4697591940975,
+      "ns_per_op_median": 204.4006524462215,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 98152235,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005206542,
+        "median_s": 0.005713209,
+        "samples_s": [
+          0.005801958,
+          0.005713209,
+          0.005206542
+        ]
+      },
+      "total": {
+        "min_s": 0.301253166,
+        "median_s": 0.301684708,
+        "samples_s": [
+          0.301684708,
+          0.301904458,
+          0.301253166
+        ]
+      },
+      "compute_s": 0.29604662400000004,
+      "ns_per_op_min": 3.0161985002175453,
+      "ns_per_op_median": 3.0154331075599043,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 11456227,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004110083,
+        "median_s": 0.004460458,
+        "samples_s": [
+          0.004110083,
+          0.004627125,
+          0.004460458
+        ]
+      },
+      "total": {
+        "min_s": 0.240392208,
+        "median_s": 0.24041525,
+        "samples_s": [
+          0.240392208,
+          0.24041525,
+          0.241801125
+        ]
+      },
+      "compute_s": 0.236282125,
+      "ns_per_op_min": 20.6247768135181,
+      "ns_per_op_median": 20.596204317529672,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 734318,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040649834,
+        "median_s": 0.041373167,
+        "samples_s": [
+          0.041373167,
+          0.040649834,
+          0.041589375
+        ]
+      },
+      "total": {
+        "min_s": 0.34281,
+        "median_s": 0.343527792,
+        "samples_s": [
+          0.343527792,
+          0.34503175,
+          0.34281
+        ]
+      },
+      "compute_s": 0.302160166,
+      "ns_per_op_min": 411.4840791046931,
+      "ns_per_op_median": 411.47653332752293,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 1031431,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.041586584,
+        "median_s": 0.041705,
+        "samples_s": [
+          0.041586584,
+          0.041705,
+          0.042545583
+        ]
+      },
+      "total": {
+        "min_s": 0.324561459,
+        "median_s": 0.325075667,
+        "samples_s": [
+          0.324561459,
+          0.325305292,
+          0.325075667
+        ]
+      },
+      "compute_s": 0.282974875,
+      "ns_per_op_min": 274.35172590313846,
+      "ns_per_op_median": 274.7354568555725,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 1001900,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.042371959,
+        "median_s": 0.043530916,
+        "samples_s": [
+          0.043739875,
+          0.043530916,
+          0.042371959
+        ]
+      },
+      "total": {
+        "min_s": 0.3384875,
+        "median_s": 0.338556,
+        "samples_s": [
+          0.3384875,
+          0.338556,
+          0.339655458
+        ]
+      },
+      "compute_s": 0.296115541,
+      "ns_per_op_min": 295.5539884219982,
+      "ns_per_op_median": 294.4655993612138,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 332108,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.033473666,
+        "median_s": 0.033901167,
+        "samples_s": [
+          0.033473666,
+          0.033901167,
+          0.034094458
+        ]
+      },
+      "total": {
+        "min_s": 0.331596708,
+        "median_s": 0.334502916,
+        "samples_s": [
+          0.331596708,
+          0.334593083,
+          0.334502916
+        ]
+      },
+      "compute_s": 0.298123042,
+      "ns_per_op_min": 897.6689570862491,
+      "ns_per_op_median": 905.1325141219121,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 3966877,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.045002459,
+        "median_s": 0.045116667,
+        "samples_s": [
+          0.0465895,
+          0.045002459,
+          0.045116667
+        ]
+      },
+      "total": {
+        "min_s": 0.27422725,
+        "median_s": 0.274813792,
+        "samples_s": [
+          0.276624583,
+          0.274813792,
+          0.27422725
+        ]
+      },
+      "compute_s": 0.22922479099999998,
+      "ns_per_op_min": 57.784698391202944,
+      "ns_per_op_median": 57.90376787583784,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 201170,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.018808375,
+        "median_s": 0.0188265,
+        "samples_s": [
+          0.018891333,
+          0.018808375,
+          0.0188265
+        ]
+      },
+      "total": {
+        "min_s": 0.317061541,
+        "median_s": 0.318238709,
+        "samples_s": [
+          0.318238709,
+          0.319122208,
+          0.317061541
+        ]
+      },
+      "compute_s": 0.298253166,
+      "ns_per_op_min": 1482.5926629219068,
+      "ns_per_op_median": 1488.3541730874385,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 120124698,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002858958,
+        "median_s": 0.002944958,
+        "samples_s": [
+          0.003017709,
+          0.002944958,
+          0.002858958
+        ]
+      },
+      "total": {
+        "min_s": 0.290714875,
+        "median_s": 0.291134625,
+        "samples_s": [
+          0.290714875,
+          0.291614125,
+          0.291134625
+        ]
+      },
+      "compute_s": 0.28785591699999996,
+      "ns_per_op_min": 2.396309183645148,
+      "ns_per_op_median": 2.399087546509378,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 75044080,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.066646708,
+        "median_s": 0.0672255,
+        "samples_s": [
+          0.066646708,
+          0.067261291,
+          0.0672255
+        ]
+      },
+      "total": {
+        "min_s": 0.318639834,
+        "median_s": 0.318926167,
+        "samples_s": [
+          0.318926167,
+          0.326145458,
+          0.318639834
+        ]
+      },
+      "compute_s": 0.251993126,
+      "ns_per_op_min": 3.3579347764673777,
+      "ns_per_op_median": 3.3540376136265513,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 6470,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.124292167,
+        "median_s": 0.124834459,
+        "samples_s": [
+          0.124834459,
+          0.125581458,
+          0.124292167
+        ]
+      },
+      "total": {
+        "min_s": 0.40008975,
+        "median_s": 0.400325958,
+        "samples_s": [
+          0.401482542,
+          0.400325958,
+          0.40008975
+        ]
+      },
+      "compute_s": 0.275797583,
+      "ns_per_op_min": 42627.13802163833,
+      "ns_per_op_median": 42579.82982998454,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 4509,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.282264291,
+        "median_s": 0.282863333,
+        "samples_s": [
+          0.282863333,
+          0.285033834,
+          0.282264291
+        ]
+      },
+      "total": {
+        "min_s": 0.55178975,
+        "median_s": 0.555028041,
+        "samples_s": [
+          0.556583875,
+          0.555028041,
+          0.55178975
+        ]
+      },
+      "compute_s": 0.26952545899999997,
+      "ns_per_op_min": 59774.996451541345,
+      "ns_per_op_median": 60360.32557108007,
+      "load_ms": 1.33,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 12340,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.195377958,
+        "median_s": 0.196771875,
+        "samples_s": [
+          0.196771875,
+          0.195377958,
+          0.196822875
+        ]
+      },
+      "total": {
+        "min_s": 0.394982166,
+        "median_s": 0.39680675,
+        "samples_s": [
+          0.39680675,
+          0.394982166,
+          0.3977995
+        ]
+      },
+      "compute_s": 0.19960420800000003,
+      "ns_per_op_min": 16175.381523500813,
+      "ns_per_op_median": 16210.281604538086,
+      "load_ms": 8.203,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 11079,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.121284167,
+        "median_s": 0.122778792,
+        "samples_s": [
+          0.121284167,
+          0.122778792,
+          0.123199375
+        ]
+      },
+      "total": {
+        "min_s": 0.355028083,
+        "median_s": 0.355067125,
+        "samples_s": [
+          0.355067125,
+          0.355028083,
+          0.35622425
+        ]
+      },
+      "compute_s": 0.233743916,
+      "ns_per_op_min": 21097.925444534707,
+      "ns_per_op_median": 20966.54328007943,
+      "load_ms": 4.539,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 30193,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.143970875,
+        "median_s": 0.144075542,
+        "samples_s": [
+          0.143970875,
+          0.14626025,
+          0.144075542
+        ]
+      },
+      "total": {
+        "min_s": 0.439534584,
+        "median_s": 0.439651833,
+        "samples_s": [
+          0.439651833,
+          0.439534584,
+          0.44018475
+        ]
+      },
+      "compute_s": 0.295563709,
+      "ns_per_op_min": 9789.146788990825,
+      "ns_per_op_median": 9789.563508097903,
+      "load_ms": 10.446,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 23,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.00995159943478261,
+        "median_s": 0.010010788,
+        "samples_s": [
+          0.010029001826086957,
+          0.00995159943478261,
+          0.010010788
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 18,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.01386367138888889,
+        "median_s": 0.013871905055555555,
+        "samples_s": [
+          0.01386367138888889,
+          0.013899546277777773,
+          0.013871905055555555
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 12,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.026491427166666665,
+        "median_s": 0.026532149333333335,
+        "samples_s": [
+          0.026532149333333335,
+          0.026491427166666665,
+          0.02666331583333333
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 3,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.10626077766666668,
+        "median_s": 0.10689409733333333,
+        "samples_s": [
+          0.10626077766666668,
+          0.10689409733333333,
+          0.107111
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 43,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.007002745209302325,
+        "median_s": 0.0070164680697674415,
+        "samples_s": [
+          0.007028890558139534,
+          0.007002745209302325,
+          0.0070164680697674415
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 3,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.14292576399999998,
+        "median_s": 0.14394901366666665,
+        "samples_s": [
+          0.14394901366666665,
+          0.14292576399999998,
+          0.144301958
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 2,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.1962348545,
+        "median_s": 0.196505604,
+        "samples_s": [
+          0.196710625,
+          0.1962348545,
+          0.196505604
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 2,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.2536130205,
+        "median_s": 0.254163458,
+        "samples_s": [
+          0.254163458,
+          0.2536130205,
+          0.25582981250000003
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.409286583,
+        "median_s": 0.41296275,
+        "samples_s": [
+          0.41587175,
+          0.409286583,
+          0.41296275
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.621801458,
+        "median_s": 0.622465375,
+        "samples_s": [
+          0.624537458,
+          0.621801458,
+          0.622465375
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 3,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.110540264,
+        "median_s": 0.11074156966666666,
+        "samples_s": [
+          0.11129847233333333,
+          0.11074156966666666,
+          0.110540264
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 21,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.004378029761904762,
+        "median_s": 0.004431740047619047,
+        "samples_s": [
+          0.004431740047619047,
+          0.004463884857142856,
+          0.004378029761904762
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 3,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.131355111,
+        "median_s": 0.131655264,
+        "samples_s": [
+          0.1320057503333333,
+          0.131355111,
+          0.131655264
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 1.335105667,
+        "median_s": 1.3392815,
+        "samples_s": [
+          1.348442333,
+          1.335105667,
+          1.3392815
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.499814375,
+        "median_s": 0.500944083,
+        "samples_s": [
+          0.500944083,
+          0.499814375,
+          0.50378725
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": 276.685,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.9090335,
+        "median_s": 0.914104583,
+        "samples_s": [
+          0.9090335,
+          0.927059334,
+          0.914104583
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": 476.614,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 2,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.23872716649999998,
+        "median_s": 0.24041825,
+        "samples_s": [
+          0.24041825,
+          0.251269021,
+          0.23872716649999998
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": 112.91,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 2,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.27404925,
+        "median_s": 0.274083729,
+        "samples_s": [
+          0.2743821875,
+          0.27404925,
+          0.274083729
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": 89.434,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 4,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.07901568775,
+        "median_s": 0.07909848975,
+        "samples_s": [
+          0.07982353125,
+          0.07901568775,
+          0.07909848975
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 4,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.0876037605,
+        "median_s": 0.087901677,
+        "samples_s": [
+          0.0876037605,
+          0.087901677,
+          0.087904229
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 9.694891083,
+        "median_s": 9.755692541,
+        "samples_s": [
+          9.755692541,
+          9.762394041,
+          9.694891083
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.644380167,
+        "median_s": 0.644762167,
+        "samples_s": [
+          0.644762167,
+          0.645386208,
+          0.644380167
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 1.086231708,
+        "median_s": 1.0926555,
+        "samples_s": [
+          1.0926555,
+          1.086231708,
+          1.094670666
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 19.165999292,
+        "median_s": 19.198562584,
+        "samples_s": [
+          19.198562584,
+          19.232224167,
+          19.165999292
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 9.217775584,
+        "median_s": 9.233897167,
+        "samples_s": [
+          9.217775584,
+          9.256753042,
+          9.233897167
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 14.023507875,
+        "median_s": 14.046123333,
+        "samples_s": [
+          14.046123333,
+          14.05459625,
+          14.023507875
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-python",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: dewasm-python runs this program correctly but at 56 s and 57 s per run (median, sqlite3_query and sqlite3_mod_query), costing roughly 9 minutes of the roughly 65 minute full suite; dewasm-python stays measured on the other app cases and the microbenchmarks"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 11.810521916999999,
+        "median_s": 11.8609145,
+        "samples_s": [
+          11.91904425,
+          11.810521916999999,
+          11.8609145
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-perl",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: dewasm-perl runs this program correctly but at 113 s and 115 s per run (median, sqlite3_query and sqlite3_mod_query), so one warmup plus the timed repetitions across both cases alone cost roughly 19 minutes of the roughly 65 minute full suite; dewasm-perl stays measured on the other app cases and the microbenchmarks"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 2,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.1722853335,
+        "median_s": 0.172827375,
+        "samples_s": [
+          0.1740025,
+          0.1722853335,
+          0.172827375
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 2.375157875,
+        "median_s": 2.391589833,
+        "samples_s": [
+          2.391589833,
+          2.432147334,
+          2.375157875
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-bash",
+      "status": "skipped",
+      "reason": "excluded: bash runs ~10000x slower than wasmtime on compute, so 100k SQL inserts do not finish in a practical time"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "pywasm-cpython",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: pywasm runs this program correctly (byte-identical to wasmtime under -batch) at ~17.9 ms/row: measured 358 s at 20k rows, so the 100k-row script needs roughly half an hour per sample"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "pywasm-pypy",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: pywasm runs this program correctly (byte-identical to wasmtime under -batch) at ~17.9 ms/row: measured 358 s at 20k rows, so the 100k-row script needs roughly half an hour per sample"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wardite",
+      "status": "skipped",
+      "reason": "excluded: wardite loads the sqlite3 shell but cannot execute a query, raising Wardite::EvalError (\"maybe empty or invalid stack\", convert.generated.rb:200) as soon as any SQL runs"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wardite-yjit",
+      "status": "skipped",
+      "reason": "excluded: wardite loads the sqlite3 shell but cannot execute a query, raising Wardite::EvalError (\"maybe empty or invalid stack\", convert.generated.rb:200) as soon as any SQL runs"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 4,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.08697107250000001,
+        "median_s": 0.08719192725000001,
+        "samples_s": [
+          0.08825186474999999,
+          0.08697107250000001,
+          0.08719192725000001
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 3,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.09048943066666666,
+        "median_s": 0.09081155566666665,
+        "samples_s": [
+          0.09048943066666666,
+          0.09081155566666665,
+          0.091683833
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 10.121184125,
+        "median_s": 10.127484667,
+        "samples_s": [
+          10.121184125,
+          10.140634125,
+          10.127484667
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.636385833,
+        "median_s": 0.63703275,
+        "samples_s": [
+          0.63703275,
+          0.641741459,
+          0.636385833
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 1.013879916,
+        "median_s": 1.1869065,
+        "samples_s": [
+          1.18892675,
+          1.1869065,
+          1.013879916
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 20.248825375,
+        "median_s": 20.252898708,
+        "samples_s": [
+          20.252898708,
+          20.248825375,
+          20.302217875
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 8.294143208,
+        "median_s": 8.320990291,
+        "samples_s": [
+          8.320990291,
+          8.321376625,
+          8.294143208
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 14.394576709,
+        "median_s": 14.489051209,
+        "samples_s": [
+          14.575222583,
+          14.394576709,
+          14.489051209
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-python",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: dewasm-python runs this program correctly but at 56 s and 57 s per run (median, sqlite3_query and sqlite3_mod_query), costing roughly 9 minutes of the roughly 65 minute full suite; dewasm-python stays measured on the other app cases and the microbenchmarks"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 12.7078215,
+        "median_s": 12.755644709,
+        "samples_s": [
+          12.920671792,
+          12.7078215,
+          12.755644709
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-perl",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: dewasm-perl runs this program correctly but at 113 s and 115 s per run (median, sqlite3_query and sqlite3_mod_query), so one warmup plus the timed repetitions across both cases alone cost roughly 19 minutes of the roughly 65 minute full suite; dewasm-perl stays measured on the other app cases and the microbenchmarks"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 3,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.12662879200000002,
+        "median_s": 0.12671266633333333,
+        "samples_s": [
+          0.1274852363333333,
+          0.12671266633333333,
+          0.12662879200000002
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 5.533769625,
+        "median_s": 5.556354625,
+        "samples_s": [
+          5.533769625,
+          5.5563575,
+          5.556354625
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-bash",
+      "status": "skipped",
+      "reason": "excluded: bash runs ~10000x slower than wasmtime on compute, so 100k SQL inserts do not finish in a practical time"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "pywasm-cpython",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: pywasm runs this program correctly (byte-identical to wasmtime under -batch) at ~17.9 ms/row: measured 358 s at 20k rows, so the 100k-row script needs roughly half an hour per sample"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "pywasm-pypy",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: pywasm runs this program correctly (byte-identical to wasmtime under -batch) at ~17.9 ms/row: measured 358 s at 20k rows, so the 100k-row script needs roughly half an hour per sample"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wardite",
+      "status": "skipped",
+      "reason": "excluded: wardite loads the sqlite3 shell but cannot execute a query, raising Wardite::EvalError (\"maybe empty or invalid stack\", convert.generated.rb:200) as soon as any SQL runs"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wardite-yjit",
+      "status": "skipped",
+      "reason": "excluded: wardite loads the sqlite3 shell but cannot execute a query, raising Wardite::EvalError (\"maybe empty or invalid stack\", convert.generated.rb:200) as soon as any SQL runs"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 7,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.044783881000000005,
+        "median_s": 0.044886214285714286,
+        "samples_s": [
+          0.044886214285714286,
+          0.044783881000000005,
+          0.04500218457142857
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 6,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.052195951666666664,
+        "median_s": 0.05222345833333334,
+        "samples_s": [
+          0.052195951666666664,
+          0.05247800016666667,
+          0.05222345833333334
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 2.255346625,
+        "median_s": 2.255555,
+        "samples_s": [
+          2.256948791,
+          2.255346625,
+          2.255555
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 4,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.08840379175,
+        "median_s": 0.08846870849999999,
+        "samples_s": [
+          0.08905212500000001,
+          0.08840379175,
+          0.08846870849999999
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wasm3",
+      "status": "skipped",
+      "reason": "excluded: wasm3's WASI does not provide fd_tell, which minigzip's stdio imports, so the module fails before running (\"missing imported function ('wasi_snapshot_preview1.fd_tell')\")"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 5.259463708,
+        "median_s": 5.267579459,
+        "samples_s": [
+          5.269595958,
+          5.267579459,
+          5.259463708
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 1.637880875,
+        "median_s": 1.6408797910000001,
+        "samples_s": [
+          1.637880875,
+          1.6408797910000001,
+          1.642995958
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 3.346681417,
+        "median_s": 3.348155583,
+        "samples_s": [
+          3.351646708,
+          3.348155583,
+          3.346681417
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 15.27405325,
+        "median_s": 15.385912417,
+        "samples_s": [
+          15.385912417,
+          15.27405325,
+          15.4286435
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 2.863532042,
+        "median_s": 2.866455292,
+        "samples_s": [
+          2.863532042,
+          2.866455292,
+          2.874952542
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 24.361654792,
+        "median_s": 24.364769208,
+        "samples_s": [
+          24.361654792,
+          24.4010865,
+          24.364769208
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 5,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.057990158199999996,
+        "median_s": 0.058216083200000004,
+        "samples_s": [
+          0.0583953416,
+          0.058216083200000004,
+          0.057990158199999996
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.54010175,
+        "median_s": 0.570634375,
+        "samples_s": [
+          0.572355125,
+          0.54010175,
+          0.570634375
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-bash",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: bash compresses this workload's generated text at ~0.61 ms/byte (measured 30.6 s on a 50000-byte prefix), so the full 1.2 MB input needs roughly 12 minutes per run"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "pywasm-cpython",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: pywasm under CPython compresses this workload's generated text at ~0.46 ms/byte (measured 9.2 s on a 20000-byte prefix), so the full 1.2 MB input needs roughly 9 minutes per run"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 81.182713125,
+        "median_s": 81.404914667,
+        "samples_s": [
+          81.182713125,
+          82.255231833,
+          81.404914667
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": 330.269,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wardite",
+      "status": "skipped",
+      "reason": "excluded: wardite computes the correct compressed output but its driver crashes on exit (IOError: closed stream at wardite.rb:40) because minigzip closes stdout itself and wardite's fd_close closes the real fd under it, so the driver's own trailing flush fails and the process exits 1"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wardite-yjit",
+      "status": "skipped",
+      "reason": "excluded: wardite computes the correct compressed output but its driver crashes on exit (IOError: closed stream at wardite.rb:40) because minigzip closes stdout itself and wardite's fd_close closes the real fd under it, so the driver's own trailing flush fails and the process exits 1"
+    }
+  ]
+}

--- a/records/README.md
+++ b/records/README.md
@@ -16,6 +16,7 @@ A run appends its line with a `TODO`; fill it in when committing the record.
 - `2026-08-21T02-38-15Z-speed.json`: TODO: describe the occasion.
 - `2026-08-21T03-50-04Z-speed.json`: TODO: describe the occasion.
 - `2026-08-22T06-26-23Z-speed.json`: the first record with the shortened suite and the eight new wat cases (#266); measured 29 minutes wall.
+- `2026-08-22T08-27-05Z-speed.json`: re-baseline after the f32 rounding change (#268).
 
 ## Size records
 


### PR DESCRIPTION
The full `cargo xtask record-speed` run after #268, with the rendered results.md and charts.

`wat/f32_alu` confirms the change in the published harness: dewasm-ruby 677 to 366 ns/op, dewasm-ruby-yjit 587 to 229, dewasm-python 849 to 545, dewasm-pypy 377 to 6, dewasm-perl unchanged (it keeps the pack path, decision 84).
`wat/f64_alu` and the other workloads are unchanged within noise for every dewasm and native runner; the only pairs moving more than 10% either way are pywasm-pypy ones, whose trace-based timing swings in both directions between runs independently of this change.
341 measured pairs, 37 declared exclusions, 30 minutes wall, on mains power.
