### PR TITLE
Access f32 memory directly, with a NaN fallback

### DIFF
--- a/runtime/python/units/memory/fwl.py
+++ b/runtime/python/units/memory/fwl.py
@@ -1,4 +1,10 @@
-# requires: memory/iwl, rt/f32_from_bits
-# Goes through the bit-exact helper to preserve NaN sign/payload.
+# requires: rt/f32_from_bits
+# Unpacking "<f" is bit-exact for every non-NaN value.
+# A NaN takes the bit path because the float-to-double conversion quietens it, and wasm's f32.load is bit-preserving.
 def fwl(self, a):
-    return Rt.f32_from_bits(self.iwl(a))
+    a &= 0xFFFFFFFF
+    self.check(a, 4)
+    r = struct.unpack("<f", self.data[a:a + 4])[0]
+    if r != r:
+        return Rt.f32_from_bits(int.from_bytes(self.data[a:a + 4], "little"))
+    return r

--- a/runtime/python/units/memory/fwla.py
+++ b/runtime/python/units/memory/fwla.py
@@ -1,4 +1,10 @@
-# requires: memory/iwla, rt/f32_from_bits
-# Goes through the bit-exact helper to preserve NaN sign/payload.
+# requires: rt/f32_from_bits
+# Unpacking "<f" is bit-exact for every non-NaN value.
+# A NaN takes the bit path because the float-to-double conversion quietens it, and wasm's f32.load is bit-preserving.
 def fwla(self, a, b):
-    return Rt.f32_from_bits(self.iwla(a, b))
+    a = (a + b) & 0xFFFFFFFF
+    self.check(a, 4)
+    r = struct.unpack("<f", self.data[a:a + 4])[0]
+    if r != r:
+        return Rt.f32_from_bits(int.from_bytes(self.data[a:a + 4], "little"))
+    return r

--- a/runtime/python/units/memory/fwlo.py
+++ b/runtime/python/units/memory/fwlo.py
@@ -1,4 +1,10 @@
-# requires: memory/iwlo, rt/f32_from_bits
-# Goes through the bit-exact helper to preserve NaN sign/payload.
+# requires: rt/f32_from_bits
+# Unpacking "<f" is bit-exact for every non-NaN value.
+# A NaN takes the bit path because the float-to-double conversion quietens it, and wasm's f32.load is bit-preserving.
 def fwlo(self, a, off):
-    return Rt.f32_from_bits(self.iwlo(a, off))
+    a = (a & 0xFFFFFFFF) + off
+    self.check(a, 4)
+    r = struct.unpack("<f", self.data[a:a + 4])[0]
+    if r != r:
+        return Rt.f32_from_bits(int.from_bytes(self.data[a:a + 4], "little"))
+    return r

--- a/runtime/python/units/memory/fws.py
+++ b/runtime/python/units/memory/fws.py
@@ -1,3 +1,10 @@
 # requires: memory/iws, rt/f32_bits
+# Packing "<f" is bit-exact for every non-NaN value.
+# A NaN takes the bit path because the double-to-float conversion quietens it, and wasm's f32.store is bit-preserving.
 def fws(self, a, v):
-    self.iws(a, Rt.f32_bits(v))
+    if v != v:
+        self.iws(a, Rt.f32_bits(v))
+        return
+    a &= 0xFFFFFFFF
+    self.check(a, 4)
+    self.data[a:a + 4] = struct.pack("<f", v)

--- a/runtime/python/units/memory/fwsa.py
+++ b/runtime/python/units/memory/fwsa.py
@@ -1,3 +1,10 @@
 # requires: memory/iwsa, rt/f32_bits
+# Packing "<f" is bit-exact for every non-NaN value.
+# A NaN takes the bit path because the double-to-float conversion quietens it, and wasm's f32.store is bit-preserving.
 def fwsa(self, a, b, v):
-    self.iwsa(a, b, Rt.f32_bits(v))
+    if v != v:
+        self.iwsa(a, b, Rt.f32_bits(v))
+        return
+    a = (a + b) & 0xFFFFFFFF
+    self.check(a, 4)
+    self.data[a:a + 4] = struct.pack("<f", v)

--- a/runtime/python/units/memory/fwso.py
+++ b/runtime/python/units/memory/fwso.py
@@ -1,3 +1,10 @@
 # requires: memory/iwso, rt/f32_bits
+# Packing "<f" is bit-exact for every non-NaN value.
+# A NaN takes the bit path because the double-to-float conversion quietens it, and wasm's f32.store is bit-preserving.
 def fwso(self, a, off, v):
-    self.iwso(a, off, Rt.f32_bits(v))
+    if v != v:
+        self.iwso(a, off, Rt.f32_bits(v))
+        return
+    a = (a & 0xFFFFFFFF) + off
+    self.check(a, 4)
+    self.data[a:a + 4] = struct.pack("<f", v)

--- a/runtime/ruby/units/memory/fwl.rb
+++ b/runtime/ruby/units/memory/fwl.rb
@@ -1,3 +1,4 @@
-# requires: memory/iwl, rt/f32_from_bits
-# The bit path preserves a NaN's sign and payload.
-def fwl(a) = Rt.f32_from_bits(iwl(a))
+# requires: rt/f32_from_bits, rt/trap
+# Reading :f32 is bit-exact for every non-NaN value.
+# A NaN takes the bit path because the float-to-double conversion quietens it, and wasm's f32.load is bit-preserving.
+def fwl(a) = (a &= M32; Rt.trap("out of bounds memory access") if a + 4 > @size; r = @buffer.get_value(:f32, a); r.nan? ? Rt.f32_from_bits(@buffer.get_value(:u32, a)) : r)

--- a/runtime/ruby/units/memory/fwla.rb
+++ b/runtime/ruby/units/memory/fwla.rb
@@ -1,3 +1,4 @@
-# requires: memory/iwla, rt/f32_from_bits
-# The bit path preserves a NaN's sign and payload.
-def fwla(a, b) = Rt.f32_from_bits(iwla(a, b))
+# requires: rt/f32_from_bits, rt/trap
+# Reading :f32 is bit-exact for every non-NaN value.
+# A NaN takes the bit path because the float-to-double conversion quietens it, and wasm's f32.load is bit-preserving.
+def fwla(a, b) = (a = (a + b) & M32; Rt.trap("out of bounds memory access") if a + 4 > @size; r = @buffer.get_value(:f32, a); r.nan? ? Rt.f32_from_bits(@buffer.get_value(:u32, a)) : r)

--- a/runtime/ruby/units/memory/fwlo.rb
+++ b/runtime/ruby/units/memory/fwlo.rb
@@ -1,3 +1,4 @@
-# requires: memory/iwlo, rt/f32_from_bits
-# The bit path preserves a NaN's sign and payload.
-def fwlo(a, off) = Rt.f32_from_bits(iwlo(a, off))
+# requires: rt/f32_from_bits, rt/trap
+# Reading :f32 is bit-exact for every non-NaN value.
+# A NaN takes the bit path because the float-to-double conversion quietens it, and wasm's f32.load is bit-preserving.
+def fwlo(a, off) = (a = (a & M32) + off; Rt.trap("out of bounds memory access") if a + 4 > @size; r = @buffer.get_value(:f32, a); r.nan? ? Rt.f32_from_bits(@buffer.get_value(:u32, a)) : r)

--- a/runtime/ruby/units/memory/fws.rb
+++ b/runtime/ruby/units/memory/fws.rb
@@ -1,2 +1,4 @@
-# requires: memory/iws, rt/f32_bits
-def fws(a, v) = iws(a, Rt.f32_bits(v))
+# requires: memory/iws, rt/f32_bits, rt/trap
+# Writing :f32 is bit-exact for every non-NaN value.
+# A NaN takes the bit path because the double-to-float conversion quietens it, and wasm's f32.store is bit-preserving.
+def fws(a, v) = v.nan? ? iws(a, Rt.f32_bits(v)) : (a &= M32; Rt.trap("out of bounds memory access") if a + 4 > @size; @buffer.set_value(:f32, a, v))

--- a/runtime/ruby/units/memory/fwsa.rb
+++ b/runtime/ruby/units/memory/fwsa.rb
@@ -1,2 +1,4 @@
-# requires: memory/iwsa, rt/f32_bits
-def fwsa(a, b, v) = iwsa(a, b, Rt.f32_bits(v))
+# requires: memory/iwsa, rt/f32_bits, rt/trap
+# Writing :f32 is bit-exact for every non-NaN value.
+# A NaN takes the bit path because the double-to-float conversion quietens it, and wasm's f32.store is bit-preserving.
+def fwsa(a, b, v) = v.nan? ? iwsa(a, b, Rt.f32_bits(v)) : (a = (a + b) & M32; Rt.trap("out of bounds memory access") if a + 4 > @size; @buffer.set_value(:f32, a, v))

--- a/runtime/ruby/units/memory/fwso.rb
+++ b/runtime/ruby/units/memory/fwso.rb
@@ -1,2 +1,4 @@
-# requires: memory/iwso, rt/f32_bits
-def fwso(a, off, v) = iwso(a, off, Rt.f32_bits(v))
+# requires: memory/iwso, rt/f32_bits, rt/trap
+# Writing :f32 is bit-exact for every non-NaN value.
+# A NaN takes the bit path because the double-to-float conversion quietens it, and wasm's f32.store is bit-preserving.
+def fwso(a, off, v) = v.nan? ? iwso(a, off, Rt.f32_bits(v)) : (a = (a & M32) + off; Rt.trap("out of bounds memory access") if a + 4 > @size; @buffer.set_value(:f32, a, v))


### PR DESCRIPTION
The six f32 memory accessors read a u32 and convert (`Rt.f32_from_bits(iwl(a))`), and store through `Rt.f32_bits`, because the float/double conversion the buffer performs quietens a signaling NaN while wasm's `f32.load` and `f32.store` are bit-preserving.
The f64 accessors have no width conversion and already read and write their slot directly.

Only a NaN needs the bit path.
Every other f32 value converts to double and back exactly, so the accessors now read and write `:f32` (Ruby) or `"<f"` (Python) directly and fall back to the bit path only when the value is a NaN.
That removes one primitive call, one runtime call, and the pack allocations behind them from every non-NaN access, with no new mutable state.

## The invariant

Each unit's rationale comment now states it in place: direct f32 access is bit-exact for every non-NaN value, and a NaN takes the bit path because the float/double conversion would quieten it.
A load's fallback reuses the bounds check it has already made, so reading the f32 slot and then the u32 slot costs one check.
The `# requires:` headers follow: the loads no longer call an `iwl`-family method and now trap directly (Ruby gains `rt/trap`, Python reaches `self.check` through the implicit class prelude), while the stores keep their `iws`-family and `f32_bits` requires for the NaN branch.

## Measurements

sghtmltopdf's receipt render (168k f32 loads and 99k stores per render), three interleaved runs per side, ISeq cache warm:

| | before | after |
| --- | --- | --- |
| Ruby wall | 1.495 / 1.529 / 1.492 s | 1.454 / 1.450 / 1.450 s |
| Ruby `GC.stat[:total_allocated_objects]` | 1.08M | 0.34M |
| Python wall | 4.199 / 4.203 / 4.227 s | 4.150 / 4.155 / 4.116 s |

A micro benchmark whose inner loop is nothing but f32 traffic (all six accessors, 512 source values spread over the bit space so about 1.5% are NaNs, plus explicit quiet, signaling, and negative NaNs with payloads, both zeros, both infinities, and both subnormals), three interleaved runs per side:

| | before | after |
| --- | --- | --- |
| Ruby wall | 1.073 / 1.072 / 1.072 s | 0.607 / 0.619 / 0.611 s |
| Ruby allocations | 15,622,148 | 6,560,121 |
| Python wall | 2.003 / 2.020 / 2.028 s | 1.317 / 1.344 / 1.318 s |

Output is byte-identical throughout: the micro benchmark dumps 12 KiB of raw memory and the before, after, and wasmtime dumps agree bit for bit, NaN payloads included; the receipt PDFs agree after normalizing the `/CreationDate` string, both within each backend and between Ruby and Python.

## Checks

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` all pass.
The float memory filters pass for both backends before and after: `float_memory`, `float_memory0`, and `float_memory64` (3 of 3 each, Python run with `--features slow_test` so none are skipped), along with the `f32` (9), `memory` (32), `conversions` (2), and `float_exprs` (3) filters.

The Perl backend keeps its current shape.

Closes #270
