### PR TITLE
Memoize the fdstat filetype per fd in the generated runtimes

### DIFF
--- a/crates/dewasm-backend-go/units/wasi/_class.go
+++ b/crates/dewasm-backend-go/units/wasi/_class.go
@@ -76,10 +76,14 @@ const (
 
 // Per-fd rights/flags carried alongside the fd-table entry.
 // Every live fd (stdio, preopen, path_open'd) has one; fd_renumber moves it.
+// filetype memoizes what fd_fdstat_get reports, valid once filetypeKnown is set.
+// An open descriptor's filetype cannot change while it is open, and this meta travels with its fd-table entry (fd_renumber moves both, and fds are never reused after close), so the memoized answer cannot outlive the descriptor it describes.
 type wasiFdMeta struct {
-    base       uint64
-    inheriting uint64
-    fdflags    uint16
+    base          uint64
+    inheriting    uint64
+    fdflags       uint16
+    filetype      uint32
+    filetypeKnown bool
 }
 
 // A directory descriptor: either a preopen (preopenName set to the guest-visible path passed in preopens) or a directory the guest opened itself via path_open (preopenName nil). entries is the fd_readdir listing cache, filled lazily; loaded guards the one-shot snapshot.

--- a/crates/dewasm-backend-go/units/wasi/fd_fdstat_get.go
+++ b/crates/dewasm-backend-go/units/wasi/fd_fdstat_get.go
@@ -4,21 +4,31 @@ func (w *WASI) wasi_fd_fdstat_get(fd, outPtr uint32) uint32 {
     if !present {
         return wasiBadf
     }
-    var filetype uint32 = 4 // regular file
-    if _, ok := entry.(*wasiDir); ok {
-        filetype = 3 // directory
-    } else if f, ok := entry.(*os.File); ok {
-        if fi, err := f.Stat(); err == nil && fi.Mode()&os.ModeCharDevice != 0 {
-            filetype = 2 // character device (tty)
-        }
-    }
     // fdstat: fs_filetype (u8) + pad + fs_flags (u16) + pad + fs_rights_base
     // (u64) + fs_rights_inheriting (u64) = 24 bytes.
     // Rights and fdflags come from the stored per-fd meta; a missing entry (should not happen for a live fd) reports the permissive all-ones.
     base, inheriting := ^uint64(0), ^uint64(0)
     var fdflags uint16
-    if m, ok := w.meta[fd]; ok {
+    m, hasMeta := w.meta[fd]
+    if hasMeta {
         base, inheriting, fdflags = m.base, m.inheriting, m.fdflags
+    }
+    // The Stat behind the character-device answer is a host syscall, and an open descriptor's filetype cannot change while it is open, so it runs at most once per fd (see wasiFdMeta): a guest polling isatty in a loop would otherwise pay one syscall per call.
+    var filetype uint32
+    if hasMeta && m.filetypeKnown {
+        filetype = m.filetype
+    } else {
+        filetype = 4 // regular file
+        if _, ok := entry.(*wasiDir); ok {
+            filetype = 3 // directory
+        } else if f, ok := entry.(*os.File); ok {
+            if fi, err := f.Stat(); err == nil && fi.Mode()&os.ModeCharDevice != 0 {
+                filetype = 2 // character device (tty)
+            }
+        }
+        if hasMeta {
+            m.filetype, m.filetypeKnown = filetype, true
+        }
     }
     w.memory.fill(uint64(outPtr), 0, 24)
     w.memory.i32_store8(uint64(outPtr), filetype)

--- a/crates/dewasm-backend-perl/units/wasi/_package.pl
+++ b/crates/dewasm-backend-perl/units/wasi/_package.pl
@@ -74,6 +74,11 @@ use constant DIR_RIGHTS_INHERITING => DIR_RIGHTS_BASE | FILE_RIGHTS_BASE;
 # * dir:    { dir => 1, path => realpath'd host path, preopen => guest
 # name (undef when the guest opened it itself via path_open),
 # entries => lazily built fd_readdir cache }.
+# Any shape may also carry `filetype`, what fd_fdstat_get reports, filled in
+# on its first query.
+# An open descriptor's filetype cannot change while it is open, and the entry
+# is the descriptor (fd_renumber moves it, fd_close drops it), so the memoized
+# answer cannot outlive the descriptor it describes.
 sub new {
     my ($class, %opts) = @_;
     my $env = $opts{env} // {};

--- a/crates/dewasm-backend-perl/units/wasi/fd_fdstat_get.pl
+++ b/crates/dewasm-backend-perl/units/wasi/fd_fdstat_get.pl
@@ -3,7 +3,8 @@ sub wasi_fd_fdstat_get {
     my ($self, $fd, $out_ptr) = @_;
     my $e = $self->{fds}{$fd};
     return ERRNO_BADF unless defined $e;
-    my $filetype = $e->{dir} ? 3 : (-t $e->{fh} ? 2 : 4);  # directory / char device / regular file
+    # `-t` is a host syscall, and an open descriptor's filetype cannot change while it is open, so it runs at most once per fd (the answer is memoized in the fd-table entry, which fd_renumber moves and fd_close drops): a guest polling isatty in a loop would otherwise pay one syscall per call.
+    my $filetype = $e->{filetype} //= $e->{dir} ? 3 : (-t $e->{fh} ? 2 : 4);  # directory / char device / regular file
     my ($base, $inheriting, $fdflags) = @{$self->{meta}{$fd}};
     # fdstat: fs_filetype (u8) + pad + fs_flags (u16) + pad + fs_rights_base
     # (u64) + fs_rights_inheriting (u64) = 24 bytes.

--- a/crates/dewasm-backend-python/units/wasi/_class.py
+++ b/crates/dewasm-backend-python/units/wasi/_class.py
@@ -73,11 +73,13 @@ def __init__(self, args=None, env=None, preopens=None):
     self.args = [a if isinstance(a, bytes) else str(a).encode("utf-8") for a in (args or [])]
     self.env = [("%s=%s" % (k, v)).encode("utf-8") for k, v in (env or {}).items()]
     self.fds = {0: sys.stdin.buffer, 1: sys.stdout.buffer, 2: sys.stderr.buffer}
-    # Parallel per-fd capability map: fd -> [base, inheriting, fdflags]. stdio gets the full file-right set (a stream can read/write/etc.); preopens get the directory base and the directory-plus-file inheriting set.
+    # Parallel per-fd capability map: fd -> [base, inheriting, fdflags, filetype]. stdio gets the full file-right set (a stream can read/write/etc.); preopens get the directory base and the directory-plus-file inheriting set.
+    # `filetype` is what fd_fdstat_get reports, filled in on its first query and None until then.
+    # An open descriptor's filetype cannot change while it is open, and this entry travels with its fd-table entry (fd_renumber moves both, and fds are never revived after close), so the memoized answer cannot outlive the descriptor it describes.
     self.fd_meta = {
-        0: [self.FILE_RIGHTS_BASE, 0, 0],
-        1: [self.FILE_RIGHTS_BASE, 0, 0],
-        2: [self.FILE_RIGHTS_BASE, 0, 0],
+        0: [self.FILE_RIGHTS_BASE, 0, 0, None],
+        1: [self.FILE_RIGHTS_BASE, 0, 0, None],
+        2: [self.FILE_RIGHTS_BASE, 0, 0, None],
     }
     # The stdio special-cases (SPIPE on seek/tell/pread/pwrite, no close) key on the objects captured here, in lockstep with the fd table.
     self.std_ios = (sys.stdin.buffer, sys.stdout.buffer, sys.stderr.buffer)
@@ -91,7 +93,7 @@ def __init__(self, args=None, env=None, preopens=None):
             raise ValueError("preopen %r => %r: does not exist" % (guest, host))
         name = guest if isinstance(guest, bytes) else str(guest).encode("utf-8")
         self.fds[next_fd] = self.WasiDir(real, name, None)
-        self.fd_meta[next_fd] = [self.DIR_RIGHTS_BASE, self.DIR_RIGHTS_INHERITING, 0]
+        self.fd_meta[next_fd] = [self.DIR_RIGHTS_BASE, self.DIR_RIGHTS_INHERITING, 0, None]
         next_fd += 1
     self.next_fd = next_fd
 

--- a/crates/dewasm-backend-python/units/wasi/fd_fdstat_get.py
+++ b/crates/dewasm-backend-python/units/wasi/fd_fdstat_get.py
@@ -3,15 +3,20 @@ def wasi_fd_fdstat_get(self, fd, out_ptr):
     io = self.fds.get(fd)
     if io is None:
         return self.ERRNO_BADF
-    if isinstance(io, self.WasiDir):
-        filetype = 3  # directory
-    else:
-        try:
-            is_tty = io.isatty()
-        except (AttributeError, OSError, ValueError):
-            is_tty = False
-        filetype = 2 if is_tty else 4  # char device / regular file
-    base, inheriting, fdflags = self.fd_meta[fd]
+    meta = self.fd_meta[fd]
+    base, inheriting, fdflags = meta[0], meta[1], meta[2]
+    # isatty() is a host syscall, and an open descriptor's filetype cannot change while it is open, so it runs at most once per fd (see the fourth meta slot in wasi/_class): a guest polling isatty in a loop would otherwise pay one syscall per call.
+    filetype = meta[3]
+    if filetype is None:
+        if isinstance(io, self.WasiDir):
+            filetype = 3  # directory
+        else:
+            try:
+                is_tty = io.isatty()
+            except (AttributeError, OSError, ValueError):
+                is_tty = False
+            filetype = 2 if is_tty else 4  # char device / regular file
+        meta[3] = filetype
     # fdstat: fs_filetype (u8) + pad + fs_flags (u16) + pad + fs_rights_base
     # (u64) + fs_rights_inheriting (u64) = 24 bytes.
     self.memory.fill(out_ptr, 0, 24)

--- a/crates/dewasm-backend-python/units/wasi/path_open.py
+++ b/crates/dewasm-backend-python/units/wasi/path_open.py
@@ -56,7 +56,7 @@ def wasi_path_open(self, dirfd, dirflags, path_ptr, path_len, oflags, fs_rights_
             inheriting = fs_rights_inheriting & self.fd_meta[dirfd][1] & self.FILE_RIGHTS_BASE
     except OSError as e:
         return self.fs_errno(e)
-    self.fd_meta[self.next_fd] = [base, inheriting, fdflags & 0xFFFF]
+    self.fd_meta[self.next_fd] = [base, inheriting, fdflags & 0xFFFF, None]
     self.memory.iws(opened_fd_ptr, self.next_fd)
     self.next_fd += 1
     return self.ERRNO_SUCCESS

--- a/crates/dewasm-backend-ruby/units/wasi/_class.rb
+++ b/crates/dewasm-backend-ruby/units/wasi/_class.rb
@@ -21,11 +21,14 @@ def initialize(args: [], env: {}, preopens: {})
   @args = args.map(&:to_s)
   @env = env.map { |k, v| "#{k}=#{v}" }
   @fds = { 0 => $stdin, 1 => $stdout, 2 => $stderr }
-  # Per-fd capability metadata: fd => [rights_base, rights_inheriting, fdflags]. stdio is seeded all-rights (it is never rights-tested and must stay readable/writable); preopens likewise, so a real embedder keeps unrestricted access and path_open derives the narrowed rights from them.
+  # Per-fd capability metadata: fd => [rights_base, rights_inheriting, fdflags, filetype].
+  # `filetype` is what fd_fdstat_get reports, filled in on its first query and nil until then.
+  # An open descriptor's filetype cannot change while it is open, and this metadata travels with its fd-table entry (fd_renumber moves both, and fds are never revived after close), so the memoized answer cannot outlive the descriptor it describes.
+  # stdio is seeded all-rights (it is never rights-tested and must stay readable/writable); preopens likewise, so a real embedder keeps unrestricted access and path_open derives the narrowed rights from them.
   @fd_meta = {
-    0 => [Rt::M64, Rt::M64, 0],
-    1 => [Rt::M64, Rt::M64, 0],
-    2 => [Rt::M64, Rt::M64, 0],
+    0 => [Rt::M64, Rt::M64, 0, nil],
+    1 => [Rt::M64, Rt::M64, 0, nil],
+    2 => [Rt::M64, Rt::M64, 0, nil],
   }
   # The stdio special-cases (SPIPE on seek/tell/pread/pwrite, no close)
   # key on the objects captured here, in lockstep with the fd table, not on whatever the globals point at when a syscall runs.
@@ -42,7 +45,7 @@ def initialize(args: [], env: {}, preopens: {})
     # A preopen is a directory, so its base is the directory-rights set
     # (no FD_WRITE etc.); its inheriting rights carry the full file-rights set so guest-opened files under it get real read/write capability.
     # root_directory() in the testsuite reopens the preopen with exactly these, so seeding all-of-M64 here would wrongly hand a directory the write right and make that reopen fail EISDIR.
-    @fd_meta[next_fd] = [DIR_BASE_RIGHTS, DIR_INHERITING_RIGHTS, 0]
+    @fd_meta[next_fd] = [DIR_BASE_RIGHTS, DIR_INHERITING_RIGHTS, 0, nil]
     next_fd += 1
   end
   @next_fd = next_fd

--- a/crates/dewasm-backend-ruby/units/wasi/fd_fdstat_get.rb
+++ b/crates/dewasm-backend-ruby/units/wasi/fd_fdstat_get.rb
@@ -2,13 +2,19 @@
 def wasi_fd_fdstat_get(fd, out_ptr)
   io = @fds[fd]
   return ERRNO_BADF unless io
-  filetype =
-    if io.is_a?(WasiDir)
-      3 # directory
-    else
-      io.respond_to?(:tty?) && io.tty? ? 2 : 4 # char device / regular file
-    end
-  base, inheriting, fdflags = @fd_meta[fd] || [Rt::M64, Rt::M64, 0]
+  meta = @fd_meta[fd]
+  base, inheriting, fdflags = meta || [Rt::M64, Rt::M64, 0]
+  # `tty?` is a host syscall, and an open descriptor's filetype cannot change while it is open, so it runs at most once per fd (see the fourth meta slot in wasi/_class): a guest polling isatty in a loop would otherwise pay one syscall per call.
+  filetype = meta && meta[3]
+  unless filetype
+    filetype =
+      if io.is_a?(WasiDir)
+        3 # directory
+      else
+        io.respond_to?(:tty?) && io.tty? ? 2 : 4 # char device / regular file
+      end
+    meta[3] = filetype if meta
+  end
   @memory.fill(out_ptr, 0, 24)
   @memory.iwsb(out_ptr, filetype)
   @memory.iwsh(out_ptr + 2, fdflags)

--- a/crates/dewasm-backend-ruby/units/wasi/path_open.rb
+++ b/crates/dewasm-backend-ruby/units/wasi/path_open.rb
@@ -46,6 +46,7 @@ def wasi_path_open(dirfd, dirflags, path_ptr, path_len, oflags, base, inheriting
       base & parent_inheriting & DIR_BASE_RIGHTS,
       inheriting & parent_inheriting & DIR_INHERITING_RIGHTS,
       0,
+      nil,
     ]
   else
     granted = base & parent_inheriting & FILE_BASE_RIGHTS
@@ -65,7 +66,7 @@ def wasi_path_open(dirfd, dirflags, path_ptr, path_len, oflags, base, inheriting
     io.binmode
     @fds[@next_fd] = io
     # APPEND is honored by fd_write (seek-to-end) rather than O_APPEND, so fd_fdstat_set_flags can toggle it; store the whole fdflags word.
-    @fd_meta[@next_fd] = [granted, inheriting & parent_inheriting & FILE_BASE_RIGHTS, fdflags & 0x1f]
+    @fd_meta[@next_fd] = [granted, inheriting & parent_inheriting & FILE_BASE_RIGHTS, fdflags & 0x1f, nil]
   end
   @memory.iws(opened_fd_ptr, @next_fd)
   @next_fd += 1

--- a/crates/dewasm-backend-ruby/units/wasi/rights.rb
+++ b/crates/dewasm-backend-ruby/units/wasi/rights.rb
@@ -1,7 +1,7 @@
 # WASI p1 rights bits and the per-filetype masks used to grant and enforce capabilities.
 # Kept in its own unit so every rights-aware syscall can require it without pulling extra filesystem code.
 # The `@fd_meta` map
-# (fd => [base, inheriting, fdflags]) that these operate on is seeded in wasi/_class.
+# (fd => [base, inheriting, fdflags, filetype]) that these operate on is seeded in wasi/_class.
 RIGHT_FD_DATASYNC = 1 << 0
 RIGHT_FD_READ = 1 << 1
 RIGHT_FD_SEEK = 1 << 2


### PR DESCRIPTION
## What

The generated `fd_fdstat_get` in the Go, Ruby, Python and Perl runtimes queried tty-ness (a real fstat or isatty syscall) on every call to pick the reported filetype.
The filetype is now memoized per descriptor, so the query runs at most once per fd.
Bash is deliberately left as is, and Java has no per-fd query to cache; details below.

## Why

Guests that call C `isatty` repeatedly pay one host syscall per call.
Measured through go-mruby-pure (mruby 4.0.0 converted by the Go backend), a 300k-`print` Ruby loop runs 1.69x faster with the cache (756.8 ms to 448.1 ms, system time 383 ms to 143 ms), stdout byte-identical.
The same per-call pattern existed in the Ruby, Python and Perl units; there the syscalls also disappear (mruby 3.4.0 on the Ruby backend: system time 198 ms to 150 ms on a 100k-print script, one `fd_fdstat_get` per print confirmed by instrumentation), though the end-to-end effect is small because interpretation dominates in those backends.

The cache is sound because an open descriptor's filetype cannot change while it is open; the invariant is stated at each cache site.
Per backend, the cache lives where the descriptor bookkeeping already moves through `fd_renumber`: `wasiFdMeta` (Go), a fourth `fd_meta` slot (Ruby, Python), the fd-table entry hashref itself (Perl).
Memoization is lazy so guests that never ask pay no startup queries.

## Not changed

- **Bash**: `[[ -t $__fd ]]` is a builtin costing 0.35 us/call while the same function's `mem_fill` costs 94 us/call, so a cache would buy under 0.5% of the call and would need a new parallel array threaded through `fd_renumber.sh` and `fd_close.sh`; skipped with the measurement recorded in the commit body.
- **Java**: answers from the process-global, JDK-memoized `System.console()`, so there is no per-fd query to cache. (Separately noted for a follow-up: on JDK 22+ `System.console()` is non-null under redirected I/O, so its filetype answer looks wrong there independently of this change.)

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all pass (each backend's spec harness, e2e, convert, wasi-testsuite, units lint).
- `qjs_repl_pty` (the slow_test case that requires fd 0 to report a character device on a real pty, transcript compared byte-for-byte against wasmtime) run explicitly for ruby, python and perl: all pass.
- go-mruby-pure reconverted with the patched converter: generated diff is exactly the unit change; `go test ./...` and `go test -race ./...` pass; fib / so_lists / ao_render stdout unchanged.

## Review notes

- Go: `fd_fdstat_get` was a pure read and now writes the memo into `w.meta[fd]`; the `WASI` struct was already unsynchronized, and the race detector run above covers the library's concurrent use.
- Ruby/Python: `fd_close` leaves the meta entry behind (pre-existing); the memo cannot be revived at a stale number because fd numbers grow monotonically and `fd_renumber` refuses an unopened destination.
- Python: an `isatty()` that raises now caches filetype 4 instead of re-raising the same answer per call.
- A `Stat` error on the Go side is likewise cached as filetype 4 instead of retried.