### PR TITLE
Add converted-wasm3 runners to the speed benchmark suite

### DIFF
--- a/agents/decisions/86-converted-interpreter-benchmark-runner.md
+++ b/agents/decisions/86-converted-interpreter-benchmark-runner.md
@@ -1,6 +1,6 @@
 # Decision 86: wasm3 as the Converted-Interpreter Benchmark Runner
 
-Status: **Accepted, 2026-08-29.** The speed suite carries four `wasm3-*` runners (`Kind::ConvertedInterpreter` in [`crates/xtask/src/bench/runner.rs`](../../crates/xtask/src/bench/runner.rs)): the meta-WASI wasm3 v0.5.0 build from the app cache, converted standalone by the Ruby and Python backends, interpreting each workload on ruby, ruby+yjit, cpython, and pypy.
+Status: **Accepted, 2026-08-29.** The speed suite carries four `wasm3-*` runners (`Kind::ConvertedInterpreter` in [`crates/xtask/src/bench/runner.rs`](../../crates/xtask/src/bench/runner.rs)): the meta-WASI wasm3 build from the app cache (pinned v0.9.0), converted standalone by the Ruby and Python backends, interpreting each workload on ruby, ruby+yjit, cpython, and pypy.
 
 ## Context
 
@@ -10,7 +10,7 @@ A wasm interpreter that is itself dewasm output closes the category gap: it also
 
 ## Decision
 
-The interpreter the suite converts is wasm3 v0.5.0, and the criterion is the interpreter's own native speed: conversion multiplies the interpreter's cost by a roughly constant factor (about 270x on ruby+yjit for interpreter-shaped code, measured 2026-08-29), so only an interpreter that is fast natively keeps the converted stack ahead of the hand-written interpreters.
+The interpreter the suite converts is wasm3 (pinned v0.9.0; the comparative measurements below were taken on the v0.5.0 build, with the v0.9.0 build measured at parity the same day), and the criterion is the interpreter's own native speed: conversion multiplies the interpreter's cost by a roughly constant factor (about 270x on ruby+yjit for interpreter-shaped code, measured 2026-08-29), so only an interpreter that is fast natively keeps the converted stack ahead of the hand-written interpreters.
 wasm3 interprets at roughly 6x wasmtime natively and the converted build won every same-language pairing against wardite and pywasm (1.3x to 3.4x on `wat/i32_alu` and `wat/mem_rw`, 2026-08-29); toywasm sits near 300x natively and the converted build lost the same pairings by 5x to 14x, measured the same day with the same harness discipline.
 
 ## Rejected alternatives

--- a/agents/decisions/86-converted-interpreter-benchmark-runner.md
+++ b/agents/decisions/86-converted-interpreter-benchmark-runner.md
@@ -1,0 +1,30 @@
+# Decision 86: wasm3 as the Converted-Interpreter Benchmark Runner
+
+Status: **Accepted, 2026-08-29.** The speed suite carries four `wasm3-*` runners (`Kind::ConvertedInterpreter` in [`crates/xtask/src/bench/runner.rs`](../../crates/xtask/src/bench/runner.rs)): the meta-WASI wasm3 v0.5.0 build from the app cache, converted standalone by the Ruby and Python backends, interpreting each workload on ruby, ruby+yjit, cpython, and pypy.
+
+## Context
+
+The suite compares dewasm's converted output against the wasm interpreters hand-written in the target languages (pywasm, wardite).
+That comparison mixes categories: dewasm's output is converted ahead of time, while those interpreters load an arbitrary module at run time.
+A wasm interpreter that is itself dewasm output closes the category gap: it also loads an arbitrary module at run time, and everything below that module is dewasm's own code, so the pairing measures dewasm against a hand-written interpreter on equal terms.
+
+## Decision
+
+The interpreter the suite converts is wasm3 v0.5.0, and the criterion is the interpreter's own native speed: conversion multiplies the interpreter's cost by a roughly constant factor (about 270x on ruby+yjit for interpreter-shaped code, measured 2026-08-29), so only an interpreter that is fast natively keeps the converted stack ahead of the hand-written interpreters.
+wasm3 interprets at roughly 6x wasmtime natively and the converted build won every same-language pairing against wardite and pywasm (1.3x to 3.4x on `wat/i32_alu` and `wat/mem_rw`, 2026-08-29); toywasm sits near 300x natively and the converted build lost the same pairings by 5x to 14x, measured the same day with the same harness discipline.
+
+## Rejected alternatives
+
+- **Converted toywasm as the runner.**
+  Loses every same-language pairing by 5x to 14x (measured above): its own interpretation overhead, not the conversion, is what sinks it.
+  It stays an e2e app; the two interpreters' cases are deliberately parallel (`toywasm_cowsay`, `wasm3_cowsay`).
+- **Self-application: dewasm converted by itself, converting the workload at load time and evaluating the result.**
+  Executes at direct-conversion speed but pays roughly 250x to 300x the native conversion time at every cold load (measured 2026-08-02); a different trade, set aside rather than folded into the benchmark matrix.
+- **A committed driver script per host, the pywasm/wardite shape.**
+  Unnecessary: the standalone interface's `--dir` shim already carries the workload's directory and module path through to the guest, and the runner reuses the same `Workshop` conversion cache as the `dewasm-*` runners, so there is no separate artifact to provision.
+
+## Consequences
+
+- Positive: the same-category comparison ("a runtime-loading wasm runtime in pure Ruby/Python") is measured continuously instead of living in a one-off experiment.
+- Negative: wasm3's dispatch nests one host-language call per guest opcode until a loop or return unwinds it, so the ruby runners carry `RUBY_THREAD_VM_STACK_SIZE` in their launch environment, and workloads that still exceed a host's limits get measured exclusions in [`crates/xtask/src/bench/workload.rs`](../../crates/xtask/src/bench/workload.rs).
+- Carry-over: `wasm3-*` labels classify as the interpreter family in the charts; the native `wasm3` runner stays in the native family, so the two readings of "wasm3" never share a color.

--- a/agents/decisions/README.md
+++ b/agents/decisions/README.md
@@ -105,6 +105,7 @@ An entry is numbered: `<N>-<slug>.md`, cited as "decision N".
 | 83 | [Byte-Scatter Store Fusion Behind a Runtime Precondition](83-byte-scatter-store-fusion.md) | Accepted |
 | 84 | [Round to f32 by Veltkamp Splitting, with the Pack Path as Fallback](84-f32-rounding-by-splitting.md) | Accepted |
 | 85 | [crates.io Publish Layout (Units Inside Their Crates, CLI Crate Named `dewasm`)](85-crates-io-publish-layout.md) | Accepted |
+| 86 | [wasm3 as the Converted-Interpreter Benchmark Runner](86-converted-interpreter-benchmark-runner.md) | Accepted |
 
 ## Adding a new decision
 

--- a/crates/xtask/src/bench/chart.rs
+++ b/crates/xtask/src/bench/chart.rs
@@ -73,7 +73,7 @@ pub enum Family {
     /// A wasm runtime executing the module natively: wasmer, wasmedge, wazero, wasm3.
     /// Split out from [`Family::Baseline`] so a reader does not have to know which of them is the reference, and from [`Family::Interpreter`] because "an interpreter written in Go" and "an interpreter written in Ruby" are not the same class of thing.
     Native,
-    /// A wasm interpreter written in a host language: pywasm, wardite.
+    /// A wasm interpreter running on a host language, whether hand-written (pywasm, wardite) or converted by dewasm (the `wasm3-*` runners).
     /// The comparison dewasm actually cares about.
     Interpreter,
 }
@@ -83,7 +83,9 @@ fn family(runner: &str) -> Family {
         "wasmtime" => Family::Baseline,
         "wasmer" | "wasmedge" | "wazero" | "wasm3" => Family::Native,
         r if r.starts_with("dewasm-") => Family::Dewasm,
-        r if r.starts_with("pywasm") || r.starts_with("wardite") => Family::Interpreter,
+        r if r.starts_with("pywasm") || r.starts_with("wardite") || r.starts_with("wasm3-") => {
+            Family::Interpreter
+        }
         // Anything later added beside wasmtime as a reference runtime.
         _ => Family::Baseline,
     }

--- a/crates/xtask/src/bench/mod.rs
+++ b/crates/xtask/src/bench/mod.rs
@@ -1,6 +1,7 @@
 //! `cargo xtask record-speed` and `cargo xtask render-speed`: the cross-runtime benchmark suite and the document it feeds.
 //!
 //! It answers one question with numbers: what does a wasm program cost once dewasm has turned it into Ruby, Python, Perl, Go, Java, or Bash source, measured against the AOT ceiling (wasmtime) and against the wasm interpreters written in those same languages (pywasm, wardite).
+//! The `wasm3-*` runners add the same-category counterpart to those interpreters: the converted wasm3 build interpreting the workload at run time, so "a runtime-loading wasm runtime in pure Ruby/Python" is compared hand-written against converted.
 //! Measuring and rendering are separate commands: `record-speed` writes a dated record under `records/`, `render-speed` turns a record into `docs/benchmarks/results.md` with its charts.
 //! A full run takes tens of minutes, so a wording fix in the renderer must not require re-measuring: the JSON is the record, the markdown is only a view of it.
 //! Neither is a compared snapshot: a timing is not reproducible byte-for-byte, so unlike `docs/support.md` there is no freshness test (contrast the checked-in execution snapshots).

--- a/crates/xtask/src/bench/runner.rs
+++ b/crates/xtask/src/bench/runner.rs
@@ -1,6 +1,6 @@
 //! The runner matrix: every execution environment a workload is measured on, how to tell whether it is usable on this host, and how to turn a `.wasm` into something runnable on it.
 //!
-//! Four families:
+//! Five families:
 //!
 //! * **wasmtime**: the AOT ceiling and the correctness reference.
 //! * **native runtimes** (wasmer, wasmedge, wazero, wasm3): consume the `.wasm` directly; [`Native`] holds the per-runtime command-line spelling.
@@ -8,6 +8,8 @@
 //! * **dewasm-\***: generated source on the host language.
 //!   Codegen goes through the [`Backend`] trait, never the CLI binary.
 //!   Go and Java build first, mirroring their e2e suites (`go run` swallows the guest exit code; generated Java requires the file to be named `Main.java`).
+//! * **wasm3-\***: the meta-WASI wasm3 build from the app cache, converted to host-language source by a dewasm backend, interpreting the workload module at run time.
+//!   The runtime-loading counterpart the pure-source interpreters below are compared against.
 //! * **pywasm / wardite**: third-party interpreters, driven via `benchmarks/drivers/`, provisioned by `benchmarks/setup.sh`.
 //!
 //! Availability is a `Result<(), String>` whose error is the setup instruction that would fix it (the harness keeps going, the gap is named in both outputs).
@@ -22,7 +24,7 @@ use std::sync::OnceLock;
 use anyhow::{bail, Context, Result};
 use dewasm_backend::{Backend, GenOptions, Mode, RuntimeLinkage};
 
-use crate::bench::{bench_cache_dir, display_path, drivers_dir};
+use crate::bench::{apps_cache_dir, bench_cache_dir, display_path, drivers_dir};
 
 /// A launchable recipe: `program args... <workload args...>`, with `env` overlaid on the inherited environment.
 #[derive(Clone)]
@@ -111,6 +113,9 @@ pub enum Kind {
     Wasmtime,
     Native(Native),
     Dewasm(Target),
+    /// A wasm interpreter (the meta-WASI wasm3 from the app cache), itself converted standalone by the [`Target`]'s backend, interpreting the workload module.
+    /// The launch preopens the workload's directory and passes the module's guest path through, so the workload contract holds unchanged one interpretation layer down.
+    ConvertedInterpreter(Target),
     Driver(Driver),
 }
 
@@ -137,6 +142,16 @@ pub fn runners() -> Vec<Runner> {
         r("dewasm-go", Kind::Dewasm(Target::Go)),
         r("dewasm-java", Kind::Dewasm(Target::Java)),
         r("dewasm-bash", Kind::Dewasm(Target::Bash)),
+        r(
+            "wasm3-ruby",
+            Kind::ConvertedInterpreter(Target::Ruby("--disable-yjit")),
+        ),
+        r(
+            "wasm3-ruby-yjit",
+            Kind::ConvertedInterpreter(Target::Ruby("--yjit")),
+        ),
+        r("wasm3-python", Kind::ConvertedInterpreter(Target::Python)),
+        r("wasm3-pypy", Kind::ConvertedInterpreter(Target::PyPy)),
         r("pywasm-cpython", Kind::Driver(Driver::PywasmCPython)),
         r("pywasm-pypy", Kind::Driver(Driver::PywasmPyPy)),
         r("wardite", Kind::Driver(Driver::Wardite("--disable-yjit"))),
@@ -160,6 +175,12 @@ impl Runner {
                 )
             }),
             Kind::Dewasm(target) => target.availability(),
+            Kind::ConvertedInterpreter(target) => {
+                target.availability()?;
+                converted_wasm3().map(|_| ()).ok_or_else(|| {
+                    "examples/apps/cache/wasm3.wasm missing: run examples/apps/setup.sh".to_string()
+                })
+            }
             Kind::Driver(driver) => driver.availability(),
         }
     }
@@ -171,7 +192,7 @@ impl Runner {
         match &self.kind {
             Kind::Wasmtime => wasmtime_bin(),
             Kind::Native(native) => native.bin_path(),
-            Kind::Dewasm(_) | Kind::Driver(_) => None,
+            Kind::Dewasm(_) | Kind::ConvertedInterpreter(_) | Kind::Driver(_) => None,
         }
     }
 
@@ -181,6 +202,7 @@ impl Runner {
             Kind::Wasmtime => capture_version(&wasmtime_bin()?, &["--version"]),
             Kind::Native(native) => capture_version(&native.bin_path()?, native.version_args),
             Kind::Dewasm(target) => target.version(),
+            Kind::ConvertedInterpreter(target) => converted_interpreter_version(*target),
             Kind::Driver(driver) => driver.version(),
         }
     }
@@ -410,6 +432,7 @@ impl Workshop {
             }),
             Kind::Native(native) => native.launch(wasm),
             Kind::Dewasm(target) => self.dewasm_launch(*target, wasm),
+            Kind::ConvertedInterpreter(target) => self.converted_interpreter_launch(*target, wasm),
             Kind::Driver(driver) => driver_launch(*driver, wasm),
         }
     }
@@ -417,56 +440,94 @@ impl Workshop {
     fn dewasm_launch(&mut self, target: Target, wasm: &Path) -> Result<Launch> {
         let bytes =
             std::fs::read(wasm).with_context(|| format!("failed to read {}", wasm.display()))?;
-        let backend = target.backend();
-        let key = (hash_bytes(&bytes), backend.name());
-        let artifact = match self.artifacts.get(&key) {
+        let artifact = self.artifact_for(target, &bytes)?;
+        host_launch(target, artifact)
+    }
+
+    /// The converted wasm3 on `target`'s host, told to run `wasm`: the interpreter artifact's launch plus `--dir <wasm's dir>::/work` and the module's guest path, so the caller-appended guest arguments reach the module one interpretation layer down.
+    /// The Ruby hosts get `RUBY_THREAD_VM_STACK_SIZE` raised: wasm3's dispatch nests one host call per guest opcode until a loop or return unwinds it, deeper than the default VM stack for guests with a deep startup, and Ruby cannot raise that stack after boot.
+    fn converted_interpreter_launch(&mut self, target: Target, wasm: &Path) -> Result<Launch> {
+        let interpreter = converted_wasm3()
+            .context("examples/apps/cache/wasm3.wasm missing: run examples/apps/setup.sh")?;
+        let bytes = std::fs::read(&interpreter)
+            .with_context(|| format!("failed to read {}", interpreter.display()))?;
+        let artifact = self.artifact_for(target, &bytes)?;
+        let mut launch = host_launch(target, artifact)?;
+        if let Target::Ruby(_) = target {
+            launch.env.push((
+                "RUBY_THREAD_VM_STACK_SIZE".to_string(),
+                (64 << 20).to_string(),
+            ));
+        }
+        let dir = wasm
+            .parent()
+            .with_context(|| format!("{} has no parent directory", wasm.display()))?;
+        let base = wasm
+            .file_name()
+            .with_context(|| format!("{} has no file name", wasm.display()))?
+            .to_string_lossy()
+            .into_owned();
+        launch.args.push("--dir".to_string());
+        launch.args.push(format!("{}::/work", path_arg(dir)));
+        launch.args.push(format!("/work/{base}"));
+        Ok(launch)
+    }
+
+    /// The runnable artifact for `bytes` under `target`'s backend, through both cache levels.
+    fn artifact_for(&mut self, target: Target, bytes: &[u8]) -> Result<Artifact> {
+        let key = (hash_bytes(bytes), target.backend().name());
+        Ok(match self.artifacts.get(&key) {
             Some(cached) => cached.clone(),
             None => {
-                let built = build_artifact(target, &bytes)?;
+                let built = build_artifact(target, bytes)?;
                 self.artifacts.insert(key, built.clone());
                 built
             }
-        };
-        Ok(match (target, artifact) {
-            (Target::Ruby(flag), Artifact::Script(path)) => Launch {
-                program: dewasm_backend_ruby::find_ruby().context("ruby not found")?,
-                args: vec![flag.to_string(), path_arg(&path)],
-                env: Vec::new(),
-            },
-            (Target::Python, Artifact::Script(path)) => Launch {
-                program: dewasm_backend_python::find_python().context("python3 not found")?,
-                args: vec![path_arg(&path)],
-                env: Vec::new(),
-            },
-            (Target::PyPy, Artifact::Script(path)) => Launch {
-                program: pypy_bin().context("pypy3 not found")?,
-                args: vec![path_arg(&path)],
-                env: Vec::new(),
-            },
-            (Target::Perl, Artifact::Script(path)) => Launch {
-                program: dewasm_backend_perl::find_perl().context("perl not found")?,
-                args: vec![path_arg(&path)],
-                env: Vec::new(),
-            },
-            (Target::Bash, Artifact::Script(path)) => Launch {
-                program: dewasm_backend_bash::find_bash5().context("bash >= 5 not found")?,
-                args: vec![path_arg(&path)],
-                env: Vec::new(),
-            },
-            // `go run` prints "exit status N" and exits 1 instead of propagating the guest's exit code, so the built binary is executed directly (same reason the Go e2e suite does).
-            (Target::Go, Artifact::Binary(bin)) => Launch {
-                program: bin,
-                args: Vec::new(),
-                env: Vec::new(),
-            },
-            (Target::Java, Artifact::ClassDir(dir)) => Launch {
-                program: dewasm_backend_java::find_java().context("java not found")?,
-                args: vec!["-cp".to_string(), path_arg(&dir), "Main".to_string()],
-                env: Vec::new(),
-            },
-            _ => bail!("internal: artifact kind does not match the target"),
         })
     }
+}
+
+/// How `target`'s host interpreter launches a built artifact, up to but excluding the guest's own arguments.
+fn host_launch(target: Target, artifact: Artifact) -> Result<Launch> {
+    Ok(match (target, artifact) {
+        (Target::Ruby(flag), Artifact::Script(path)) => Launch {
+            program: dewasm_backend_ruby::find_ruby().context("ruby not found")?,
+            args: vec![flag.to_string(), path_arg(&path)],
+            env: Vec::new(),
+        },
+        (Target::Python, Artifact::Script(path)) => Launch {
+            program: dewasm_backend_python::find_python().context("python3 not found")?,
+            args: vec![path_arg(&path)],
+            env: Vec::new(),
+        },
+        (Target::PyPy, Artifact::Script(path)) => Launch {
+            program: pypy_bin().context("pypy3 not found")?,
+            args: vec![path_arg(&path)],
+            env: Vec::new(),
+        },
+        (Target::Perl, Artifact::Script(path)) => Launch {
+            program: dewasm_backend_perl::find_perl().context("perl not found")?,
+            args: vec![path_arg(&path)],
+            env: Vec::new(),
+        },
+        (Target::Bash, Artifact::Script(path)) => Launch {
+            program: dewasm_backend_bash::find_bash5().context("bash >= 5 not found")?,
+            args: vec![path_arg(&path)],
+            env: Vec::new(),
+        },
+        // `go run` prints "exit status N" and exits 1 instead of propagating the guest's exit code, so the built binary is executed directly (same reason the Go e2e suite does).
+        (Target::Go, Artifact::Binary(bin)) => Launch {
+            program: bin,
+            args: Vec::new(),
+            env: Vec::new(),
+        },
+        (Target::Java, Artifact::ClassDir(dir)) => Launch {
+            program: dewasm_backend_java::find_java().context("java not found")?,
+            args: vec!["-cp".to_string(), path_arg(&dir), "Main".to_string()],
+            env: Vec::new(),
+        },
+        _ => bail!("internal: artifact kind does not match the target"),
+    })
 }
 
 /// Convert `bytes` with `target`'s backend and get it into runnable shape, reusing the content-addressed `/tmp` cache when a previous run already produced it.
@@ -636,6 +697,25 @@ fn venv_python() -> Option<PathBuf> {
         .find(|path| path.is_file())
 }
 
+/// The wasm3 interpreter binary the converted-interpreter runners convert, when the app cache has it.
+fn converted_wasm3() -> Option<PathBuf> {
+    let path = apps_cache_dir().join("wasm3.wasm");
+    path.is_file().then_some(path)
+}
+
+/// The converted interpreter's version, captured by running the converted artifact's own `--version`, so it records what actually ran rather than what was pinned.
+fn converted_interpreter_version(target: Target) -> Option<String> {
+    let bytes = std::fs::read(converted_wasm3()?).ok()?;
+    let launch = host_launch(target, build_artifact(target, &bytes).ok()?).ok()?;
+    let out = Command::new(&launch.program)
+        .args(&launch.args)
+        .arg("--version")
+        .envs(launch.env)
+        .output()
+        .ok()?;
+    first_line(&out)
+}
+
 /// The `GEM_HOME` under `benchmarks/cache/` that holds wardite.
 /// Found by looking for the `<gem_home>/gems/wardite-*` layout rather than by hardcoding a directory name, so the exact name `benchmarks/setup.sh` picks does not matter here.
 fn wardite_gem_home() -> Option<PathBuf> {
@@ -696,6 +776,10 @@ fn probe(program: &Path, args: &[&str]) -> bool {
 /// The first non-empty line of `program args...`, reading stdout and stderr both: `java -version` and `perl -v` each pick a different one.
 fn capture_version(program: &Path, args: &[&str]) -> Option<String> {
     let out = Command::new(program).args(args).output().ok()?;
+    first_line(&out)
+}
+
+fn first_line(out: &std::process::Output) -> Option<String> {
     let mut text = String::from_utf8_lossy(&out.stdout).into_owned();
     text.push('\n');
     text.push_str(&String::from_utf8_lossy(&out.stderr));

--- a/crates/xtask/src/bench/workload.rs
+++ b/crates/xtask/src/bench/workload.rs
@@ -59,7 +59,7 @@ const EH_EXCLUDES: &[(&str, &str)] = &[
     ),
     (
         "wasm3",
-        "excluded: wasm3 0.5.0 fails to load it: \"out of order Wasm section\" (the tag section is unknown to it)",
+        "excluded: wasm3 0.9.0 fails to load it: \"out of order Wasm section\" (the tag section is unknown to it)",
     ),
     ("wasm3-ruby", CONVERTED_WASM3_EH_REASON),
     ("wasm3-ruby-yjit", CONVERTED_WASM3_EH_REASON),
@@ -71,7 +71,7 @@ const EH_EXCLUDES: &[(&str, &str)] = &[
     ("wardite-yjit", WARDITE_EH_REASON),
 ];
 
-const CONVERTED_WASM3_EH_REASON: &str = "excluded: the converted wasm3 0.5.0 fails to load it like the native one, \"out of order Wasm section\" (the tag section is unknown to it), measured through the converted interpreter";
+const CONVERTED_WASM3_EH_REASON: &str = "excluded: the converted wasm3 0.9.0 fails to load it like the native one, \"out of order Wasm section\" (the tag section is unknown to it), measured through the converted interpreter";
 
 const PYWASM_EH_REASON: &str = "excluded: pywasm 2.2.3 has no exception-handling opcodes; decoding dies with AssertionError on the throw/try_table opcode (pywasm/core.py, from_reader)";
 
@@ -340,12 +340,7 @@ const DEWASM_PYTHON_SQLITE_REASON: &str = "excluded on cost, not capability: dew
 /// Runners excluded from the compression case; each reason is a measurement, not a guess (see the module doc comment on [`SQLITE_QUERY_EXCLUDES`] for why that discipline matters here too).
 const MINIGZIP_EXCLUDES: &[(&str, &str)] = &[
     ("dewasm-bash", BASH_MINIGZIP_REASON),
-    (
-        "wasm3",
-        "excluded: wasm3's WASI does not provide fd_tell, which minigzip's stdio imports, so the module fails before running (\"missing imported function ('wasi_snapshot_preview1.fd_tell')\")",
-    ),
     ("wasm3-ruby", CONVERTED_WASM3_MINIGZIP_REASON),
-    ("wasm3-ruby-yjit", CONVERTED_WASM3_MINIGZIP_REASON),
     ("wasm3-python", CONVERTED_WASM3_MINIGZIP_REASON),
     ("wasm3-pypy", CONVERTED_WASM3_MINIGZIP_REASON),
     ("pywasm-cpython", PYWASM_MINIGZIP_REASON),
@@ -353,7 +348,7 @@ const MINIGZIP_EXCLUDES: &[(&str, &str)] = &[
     ("wardite-yjit", WARDITE_MINIGZIP_REASON),
 ];
 
-const CONVERTED_WASM3_MINIGZIP_REASON: &str = "excluded: the converted wasm3's meta-WASI layer does not provide fd_tell either, so the module fails before running (\"missing imported function ('wasi_snapshot_preview1.fd_tell')\"), measured through the converted interpreter";
+const CONVERTED_WASM3_MINIGZIP_REASON: &str = "excluded on cost, not capability: the converted wasm3 compresses the full 1.2 MB input correctly (byte-identical to wasmtime) but at 149 s per run on plain ruby and 301 s on pypy, both measured, and roughly 7 minutes on cpython (measured 107 s on a 300000-byte prefix); wasm3-ruby-yjit runs it at 54 s and stays measured";
 
 const BASH_MINIGZIP_REASON: &str = "excluded on cost, not capability: bash compresses this workload's generated text at ~0.61 ms/byte (measured 30.6 s on a 50000-byte prefix), so the full 1.2 MB input needs roughly 12 minutes per run";
 

--- a/crates/xtask/src/bench/workload.rs
+++ b/crates/xtask/src/bench/workload.rs
@@ -61,11 +61,17 @@ const EH_EXCLUDES: &[(&str, &str)] = &[
         "wasm3",
         "excluded: wasm3 0.5.0 fails to load it: \"out of order Wasm section\" (the tag section is unknown to it)",
     ),
+    ("wasm3-ruby", CONVERTED_WASM3_EH_REASON),
+    ("wasm3-ruby-yjit", CONVERTED_WASM3_EH_REASON),
+    ("wasm3-python", CONVERTED_WASM3_EH_REASON),
+    ("wasm3-pypy", CONVERTED_WASM3_EH_REASON),
     ("pywasm-cpython", PYWASM_EH_REASON),
     ("pywasm-pypy", PYWASM_EH_REASON),
     ("wardite", WARDITE_EH_REASON),
     ("wardite-yjit", WARDITE_EH_REASON),
 ];
+
+const CONVERTED_WASM3_EH_REASON: &str = "excluded: the converted wasm3 0.5.0 fails to load it like the native one, \"out of order Wasm section\" (the tag section is unknown to it), measured through the converted interpreter";
 
 const PYWASM_EH_REASON: &str = "excluded: pywasm 2.2.3 has no exception-handling opcodes; decoding dies with AssertionError on the throw/try_table opcode (pywasm/core.py, from_reader)";
 
@@ -315,7 +321,14 @@ const SQLITE_QUERY_EXCLUDES: &[(&str, &str)] = &[
     ("wardite-yjit", WARDITE_SQLITE_REASON),
     ("dewasm-perl", DEWASM_PERL_SQLITE_REASON),
     ("dewasm-python", DEWASM_PYTHON_SQLITE_REASON),
+    ("wasm3-ruby", CONVERTED_WASM3_SQLITE_REASON),
+    ("wasm3-ruby-yjit", CONVERTED_WASM3_SQLITE_REASON),
+    ("wasm3-python", CONVERTED_WASM3_SQLITE_REASON),
+    ("wasm3-pypy", CONVERTED_WASM3_SQLITE_REASON),
 ];
+
+/// Cost, not capability: measured 2026-08-29 on `sqlite3-shell.wasm` with the fastest of the four converted-wasm3 runners; the other three are slower than wasm3-ruby-yjit on every microbenchmark (plain ruby by ~2.4x, cpython by ~7x on `wat/i32_alu`), so their cells only get worse.
+const CONVERTED_WASM3_SQLITE_REASON: &str = "excluded on cost, not capability: the converted wasm3 runs this program correctly (stdout matching the oracle) at 160 s per run on wasm3-ruby-yjit, the fastest of the four wasm3-* runners, so one warmup plus the timed repetitions across both query cases and all four runners would add hours to the suite";
 
 /// wardite loads the module and handles a bare `.quit`, but any actual query dies.
 const WARDITE_SQLITE_REASON: &str = "excluded: wardite loads the sqlite3 shell but cannot execute a query, raising Wardite::EvalError (\"maybe empty or invalid stack\", convert.generated.rb:200) as soon as any SQL runs";
@@ -338,10 +351,17 @@ const MINIGZIP_EXCLUDES: &[(&str, &str)] = &[
         "wasm3",
         "excluded: wasm3's WASI does not provide fd_tell, which minigzip's stdio imports, so the module fails before running (\"missing imported function ('wasi_snapshot_preview1.fd_tell')\")",
     ),
+    ("wasm3-ruby", CONVERTED_WASM3_MINIGZIP_REASON),
+    ("wasm3-ruby-yjit", CONVERTED_WASM3_MINIGZIP_REASON),
+    ("wasm3-python", CONVERTED_WASM3_MINIGZIP_REASON),
+    ("wasm3-pypy", CONVERTED_WASM3_MINIGZIP_REASON),
     ("pywasm-cpython", PYWASM_MINIGZIP_REASON),
     ("wardite", WARDITE_MINIGZIP_REASON),
     ("wardite-yjit", WARDITE_MINIGZIP_REASON),
 ];
+
+/// The same fd_tell gap as the native wasm3 entry above: the meta-WASI layer serves its guest only the functions it implements, and fd_tell is not among them, measured through the converted interpreter on Ruby.
+const CONVERTED_WASM3_MINIGZIP_REASON: &str = "excluded: the converted wasm3's meta-WASI layer does not provide fd_tell either, so the module fails before running (\"missing imported function ('wasi_snapshot_preview1.fd_tell')\"), measured through the converted interpreter";
 
 /// Extrapolated linearly from two prefix sizes (20000 and 50000 bytes) of the same generated text, both close enough to the per-byte rate that the fit is not just two points hiding curvature.
 /// At 4 runs per cell (one warmup plus the default 3 reps) that is roughly 48 minutes on this workload alone, which is why the input size is fixed for wasmtime rather than calibrated down to fit bash: the doc comment on [`minigzip_input`] gives the reason it must stay put.

--- a/crates/xtask/src/bench/workload.rs
+++ b/crates/xtask/src/bench/workload.rs
@@ -329,18 +329,12 @@ const SQLITE_QUERY_EXCLUDES: &[(&str, &str)] = &[
 
 const CONVERTED_WASM3_SQLITE_REASON: &str = "excluded on cost, not capability: the converted wasm3 runs this program correctly (stdout matching the oracle) at 160 s per run on wasm3-ruby-yjit, the fastest of the four wasm3-* runners, so one warmup plus the timed repetitions across both query cases and all four runners would add hours to the suite";
 
-/// wardite loads the module and handles a bare `.quit`, but any actual query dies.
 const WARDITE_SQLITE_REASON: &str = "excluded: wardite loads the sqlite3 shell but cannot execute a query, raising Wardite::EvalError (\"maybe empty or invalid stack\", convert.generated.rb:200) as soon as any SQL runs";
 
-/// Cost, not capability: pywasm runs this correctly (byte-identical under `-batch`) at ~17.9 ms/row, so 100k rows is ~half an hour per sample.
-/// The row count cannot be lowered to meet it: below ~20k rows wasmtime's side is all process startup and the baseline dissolves.
 const PYWASM_SQLITE_REASON: &str = "excluded on cost, not capability: pywasm runs this program correctly (byte-identical to wasmtime under -batch) at ~17.9 ms/row: measured 358 s at 20k rows, so the 100k-row script needs roughly half an hour per sample";
 
-/// Cost, not capability: dewasm-perl runs this correctly but at 113 s and 115 s per run (median, sqlite3_query and sqlite3_mod_query), measured in the 2026-08-21 full record.
-/// One warmup plus the timed repetitions across both query cases alone cost roughly 19 of the suite's roughly 65 minutes.
 const DEWASM_PERL_SQLITE_REASON: &str = "excluded on cost, not capability: dewasm-perl runs this program correctly but at 113 s and 115 s per run (median, sqlite3_query and sqlite3_mod_query), so one warmup plus the timed repetitions across both cases alone cost roughly 19 minutes of the roughly 65 minute full suite; dewasm-perl stays measured on the other app cases and the microbenchmarks";
 
-/// Cost, not capability: dewasm-python runs this correctly but at 56 s and 57 s per run (median, sqlite3_query and sqlite3_mod_query), measured in the 2026-08-21 full record.
 const DEWASM_PYTHON_SQLITE_REASON: &str = "excluded on cost, not capability: dewasm-python runs this program correctly but at 56 s and 57 s per run (median, sqlite3_query and sqlite3_mod_query), costing roughly 9 minutes of the roughly 65 minute full suite; dewasm-python stays measured on the other app cases and the microbenchmarks";
 
 /// Runners excluded from the compression case; each reason is a measurement, not a guess (see the module doc comment on [`SQLITE_QUERY_EXCLUDES`] for why that discipline matters here too).
@@ -361,13 +355,8 @@ const MINIGZIP_EXCLUDES: &[(&str, &str)] = &[
 
 const CONVERTED_WASM3_MINIGZIP_REASON: &str = "excluded: the converted wasm3's meta-WASI layer does not provide fd_tell either, so the module fails before running (\"missing imported function ('wasi_snapshot_preview1.fd_tell')\"), measured through the converted interpreter";
 
-/// Extrapolated linearly from two prefix sizes (20000 and 50000 bytes) of the same generated text, both close enough to the per-byte rate that the fit is not just two points hiding curvature.
-/// At 4 runs per cell (one warmup plus the default 3 reps) that is roughly 48 minutes on this workload alone, which is why the input size is fixed for wasmtime rather than calibrated down to fit bash: the doc comment on [`minigzip_input`] gives the reason it must stay put.
 const BASH_MINIGZIP_REASON: &str = "excluded on cost, not capability: bash compresses this workload's generated text at ~0.61 ms/byte (measured 30.6 s on a 50000-byte prefix), so the full 1.2 MB input needs roughly 12 minutes per run";
 
-/// Extrapolated the same way as [`BASH_MINIGZIP_REASON`], from prefixes of 5000 and 20000 bytes.
-/// pypy runs the same driver roughly 6.6x faster (measured 84 s on the full 1.2 MB input, byte-identical to wasmtime), which is why only the CPython interpreter is excluded here.
 const PYWASM_MINIGZIP_REASON: &str = "excluded on cost, not capability: pywasm under CPython compresses this workload's generated text at ~0.46 ms/byte (measured 9.2 s on a 20000-byte prefix), so the full 1.2 MB input needs roughly 9 minutes per run";
 
-/// wardite runs the compression correctly (byte-identical to wasmtime, verified on small inputs) but the driver crashes on exit: minigzip closes stdout at the end of the run, wardite's `fd_close` closes the underlying host fd along with it, and the driver's own trailing `$stdout.flush` then raises `IOError: closed stream`, so the process exits 1 and the harness's success check fails every run.
 const WARDITE_MINIGZIP_REASON: &str = "excluded: wardite computes the correct compressed output but its driver crashes on exit (IOError: closed stream at wardite.rb:40) because minigzip closes stdout itself and wardite's fd_close closes the real fd under it, so the driver's own trailing flush fails and the process exits 1";

--- a/crates/xtask/src/bench/workload.rs
+++ b/crates/xtask/src/bench/workload.rs
@@ -327,7 +327,6 @@ const SQLITE_QUERY_EXCLUDES: &[(&str, &str)] = &[
     ("wasm3-pypy", CONVERTED_WASM3_SQLITE_REASON),
 ];
 
-/// Cost, not capability: measured 2026-08-29 on `sqlite3-shell.wasm` with the fastest of the four converted-wasm3 runners; the other three are slower than wasm3-ruby-yjit on every microbenchmark (plain ruby by ~2.4x, cpython by ~7x on `wat/i32_alu`), so their cells only get worse.
 const CONVERTED_WASM3_SQLITE_REASON: &str = "excluded on cost, not capability: the converted wasm3 runs this program correctly (stdout matching the oracle) at 160 s per run on wasm3-ruby-yjit, the fastest of the four wasm3-* runners, so one warmup plus the timed repetitions across both query cases and all four runners would add hours to the suite";
 
 /// wardite loads the module and handles a bare `.quit`, but any actual query dies.
@@ -360,7 +359,6 @@ const MINIGZIP_EXCLUDES: &[(&str, &str)] = &[
     ("wardite-yjit", WARDITE_MINIGZIP_REASON),
 ];
 
-/// The same fd_tell gap as the native wasm3 entry above: the meta-WASI layer serves its guest only the functions it implements, and fd_tell is not among them, measured through the converted interpreter on Ruby.
 const CONVERTED_WASM3_MINIGZIP_REASON: &str = "excluded: the converted wasm3's meta-WASI layer does not provide fd_tell either, so the module fails before running (\"missing imported function ('wasi_snapshot_preview1.fd_tell')\"), measured through the converted interpreter";
 
 /// Extrapolated linearly from two prefix sizes (20000 and 50000 bytes) of the same generated text, both close enough to the per-byte rate that the fit is not just two points hiding curvature.

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -6,7 +6,7 @@ The results are in [results.md](results.md) with its figures under `figs/`; the 
 ## Running
 
 ```console
-$ examples/apps/setup.sh             # the cached apps (sqlite3-shell, cowsay, ...) and the wasm3 build the wasm3-* runners convert
+$ examples/apps/setup.sh             # the cached apps (sqlite3-shell, cowsay, ...)
 $ benchmarks/setup.sh                # builds the microbenchmarks, pins pywasm and wardite
 $ cargo xtask record-speed           # the full matrix, roughly 30 minutes
 $ cargo xtask render-speed           # results.md and its charts, from that record

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -6,7 +6,7 @@ The results are in [results.md](results.md) with its figures under `figs/`; the 
 ## Running
 
 ```console
-$ examples/apps/setup.sh             # the cached apps (sqlite3-shell, cowsay, ...)
+$ examples/apps/setup.sh             # the cached apps (sqlite3-shell, cowsay, ...) and the wasm3 build the wasm3-* runners convert
 $ benchmarks/setup.sh                # builds the microbenchmarks, pins pywasm and wardite
 $ cargo xtask record-speed           # the full matrix, roughly 30 minutes
 $ cargo xtask render-speed           # results.md and its charts, from that record


### PR DESCRIPTION
Closes #277.
Stacked on #278 (needs `cache/wasm3.wasm` from its `setup.sh` script, now pinned to v0.9.0); merge that first, then retarget or let the base update.

## What

- Four `wasm3-*` runners (`Kind::ConvertedInterpreter` in `runner.rs`): the meta-WASI wasm3 build from the app cache, converted standalone by the Ruby and Python backends, interpreting each workload on ruby / ruby+yjit / cpython / pypy.
  They slot between the `dewasm-*` runners and the hand-written interpreters in the matrix, and classify as the interpreter family in the charts.
- No driver script: the standalone interface's `--dir` shim preopens the workload's directory and passes the module's guest path through, so the `<module> <iterations>` contract holds one interpretation layer down, and the artifact reuses the same `Workshop` conversion cache as the `dewasm-*` runners.
- The runner's version string comes from executing the converted artifact's own `--version` ("Wasm3 v0.9.0 on wasm"), so the record reports what actually ran.
- The ruby runners carry `RUBY_THREAD_VM_STACK_SIZE` in the launch environment; the Python standalone output already raises its own recursion limit.
- Decision 86 records the carrier choice (wasm3, not toywasm, and why not self-application); the comparative measurements were taken on the v0.5.0 build, with the v0.9.0 build measured at parity the same day.

## Measured exclusions

- `wat/eh_throw` / `wat/eh_try`: the converted wasm3 fails to load the tag section like the native one ("out of order Wasm section", remeasured on v0.9.0).
- `app/minigzip`: cost, not capability, since v0.9.0's meta-WASI serves fd_tell.
  The `wasm3-ruby-yjit` leg joins the measurement (50 s per run, the order of the already-included pywasm-pypy cell), and the native `wasm3` exclusion is lifted (249 ms per run); plain ruby (149 s), pypy (301 s), and cpython (roughly 7 minutes, extrapolated from a 300000-byte prefix) stay out on cost.
- `app/sqlite3_query` / `app/sqlite3_mod_query`: cost, not capability; correct output at 160 s per run on `wasm3-ruby-yjit` (remeasured at 161 s on v0.9.0).

## Verification

- `cargo xtask record-speed wasm3` (native wasm3 plus all four converted runners, every workload) passes against the v0.9.0 pin: all seventeen microbenchmarks, `app/cowsay` on all four legs, and the newly included minigzip cells verify byte-identical to wasmtime; the filtered record is not committed (publishing needs a full run).
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test -p xtask` pass.

Re-measuring and publishing `docs/benchmarks/results.md` from a full `record-speed` run stays a separate manual step.