### PR TITLE
Record the first full run with the wasm3-* runners and render the results

### DIFF
--- a/docs/benchmarks/figs/app-cowsay-dark.svg
+++ b/docs/benchmarks/figs/app-cowsay-dark.svg
@@ -1,87 +1,103 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/cowsay: seconds per run for 18 runners on a log scale, fastest first. dewasm-go is fastest at 4.04 ms, then wasm3 at 6.64 ms; dewasm-bash is slowest at 1.27 s, a span of 316x. The table below carries every number.">
-<title>app/cowsay: seconds per run for 18 runners on a log scale, fastest first. dewasm-go is fastest at 4.04 ms, then wasm3 at 6.64 ms; dewasm-bash is slowest at 1.27 s, a span of 316x. The table below carries every number.</title>
-<rect width="820" height="536" fill="#1a1a19"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ms</text>
-<line x1="345.1" y1="68.0" x2="345.1" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="345.1" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
-<line x1="522.2" y1="68.0" x2="522.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="522.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
-<line x1="699.3" y1="68.0" x2="699.3" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="699.3" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
-<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/cowsay: seconds per run for 22 runners on a log scale, fastest first. dewasm-go is fastest at 5.75 ms, then wasm3 at 8.16 ms; wasm3-python is slowest at 3.84 s, a span of 668x. The table below carries every number.">
+<title>app/cowsay: seconds per run for 22 runners on a log scale, fastest first. dewasm-go is fastest at 5.75 ms, then wasm3 at 8.16 ms; wasm3-python is slowest at 3.84 s, a span of 668x. The table below carries every number.</title>
+<rect width="820" height="632" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ms</text>
+<line x1="321.4" y1="68.0" x2="321.4" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="321.4" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
+<line x1="474.9" y1="68.0" x2="474.9" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="474.9" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
+<line x1="628.3" y1="68.0" x2="628.3" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="628.3" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
+<line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="86.0" x2="275.4" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="275.4" cy="86.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.04 ms</text>
+<line x1="168.0" y1="86.0" x2="284.6" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="284.6" cy="86.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.75 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="110.0" x2="313.7" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="313.7" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.64 ms</text>
+<line x1="168.0" y1="110.0" x2="307.8" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="307.8" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.16 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="134.0" x2="341.1" y2="134.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="341.1" cy="134.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.50 ms</text>
+<line x1="168.0" y1="134.0" x2="323.3" y2="134.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="323.3" cy="134.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.3 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="158.0" x2="364.2" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="364.2" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.8 ms</text>
+<line x1="168.0" y1="158.0" x2="345.2" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="345.2" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.3 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="182.0" x2="414.5" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="414.5" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">24.7 ms</text>
+<line x1="168.0" y1="182.0" x2="387.0" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="387.0" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">26.7 ms</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="206.0" x2="523.4" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="523.4" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">101 ms</text>
+<line x1="168.0" y1="206.0" x2="479.5" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="479.5" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">107 ms</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="230.0" x2="525.3" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="525.3" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">104 ms</text>
+<line x1="168.0" y1="230.0" x2="482.3" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="482.3" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">112 ms</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="254.0" x2="539.0" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="539.0" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">124 ms</text>
+<line x1="168.0" y1="254.0" x2="494.3" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="494.3" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">134 ms</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="278.0" x2="545.4" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="545.4" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">135 ms</text>
+<line x1="168.0" y1="278.0" x2="500.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="500.1" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">146 ms</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="302.0" x2="567.9" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="567.9" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">181 ms</text>
+<line x1="168.0" y1="302.0" x2="520.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="520.8" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">199 ms</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="326.0" x2="584.1" y2="326.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="584.1" cy="326.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">224 ms</text>
+<line x1="168.0" y1="326.0" x2="533.5" y2="326.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="533.5" cy="326.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">241 ms</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="350.0" x2="589.9" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="589.9" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">241 ms</text>
+<line x1="168.0" y1="350.0" x2="538.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="538.1" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">258 ms</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="374.0" x2="592.4" y2="374.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="592.4" cy="374.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">249 ms</text>
+<line x1="168.0" y1="374.0" x2="542.6" y2="374.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="542.6" cy="374.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">276 ms</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="398.0" x2="629.2" y2="398.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="629.2" cy="398.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">402 ms</text>
+<line x1="168.0" y1="398.0" x2="571.8" y2="398.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="571.8" cy="398.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">428 ms</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="422.0" x2="642.8" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="642.8" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">479 ms</text>
+<line x1="168.0" y1="422.0" x2="582.7" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="582.7" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">504 ms</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="660.4" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="660.4" cy="446.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">603 ms</text>
+<line x1="168.0" y1="446.0" x2="597.6" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="597.6" cy="446.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">631 ms</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="470.0" x2="687.5" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="687.5" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">857 ms</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.27 s</text>
+<line x1="168.0" y1="470.0" x2="620.7" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="620.7" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">892 ms</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="494.0" x2="643.3" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="643.3" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.25 s</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="518.0" x2="647.7" y2="518.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="647.7" cy="518.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.34 s</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
+<line x1="168.0" y1="542.0" x2="657.8" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="657.8" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.56 s</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
+<line x1="168.0" y1="566.0" x2="664.4" y2="566.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="664.4" cy="566.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.72 s</text>
+<text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
+<line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="590.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.84 s</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">app/cowsay: seconds per run, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/app-cowsay.svg
+++ b/docs/benchmarks/figs/app-cowsay.svg
@@ -1,87 +1,103 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/cowsay: seconds per run for 18 runners on a log scale, fastest first. dewasm-go is fastest at 4.04 ms, then wasm3 at 6.64 ms; dewasm-bash is slowest at 1.27 s, a span of 316x. The table below carries every number.">
-<title>app/cowsay: seconds per run for 18 runners on a log scale, fastest first. dewasm-go is fastest at 4.04 ms, then wasm3 at 6.64 ms; dewasm-bash is slowest at 1.27 s, a span of 316x. The table below carries every number.</title>
-<rect width="820" height="536" fill="#fcfcfb"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ms</text>
-<line x1="345.1" y1="68.0" x2="345.1" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="345.1" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
-<line x1="522.2" y1="68.0" x2="522.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="522.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
-<line x1="699.3" y1="68.0" x2="699.3" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="699.3" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
-<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/cowsay: seconds per run for 22 runners on a log scale, fastest first. dewasm-go is fastest at 5.75 ms, then wasm3 at 8.16 ms; wasm3-python is slowest at 3.84 s, a span of 668x. The table below carries every number.">
+<title>app/cowsay: seconds per run for 22 runners on a log scale, fastest first. dewasm-go is fastest at 5.75 ms, then wasm3 at 8.16 ms; wasm3-python is slowest at 3.84 s, a span of 668x. The table below carries every number.</title>
+<rect width="820" height="632" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 ms</text>
+<line x1="321.4" y1="68.0" x2="321.4" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="321.4" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
+<line x1="474.9" y1="68.0" x2="474.9" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="474.9" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
+<line x1="628.3" y1="68.0" x2="628.3" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="628.3" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
+<line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="86.0" x2="275.4" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="275.4" cy="86.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.04 ms</text>
+<line x1="168.0" y1="86.0" x2="284.6" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="284.6" cy="86.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.75 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="110.0" x2="313.7" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="313.7" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.64 ms</text>
+<line x1="168.0" y1="110.0" x2="307.8" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="307.8" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.16 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="134.0" x2="341.1" y2="134.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="341.1" cy="134.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.50 ms</text>
+<line x1="168.0" y1="134.0" x2="323.3" y2="134.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="323.3" cy="134.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.3 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="158.0" x2="364.2" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="364.2" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.8 ms</text>
+<line x1="168.0" y1="158.0" x2="345.2" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="345.2" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.3 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="182.0" x2="414.5" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="414.5" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">24.7 ms</text>
+<line x1="168.0" y1="182.0" x2="387.0" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="387.0" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">26.7 ms</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="206.0" x2="523.4" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="523.4" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">101 ms</text>
+<line x1="168.0" y1="206.0" x2="479.5" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="479.5" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">107 ms</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="230.0" x2="525.3" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="525.3" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">104 ms</text>
+<line x1="168.0" y1="230.0" x2="482.3" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="482.3" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">112 ms</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="254.0" x2="539.0" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="539.0" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">124 ms</text>
+<line x1="168.0" y1="254.0" x2="494.3" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="494.3" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">134 ms</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="278.0" x2="545.4" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="545.4" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">135 ms</text>
+<line x1="168.0" y1="278.0" x2="500.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="500.1" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">146 ms</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="302.0" x2="567.9" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="567.9" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">181 ms</text>
+<line x1="168.0" y1="302.0" x2="520.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="520.8" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">199 ms</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="326.0" x2="584.1" y2="326.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="584.1" cy="326.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">224 ms</text>
+<line x1="168.0" y1="326.0" x2="533.5" y2="326.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="533.5" cy="326.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">241 ms</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="350.0" x2="589.9" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="589.9" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">241 ms</text>
+<line x1="168.0" y1="350.0" x2="538.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="538.1" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">258 ms</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="374.0" x2="592.4" y2="374.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="592.4" cy="374.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">249 ms</text>
+<line x1="168.0" y1="374.0" x2="542.6" y2="374.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="542.6" cy="374.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">276 ms</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="398.0" x2="629.2" y2="398.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="629.2" cy="398.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">402 ms</text>
+<line x1="168.0" y1="398.0" x2="571.8" y2="398.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="571.8" cy="398.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">428 ms</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="422.0" x2="642.8" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="642.8" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">479 ms</text>
+<line x1="168.0" y1="422.0" x2="582.7" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="582.7" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">504 ms</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="660.4" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="660.4" cy="446.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">603 ms</text>
+<line x1="168.0" y1="446.0" x2="597.6" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="597.6" cy="446.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">631 ms</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="470.0" x2="687.5" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="687.5" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">857 ms</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.27 s</text>
+<line x1="168.0" y1="470.0" x2="620.7" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="620.7" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">892 ms</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="494.0" x2="643.3" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="643.3" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.25 s</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="518.0" x2="647.7" y2="518.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="647.7" cy="518.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.34 s</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
+<line x1="168.0" y1="542.0" x2="657.8" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="657.8" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.56 s</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
+<line x1="168.0" y1="566.0" x2="664.4" y2="566.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="664.4" cy="566.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.72 s</text>
+<text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
+<line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="590.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.84 s</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">app/cowsay: seconds per run, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/app-minigzip-dark.svg
+++ b/docs/benchmarks/figs/app-minigzip-dark.svg
@@ -1,67 +1,75 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="416" viewBox="0 0 820 416" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/minigzip: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 42.9 ms, then wasmer at 49.4 ms; pywasm-pypy is slowest at 78.6 s, a span of 1830x. The table below carries every number.">
-<title>app/minigzip: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 42.9 ms, then wasmer at 49.4 ms; pywasm-pypy is slowest at 78.6 s, a span of 1830x. The table below carries every number.</title>
-<rect width="820" height="416" fill="#1a1a19"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
-<line x1="309.2" y1="68.0" x2="309.2" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="309.2" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
-<line x1="450.4" y1="68.0" x2="450.4" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="450.4" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
-<line x1="591.6" y1="68.0" x2="591.6" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="591.6" y="402.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 s</text>
-<line x1="168.0" y1="386.0" x2="726.0" y2="386.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="464" viewBox="0 0 820 464" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/minigzip: seconds per run for 15 runners on a log scale, fastest first. wasmtime is fastest at 45.0 ms, then wasmer at 53.0 ms; pywasm-pypy is slowest at 81.3 s, a span of 1810x. The table below carries every number.">
+<title>app/minigzip: seconds per run for 15 runners on a log scale, fastest first. wasmtime is fastest at 45.0 ms, then wasmer at 53.0 ms; pywasm-pypy is slowest at 81.3 s, a span of 1810x. The table below carries every number.</title>
+<rect width="820" height="464" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
+<line x1="308.7" y1="68.0" x2="308.7" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="308.7" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
+<line x1="449.3" y1="68.0" x2="449.3" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="449.3" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
+<line x1="590.0" y1="68.0" x2="590.0" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="590.0" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 s</text>
+<line x1="168.0" y1="434.0" x2="726.0" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="257.3" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="257.3" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">42.9 ms</text>
+<line x1="168.0" y1="86.0" x2="259.9" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="259.9" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">45.0 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="265.9" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="265.9" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">49.4 ms</text>
+<line x1="168.0" y1="110.0" x2="269.8" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="269.8" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">53.0 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="274.0" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="274.0" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">56.4 ms</text>
+<line x1="168.0" y1="134.0" x2="275.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="275.6" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">58.2 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="299.4" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="299.4" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">85.3 ms</text>
-<text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="413.4" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="413.4" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">547 ms</text>
-<text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="206.0" x2="478.5" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="478.5" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.58 s</text>
-<text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="230.0" x2="499.1" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="499.1" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.21 s</text>
-<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="254.0" x2="511.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="511.6" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.71 s</text>
-<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="278.0" x2="522.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="522.1" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.22 s</text>
-<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="302.0" x2="551.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="551.1" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.17 s</text>
-<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="326.0" x2="616.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="616.7" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.1 s</text>
-<text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="350.0" x2="644.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="644.7" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">23.8 s</text>
-<text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="374.0" x2="718.0" y2="374.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="374.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">78.6 s</text>
+<line x1="168.0" y1="158.0" x2="301.3" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="301.3" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">88.6 ms</text>
+<text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
+<line x1="168.0" y1="182.0" x2="366.2" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="366.2" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">257 ms</text>
+<text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
+<line x1="168.0" y1="206.0" x2="409.9" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="409.9" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">524 ms</text>
+<text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
+<line x1="168.0" y1="230.0" x2="479.3" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="479.3" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.63 s</text>
+<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
+<line x1="168.0" y1="254.0" x2="497.4" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="497.4" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.20 s</text>
+<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
+<line x1="168.0" y1="278.0" x2="511.4" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="511.4" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.76 s</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
+<line x1="168.0" y1="302.0" x2="522.4" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="522.4" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.31 s</text>
+<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
+<line x1="168.0" y1="326.0" x2="551.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="551.0" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.29 s</text>
+<text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
+<line x1="168.0" y1="350.0" x2="616.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="616.1" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.3 s</text>
+<text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
+<line x1="168.0" y1="374.0" x2="644.5" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="644.5" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">24.4 s</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="398.0" x2="690.3" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="690.3" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">51.7 s</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="422.0" x2="718.0" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">81.3 s</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">app/minigzip: seconds per run, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/app-minigzip.svg
+++ b/docs/benchmarks/figs/app-minigzip.svg
@@ -1,67 +1,75 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="416" viewBox="0 0 820 416" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/minigzip: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 42.9 ms, then wasmer at 49.4 ms; pywasm-pypy is slowest at 78.6 s, a span of 1830x. The table below carries every number.">
-<title>app/minigzip: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 42.9 ms, then wasmer at 49.4 ms; pywasm-pypy is slowest at 78.6 s, a span of 1830x. The table below carries every number.</title>
-<rect width="820" height="416" fill="#fcfcfb"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
-<line x1="309.2" y1="68.0" x2="309.2" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="309.2" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
-<line x1="450.4" y1="68.0" x2="450.4" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="450.4" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
-<line x1="591.6" y1="68.0" x2="591.6" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="591.6" y="402.0" text-anchor="middle" font-size="11" fill="#52514e">10 s</text>
-<line x1="168.0" y1="386.0" x2="726.0" y2="386.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="464" viewBox="0 0 820 464" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/minigzip: seconds per run for 15 runners on a log scale, fastest first. wasmtime is fastest at 45.0 ms, then wasmer at 53.0 ms; pywasm-pypy is slowest at 81.3 s, a span of 1810x. The table below carries every number.">
+<title>app/minigzip: seconds per run for 15 runners on a log scale, fastest first. wasmtime is fastest at 45.0 ms, then wasmer at 53.0 ms; pywasm-pypy is slowest at 81.3 s, a span of 1810x. The table below carries every number.</title>
+<rect width="820" height="464" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
+<line x1="308.7" y1="68.0" x2="308.7" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="308.7" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
+<line x1="449.3" y1="68.0" x2="449.3" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="449.3" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
+<line x1="590.0" y1="68.0" x2="590.0" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="590.0" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">10 s</text>
+<line x1="168.0" y1="434.0" x2="726.0" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="257.3" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="257.3" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">42.9 ms</text>
+<line x1="168.0" y1="86.0" x2="259.9" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="259.9" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">45.0 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="265.9" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="265.9" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">49.4 ms</text>
+<line x1="168.0" y1="110.0" x2="269.8" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="269.8" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">53.0 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="274.0" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="274.0" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">56.4 ms</text>
+<line x1="168.0" y1="134.0" x2="275.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="275.6" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">58.2 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="299.4" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="299.4" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">85.3 ms</text>
-<text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="413.4" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="413.4" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">547 ms</text>
-<text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="206.0" x2="478.5" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="478.5" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.58 s</text>
-<text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="230.0" x2="499.1" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="499.1" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.21 s</text>
-<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="254.0" x2="511.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="511.6" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.71 s</text>
-<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="278.0" x2="522.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="522.1" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.22 s</text>
-<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="302.0" x2="551.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="551.1" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.17 s</text>
-<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="326.0" x2="616.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="616.7" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.1 s</text>
-<text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="350.0" x2="644.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="644.7" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">23.8 s</text>
-<text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="374.0" x2="718.0" y2="374.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="374.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">78.6 s</text>
+<line x1="168.0" y1="158.0" x2="301.3" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="301.3" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">88.6 ms</text>
+<text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
+<line x1="168.0" y1="182.0" x2="366.2" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="366.2" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">257 ms</text>
+<text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
+<line x1="168.0" y1="206.0" x2="409.9" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="409.9" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">524 ms</text>
+<text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
+<line x1="168.0" y1="230.0" x2="479.3" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="479.3" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.63 s</text>
+<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
+<line x1="168.0" y1="254.0" x2="497.4" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="497.4" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.20 s</text>
+<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
+<line x1="168.0" y1="278.0" x2="511.4" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="511.4" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.76 s</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
+<line x1="168.0" y1="302.0" x2="522.4" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="522.4" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.31 s</text>
+<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
+<line x1="168.0" y1="326.0" x2="551.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="551.0" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.29 s</text>
+<text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
+<line x1="168.0" y1="350.0" x2="616.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="616.1" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.3 s</text>
+<text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
+<line x1="168.0" y1="374.0" x2="644.5" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="644.5" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">24.4 s</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="398.0" x2="690.3" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="690.3" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">51.7 s</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="422.0" x2="718.0" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">81.3 s</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">app/minigzip: seconds per run, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/app-sqlite3-mod-query-dark.svg
+++ b/docs/benchmarks/figs/app-sqlite3-mod-query-dark.svg
@@ -1,59 +1,59 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 84.5 ms, then wasmer at 87.1 ms; dewasm-ruby is slowest at 19.9 s, a span of 236x. The table below carries every number.">
-<title>app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 84.5 ms, then wasmer at 87.1 ms; dewasm-ruby is slowest at 19.9 s, a span of 236x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 85.8 ms, then wasmer at 90.0 ms; dewasm-ruby is slowest at 20.3 s, a span of 236x. The table below carries every number.">
+<title>app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 85.8 ms, then wasmer at 90.0 ms; dewasm-ruby is slowest at 20.3 s, a span of 236x. The table below carries every number.</title>
 <rect width="820" height="368" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
-<line x1="334.7" y1="68.0" x2="334.7" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="334.7" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
-<line x1="501.4" y1="68.0" x2="501.4" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="501.4" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
-<line x1="668.2" y1="68.0" x2="668.2" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="668.2" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 s</text>
+<line x1="334.3" y1="68.0" x2="334.3" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="334.3" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
+<line x1="500.6" y1="68.0" x2="500.6" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="500.6" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
+<line x1="666.9" y1="68.0" x2="666.9" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="666.9" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 s</text>
 <line x1="168.0" y1="338.0" x2="726.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="322.5" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="322.5" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">84.5 ms</text>
+<line x1="168.0" y1="86.0" x2="323.3" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="323.3" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">85.8 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="324.7" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="324.7" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">87.1 ms</text>
+<line x1="168.0" y1="110.0" x2="326.7" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="326.7" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">90.0 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="350.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="350.6" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">125 ms</text>
+<line x1="168.0" y1="134.0" x2="351.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="351.6" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">127 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="465.5" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="465.5" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">609 ms</text>
+<line x1="168.0" y1="158.0" x2="467.7" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="467.7" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">634 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="182.0" x2="511.8" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="511.8" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.15 s</text>
+<line x1="168.0" y1="182.0" x2="513.5" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="513.5" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.20 s</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="206.0" x2="623.5" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="623.5" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.39 s</text>
+<line x1="168.0" y1="206.0" x2="624.4" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="624.4" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.55 s</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="230.0" x2="653.0" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="653.0" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.11 s</text>
+<line x1="168.0" y1="230.0" x2="653.6" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="653.6" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.31 s</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="667.7" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="667.7" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.94 s</text>
+<line x1="168.0" y1="254.0" x2="666.7" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="666.7" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.97 s</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="278.0" x2="682.0" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="682.0" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.1 s</text>
+<line x1="168.0" y1="278.0" x2="686.3" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="686.3" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.1 s</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="692.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="692.7" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.0 s</text>
+<line x1="168.0" y1="302.0" x2="694.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="694.0" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.5 s</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
 <line x1="168.0" y1="326.0" x2="718.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">19.9 s</text>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.3 s</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">app/sqlite3_mod_query: seconds per run, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/app-sqlite3-mod-query.svg
+++ b/docs/benchmarks/figs/app-sqlite3-mod-query.svg
@@ -1,59 +1,59 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 84.5 ms, then wasmer at 87.1 ms; dewasm-ruby is slowest at 19.9 s, a span of 236x. The table below carries every number.">
-<title>app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 84.5 ms, then wasmer at 87.1 ms; dewasm-ruby is slowest at 19.9 s, a span of 236x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 85.8 ms, then wasmer at 90.0 ms; dewasm-ruby is slowest at 20.3 s, a span of 236x. The table below carries every number.">
+<title>app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 85.8 ms, then wasmer at 90.0 ms; dewasm-ruby is slowest at 20.3 s, a span of 236x. The table below carries every number.</title>
 <rect width="820" height="368" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
-<line x1="334.7" y1="68.0" x2="334.7" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="334.7" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
-<line x1="501.4" y1="68.0" x2="501.4" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="501.4" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
-<line x1="668.2" y1="68.0" x2="668.2" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="668.2" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 s</text>
+<line x1="334.3" y1="68.0" x2="334.3" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="334.3" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
+<line x1="500.6" y1="68.0" x2="500.6" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="500.6" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
+<line x1="666.9" y1="68.0" x2="666.9" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="666.9" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 s</text>
 <line x1="168.0" y1="338.0" x2="726.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="322.5" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="322.5" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">84.5 ms</text>
+<line x1="168.0" y1="86.0" x2="323.3" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="323.3" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">85.8 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="324.7" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="324.7" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">87.1 ms</text>
+<line x1="168.0" y1="110.0" x2="326.7" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="326.7" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">90.0 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="350.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="350.6" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">125 ms</text>
+<line x1="168.0" y1="134.0" x2="351.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="351.6" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">127 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="465.5" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="465.5" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">609 ms</text>
+<line x1="168.0" y1="158.0" x2="467.7" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="467.7" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">634 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="182.0" x2="511.8" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="511.8" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.15 s</text>
+<line x1="168.0" y1="182.0" x2="513.5" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="513.5" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.20 s</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="206.0" x2="623.5" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="623.5" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.39 s</text>
+<line x1="168.0" y1="206.0" x2="624.4" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="624.4" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.55 s</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="230.0" x2="653.0" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="653.0" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.11 s</text>
+<line x1="168.0" y1="230.0" x2="653.6" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="653.6" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.31 s</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="667.7" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="667.7" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.94 s</text>
+<line x1="168.0" y1="254.0" x2="666.7" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="666.7" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.97 s</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="278.0" x2="682.0" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="682.0" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.1 s</text>
+<line x1="168.0" y1="278.0" x2="686.3" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="686.3" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.1 s</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="692.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="692.7" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.0 s</text>
+<line x1="168.0" y1="302.0" x2="694.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="694.0" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.5 s</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
 <line x1="168.0" y1="326.0" x2="718.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">19.9 s</text>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.3 s</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">app/sqlite3_mod_query: seconds per run, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/app-sqlite3-query-dark.svg
+++ b/docs/benchmarks/figs/app-sqlite3-query-dark.svg
@@ -1,59 +1,59 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 76.7 ms, then wasmer at 85.3 ms; dewasm-ruby is slowest at 18.8 s, a span of 245x. The table below carries every number.">
-<title>app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 76.7 ms, then wasmer at 85.3 ms; dewasm-ruby is slowest at 18.8 s, a span of 245x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 79.4 ms, then wasmer at 87.5 ms; dewasm-ruby is slowest at 19.3 s, a span of 243x. The table below carries every number.">
+<title>app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 79.4 ms, then wasmer at 87.5 ms; dewasm-ruby is slowest at 19.3 s, a span of 243x. The table below carries every number.</title>
 <rect width="820" height="368" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
-<line x1="336.0" y1="68.0" x2="336.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="336.0" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
-<line x1="503.9" y1="68.0" x2="503.9" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="503.9" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
-<line x1="671.9" y1="68.0" x2="671.9" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="671.9" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 s</text>
+<line x1="335.4" y1="68.0" x2="335.4" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="335.4" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
+<line x1="502.8" y1="68.0" x2="502.8" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="502.8" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
+<line x1="670.2" y1="68.0" x2="670.2" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="670.2" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 s</text>
 <line x1="168.0" y1="338.0" x2="726.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="316.6" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="316.6" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">76.7 ms</text>
+<line x1="168.0" y1="86.0" x2="318.7" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="318.7" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">79.4 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="324.4" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="324.4" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">85.3 ms</text>
+<line x1="168.0" y1="110.0" x2="325.7" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="325.7" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">87.5 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="374.3" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="374.3" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">169 ms</text>
+<line x1="168.0" y1="134.0" x2="374.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="374.1" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">170 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="468.5" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="468.5" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">616 ms</text>
+<line x1="168.0" y1="158.0" x2="471.3" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="471.3" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">649 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="182.0" x2="508.7" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="508.7" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.07 s</text>
+<line x1="168.0" y1="182.0" x2="511.8" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="511.8" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.13 s</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="206.0" x2="566.2" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="566.2" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.35 s</text>
+<line x1="168.0" y1="206.0" x2="565.6" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="565.6" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.37 s</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="230.0" x2="664.1" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="664.1" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.99 s</text>
+<line x1="168.0" y1="230.0" x2="665.1" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="665.1" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.32 s</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="668.6" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="668.6" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.56 s</text>
+<line x1="168.0" y1="254.0" x2="667.3" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="667.3" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.61 s</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="278.0" x2="680.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="680.8" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">11.3 s</text>
+<line x1="168.0" y1="278.0" x2="683.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="683.5" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.0 s</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="694.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="694.2" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.6 s</text>
+<line x1="168.0" y1="302.0" x2="694.9" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="694.9" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.0 s</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
 <line x1="168.0" y1="326.0" x2="718.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">18.8 s</text>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">19.3 s</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">app/sqlite3_query: seconds per run, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/app-sqlite3-query.svg
+++ b/docs/benchmarks/figs/app-sqlite3-query.svg
@@ -1,59 +1,59 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 76.7 ms, then wasmer at 85.3 ms; dewasm-ruby is slowest at 18.8 s, a span of 245x. The table below carries every number.">
-<title>app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 76.7 ms, then wasmer at 85.3 ms; dewasm-ruby is slowest at 18.8 s, a span of 245x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 79.4 ms, then wasmer at 87.5 ms; dewasm-ruby is slowest at 19.3 s, a span of 243x. The table below carries every number.">
+<title>app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 79.4 ms, then wasmer at 87.5 ms; dewasm-ruby is slowest at 19.3 s, a span of 243x. The table below carries every number.</title>
 <rect width="820" height="368" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
-<line x1="336.0" y1="68.0" x2="336.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="336.0" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
-<line x1="503.9" y1="68.0" x2="503.9" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="503.9" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
-<line x1="671.9" y1="68.0" x2="671.9" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="671.9" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 s</text>
+<line x1="335.4" y1="68.0" x2="335.4" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="335.4" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
+<line x1="502.8" y1="68.0" x2="502.8" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="502.8" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
+<line x1="670.2" y1="68.0" x2="670.2" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="670.2" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 s</text>
 <line x1="168.0" y1="338.0" x2="726.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="316.6" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="316.6" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">76.7 ms</text>
+<line x1="168.0" y1="86.0" x2="318.7" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="318.7" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">79.4 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="324.4" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="324.4" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">85.3 ms</text>
+<line x1="168.0" y1="110.0" x2="325.7" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="325.7" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">87.5 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="374.3" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="374.3" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">169 ms</text>
+<line x1="168.0" y1="134.0" x2="374.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="374.1" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">170 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="468.5" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="468.5" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">616 ms</text>
+<line x1="168.0" y1="158.0" x2="471.3" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="471.3" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">649 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="182.0" x2="508.7" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="508.7" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.07 s</text>
+<line x1="168.0" y1="182.0" x2="511.8" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="511.8" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.13 s</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="206.0" x2="566.2" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="566.2" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.35 s</text>
+<line x1="168.0" y1="206.0" x2="565.6" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="565.6" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.37 s</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="230.0" x2="664.1" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="664.1" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.99 s</text>
+<line x1="168.0" y1="230.0" x2="665.1" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="665.1" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.32 s</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="668.6" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="668.6" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.56 s</text>
+<line x1="168.0" y1="254.0" x2="667.3" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="667.3" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.61 s</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="278.0" x2="680.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="680.8" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">11.3 s</text>
+<line x1="168.0" y1="278.0" x2="683.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="683.5" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.0 s</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="694.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="694.2" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.6 s</text>
+<line x1="168.0" y1="302.0" x2="694.9" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="694.9" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.0 s</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
 <line x1="168.0" y1="326.0" x2="718.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">18.8 s</text>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">19.3 s</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">app/sqlite3_query: seconds per run, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/c-mandelbrot-dark.svg
+++ b/docs/benchmarks/figs/c-mandelbrot-dark.svg
@@ -1,93 +1,109 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/mandelbrot: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-java is fastest at 94.3 ns, then wasmer at 94.6 ns; dewasm-bash is slowest at 19.9 ms, a span of 211000x. The table below carries every number.">
-<title>c/mandelbrot: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-java is fastest at 94.3 ns, then wasmer at 94.6 ns; dewasm-bash is slowest at 19.9 ms, a span of 211000x. The table below carries every number.</title>
-<rect width="820" height="536" fill="#1a1a19"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="255.3" y1="68.0" x2="255.3" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="255.3" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="342.6" y1="68.0" x2="342.6" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="342.6" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="429.9" y1="68.0" x2="429.9" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="429.9" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="517.3" y1="68.0" x2="517.3" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="517.3" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
-<line x1="604.6" y1="68.0" x2="604.6" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="604.6" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ms</text>
-<line x1="691.9" y1="68.0" x2="691.9" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="691.9" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
-<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="86.0" x2="253.1" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="253.1" cy="86.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">94.3 ns</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/mandelbrot: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 96.4 ns, then wasmer at 96.4 ns; dewasm-bash is slowest at 20.3 ms, a span of 211000x. The table below carries every number.">
+<title>c/mandelbrot: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 96.4 ns, then wasmer at 96.4 ns; dewasm-bash is slowest at 20.3 ms, a span of 211000x. The table below carries every number.</title>
+<rect width="820" height="632" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="255.2" y1="68.0" x2="255.2" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="255.2" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="342.4" y1="68.0" x2="342.4" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="342.4" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="429.6" y1="68.0" x2="429.6" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="429.6" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="516.8" y1="68.0" x2="516.8" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="516.8" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="604.0" y1="68.0" x2="604.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="604.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ms</text>
+<line x1="691.2" y1="68.0" x2="691.2" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="691.2" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
+<line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="253.8" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="253.8" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">96.4 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="253.2" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="253.2" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">94.6 ns</text>
-<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="134.0" x2="253.2" y2="134.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="253.2" cy="134.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">94.7 ns</text>
+<line x1="168.0" y1="110.0" x2="253.8" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="253.8" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">96.4 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
+<line x1="168.0" y1="134.0" x2="253.9" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="253.9" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">96.6 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="257.3" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="257.3" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">106 ns</text>
+<line x1="168.0" y1="158.0" x2="258.0" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="258.0" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">108 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="182.0" x2="267.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="267.7" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">139 ns</text>
+<line x1="168.0" y1="182.0" x2="268.5" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="268.5" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">142 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="206.0" x2="287.2" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="287.2" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">232 ns</text>
+<line x1="168.0" y1="206.0" x2="287.3" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="287.3" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">233 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="230.0" x2="312.3" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="312.3" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">449 ns</text>
+<line x1="168.0" y1="230.0" x2="312.4" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="312.4" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">453 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="358.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="358.8" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.53 µs</text>
+<line x1="168.0" y1="254.0" x2="359.0" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="359.0" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.55 µs</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="278.0" x2="389.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="389.8" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.47 µs</text>
+<line x1="168.0" y1="278.0" x2="389.9" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="389.9" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.50 µs</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="302.0" x2="390.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="390.6" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.54 µs</text>
+<line x1="168.0" y1="302.0" x2="390.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="390.7" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.58 µs</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="326.0" x2="393.1" y2="326.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="393.1" cy="326.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.79 µs</text>
+<line x1="168.0" y1="326.0" x2="391.9" y2="326.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="391.9" cy="326.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.70 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="350.0" x2="399.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="399.2" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.45 µs</text>
+<line x1="168.0" y1="350.0" x2="399.6" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="399.6" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.53 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="495.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="495.0" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">55.7 µs</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="539.1" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="539.1" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">178 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="422.0" x2="566.7" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="566.7" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">368 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="614.8" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="614.8" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.31 ms</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="470.0" x2="618.9" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="618.9" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.46 ms</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">19.9 ms</text>
+<line x1="168.0" y1="374.0" x2="494.9" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="494.9" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">56.1 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="398.0" x2="515.4" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="515.4" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">96.5 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
+<line x1="168.0" y1="422.0" x2="539.4" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="539.4" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">182 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
+<line x1="168.0" y1="446.0" x2="540.3" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="540.3" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">186 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
+<line x1="168.0" y1="470.0" x2="547.9" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="547.9" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">227 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
+<line x1="168.0" y1="494.0" x2="568.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="568.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">386 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
+<line x1="168.0" y1="518.0" x2="586.6" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="586.6" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">632 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="542.0" x2="619.0" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="619.0" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.49 ms</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="566.0" x2="627.2" y2="566.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="627.2" cy="566.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.85 ms</text>
+<text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="590.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.3 ms</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">c/mandelbrot: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/c-mandelbrot.svg
+++ b/docs/benchmarks/figs/c-mandelbrot.svg
@@ -1,93 +1,109 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/mandelbrot: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-java is fastest at 94.3 ns, then wasmer at 94.6 ns; dewasm-bash is slowest at 19.9 ms, a span of 211000x. The table below carries every number.">
-<title>c/mandelbrot: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-java is fastest at 94.3 ns, then wasmer at 94.6 ns; dewasm-bash is slowest at 19.9 ms, a span of 211000x. The table below carries every number.</title>
-<rect width="820" height="536" fill="#fcfcfb"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="255.3" y1="68.0" x2="255.3" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="255.3" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="342.6" y1="68.0" x2="342.6" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="342.6" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="429.9" y1="68.0" x2="429.9" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="429.9" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="517.3" y1="68.0" x2="517.3" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="517.3" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
-<line x1="604.6" y1="68.0" x2="604.6" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="604.6" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ms</text>
-<line x1="691.9" y1="68.0" x2="691.9" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="691.9" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
-<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="86.0" x2="253.1" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="253.1" cy="86.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">94.3 ns</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/mandelbrot: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 96.4 ns, then wasmer at 96.4 ns; dewasm-bash is slowest at 20.3 ms, a span of 211000x. The table below carries every number.">
+<title>c/mandelbrot: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 96.4 ns, then wasmer at 96.4 ns; dewasm-bash is slowest at 20.3 ms, a span of 211000x. The table below carries every number.</title>
+<rect width="820" height="632" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="255.2" y1="68.0" x2="255.2" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="255.2" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="342.4" y1="68.0" x2="342.4" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="342.4" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="429.6" y1="68.0" x2="429.6" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="429.6" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="516.8" y1="68.0" x2="516.8" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="516.8" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="604.0" y1="68.0" x2="604.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="604.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 ms</text>
+<line x1="691.2" y1="68.0" x2="691.2" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="691.2" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
+<line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="253.8" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="253.8" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">96.4 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="253.2" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="253.2" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">94.6 ns</text>
-<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="134.0" x2="253.2" y2="134.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="253.2" cy="134.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">94.7 ns</text>
+<line x1="168.0" y1="110.0" x2="253.8" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="253.8" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">96.4 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
+<line x1="168.0" y1="134.0" x2="253.9" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="253.9" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">96.6 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="257.3" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="257.3" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">106 ns</text>
+<line x1="168.0" y1="158.0" x2="258.0" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="258.0" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">108 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="182.0" x2="267.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="267.7" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">139 ns</text>
+<line x1="168.0" y1="182.0" x2="268.5" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="268.5" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">142 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="206.0" x2="287.2" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="287.2" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">232 ns</text>
+<line x1="168.0" y1="206.0" x2="287.3" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="287.3" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">233 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="230.0" x2="312.3" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="312.3" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">449 ns</text>
+<line x1="168.0" y1="230.0" x2="312.4" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="312.4" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">453 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="358.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="358.8" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.53 µs</text>
+<line x1="168.0" y1="254.0" x2="359.0" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="359.0" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.55 µs</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="278.0" x2="389.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="389.8" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.47 µs</text>
+<line x1="168.0" y1="278.0" x2="389.9" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="389.9" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.50 µs</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="302.0" x2="390.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="390.6" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.54 µs</text>
+<line x1="168.0" y1="302.0" x2="390.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="390.7" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.58 µs</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="326.0" x2="393.1" y2="326.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="393.1" cy="326.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.79 µs</text>
+<line x1="168.0" y1="326.0" x2="391.9" y2="326.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="391.9" cy="326.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.70 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="350.0" x2="399.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="399.2" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.45 µs</text>
+<line x1="168.0" y1="350.0" x2="399.6" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="399.6" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.53 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="495.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="495.0" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">55.7 µs</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="539.1" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="539.1" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">178 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="422.0" x2="566.7" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="566.7" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">368 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="614.8" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="614.8" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.31 ms</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="470.0" x2="618.9" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="618.9" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.46 ms</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">19.9 ms</text>
+<line x1="168.0" y1="374.0" x2="494.9" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="494.9" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">56.1 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="398.0" x2="515.4" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="515.4" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">96.5 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
+<line x1="168.0" y1="422.0" x2="539.4" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="539.4" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">182 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
+<line x1="168.0" y1="446.0" x2="540.3" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="540.3" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">186 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
+<line x1="168.0" y1="470.0" x2="547.9" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="547.9" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">227 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
+<line x1="168.0" y1="494.0" x2="568.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="568.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">386 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
+<line x1="168.0" y1="518.0" x2="586.6" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="586.6" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">632 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="542.0" x2="619.0" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="619.0" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.49 ms</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="566.0" x2="627.2" y2="566.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="627.2" cy="566.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.85 ms</text>
+<text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="590.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.3 ms</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">c/mandelbrot: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/c-sha256-dark.svg
+++ b/docs/benchmarks/figs/c-sha256-dark.svg
@@ -1,91 +1,107 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/sha256: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 290 ns, then wasmtime at 290 ns; dewasm-bash is slowest at 15.4 ms, a span of 53100x. The table below carries every number.">
-<title>c/sha256: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 290 ns, then wasmtime at 290 ns; dewasm-bash is slowest at 15.4 ms, a span of 53100x. The table below carries every number.</title>
-<rect width="820" height="536" fill="#1a1a19"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="274.0" y1="68.0" x2="274.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="274.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="380.1" y1="68.0" x2="380.1" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="380.1" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="486.1" y1="68.0" x2="486.1" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="486.1" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
-<line x1="592.1" y1="68.0" x2="592.1" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="592.1" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ms</text>
-<line x1="698.1" y1="68.0" x2="698.1" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="698.1" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
-<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/sha256: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 293 ns, then wasmtime at 294 ns; dewasm-bash is slowest at 15.9 ms, a span of 54300x. The table below carries every number.">
+<title>c/sha256: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 293 ns, then wasmtime at 294 ns; dewasm-bash is slowest at 15.9 ms, a span of 54300x. The table below carries every number.</title>
+<rect width="820" height="632" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="273.7" y1="68.0" x2="273.7" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="273.7" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="379.5" y1="68.0" x2="379.5" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="379.5" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="485.2" y1="68.0" x2="485.2" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="485.2" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="590.9" y1="68.0" x2="590.9" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="590.9" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ms</text>
+<line x1="696.6" y1="68.0" x2="696.6" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="696.6" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
+<line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="86.0" x2="217.0" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="217.0" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">290 ns</text>
+<line x1="168.0" y1="86.0" x2="217.4" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="217.4" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">293 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="217.0" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="217.0" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">290 ns</text>
+<line x1="168.0" y1="110.0" x2="217.5" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="217.5" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">294 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="224.7" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="224.7" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">343 ns</text>
+<line x1="168.0" y1="134.0" x2="225.4" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="225.4" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">349 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="228.5" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="228.5" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">372 ns</text>
+<line x1="168.0" y1="158.0" x2="229.1" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="229.1" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">378 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="242.1" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="242.1" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">500 ns</text>
+<line x1="168.0" y1="182.0" x2="245.6" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="245.6" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">541 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="347.9" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="347.9" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.98 µs</text>
+<line x1="168.0" y1="206.0" x2="346.9" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="346.9" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.92 µs</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="396.9" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="396.9" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.4 µs</text>
+<line x1="168.0" y1="230.0" x2="394.9" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="394.9" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.0 µs</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="435.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="435.5" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">33.3 µs</text>
+<line x1="168.0" y1="254.0" x2="435.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="435.6" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">34.0 µs</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="278.0" x2="445.3" y2="278.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="445.3" cy="278.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">41.3 µs</text>
+<line x1="168.0" y1="278.0" x2="443.8" y2="278.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="443.8" cy="278.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">40.6 µs</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="456.4" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="456.4" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">52.5 µs</text>
+<line x1="168.0" y1="302.0" x2="457.3" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="457.3" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">54.5 µs</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="474.6" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="474.6" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">77.9 µs</text>
+<line x1="168.0" y1="326.0" x2="474.5" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="474.5" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">79.3 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="531.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="531.2" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">266 µs</text>
+<line x1="168.0" y1="350.0" x2="530.6" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="530.6" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">269 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="538.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="538.8" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">314 µs</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="621.5" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="621.5" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.89 ms</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="422.0" x2="656.6" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="656.6" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.06 ms</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="680.6" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="680.6" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.83 ms</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="470.0" x2="714.6" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="714.6" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.3 ms</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.4 ms</text>
+<line x1="168.0" y1="374.0" x2="538.7" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="538.7" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">321 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="398.0" x2="600.9" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="600.9" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.24 ms</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
+<line x1="168.0" y1="422.0" x2="621.6" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="621.6" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.95 ms</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
+<line x1="168.0" y1="446.0" x2="642.8" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="642.8" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.10 ms</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
+<line x1="168.0" y1="470.0" x2="652.3" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="652.3" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.81 ms</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
+<line x1="168.0" y1="494.0" x2="656.2" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="656.2" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.15 ms</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="518.0" x2="682.1" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="682.1" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.28 ms</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
+<line x1="168.0" y1="542.0" x2="691.4" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="691.4" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.93 ms</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="566.0" x2="714.0" y2="566.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="714.0" cy="566.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.6 ms</text>
+<text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="590.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.9 ms</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">c/sha256: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/c-sha256.svg
+++ b/docs/benchmarks/figs/c-sha256.svg
@@ -1,91 +1,107 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/sha256: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 290 ns, then wasmtime at 290 ns; dewasm-bash is slowest at 15.4 ms, a span of 53100x. The table below carries every number.">
-<title>c/sha256: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 290 ns, then wasmtime at 290 ns; dewasm-bash is slowest at 15.4 ms, a span of 53100x. The table below carries every number.</title>
-<rect width="820" height="536" fill="#fcfcfb"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="274.0" y1="68.0" x2="274.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="274.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="380.1" y1="68.0" x2="380.1" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="380.1" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="486.1" y1="68.0" x2="486.1" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="486.1" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
-<line x1="592.1" y1="68.0" x2="592.1" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="592.1" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ms</text>
-<line x1="698.1" y1="68.0" x2="698.1" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="698.1" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
-<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/sha256: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 293 ns, then wasmtime at 294 ns; dewasm-bash is slowest at 15.9 ms, a span of 54300x. The table below carries every number.">
+<title>c/sha256: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 293 ns, then wasmtime at 294 ns; dewasm-bash is slowest at 15.9 ms, a span of 54300x. The table below carries every number.</title>
+<rect width="820" height="632" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="273.7" y1="68.0" x2="273.7" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="273.7" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="379.5" y1="68.0" x2="379.5" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="379.5" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="485.2" y1="68.0" x2="485.2" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="485.2" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="590.9" y1="68.0" x2="590.9" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="590.9" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 ms</text>
+<line x1="696.6" y1="68.0" x2="696.6" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="696.6" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
+<line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="86.0" x2="217.0" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="217.0" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">290 ns</text>
+<line x1="168.0" y1="86.0" x2="217.4" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="217.4" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">293 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="217.0" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="217.0" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">290 ns</text>
+<line x1="168.0" y1="110.0" x2="217.5" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="217.5" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">294 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="224.7" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="224.7" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">343 ns</text>
+<line x1="168.0" y1="134.0" x2="225.4" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="225.4" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">349 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="228.5" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="228.5" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">372 ns</text>
+<line x1="168.0" y1="158.0" x2="229.1" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="229.1" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">378 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="242.1" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="242.1" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">500 ns</text>
+<line x1="168.0" y1="182.0" x2="245.6" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="245.6" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">541 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="347.9" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="347.9" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.98 µs</text>
+<line x1="168.0" y1="206.0" x2="346.9" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="346.9" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.92 µs</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="396.9" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="396.9" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.4 µs</text>
+<line x1="168.0" y1="230.0" x2="394.9" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="394.9" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.0 µs</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="435.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="435.5" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">33.3 µs</text>
+<line x1="168.0" y1="254.0" x2="435.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="435.6" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">34.0 µs</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="278.0" x2="445.3" y2="278.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="445.3" cy="278.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">41.3 µs</text>
+<line x1="168.0" y1="278.0" x2="443.8" y2="278.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="443.8" cy="278.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">40.6 µs</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="456.4" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="456.4" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">52.5 µs</text>
+<line x1="168.0" y1="302.0" x2="457.3" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="457.3" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">54.5 µs</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="474.6" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="474.6" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">77.9 µs</text>
+<line x1="168.0" y1="326.0" x2="474.5" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="474.5" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">79.3 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="531.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="531.2" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">266 µs</text>
+<line x1="168.0" y1="350.0" x2="530.6" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="530.6" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">269 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="538.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="538.8" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">314 µs</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="621.5" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="621.5" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.89 ms</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="422.0" x2="656.6" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="656.6" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.06 ms</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="680.6" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="680.6" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.83 ms</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="470.0" x2="714.6" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="714.6" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.3 ms</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.4 ms</text>
+<line x1="168.0" y1="374.0" x2="538.7" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="538.7" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">321 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="398.0" x2="600.9" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="600.9" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.24 ms</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
+<line x1="168.0" y1="422.0" x2="621.6" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="621.6" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.95 ms</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
+<line x1="168.0" y1="446.0" x2="642.8" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="642.8" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.10 ms</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
+<line x1="168.0" y1="470.0" x2="652.3" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="652.3" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.81 ms</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
+<line x1="168.0" y1="494.0" x2="656.2" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="656.2" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.15 ms</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="518.0" x2="682.1" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="682.1" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.28 ms</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
+<line x1="168.0" y1="542.0" x2="691.4" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="691.4" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.93 ms</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="566.0" x2="714.0" y2="566.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="714.0" cy="566.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.6 ms</text>
+<text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="590.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.9 ms</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">c/sha256: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/c-wordcount-dark.svg
+++ b/docs/benchmarks/figs/c-wordcount-dark.svg
@@ -1,89 +1,105 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/wordcount: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.53 ns, then wasmer at 1.62 ns; pywasm-cpython is slowest at 58.7 µs, a span of 38300x. The table below carries every number.">
-<title>c/wordcount: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.53 ns, then wasmer at 1.62 ns; pywasm-cpython is slowest at 58.7 µs, a span of 38300x. The table below carries every number.</title>
-<rect width="820" height="536" fill="#1a1a19"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="283.3" y1="68.0" x2="283.3" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="283.3" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="398.7" y1="68.0" x2="398.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="398.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="514.0" y1="68.0" x2="514.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="514.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="629.3" y1="68.0" x2="629.3" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="629.3" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/wordcount: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.62 ns; pywasm-cpython is slowest at 59.7 µs, a span of 39800x. The table below carries every number.">
+<title>c/wordcount: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.62 ns; pywasm-cpython is slowest at 59.7 µs, a span of 39800x. The table below carries every number.</title>
+<rect width="820" height="632" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
+<line x1="283.2" y1="68.0" x2="283.2" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="283.2" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="398.3" y1="68.0" x2="398.3" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="398.3" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="513.5" y1="68.0" x2="513.5" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="513.5" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="628.6" y1="68.0" x2="628.6" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="628.6" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="189.4" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="189.4" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.53 ns</text>
+<line x1="168.0" y1="86.0" x2="188.2" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="188.2" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.50 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="192.0" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="192.0" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="110.0" x2="192.1" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="192.1" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.62 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="212.8" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="212.8" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.45 ns</text>
+<line x1="168.0" y1="134.0" x2="218.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="218.1" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.72 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="222.7" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="222.7" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.98 ns</text>
+<line x1="168.0" y1="158.0" x2="223.2" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="223.2" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.01 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="227.4" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="227.4" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.28 ns</text>
+<line x1="168.0" y1="182.0" x2="230.9" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="230.9" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.52 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="319.0" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="319.0" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.4 ns</text>
+<line x1="168.0" y1="206.0" x2="318.6" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="318.6" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.3 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="369.2" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="369.2" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">55.6 ns</text>
+<line x1="168.0" y1="230.0" x2="370.2" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="370.2" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">57.0 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="434.3" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="434.3" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">204 ns</text>
+<line x1="168.0" y1="254.0" x2="432.3" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="432.3" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">197 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="448.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="448.8" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">272 ns</text>
+<line x1="168.0" y1="278.0" x2="448.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="448.6" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">273 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="452.4" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="452.4" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">292 ns</text>
+<line x1="168.0" y1="302.0" x2="452.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="452.6" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">296 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="468.4" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="468.4" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">403 ns</text>
+<line x1="168.0" y1="326.0" x2="469.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="469.0" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">411 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="508.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="508.1" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">888 ns</text>
+<line x1="168.0" y1="350.0" x2="508.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="508.2" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">899 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="533.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="533.0" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.46 µs</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="626.5" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="626.5" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.44 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="422.0" x2="645.9" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="645.9" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.9 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="446.0" x2="664.7" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="664.7" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.2 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="470.0" x2="701.3" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="701.3" cy="470.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">42.0 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">58.7 µs</text>
+<line x1="168.0" y1="374.0" x2="533.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="533.1" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.48 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="398.0" x2="587.3" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="587.3" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.37 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
+<line x1="168.0" y1="422.0" x2="627.9" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="627.9" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.85 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
+<line x1="168.0" y1="446.0" x2="632.7" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="632.7" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.8 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
+<line x1="168.0" y1="470.0" x2="636.2" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="636.2" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">11.6 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="494.0" x2="652.2" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="652.2" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">16.0 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
+<line x1="168.0" y1="518.0" x2="665.3" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="665.3" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.8 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
+<line x1="168.0" y1="542.0" x2="688.4" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="688.4" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">33.0 µs</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="566.0" x2="701.0" y2="566.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="701.0" cy="566.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">42.5 µs</text>
+<text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="590.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">59.7 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">c/wordcount: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/c-wordcount.svg
+++ b/docs/benchmarks/figs/c-wordcount.svg
@@ -1,89 +1,105 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/wordcount: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.53 ns, then wasmer at 1.62 ns; pywasm-cpython is slowest at 58.7 µs, a span of 38300x. The table below carries every number.">
-<title>c/wordcount: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.53 ns, then wasmer at 1.62 ns; pywasm-cpython is slowest at 58.7 µs, a span of 38300x. The table below carries every number.</title>
-<rect width="820" height="536" fill="#fcfcfb"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="283.3" y1="68.0" x2="283.3" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="283.3" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="398.7" y1="68.0" x2="398.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="398.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="514.0" y1="68.0" x2="514.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="514.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="629.3" y1="68.0" x2="629.3" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="629.3" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/wordcount: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.62 ns; pywasm-cpython is slowest at 59.7 µs, a span of 39800x. The table below carries every number.">
+<title>c/wordcount: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.62 ns; pywasm-cpython is slowest at 59.7 µs, a span of 39800x. The table below carries every number.</title>
+<rect width="820" height="632" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
+<line x1="283.2" y1="68.0" x2="283.2" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="283.2" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="398.3" y1="68.0" x2="398.3" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="398.3" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="513.5" y1="68.0" x2="513.5" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="513.5" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="628.6" y1="68.0" x2="628.6" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="628.6" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="189.4" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="189.4" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.53 ns</text>
+<line x1="168.0" y1="86.0" x2="188.2" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="188.2" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.50 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="192.0" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="192.0" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="110.0" x2="192.1" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="192.1" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.62 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="212.8" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="212.8" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.45 ns</text>
+<line x1="168.0" y1="134.0" x2="218.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="218.1" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.72 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="222.7" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="222.7" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.98 ns</text>
+<line x1="168.0" y1="158.0" x2="223.2" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="223.2" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.01 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="227.4" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="227.4" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.28 ns</text>
+<line x1="168.0" y1="182.0" x2="230.9" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="230.9" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.52 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="319.0" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="319.0" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.4 ns</text>
+<line x1="168.0" y1="206.0" x2="318.6" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="318.6" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.3 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="369.2" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="369.2" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">55.6 ns</text>
+<line x1="168.0" y1="230.0" x2="370.2" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="370.2" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">57.0 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="434.3" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="434.3" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">204 ns</text>
+<line x1="168.0" y1="254.0" x2="432.3" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="432.3" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">197 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="448.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="448.8" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">272 ns</text>
+<line x1="168.0" y1="278.0" x2="448.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="448.6" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">273 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="452.4" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="452.4" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">292 ns</text>
+<line x1="168.0" y1="302.0" x2="452.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="452.6" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">296 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="468.4" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="468.4" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">403 ns</text>
+<line x1="168.0" y1="326.0" x2="469.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="469.0" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">411 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="508.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="508.1" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">888 ns</text>
+<line x1="168.0" y1="350.0" x2="508.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="508.2" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">899 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="533.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="533.0" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.46 µs</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="626.5" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="626.5" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.44 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="422.0" x2="645.9" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="645.9" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.9 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="446.0" x2="664.7" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="664.7" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.2 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="470.0" x2="701.3" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="701.3" cy="470.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">42.0 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">58.7 µs</text>
+<line x1="168.0" y1="374.0" x2="533.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="533.1" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.48 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="398.0" x2="587.3" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="587.3" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.37 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
+<line x1="168.0" y1="422.0" x2="627.9" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="627.9" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.85 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
+<line x1="168.0" y1="446.0" x2="632.7" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="632.7" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.8 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
+<line x1="168.0" y1="470.0" x2="636.2" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="636.2" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">11.6 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="494.0" x2="652.2" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="652.2" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">16.0 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
+<line x1="168.0" y1="518.0" x2="665.3" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="665.3" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.8 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
+<line x1="168.0" y1="542.0" x2="688.4" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="688.4" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">33.0 µs</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="566.0" x2="701.0" y2="566.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="701.0" cy="566.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">42.5 µs</text>
+<text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="590.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">59.7 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">c/wordcount: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-br-table-dark.svg
+++ b/docs/benchmarks/figs/wat-br-table-dark.svg
@@ -1,89 +1,105 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/br_table: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-go is fastest at 7.60 ns, then wasmtime at 8.52 ns; pywasm-cpython is slowest at 50.0 µs, a span of 6580x. The table below carries every number.">
-<title>wat/br_table: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-go is fastest at 7.60 ns, then wasmtime at 8.52 ns; pywasm-cpython is slowest at 50.0 µs, a span of 6580x. The table below carries every number.</title>
-<rect width="820" height="536" fill="#1a1a19"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="285.0" y1="68.0" x2="285.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="285.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="402.1" y1="68.0" x2="402.1" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="402.1" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="519.1" y1="68.0" x2="519.1" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="519.1" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="636.1" y1="68.0" x2="636.1" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="636.1" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/br_table: seconds per iteration for 22 runners on a log scale, fastest first. dewasm-go is fastest at 7.65 ns, then wasmer at 8.48 ns; pywasm-pypy is slowest at 54.2 µs, a span of 7080x. The table below carries every number.">
+<title>wat/br_table: seconds per iteration for 22 runners on a log scale, fastest first. dewasm-go is fastest at 7.65 ns, then wasmer at 8.48 ns; pywasm-pypy is slowest at 54.2 µs, a span of 7080x. The table below carries every number.</title>
+<rect width="820" height="632" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
+<line x1="284.2" y1="68.0" x2="284.2" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="284.2" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="400.4" y1="68.0" x2="400.4" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="400.4" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="516.6" y1="68.0" x2="516.6" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="516.6" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="632.8" y1="68.0" x2="632.8" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="632.8" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="86.0" x2="271.1" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="271.1" cy="86.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.60 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="276.9" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="276.9" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.52 ns</text>
-<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="134.0" x2="277.2" y2="134.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="277.2" cy="134.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.57 ns</text>
+<line x1="168.0" y1="86.0" x2="270.6" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="270.6" cy="86.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.65 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="110.0" x2="275.8" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="275.8" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.48 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="134.0" x2="276.0" y2="134.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="276.0" cy="134.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.50 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="278.7" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="278.7" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.83 ns</text>
+<line x1="168.0" y1="158.0" x2="278.1" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="278.1" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.85 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="283.3" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="283.3" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.67 ns</text>
+<line x1="168.0" y1="182.0" x2="282.9" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="282.9" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.75 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="334.0" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="334.0" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">26.2 ns</text>
+<line x1="168.0" y1="206.0" x2="333.5" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="333.5" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">26.6 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="376.9" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="376.9" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">61.0 ns</text>
+<line x1="168.0" y1="230.0" x2="377.1" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="377.1" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">63.0 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="254.0" x2="439.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="439.6" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">209 ns</text>
+<line x1="168.0" y1="254.0" x2="439.4" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="439.4" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">217 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="278.0" x2="441.4" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="441.4" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="278.0" x2="439.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="439.5" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">217 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="302.0" x2="441.9" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="441.9" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">219 ns</text>
+<line x1="168.0" y1="302.0" x2="440.3" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="440.3" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">221 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="326.0" x2="442.7" y2="326.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="442.7" cy="326.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">222 ns</text>
+<line x1="168.0" y1="326.0" x2="440.3" y2="326.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="440.3" cy="326.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">221 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="471.6" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="471.6" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">392 ns</text>
+<line x1="168.0" y1="350.0" x2="470.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="470.2" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">399 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="511.5" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="511.5" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">861 ns</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="627.2" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="627.2" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.39 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="422.0" x2="672.3" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="672.3" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.4 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="446.0" x2="700.9" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="700.9" cy="446.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">35.8 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="470.0" x2="709.3" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="709.3" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">42.2 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">50.0 µs</text>
+<line x1="168.0" y1="374.0" x2="510.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="510.0" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">878 ns</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="398.0" x2="574.1" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="574.1" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.13 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
+<line x1="168.0" y1="422.0" x2="622.3" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="622.3" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.13 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
+<line x1="168.0" y1="446.0" x2="626.0" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="626.0" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.75 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
+<line x1="168.0" y1="470.0" x2="626.6" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="626.6" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.85 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
+<line x1="168.0" y1="494.0" x2="671.2" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="671.2" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">21.4 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
+<line x1="168.0" y1="518.0" x2="674.8" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="674.8" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">23.0 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="542.0" x2="698.2" y2="542.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="698.2" cy="542.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">36.6 µs</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="566.0" x2="715.3" y2="566.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="715.3" cy="566.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">51.4 µs</text>
+<text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="590.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">54.2 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/br_table: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-br-table.svg
+++ b/docs/benchmarks/figs/wat-br-table.svg
@@ -1,89 +1,105 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/br_table: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-go is fastest at 7.60 ns, then wasmtime at 8.52 ns; pywasm-cpython is slowest at 50.0 µs, a span of 6580x. The table below carries every number.">
-<title>wat/br_table: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-go is fastest at 7.60 ns, then wasmtime at 8.52 ns; pywasm-cpython is slowest at 50.0 µs, a span of 6580x. The table below carries every number.</title>
-<rect width="820" height="536" fill="#fcfcfb"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="285.0" y1="68.0" x2="285.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="285.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="402.1" y1="68.0" x2="402.1" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="402.1" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="519.1" y1="68.0" x2="519.1" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="519.1" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="636.1" y1="68.0" x2="636.1" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="636.1" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/br_table: seconds per iteration for 22 runners on a log scale, fastest first. dewasm-go is fastest at 7.65 ns, then wasmer at 8.48 ns; pywasm-pypy is slowest at 54.2 µs, a span of 7080x. The table below carries every number.">
+<title>wat/br_table: seconds per iteration for 22 runners on a log scale, fastest first. dewasm-go is fastest at 7.65 ns, then wasmer at 8.48 ns; pywasm-pypy is slowest at 54.2 µs, a span of 7080x. The table below carries every number.</title>
+<rect width="820" height="632" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
+<line x1="284.2" y1="68.0" x2="284.2" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="284.2" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="400.4" y1="68.0" x2="400.4" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="400.4" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="516.6" y1="68.0" x2="516.6" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="516.6" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="632.8" y1="68.0" x2="632.8" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="632.8" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="86.0" x2="271.1" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="271.1" cy="86.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.60 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="276.9" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="276.9" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.52 ns</text>
-<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="134.0" x2="277.2" y2="134.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="277.2" cy="134.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.57 ns</text>
+<line x1="168.0" y1="86.0" x2="270.6" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="270.6" cy="86.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.65 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="110.0" x2="275.8" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="275.8" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.48 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="134.0" x2="276.0" y2="134.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="276.0" cy="134.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.50 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="278.7" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="278.7" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.83 ns</text>
+<line x1="168.0" y1="158.0" x2="278.1" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="278.1" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.85 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="283.3" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="283.3" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.67 ns</text>
+<line x1="168.0" y1="182.0" x2="282.9" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="282.9" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.75 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="334.0" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="334.0" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">26.2 ns</text>
+<line x1="168.0" y1="206.0" x2="333.5" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="333.5" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">26.6 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="376.9" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="376.9" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">61.0 ns</text>
+<line x1="168.0" y1="230.0" x2="377.1" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="377.1" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">63.0 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="254.0" x2="439.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="439.6" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">209 ns</text>
+<line x1="168.0" y1="254.0" x2="439.4" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="439.4" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">217 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="278.0" x2="441.4" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="441.4" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="278.0" x2="439.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="439.5" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">217 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="302.0" x2="441.9" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="441.9" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">219 ns</text>
+<line x1="168.0" y1="302.0" x2="440.3" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="440.3" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">221 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="326.0" x2="442.7" y2="326.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="442.7" cy="326.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">222 ns</text>
+<line x1="168.0" y1="326.0" x2="440.3" y2="326.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="440.3" cy="326.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">221 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="471.6" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="471.6" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">392 ns</text>
+<line x1="168.0" y1="350.0" x2="470.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="470.2" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">399 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="511.5" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="511.5" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">861 ns</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="627.2" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="627.2" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.39 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="422.0" x2="672.3" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="672.3" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.4 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="446.0" x2="700.9" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="700.9" cy="446.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">35.8 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="470.0" x2="709.3" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="709.3" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">42.2 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">50.0 µs</text>
+<line x1="168.0" y1="374.0" x2="510.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="510.0" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">878 ns</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="398.0" x2="574.1" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="574.1" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.13 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
+<line x1="168.0" y1="422.0" x2="622.3" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="622.3" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.13 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
+<line x1="168.0" y1="446.0" x2="626.0" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="626.0" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.75 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
+<line x1="168.0" y1="470.0" x2="626.6" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="626.6" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.85 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
+<line x1="168.0" y1="494.0" x2="671.2" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="671.2" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">21.4 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
+<line x1="168.0" y1="518.0" x2="674.8" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="674.8" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">23.0 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="542.0" x2="698.2" y2="542.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="698.2" cy="542.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">36.6 µs</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="566.0" x2="715.3" y2="566.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="715.3" cy="566.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">51.4 µs</text>
+<text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="590.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">54.2 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/br_table: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-call-direct-dark.svg
+++ b/docs/benchmarks/figs/wat-call-direct-dark.svg
@@ -1,89 +1,105 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_direct: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 3.44 ns, then wasmer at 3.44 ns; dewasm-bash is slowest at 54.4 µs, a span of 15800x. The table below carries every number.">
-<title>wat/call_direct: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 3.44 ns, then wasmer at 3.44 ns; dewasm-bash is slowest at 54.4 µs, a span of 15800x. The table below carries every number.</title>
-<rect width="820" height="536" fill="#1a1a19"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="284.1" y1="68.0" x2="284.1" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="284.1" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="400.3" y1="68.0" x2="400.3" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="400.3" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="516.4" y1="68.0" x2="516.4" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="516.4" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="632.5" y1="68.0" x2="632.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="632.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="230.3" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="230.3" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.44 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="230.4" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="230.4" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.44 ns</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_direct: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 3.50 ns, then wasmtime at 3.51 ns; wasm3-python is slowest at 73.3 µs, a span of 21000x. The table below carries every number.">
+<title>wat/call_direct: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 3.50 ns, then wasmtime at 3.51 ns; wasm3-python is slowest at 73.3 µs, a span of 21000x. The table below carries every number.</title>
+<rect width="820" height="632" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
+<line x1="281.0" y1="68.0" x2="281.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="281.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="394.1" y1="68.0" x2="394.1" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="394.1" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="507.1" y1="68.0" x2="507.1" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="507.1" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="620.2" y1="68.0" x2="620.2" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="620.2" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="86.0" x2="229.5" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="229.5" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.50 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="110.0" x2="229.7" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="229.7" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.51 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="231.8" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="231.8" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.55 ns</text>
+<line x1="168.0" y1="134.0" x2="231.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="231.1" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.61 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="158.0" x2="238.8" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="238.8" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.07 ns</text>
+<line x1="168.0" y1="158.0" x2="237.2" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="237.2" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.10 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="182.0" x2="257.6" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="257.6" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.91 ns</text>
+<line x1="168.0" y1="182.0" x2="256.3" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="256.3" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.03 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="363.9" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="363.9" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">48.7 ns</text>
+<line x1="168.0" y1="206.0" x2="354.7" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="354.7" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">44.9 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="393.9" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="393.9" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">88.2 ns</text>
+<line x1="168.0" y1="230.0" x2="389.0" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="389.0" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">90.1 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="403.1" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="403.1" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">106 ns</text>
+<line x1="168.0" y1="254.0" x2="398.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="398.6" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">110 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="278.0" x2="410.3" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="410.3" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">122 ns</text>
+<line x1="168.0" y1="278.0" x2="405.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="405.6" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">127 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="302.0" x2="435.7" y2="302.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="435.7" cy="302.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">202 ns</text>
+<line x1="168.0" y1="302.0" x2="429.1" y2="302.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="429.1" cy="302.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">204 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="436.1" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="436.1" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">204 ns</text>
+<line x1="168.0" y1="326.0" x2="430.3" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="430.3" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">209 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="471.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="471.7" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">412 ns</text>
+<line x1="168.0" y1="350.0" x2="465.0" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="465.0" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">424 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="520.7" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="520.7" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.09 µs</text>
+<line x1="168.0" y1="374.0" x2="512.4" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="512.4" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.11 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="619.1" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="619.1" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.67 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="422.0" x2="624.7" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="624.7" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.56 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="446.0" x2="660.3" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="660.3" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">17.3 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="470.0" x2="711.5" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="711.5" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">47.9 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">54.4 µs</text>
+<line x1="168.0" y1="398.0" x2="611.1" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="611.1" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.32 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="422.0" x2="617.8" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="617.8" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.52 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="446.0" x2="620.2" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="620.2" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.0 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
+<line x1="168.0" y1="470.0" x2="647.3" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="647.3" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">17.4 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
+<line x1="168.0" y1="494.0" x2="649.2" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="649.2" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">18.1 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
+<line x1="168.0" y1="518.0" x2="659.8" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="659.8" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">22.4 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="542.0" x2="698.7" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="698.7" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">49.5 µs</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="566.0" x2="704.9" y2="566.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="704.9" cy="566.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">56.2 µs</text>
+<text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
+<line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="590.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">73.3 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/call_direct: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-call-direct.svg
+++ b/docs/benchmarks/figs/wat-call-direct.svg
@@ -1,89 +1,105 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_direct: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 3.44 ns, then wasmer at 3.44 ns; dewasm-bash is slowest at 54.4 µs, a span of 15800x. The table below carries every number.">
-<title>wat/call_direct: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 3.44 ns, then wasmer at 3.44 ns; dewasm-bash is slowest at 54.4 µs, a span of 15800x. The table below carries every number.</title>
-<rect width="820" height="536" fill="#fcfcfb"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="284.1" y1="68.0" x2="284.1" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="284.1" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="400.3" y1="68.0" x2="400.3" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="400.3" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="516.4" y1="68.0" x2="516.4" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="516.4" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="632.5" y1="68.0" x2="632.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="632.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="230.3" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="230.3" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.44 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="230.4" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="230.4" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.44 ns</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_direct: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 3.50 ns, then wasmtime at 3.51 ns; wasm3-python is slowest at 73.3 µs, a span of 21000x. The table below carries every number.">
+<title>wat/call_direct: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 3.50 ns, then wasmtime at 3.51 ns; wasm3-python is slowest at 73.3 µs, a span of 21000x. The table below carries every number.</title>
+<rect width="820" height="632" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
+<line x1="281.0" y1="68.0" x2="281.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="281.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="394.1" y1="68.0" x2="394.1" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="394.1" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="507.1" y1="68.0" x2="507.1" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="507.1" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="620.2" y1="68.0" x2="620.2" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="620.2" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="86.0" x2="229.5" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="229.5" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.50 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="110.0" x2="229.7" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="229.7" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.51 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="231.8" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="231.8" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.55 ns</text>
+<line x1="168.0" y1="134.0" x2="231.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="231.1" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.61 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="158.0" x2="238.8" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="238.8" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.07 ns</text>
+<line x1="168.0" y1="158.0" x2="237.2" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="237.2" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.10 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="182.0" x2="257.6" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="257.6" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.91 ns</text>
+<line x1="168.0" y1="182.0" x2="256.3" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="256.3" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.03 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="363.9" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="363.9" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">48.7 ns</text>
+<line x1="168.0" y1="206.0" x2="354.7" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="354.7" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">44.9 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="393.9" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="393.9" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">88.2 ns</text>
+<line x1="168.0" y1="230.0" x2="389.0" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="389.0" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">90.1 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="403.1" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="403.1" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">106 ns</text>
+<line x1="168.0" y1="254.0" x2="398.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="398.6" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">110 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="278.0" x2="410.3" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="410.3" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">122 ns</text>
+<line x1="168.0" y1="278.0" x2="405.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="405.6" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">127 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="302.0" x2="435.7" y2="302.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="435.7" cy="302.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">202 ns</text>
+<line x1="168.0" y1="302.0" x2="429.1" y2="302.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="429.1" cy="302.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">204 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="436.1" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="436.1" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">204 ns</text>
+<line x1="168.0" y1="326.0" x2="430.3" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="430.3" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">209 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="471.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="471.7" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">412 ns</text>
+<line x1="168.0" y1="350.0" x2="465.0" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="465.0" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">424 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="520.7" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="520.7" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.09 µs</text>
+<line x1="168.0" y1="374.0" x2="512.4" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="512.4" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.11 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="619.1" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="619.1" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.67 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="422.0" x2="624.7" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="624.7" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.56 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="446.0" x2="660.3" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="660.3" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">17.3 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="470.0" x2="711.5" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="711.5" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">47.9 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">54.4 µs</text>
+<line x1="168.0" y1="398.0" x2="611.1" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="611.1" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.32 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="422.0" x2="617.8" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="617.8" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.52 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="446.0" x2="620.2" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="620.2" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.0 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
+<line x1="168.0" y1="470.0" x2="647.3" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="647.3" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">17.4 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
+<line x1="168.0" y1="494.0" x2="649.2" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="649.2" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">18.1 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
+<line x1="168.0" y1="518.0" x2="659.8" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="659.8" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">22.4 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="542.0" x2="698.7" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="698.7" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">49.5 µs</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="566.0" x2="704.9" y2="566.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="704.9" cy="566.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">56.2 µs</text>
+<text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
+<line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="590.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">73.3 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/call_direct: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-call-indirect-dark.svg
+++ b/docs/benchmarks/figs/wat-call-indirect-dark.svg
@@ -1,87 +1,105 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_indirect: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 10.3 ns, then wasmer at 10.4 ns; pywasm-cpython is slowest at 80.2 µs, a span of 7790x. The table below carries every number.">
-<title>wat/call_indirect: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 10.3 ns, then wasmer at 10.4 ns; pywasm-cpython is slowest at 80.2 µs, a span of 7790x. The table below carries every number.</title>
-<rect width="820" height="536" fill="#1a1a19"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="308.9" y1="68.0" x2="308.9" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="308.9" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="449.7" y1="68.0" x2="449.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="449.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="590.6" y1="68.0" x2="590.6" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="590.6" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_indirect: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 10.5 ns, then wasmer at 10.5 ns; wasm3-python is slowest at 107 µs, a span of 10200x. The table below carries every number.">
+<title>wat/call_indirect: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 10.5 ns, then wasmer at 10.5 ns; wasm3-python is slowest at 107 µs, a span of 10200x. The table below carries every number.</title>
+<rect width="820" height="632" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="304.5" y1="68.0" x2="304.5" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="304.5" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="441.0" y1="68.0" x2="441.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="441.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="577.6" y1="68.0" x2="577.6" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="577.6" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="714.1" y1="68.0" x2="714.1" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="714.1" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="169.8" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="169.8" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.3 ns</text>
+<line x1="168.0" y1="86.0" x2="170.7" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="170.7" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.5 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="170.1" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="170.1" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.4 ns</text>
+<line x1="168.0" y1="110.0" x2="170.8" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="170.8" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.5 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="171.7" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="171.7" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.6 ns</text>
+<line x1="168.0" y1="134.0" x2="172.5" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="172.5" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.8 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="176.8" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="176.8" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">11.6 ns</text>
+<line x1="168.0" y1="158.0" x2="178.2" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="178.2" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">11.9 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="271.4" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="271.4" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">54.2 ns</text>
+<line x1="168.0" y1="182.0" x2="272.4" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="272.4" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">58.2 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="285.2" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="285.2" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">67.9 ns</text>
+<line x1="168.0" y1="206.0" x2="280.5" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="280.5" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">66.7 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="327.6" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="327.6" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">136 ns</text>
-<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="394.2" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="394.2" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">403 ns</text>
-<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="278.0" x2="395.7" y2="278.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="395.7" cy="278.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">413 ns</text>
+<line x1="168.0" y1="230.0" x2="324.3" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="324.3" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">140 ns</text>
+<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
+<line x1="168.0" y1="254.0" x2="388.4" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="388.4" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">412 ns</text>
+<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
+<line x1="168.0" y1="278.0" x2="388.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="388.5" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">412 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="403.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="403.2" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">467 ns</text>
+<line x1="168.0" y1="302.0" x2="397.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="397.5" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">480 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="424.2" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="424.2" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">659 ns</text>
+<line x1="168.0" y1="326.0" x2="417.1" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="417.1" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">668 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="434.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="434.1" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">775 ns</text>
+<line x1="168.0" y1="350.0" x2="427.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="427.2" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">791 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="503.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="503.8" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.42 µs</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="609.8" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="609.8" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.7 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="422.0" x2="652.0" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="652.0" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">27.3 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="659.2" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="659.2" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">30.7 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="470.0" x2="712.4" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="712.4" cy="470.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">73.2 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">80.2 µs</text>
+<line x1="168.0" y1="374.0" x2="494.5" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="494.5" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.47 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="398.0" x2="588.7" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="588.7" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.1 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
+<line x1="168.0" y1="422.0" x2="597.5" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="597.5" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.0 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
+<line x1="168.0" y1="446.0" x2="639.0" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="639.0" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">28.2 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
+<line x1="168.0" y1="470.0" x2="645.8" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="645.8" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">31.6 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
+<line x1="168.0" y1="494.0" x2="647.3" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="647.3" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">32.4 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="518.0" x2="654.9" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="654.9" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">36.9 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="542.0" x2="697.2" y2="542.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="697.2" cy="542.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">75.3 µs</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="566.0" x2="702.7" y2="566.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="702.7" cy="566.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">82.6 µs</text>
+<text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
+<line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="590.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">107 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/call_indirect: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-call-indirect.svg
+++ b/docs/benchmarks/figs/wat-call-indirect.svg
@@ -1,87 +1,105 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_indirect: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 10.3 ns, then wasmer at 10.4 ns; pywasm-cpython is slowest at 80.2 µs, a span of 7790x. The table below carries every number.">
-<title>wat/call_indirect: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 10.3 ns, then wasmer at 10.4 ns; pywasm-cpython is slowest at 80.2 µs, a span of 7790x. The table below carries every number.</title>
-<rect width="820" height="536" fill="#fcfcfb"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="308.9" y1="68.0" x2="308.9" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="308.9" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="449.7" y1="68.0" x2="449.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="449.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="590.6" y1="68.0" x2="590.6" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="590.6" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_indirect: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 10.5 ns, then wasmer at 10.5 ns; wasm3-python is slowest at 107 µs, a span of 10200x. The table below carries every number.">
+<title>wat/call_indirect: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 10.5 ns, then wasmer at 10.5 ns; wasm3-python is slowest at 107 µs, a span of 10200x. The table below carries every number.</title>
+<rect width="820" height="632" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="304.5" y1="68.0" x2="304.5" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="304.5" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="441.0" y1="68.0" x2="441.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="441.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="577.6" y1="68.0" x2="577.6" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="577.6" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="714.1" y1="68.0" x2="714.1" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="714.1" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="169.8" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="169.8" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.3 ns</text>
+<line x1="168.0" y1="86.0" x2="170.7" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="170.7" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.5 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="170.1" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="170.1" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.4 ns</text>
+<line x1="168.0" y1="110.0" x2="170.8" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="170.8" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.5 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="171.7" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="171.7" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.6 ns</text>
+<line x1="168.0" y1="134.0" x2="172.5" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="172.5" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.8 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="176.8" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="176.8" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">11.6 ns</text>
+<line x1="168.0" y1="158.0" x2="178.2" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="178.2" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">11.9 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="271.4" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="271.4" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">54.2 ns</text>
+<line x1="168.0" y1="182.0" x2="272.4" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="272.4" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">58.2 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="285.2" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="285.2" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">67.9 ns</text>
+<line x1="168.0" y1="206.0" x2="280.5" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="280.5" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">66.7 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="327.6" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="327.6" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">136 ns</text>
-<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="394.2" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="394.2" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">403 ns</text>
-<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="278.0" x2="395.7" y2="278.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="395.7" cy="278.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">413 ns</text>
+<line x1="168.0" y1="230.0" x2="324.3" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="324.3" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">140 ns</text>
+<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
+<line x1="168.0" y1="254.0" x2="388.4" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="388.4" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">412 ns</text>
+<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
+<line x1="168.0" y1="278.0" x2="388.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="388.5" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">412 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="403.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="403.2" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">467 ns</text>
+<line x1="168.0" y1="302.0" x2="397.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="397.5" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">480 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="424.2" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="424.2" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">659 ns</text>
+<line x1="168.0" y1="326.0" x2="417.1" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="417.1" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">668 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="434.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="434.1" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">775 ns</text>
+<line x1="168.0" y1="350.0" x2="427.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="427.2" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">791 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="503.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="503.8" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.42 µs</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="609.8" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="609.8" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.7 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="422.0" x2="652.0" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="652.0" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">27.3 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="659.2" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="659.2" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">30.7 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="470.0" x2="712.4" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="712.4" cy="470.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">73.2 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">80.2 µs</text>
+<line x1="168.0" y1="374.0" x2="494.5" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="494.5" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.47 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="398.0" x2="588.7" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="588.7" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.1 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
+<line x1="168.0" y1="422.0" x2="597.5" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="597.5" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.0 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
+<line x1="168.0" y1="446.0" x2="639.0" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="639.0" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">28.2 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
+<line x1="168.0" y1="470.0" x2="645.8" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="645.8" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">31.6 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
+<line x1="168.0" y1="494.0" x2="647.3" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="647.3" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">32.4 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="518.0" x2="654.9" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="654.9" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">36.9 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="542.0" x2="697.2" y2="542.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="697.2" cy="542.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">75.3 µs</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="566.0" x2="702.7" y2="566.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="702.7" cy="566.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">82.6 µs</text>
+<text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
+<line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="590.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">107 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/call_indirect: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-conv-dark.svg
+++ b/docs/benchmarks/figs/wat-conv-dark.svg
@@ -1,91 +1,107 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/conv: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 7.53 ns, then wasmtime at 7.55 ns; pywasm-pypy is slowest at 657 µs, a span of 87200x. The table below carries every number.">
-<title>wat/conv: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 7.53 ns, then wasmtime at 7.55 ns; pywasm-pypy is slowest at 657 µs, a span of 87200x. The table below carries every number.</title>
-<rect width="820" height="536" fill="#1a1a19"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="262.5" y1="68.0" x2="262.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="262.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="357.1" y1="68.0" x2="357.1" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="357.1" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="451.6" y1="68.0" x2="451.6" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="451.6" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="546.2" y1="68.0" x2="546.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="546.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="640.7" y1="68.0" x2="640.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="640.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
-<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/conv: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 7.64 ns, then wasmtime at 7.67 ns; pywasm-pypy is slowest at 795 µs, a span of 104000x. The table below carries every number.">
+<title>wat/conv: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 7.64 ns, then wasmtime at 7.67 ns; pywasm-pypy is slowest at 795 µs, a span of 104000x. The table below carries every number.</title>
+<rect width="820" height="632" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
+<line x1="261.2" y1="68.0" x2="261.2" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="261.2" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="354.4" y1="68.0" x2="354.4" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="354.4" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="447.6" y1="68.0" x2="447.6" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="447.6" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="540.9" y1="68.0" x2="540.9" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="540.9" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="634.1" y1="68.0" x2="634.1" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="634.1" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="86.0" x2="250.9" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="250.9" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.53 ns</text>
+<line x1="168.0" y1="86.0" x2="250.3" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="250.3" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.64 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="251.0" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="251.0" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.55 ns</text>
+<line x1="168.0" y1="110.0" x2="250.5" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="250.5" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.67 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="263.9" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="263.9" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.3 ns</text>
+<line x1="168.0" y1="134.0" x2="263.3" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="263.3" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.5 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="158.0" x2="287.5" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="287.5" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">18.4 ns</text>
+<line x1="168.0" y1="158.0" x2="286.1" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="286.1" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">18.5 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="182.0" x2="293.1" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="293.1" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">21.0 ns</text>
+<line x1="168.0" y1="182.0" x2="292.6" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="292.6" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">21.7 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="206.0" x2="333.3" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="333.3" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">56.1 ns</text>
+<line x1="168.0" y1="206.0" x2="331.7" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="331.7" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">57.1 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="230.0" x2="391.8" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="391.8" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">233 ns</text>
+<line x1="168.0" y1="230.0" x2="387.8" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="387.8" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">228 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="254.0" x2="395.4" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="395.4" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">254 ns</text>
+<line x1="168.0" y1="254.0" x2="392.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="392.6" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">257 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="446.2" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="446.2" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">876 ns</text>
+<line x1="168.0" y1="278.0" x2="441.9" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="441.9" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">868 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="449.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="449.8" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">955 ns</text>
+<line x1="168.0" y1="302.0" x2="447.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="447.5" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">996 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="463.4" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="463.4" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.33 µs</text>
+<line x1="168.0" y1="326.0" x2="460.2" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="460.2" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.36 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="465.0" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="465.0" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.39 µs</text>
+<line x1="168.0" y1="350.0" x2="462.6" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="462.6" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.45 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="484.3" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="484.3" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.21 µs</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="562.8" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="562.8" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.0 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="422.0" x2="584.0" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="584.0" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">25.1 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="446.0" x2="640.1" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="640.1" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">98.6 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="470.0" x2="707.1" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="707.1" cy="470.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">504 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">657 µs</text>
+<line x1="168.0" y1="374.0" x2="480.3" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="480.3" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.24 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="398.0" x2="536.7" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="536.7" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.03 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
+<line x1="168.0" y1="422.0" x2="558.1" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="558.1" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.3 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
+<line x1="168.0" y1="446.0" x2="563.4" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="563.4" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">17.4 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
+<line x1="168.0" y1="470.0" x2="579.7" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="579.7" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">26.1 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
+<line x1="168.0" y1="494.0" x2="598.3" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="598.3" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">41.3 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
+<line x1="168.0" y1="518.0" x2="605.3" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="605.3" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">49.1 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="542.0" x2="634.7" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="634.7" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">102 µs</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="566.0" x2="700.9" y2="566.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="700.9" cy="566.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">521 µs</text>
+<text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="590.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">795 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/conv: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-conv.svg
+++ b/docs/benchmarks/figs/wat-conv.svg
@@ -1,91 +1,107 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/conv: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 7.53 ns, then wasmtime at 7.55 ns; pywasm-pypy is slowest at 657 µs, a span of 87200x. The table below carries every number.">
-<title>wat/conv: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 7.53 ns, then wasmtime at 7.55 ns; pywasm-pypy is slowest at 657 µs, a span of 87200x. The table below carries every number.</title>
-<rect width="820" height="536" fill="#fcfcfb"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="262.5" y1="68.0" x2="262.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="262.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="357.1" y1="68.0" x2="357.1" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="357.1" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="451.6" y1="68.0" x2="451.6" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="451.6" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="546.2" y1="68.0" x2="546.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="546.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="640.7" y1="68.0" x2="640.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="640.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
-<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/conv: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 7.64 ns, then wasmtime at 7.67 ns; pywasm-pypy is slowest at 795 µs, a span of 104000x. The table below carries every number.">
+<title>wat/conv: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 7.64 ns, then wasmtime at 7.67 ns; pywasm-pypy is slowest at 795 µs, a span of 104000x. The table below carries every number.</title>
+<rect width="820" height="632" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
+<line x1="261.2" y1="68.0" x2="261.2" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="261.2" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="354.4" y1="68.0" x2="354.4" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="354.4" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="447.6" y1="68.0" x2="447.6" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="447.6" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="540.9" y1="68.0" x2="540.9" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="540.9" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="634.1" y1="68.0" x2="634.1" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="634.1" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="86.0" x2="250.9" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="250.9" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.53 ns</text>
+<line x1="168.0" y1="86.0" x2="250.3" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="250.3" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.64 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="251.0" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="251.0" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.55 ns</text>
+<line x1="168.0" y1="110.0" x2="250.5" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="250.5" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.67 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="263.9" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="263.9" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.3 ns</text>
+<line x1="168.0" y1="134.0" x2="263.3" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="263.3" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.5 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="158.0" x2="287.5" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="287.5" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">18.4 ns</text>
+<line x1="168.0" y1="158.0" x2="286.1" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="286.1" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">18.5 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="182.0" x2="293.1" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="293.1" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">21.0 ns</text>
+<line x1="168.0" y1="182.0" x2="292.6" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="292.6" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">21.7 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="206.0" x2="333.3" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="333.3" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">56.1 ns</text>
+<line x1="168.0" y1="206.0" x2="331.7" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="331.7" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">57.1 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="230.0" x2="391.8" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="391.8" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">233 ns</text>
+<line x1="168.0" y1="230.0" x2="387.8" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="387.8" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">228 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="254.0" x2="395.4" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="395.4" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">254 ns</text>
+<line x1="168.0" y1="254.0" x2="392.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="392.6" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">257 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="446.2" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="446.2" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">876 ns</text>
+<line x1="168.0" y1="278.0" x2="441.9" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="441.9" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">868 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="449.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="449.8" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">955 ns</text>
+<line x1="168.0" y1="302.0" x2="447.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="447.5" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">996 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="463.4" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="463.4" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.33 µs</text>
+<line x1="168.0" y1="326.0" x2="460.2" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="460.2" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.36 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="465.0" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="465.0" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.39 µs</text>
+<line x1="168.0" y1="350.0" x2="462.6" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="462.6" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.45 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="484.3" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="484.3" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.21 µs</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="562.8" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="562.8" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.0 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="422.0" x2="584.0" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="584.0" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">25.1 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="446.0" x2="640.1" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="640.1" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">98.6 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="470.0" x2="707.1" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="707.1" cy="470.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">504 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">657 µs</text>
+<line x1="168.0" y1="374.0" x2="480.3" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="480.3" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.24 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="398.0" x2="536.7" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="536.7" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.03 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
+<line x1="168.0" y1="422.0" x2="558.1" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="558.1" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.3 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
+<line x1="168.0" y1="446.0" x2="563.4" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="563.4" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">17.4 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
+<line x1="168.0" y1="470.0" x2="579.7" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="579.7" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">26.1 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
+<line x1="168.0" y1="494.0" x2="598.3" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="598.3" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">41.3 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
+<line x1="168.0" y1="518.0" x2="605.3" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="605.3" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">49.1 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="542.0" x2="634.7" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="634.7" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">102 µs</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="566.0" x2="700.9" y2="566.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="700.9" cy="566.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">521 µs</text>
+<text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="590.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">795 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/conv: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-eh-throw-dark.svg
+++ b/docs/benchmarks/figs/wat-eh-throw-dark.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.96 ns, then wasmedge at 115 ns; wasmer is slowest at 10.2 µs, a span of 2060x. The table below carries every number.">
-<title>wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.96 ns, then wasmedge at 115 ns; wasmer is slowest at 10.2 µs, a span of 2060x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.61 ns, then wasmedge at 114 ns; wasmer is slowest at 10.2 µs, a span of 2220x. The table below carries every number.">
+<title>wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.61 ns, then wasmedge at 114 ns; wasmer is slowest at 10.2 µs, a span of 2220x. The table below carries every number.</title>
 <rect width="820" height="368" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
@@ -7,51 +7,51 @@
 <text x="305.2" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
 <line x1="442.4" y1="68.0" x2="442.4" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="442.4" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="579.6" y1="68.0" x2="579.6" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="579.6" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="579.5" y1="68.0" x2="579.5" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="579.5" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
 <line x1="716.7" y1="68.0" x2="716.7" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="716.7" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
 <line x1="168.0" y1="338.0" x2="726.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="86.0" x2="263.4" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="263.4" cy="86.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.96 ns</text>
+<line x1="168.0" y1="86.0" x2="259.0" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="259.0" cy="86.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.61 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="110.0" x2="450.9" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="450.9" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">115 ns</text>
+<line x1="168.0" y1="110.0" x2="450.0" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="450.0" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">114 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="481.8" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="481.8" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">194 ns</text>
+<line x1="168.0" y1="134.0" x2="483.3" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="483.3" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">199 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="158.0" x2="490.1" y2="158.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="490.1" cy="158.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">223 ns</text>
+<line x1="168.0" y1="158.0" x2="489.6" y2="158.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="489.6" cy="158.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">221 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="182.0" x2="533.4" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="533.4" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">461 ns</text>
+<line x1="168.0" y1="182.0" x2="534.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="534.7" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">471 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="206.0" x2="540.3" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="540.3" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">517 ns</text>
+<line x1="168.0" y1="206.0" x2="544.0" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="544.0" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">551 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="230.0" x2="548.9" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="548.9" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">598 ns</text>
+<line x1="168.0" y1="230.0" x2="550.2" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="550.2" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">611 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="254.0" x2="550.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="550.5" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">614 ns</text>
+<line x1="168.0" y1="254.0" x2="552.4" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="552.4" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">634 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="278.0" x2="554.2" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="554.2" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">654 ns</text>
+<line x1="168.0" y1="278.0" x2="555.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="555.6" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">669 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="302.0" x2="588.9" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="588.9" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.17 µs</text>
+<line x1="168.0" y1="302.0" x2="589.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="589.7" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.19 µs</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
 <line x1="168.0" y1="326.0" x2="718.0" y2="326.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="326.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>

--- a/docs/benchmarks/figs/wat-eh-throw.svg
+++ b/docs/benchmarks/figs/wat-eh-throw.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.96 ns, then wasmedge at 115 ns; wasmer is slowest at 10.2 µs, a span of 2060x. The table below carries every number.">
-<title>wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.96 ns, then wasmedge at 115 ns; wasmer is slowest at 10.2 µs, a span of 2060x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.61 ns, then wasmedge at 114 ns; wasmer is slowest at 10.2 µs, a span of 2220x. The table below carries every number.">
+<title>wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.61 ns, then wasmedge at 114 ns; wasmer is slowest at 10.2 µs, a span of 2220x. The table below carries every number.</title>
 <rect width="820" height="368" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
@@ -7,51 +7,51 @@
 <text x="305.2" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
 <line x1="442.4" y1="68.0" x2="442.4" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="442.4" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="579.6" y1="68.0" x2="579.6" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="579.6" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="579.5" y1="68.0" x2="579.5" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="579.5" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
 <line x1="716.7" y1="68.0" x2="716.7" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="716.7" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
 <line x1="168.0" y1="338.0" x2="726.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="86.0" x2="263.4" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="263.4" cy="86.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.96 ns</text>
+<line x1="168.0" y1="86.0" x2="259.0" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="259.0" cy="86.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.61 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="110.0" x2="450.9" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="450.9" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">115 ns</text>
+<line x1="168.0" y1="110.0" x2="450.0" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="450.0" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">114 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="481.8" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="481.8" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">194 ns</text>
+<line x1="168.0" y1="134.0" x2="483.3" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="483.3" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">199 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="158.0" x2="490.1" y2="158.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="490.1" cy="158.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">223 ns</text>
+<line x1="168.0" y1="158.0" x2="489.6" y2="158.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="489.6" cy="158.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">221 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="182.0" x2="533.4" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="533.4" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">461 ns</text>
+<line x1="168.0" y1="182.0" x2="534.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="534.7" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">471 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="206.0" x2="540.3" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="540.3" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">517 ns</text>
+<line x1="168.0" y1="206.0" x2="544.0" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="544.0" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">551 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="230.0" x2="548.9" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="548.9" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">598 ns</text>
+<line x1="168.0" y1="230.0" x2="550.2" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="550.2" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">611 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="254.0" x2="550.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="550.5" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">614 ns</text>
+<line x1="168.0" y1="254.0" x2="552.4" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="552.4" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">634 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="278.0" x2="554.2" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="554.2" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">654 ns</text>
+<line x1="168.0" y1="278.0" x2="555.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="555.6" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">669 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="302.0" x2="588.9" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="588.9" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.17 µs</text>
+<line x1="168.0" y1="302.0" x2="589.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="589.7" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.19 µs</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
 <line x1="168.0" y1="326.0" x2="718.0" y2="326.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="326.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>

--- a/docs/benchmarks/figs/wat-eh-try-dark.svg
+++ b/docs/benchmarks/figs/wat-eh-try-dark.svg
@@ -1,57 +1,57 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.25 ns, then dewasm-java at 1.42 ns; dewasm-perl is slowest at 511 ns, a span of 409x. The table below carries every number.">
-<title>wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.25 ns, then dewasm-java at 1.42 ns; dewasm-perl is slowest at 511 ns, a span of 409x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.27 ns, then dewasm-java at 1.43 ns; dewasm-perl is slowest at 515 ns, a span of 406x. The table below carries every number.">
+<title>wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.27 ns, then dewasm-java at 1.43 ns; dewasm-perl is slowest at 515 ns, a span of 406x. The table below carries every number.</title>
 <rect width="820" height="368" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="371.1" y1="68.0" x2="371.1" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="371.1" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="574.2" y1="68.0" x2="574.2" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="574.2" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="370.8" y1="68.0" x2="370.8" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="370.8" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="573.6" y1="68.0" x2="573.6" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="573.6" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
 <line x1="168.0" y1="338.0" x2="726.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="86.0" x2="187.6" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="187.6" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.25 ns</text>
+<line x1="168.0" y1="86.0" x2="189.0" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="189.0" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.27 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="110.0" x2="198.8" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="198.8" cy="110.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.42 ns</text>
+<line x1="168.0" y1="110.0" x2="199.8" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="199.8" cy="110.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.43 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="134.0" x2="251.3" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="251.3" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.57 ns</text>
+<line x1="168.0" y1="134.0" x2="252.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="252.6" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.61 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="158.0" x2="256.9" y2="158.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="256.9" cy="158.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.74 ns</text>
+<line x1="168.0" y1="158.0" x2="258.1" y2="158.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="258.1" cy="158.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.78 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="182.0" x2="295.2" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="295.2" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.23 ns</text>
+<line x1="168.0" y1="182.0" x2="295.5" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="295.5" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.25 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="206.0" x2="587.0" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="587.0" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">116 ns</text>
+<line x1="168.0" y1="206.0" x2="586.0" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="586.0" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">115 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="230.0" x2="589.8" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="589.8" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">119 ns</text>
+<line x1="168.0" y1="230.0" x2="590.8" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="590.8" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">122 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="254.0" x2="590.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="590.5" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">120 ns</text>
+<line x1="168.0" y1="254.0" x2="590.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="590.8" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">122 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="590.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="590.8" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">121 ns</text>
+<line x1="168.0" y1="278.0" x2="591.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="591.5" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">123 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="302.0" x2="634.3" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="634.3" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="302.0" x2="633.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="633.7" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">198 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
 <line x1="168.0" y1="326.0" x2="718.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">511 ns</text>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">515 ns</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/eh_try: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-eh-try.svg
+++ b/docs/benchmarks/figs/wat-eh-try.svg
@@ -1,57 +1,57 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.25 ns, then dewasm-java at 1.42 ns; dewasm-perl is slowest at 511 ns, a span of 409x. The table below carries every number.">
-<title>wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.25 ns, then dewasm-java at 1.42 ns; dewasm-perl is slowest at 511 ns, a span of 409x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.27 ns, then dewasm-java at 1.43 ns; dewasm-perl is slowest at 515 ns, a span of 406x. The table below carries every number.">
+<title>wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.27 ns, then dewasm-java at 1.43 ns; dewasm-perl is slowest at 515 ns, a span of 406x. The table below carries every number.</title>
 <rect width="820" height="368" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="371.1" y1="68.0" x2="371.1" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="371.1" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="574.2" y1="68.0" x2="574.2" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="574.2" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="370.8" y1="68.0" x2="370.8" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="370.8" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="573.6" y1="68.0" x2="573.6" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="573.6" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
 <line x1="168.0" y1="338.0" x2="726.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="86.0" x2="187.6" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="187.6" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.25 ns</text>
+<line x1="168.0" y1="86.0" x2="189.0" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="189.0" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.27 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="110.0" x2="198.8" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="198.8" cy="110.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.42 ns</text>
+<line x1="168.0" y1="110.0" x2="199.8" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="199.8" cy="110.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.43 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="134.0" x2="251.3" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="251.3" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.57 ns</text>
+<line x1="168.0" y1="134.0" x2="252.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="252.6" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.61 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="158.0" x2="256.9" y2="158.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="256.9" cy="158.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.74 ns</text>
+<line x1="168.0" y1="158.0" x2="258.1" y2="158.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="258.1" cy="158.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.78 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="182.0" x2="295.2" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="295.2" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.23 ns</text>
+<line x1="168.0" y1="182.0" x2="295.5" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="295.5" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.25 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="206.0" x2="587.0" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="587.0" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">116 ns</text>
+<line x1="168.0" y1="206.0" x2="586.0" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="586.0" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">115 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="230.0" x2="589.8" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="589.8" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">119 ns</text>
+<line x1="168.0" y1="230.0" x2="590.8" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="590.8" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">122 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="254.0" x2="590.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="590.5" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">120 ns</text>
+<line x1="168.0" y1="254.0" x2="590.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="590.8" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">122 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="590.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="590.8" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">121 ns</text>
+<line x1="168.0" y1="278.0" x2="591.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="591.5" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">123 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="302.0" x2="634.3" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="634.3" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="302.0" x2="633.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="633.7" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">198 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
 <line x1="168.0" y1="326.0" x2="718.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">511 ns</text>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">515 ns</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/eh_try: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-f32-alu-dark.svg
+++ b/docs/benchmarks/figs/wat-f32-alu-dark.svg
@@ -1,87 +1,103 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="488" viewBox="0 0 820 488" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f32_alu: seconds per iteration for 16 runners on a log scale, fastest first. wazero is fastest at 0.94 ns, then wasmtime at 0.98 ns; dewasm-bash is slowest at 1.18 ms, a span of 1250000x. The table below carries every number.">
-<title>wat/f32_alu: seconds per iteration for 16 runners on a log scale, fastest first. wazero is fastest at 0.94 ns, then wasmtime at 0.98 ns; dewasm-bash is slowest at 1.18 ms, a span of 1250000x. The table below carries every number.</title>
-<rect width="820" height="488" fill="#1a1a19"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">0 ns</text>
-<line x1="245.8" y1="68.0" x2="245.8" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="245.8" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="323.6" y1="68.0" x2="323.6" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="323.6" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="401.4" y1="68.0" x2="401.4" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="401.4" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="479.1" y1="68.0" x2="479.1" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="479.1" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="556.9" y1="68.0" x2="556.9" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="556.9" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="634.7" y1="68.0" x2="634.7" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="634.7" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
-<line x1="712.5" y1="68.0" x2="712.5" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="712.5" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ms</text>
-<line x1="168.0" y1="458.0" x2="726.0" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="584" viewBox="0 0 820 584" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f32_alu: seconds per iteration for 20 runners on a log scale, fastest first. wazero is fastest at 0.96 ns, then wasmtime at 1.00 ns; dewasm-bash is slowest at 1.21 ms, a span of 1260000x. The table below carries every number.">
+<title>wat/f32_alu: seconds per iteration for 20 runners on a log scale, fastest first. wazero is fastest at 0.96 ns, then wasmtime at 1.00 ns; dewasm-bash is slowest at 1.21 ms, a span of 1260000x. The table below carries every number.</title>
+<rect width="820" height="584" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">0 ns</text>
+<line x1="245.7" y1="68.0" x2="245.7" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="245.7" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
+<line x1="323.3" y1="68.0" x2="323.3" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="323.3" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="401.0" y1="68.0" x2="401.0" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="401.0" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="478.7" y1="68.0" x2="478.7" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="478.7" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="556.3" y1="68.0" x2="556.3" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="556.3" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="634.0" y1="68.0" x2="634.0" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="634.0" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="711.7" y1="68.0" x2="711.7" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="711.7" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ms</text>
+<line x1="168.0" y1="554.0" x2="726.0" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="86.0" x2="243.8" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="243.8" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.94 ns</text>
+<line x1="168.0" y1="86.0" x2="244.3" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="244.3" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.96 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="245.2" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="245.2" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.98 ns</text>
+<line x1="168.0" y1="110.0" x2="245.7" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="245.7" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.00 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="134.0" x2="245.2" y2="134.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="245.2" cy="134.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.98 ns</text>
+<line x1="168.0" y1="134.0" x2="245.7" y2="134.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="245.7" cy="134.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.00 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
 <line x1="168.0" y1="158.0" x2="262.3" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="262.3" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.63 ns</text>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.64 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="182.0" x2="287.5" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="287.5" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.44 ns</text>
+<line x1="168.0" y1="182.0" x2="287.8" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="287.8" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.48 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="206.0" x2="303.2" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="303.2" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.47 ns</text>
+<line x1="168.0" y1="206.0" x2="303.5" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="303.5" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.55 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="230.0" x2="309.9" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="309.9" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.67 ns</text>
+<line x1="168.0" y1="230.0" x2="311.3" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="311.3" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.00 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="394.3" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="394.3" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">81.2 ns</text>
+<line x1="168.0" y1="254.0" x2="393.0" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="393.0" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">79.0 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="429.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="429.1" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="278.0" x2="428.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="428.6" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">227 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
 <line x1="168.0" y1="302.0" x2="435.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="435.8" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">277 ns</text>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">281 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="444.8" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="444.8" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">361 ns</text>
+<line x1="168.0" y1="326.0" x2="444.5" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="444.5" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">363 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="458.3" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="458.3" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">539 ns</text>
+<line x1="168.0" y1="350.0" x2="457.9" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="457.9" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">541 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="493.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="493.8" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.54 µs</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="398.0" x2="544.7" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="544.7" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.97 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="422.0" x2="592.5" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="592.5" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">28.6 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="446.0" x2="718.0" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="446.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.18 ms</text>
+<line x1="168.0" y1="374.0" x2="493.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="493.1" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.53 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="398.0" x2="499.5" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="499.5" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.86 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
+<line x1="168.0" y1="422.0" x2="518.1" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="518.1" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.22 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
+<line x1="168.0" y1="446.0" x2="535.3" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="535.3" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.36 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="470.0" x2="540.0" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="540.0" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.17 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
+<line x1="168.0" y1="494.0" x2="567.7" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="567.7" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.0 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="518.0" x2="592.5" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="592.5" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">29.2 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="542.0" x2="718.0" y2="542.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="542.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.21 ms</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/f32_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-f32-alu.svg
+++ b/docs/benchmarks/figs/wat-f32-alu.svg
@@ -1,87 +1,103 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="488" viewBox="0 0 820 488" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f32_alu: seconds per iteration for 16 runners on a log scale, fastest first. wazero is fastest at 0.94 ns, then wasmtime at 0.98 ns; dewasm-bash is slowest at 1.18 ms, a span of 1250000x. The table below carries every number.">
-<title>wat/f32_alu: seconds per iteration for 16 runners on a log scale, fastest first. wazero is fastest at 0.94 ns, then wasmtime at 0.98 ns; dewasm-bash is slowest at 1.18 ms, a span of 1250000x. The table below carries every number.</title>
-<rect width="820" height="488" fill="#fcfcfb"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">0 ns</text>
-<line x1="245.8" y1="68.0" x2="245.8" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="245.8" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="323.6" y1="68.0" x2="323.6" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="323.6" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="401.4" y1="68.0" x2="401.4" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="401.4" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="479.1" y1="68.0" x2="479.1" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="479.1" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="556.9" y1="68.0" x2="556.9" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="556.9" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="634.7" y1="68.0" x2="634.7" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="634.7" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
-<line x1="712.5" y1="68.0" x2="712.5" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="712.5" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">1 ms</text>
-<line x1="168.0" y1="458.0" x2="726.0" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="584" viewBox="0 0 820 584" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f32_alu: seconds per iteration for 20 runners on a log scale, fastest first. wazero is fastest at 0.96 ns, then wasmtime at 1.00 ns; dewasm-bash is slowest at 1.21 ms, a span of 1260000x. The table below carries every number.">
+<title>wat/f32_alu: seconds per iteration for 20 runners on a log scale, fastest first. wazero is fastest at 0.96 ns, then wasmtime at 1.00 ns; dewasm-bash is slowest at 1.21 ms, a span of 1260000x. The table below carries every number.</title>
+<rect width="820" height="584" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">0 ns</text>
+<line x1="245.7" y1="68.0" x2="245.7" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="245.7" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
+<line x1="323.3" y1="68.0" x2="323.3" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="323.3" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="401.0" y1="68.0" x2="401.0" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="401.0" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="478.7" y1="68.0" x2="478.7" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="478.7" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="556.3" y1="68.0" x2="556.3" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="556.3" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="634.0" y1="68.0" x2="634.0" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="634.0" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="711.7" y1="68.0" x2="711.7" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="711.7" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">1 ms</text>
+<line x1="168.0" y1="554.0" x2="726.0" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="86.0" x2="243.8" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="243.8" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.94 ns</text>
+<line x1="168.0" y1="86.0" x2="244.3" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="244.3" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.96 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="245.2" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="245.2" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.98 ns</text>
+<line x1="168.0" y1="110.0" x2="245.7" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="245.7" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.00 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="134.0" x2="245.2" y2="134.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="245.2" cy="134.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.98 ns</text>
+<line x1="168.0" y1="134.0" x2="245.7" y2="134.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="245.7" cy="134.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.00 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
 <line x1="168.0" y1="158.0" x2="262.3" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="262.3" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.63 ns</text>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.64 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="182.0" x2="287.5" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="287.5" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.44 ns</text>
+<line x1="168.0" y1="182.0" x2="287.8" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="287.8" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.48 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="206.0" x2="303.2" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="303.2" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.47 ns</text>
+<line x1="168.0" y1="206.0" x2="303.5" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="303.5" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.55 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="230.0" x2="309.9" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="309.9" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.67 ns</text>
+<line x1="168.0" y1="230.0" x2="311.3" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="311.3" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.00 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="394.3" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="394.3" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">81.2 ns</text>
+<line x1="168.0" y1="254.0" x2="393.0" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="393.0" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">79.0 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="429.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="429.1" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="278.0" x2="428.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="428.6" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">227 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
 <line x1="168.0" y1="302.0" x2="435.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="435.8" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">277 ns</text>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">281 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="444.8" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="444.8" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">361 ns</text>
+<line x1="168.0" y1="326.0" x2="444.5" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="444.5" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">363 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="458.3" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="458.3" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">539 ns</text>
+<line x1="168.0" y1="350.0" x2="457.9" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="457.9" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">541 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="493.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="493.8" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.54 µs</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="398.0" x2="544.7" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="544.7" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.97 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="422.0" x2="592.5" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="592.5" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">28.6 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="446.0" x2="718.0" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="446.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.18 ms</text>
+<line x1="168.0" y1="374.0" x2="493.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="493.1" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.53 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="398.0" x2="499.5" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="499.5" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.86 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
+<line x1="168.0" y1="422.0" x2="518.1" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="518.1" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.22 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
+<line x1="168.0" y1="446.0" x2="535.3" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="535.3" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.36 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="470.0" x2="540.0" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="540.0" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.17 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
+<line x1="168.0" y1="494.0" x2="567.7" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="567.7" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.0 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="518.0" x2="592.5" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="592.5" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">29.2 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="542.0" x2="718.0" y2="542.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="542.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.21 ms</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/f32_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-f64-alu-dark.svg
+++ b/docs/benchmarks/figs/wat-f64-alu-dark.svg
@@ -1,93 +1,109 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wazero is fastest at 0.95 ns, then wasmer at 0.96 ns; dewasm-bash is slowest at 566 µs, a span of 594000x. The table below carries every number.">
-<title>wat/f64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wazero is fastest at 0.95 ns, then wasmer at 0.96 ns; dewasm-bash is slowest at 566 µs, a span of 594000x. The table below carries every number.</title>
-<rect width="820" height="536" fill="#1a1a19"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">0 ns</text>
-<line x1="249.4" y1="68.0" x2="249.4" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="249.4" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="330.9" y1="68.0" x2="330.9" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="330.9" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="412.3" y1="68.0" x2="412.3" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="412.3" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="493.8" y1="68.0" x2="493.8" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="493.8" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="575.2" y1="68.0" x2="575.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="575.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="656.7" y1="68.0" x2="656.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="656.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
-<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f64_alu: seconds per iteration for 22 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmer at 0.98 ns; dewasm-bash is slowest at 578 µs, a span of 599000x. The table below carries every number.">
+<title>wat/f64_alu: seconds per iteration for 22 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmer at 0.98 ns; dewasm-bash is slowest at 578 µs, a span of 599000x. The table below carries every number.</title>
+<rect width="820" height="632" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">0 ns</text>
+<line x1="249.3" y1="68.0" x2="249.3" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="249.3" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
+<line x1="330.7" y1="68.0" x2="330.7" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="330.7" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="412.0" y1="68.0" x2="412.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="412.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="493.3" y1="68.0" x2="493.3" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="493.3" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="574.7" y1="68.0" x2="574.7" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="574.7" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="656.0" y1="68.0" x2="656.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="656.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="86.0" x2="247.7" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="247.7" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.95 ns</text>
+<line x1="168.0" y1="86.0" x2="248.1" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="248.1" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.97 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="248.2" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="248.2" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.96 ns</text>
+<line x1="168.0" y1="110.0" x2="248.5" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="248.5" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.98 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="134.0" x2="248.2" y2="134.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="248.2" cy="134.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.96 ns</text>
+<line x1="168.0" y1="134.0" x2="248.6" y2="134.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="248.6" cy="134.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.98 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="158.0" x2="266.4" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="266.4" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.62 ns</text>
+<line x1="168.0" y1="158.0" x2="268.3" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="268.3" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.71 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="182.0" x2="276.0" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="276.0" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.12 ns</text>
+<line x1="168.0" y1="182.0" x2="276.3" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="276.3" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.15 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="206.0" x2="293.4" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="293.4" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.47 ns</text>
+<line x1="168.0" y1="206.0" x2="293.8" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="293.8" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.52 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="230.0" x2="308.8" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="308.8" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.36 ns</text>
+<line x1="168.0" y1="230.0" x2="308.9" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="308.9" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.40 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
 <line x1="168.0" y1="254.0" x2="402.2" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="402.2" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">75.1 ns</text>
-<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="278.0" x2="404.9" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="404.9" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">81.1 ns</text>
-<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="302.0" x2="405.1" y2="302.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="405.1" cy="302.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">81.4 ns</text>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">75.8 ns</text>
+<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
+<line x1="168.0" y1="278.0" x2="403.7" y2="278.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="403.7" cy="278.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">79.0 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
+<line x1="168.0" y1="302.0" x2="405.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="405.2" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">82.5 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="412.8" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="412.8" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">101 ns</text>
+<line x1="168.0" y1="326.0" x2="412.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="412.7" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">102 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="426.8" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="426.8" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">151 ns</text>
+<line x1="168.0" y1="350.0" x2="426.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="426.7" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">152 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="486.7" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="486.7" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">817 ns</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="537.5" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="537.5" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.44 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="422.0" x2="553.8" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="553.8" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.46 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="446.0" x2="564.8" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="564.8" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.45 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="470.0" x2="612.6" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="612.6" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">28.7 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">566 µs</text>
+<line x1="168.0" y1="374.0" x2="486.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="486.8" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">831 ns</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="398.0" x2="509.8" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="509.8" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.59 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
+<line x1="168.0" y1="422.0" x2="528.2" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="528.2" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.68 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
+<line x1="168.0" y1="446.0" x2="538.1" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="538.1" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.55 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
+<line x1="168.0" y1="470.0" x2="547.0" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="547.0" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.57 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
+<line x1="168.0" y1="494.0" x2="565.2" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="565.2" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.64 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="518.0" x2="565.5" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="565.5" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.72 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
+<line x1="168.0" y1="542.0" x2="582.7" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="582.7" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.6 µs</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="566.0" x2="613.1" y2="566.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="613.1" cy="566.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">29.6 µs</text>
+<text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="590.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">578 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/f64_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-f64-alu.svg
+++ b/docs/benchmarks/figs/wat-f64-alu.svg
@@ -1,93 +1,109 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wazero is fastest at 0.95 ns, then wasmer at 0.96 ns; dewasm-bash is slowest at 566 µs, a span of 594000x. The table below carries every number.">
-<title>wat/f64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wazero is fastest at 0.95 ns, then wasmer at 0.96 ns; dewasm-bash is slowest at 566 µs, a span of 594000x. The table below carries every number.</title>
-<rect width="820" height="536" fill="#fcfcfb"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">0 ns</text>
-<line x1="249.4" y1="68.0" x2="249.4" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="249.4" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="330.9" y1="68.0" x2="330.9" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="330.9" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="412.3" y1="68.0" x2="412.3" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="412.3" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="493.8" y1="68.0" x2="493.8" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="493.8" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="575.2" y1="68.0" x2="575.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="575.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="656.7" y1="68.0" x2="656.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="656.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
-<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f64_alu: seconds per iteration for 22 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmer at 0.98 ns; dewasm-bash is slowest at 578 µs, a span of 599000x. The table below carries every number.">
+<title>wat/f64_alu: seconds per iteration for 22 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmer at 0.98 ns; dewasm-bash is slowest at 578 µs, a span of 599000x. The table below carries every number.</title>
+<rect width="820" height="632" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">0 ns</text>
+<line x1="249.3" y1="68.0" x2="249.3" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="249.3" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
+<line x1="330.7" y1="68.0" x2="330.7" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="330.7" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="412.0" y1="68.0" x2="412.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="412.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="493.3" y1="68.0" x2="493.3" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="493.3" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="574.7" y1="68.0" x2="574.7" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="574.7" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="656.0" y1="68.0" x2="656.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="656.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="86.0" x2="247.7" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="247.7" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.95 ns</text>
+<line x1="168.0" y1="86.0" x2="248.1" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="248.1" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.97 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="248.2" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="248.2" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.96 ns</text>
+<line x1="168.0" y1="110.0" x2="248.5" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="248.5" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.98 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="134.0" x2="248.2" y2="134.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="248.2" cy="134.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.96 ns</text>
+<line x1="168.0" y1="134.0" x2="248.6" y2="134.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="248.6" cy="134.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.98 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="158.0" x2="266.4" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="266.4" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.62 ns</text>
+<line x1="168.0" y1="158.0" x2="268.3" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="268.3" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.71 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="182.0" x2="276.0" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="276.0" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.12 ns</text>
+<line x1="168.0" y1="182.0" x2="276.3" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="276.3" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.15 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="206.0" x2="293.4" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="293.4" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.47 ns</text>
+<line x1="168.0" y1="206.0" x2="293.8" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="293.8" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.52 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="230.0" x2="308.8" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="308.8" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.36 ns</text>
+<line x1="168.0" y1="230.0" x2="308.9" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="308.9" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.40 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
 <line x1="168.0" y1="254.0" x2="402.2" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="402.2" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">75.1 ns</text>
-<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="278.0" x2="404.9" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="404.9" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">81.1 ns</text>
-<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="302.0" x2="405.1" y2="302.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="405.1" cy="302.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">81.4 ns</text>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">75.8 ns</text>
+<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
+<line x1="168.0" y1="278.0" x2="403.7" y2="278.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="403.7" cy="278.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">79.0 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
+<line x1="168.0" y1="302.0" x2="405.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="405.2" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">82.5 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="412.8" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="412.8" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">101 ns</text>
+<line x1="168.0" y1="326.0" x2="412.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="412.7" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">102 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="426.8" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="426.8" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">151 ns</text>
+<line x1="168.0" y1="350.0" x2="426.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="426.7" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">152 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="486.7" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="486.7" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">817 ns</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="537.5" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="537.5" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.44 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="422.0" x2="553.8" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="553.8" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.46 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="446.0" x2="564.8" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="564.8" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.45 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="470.0" x2="612.6" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="612.6" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">28.7 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">566 µs</text>
+<line x1="168.0" y1="374.0" x2="486.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="486.8" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">831 ns</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="398.0" x2="509.8" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="509.8" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.59 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
+<line x1="168.0" y1="422.0" x2="528.2" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="528.2" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.68 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
+<line x1="168.0" y1="446.0" x2="538.1" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="538.1" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.55 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
+<line x1="168.0" y1="470.0" x2="547.0" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="547.0" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.57 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
+<line x1="168.0" y1="494.0" x2="565.2" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="565.2" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.64 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="518.0" x2="565.5" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="565.5" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.72 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
+<line x1="168.0" y1="542.0" x2="582.7" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="582.7" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.6 µs</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="566.0" x2="613.1" y2="566.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="613.1" cy="566.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">29.6 µs</text>
+<text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="590.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">578 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/f64_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i32-alu-dark.svg
+++ b/docs/benchmarks/figs/wat-i32-alu-dark.svg
@@ -1,89 +1,105 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.29 ns, then wasmtime at 2.29 ns; pywasm-cpython is slowest at 52.9 µs, a span of 23200x. The table below carries every number.">
-<title>wat/i32_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.29 ns, then wasmtime at 2.29 ns; pywasm-cpython is slowest at 52.9 µs, a span of 23200x. The table below carries every number.</title>
-<rect width="820" height="536" fill="#1a1a19"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="284.4" y1="68.0" x2="284.4" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="284.4" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="400.9" y1="68.0" x2="400.9" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="400.9" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="517.3" y1="68.0" x2="517.3" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="517.3" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="633.7" y1="68.0" x2="633.7" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="633.7" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="86.0" x2="209.8" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="209.8" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.29 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="210.0" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="210.0" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.29 ns</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_alu: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 2.32 ns, then wasmer at 2.32 ns; pywasm-cpython is slowest at 54.2 µs, a span of 23400x. The table below carries every number.">
+<title>wat/i32_alu: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 2.32 ns, then wasmer at 2.32 ns; pywasm-cpython is slowest at 54.2 µs, a span of 23400x. The table below carries every number.</title>
+<rect width="820" height="632" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
+<line x1="284.2" y1="68.0" x2="284.2" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="284.2" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="400.4" y1="68.0" x2="400.4" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="400.4" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="516.5" y1="68.0" x2="516.5" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="516.5" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="632.7" y1="68.0" x2="632.7" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="632.7" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="210.5" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="210.5" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.32 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="110.0" x2="210.5" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="210.5" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.32 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="211.0" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="211.0" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="134.0" x2="210.9" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="210.9" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.34 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="216.7" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="216.7" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.62 ns</text>
+<line x1="168.0" y1="158.0" x2="217.6" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="217.6" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.67 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="182.0" x2="223.9" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="223.9" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.02 ns</text>
+<line x1="168.0" y1="182.0" x2="224.3" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="224.3" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.06 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="206.0" x2="281.3" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="281.3" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.39 ns</text>
+<line x1="168.0" y1="206.0" x2="282.2" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="282.2" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.62 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="230.0" x2="297.0" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="297.0" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.8 ns</text>
+<line x1="168.0" y1="230.0" x2="297.6" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="297.6" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.1 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="416.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="416.8" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">137 ns</text>
-<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="278.0" x2="421.3" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="421.3" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">150 ns</text>
-<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="302.0" x2="423.2" y2="302.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="423.2" cy="302.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">156 ns</text>
+<line x1="168.0" y1="254.0" x2="416.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="416.5" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">138 ns</text>
+<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
+<line x1="168.0" y1="278.0" x2="421.4" y2="278.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="421.4" cy="278.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">152 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
+<line x1="168.0" y1="302.0" x2="421.4" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="421.4" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">152 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="431.1" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="431.1" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">182 ns</text>
+<line x1="168.0" y1="326.0" x2="431.3" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="431.3" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">185 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="487.4" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="487.4" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">553 ns</text>
+<line x1="168.0" y1="350.0" x2="487.5" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="487.5" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">563 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="498.2" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="498.2" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">685 ns</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="614.9" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="614.9" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.89 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="422.0" x2="654.0" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="654.0" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.9 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="661.5" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="661.5" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">17.3 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="470.0" x2="679.2" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="679.2" cy="470.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">24.6 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">52.9 µs</text>
+<line x1="168.0" y1="374.0" x2="497.9" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="497.9" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">691 ns</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="398.0" x2="581.5" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="581.5" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.62 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
+<line x1="168.0" y1="422.0" x2="614.1" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="614.1" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.92 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
+<line x1="168.0" y1="446.0" x2="622.1" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="622.1" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.11 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
+<line x1="168.0" y1="470.0" x2="629.2" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="629.2" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.32 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
+<line x1="168.0" y1="494.0" x2="654.3" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="654.3" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.4 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="518.0" x2="679.1" y2="518.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="679.1" cy="518.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">25.1 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
+<line x1="168.0" y1="542.0" x2="680.3" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="680.3" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">25.7 µs</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="566.0" x2="687.2" y2="566.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="687.2" cy="566.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">29.5 µs</text>
+<text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="590.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">54.2 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/i32_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i32-alu.svg
+++ b/docs/benchmarks/figs/wat-i32-alu.svg
@@ -1,89 +1,105 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.29 ns, then wasmtime at 2.29 ns; pywasm-cpython is slowest at 52.9 µs, a span of 23200x. The table below carries every number.">
-<title>wat/i32_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.29 ns, then wasmtime at 2.29 ns; pywasm-cpython is slowest at 52.9 µs, a span of 23200x. The table below carries every number.</title>
-<rect width="820" height="536" fill="#fcfcfb"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="284.4" y1="68.0" x2="284.4" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="284.4" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="400.9" y1="68.0" x2="400.9" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="400.9" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="517.3" y1="68.0" x2="517.3" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="517.3" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="633.7" y1="68.0" x2="633.7" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="633.7" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="86.0" x2="209.8" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="209.8" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.29 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="210.0" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="210.0" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.29 ns</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_alu: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 2.32 ns, then wasmer at 2.32 ns; pywasm-cpython is slowest at 54.2 µs, a span of 23400x. The table below carries every number.">
+<title>wat/i32_alu: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 2.32 ns, then wasmer at 2.32 ns; pywasm-cpython is slowest at 54.2 µs, a span of 23400x. The table below carries every number.</title>
+<rect width="820" height="632" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
+<line x1="284.2" y1="68.0" x2="284.2" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="284.2" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="400.4" y1="68.0" x2="400.4" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="400.4" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="516.5" y1="68.0" x2="516.5" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="516.5" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="632.7" y1="68.0" x2="632.7" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="632.7" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="210.5" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="210.5" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.32 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="110.0" x2="210.5" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="210.5" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.32 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="211.0" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="211.0" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="134.0" x2="210.9" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="210.9" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.34 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="216.7" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="216.7" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.62 ns</text>
+<line x1="168.0" y1="158.0" x2="217.6" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="217.6" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.67 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="182.0" x2="223.9" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="223.9" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.02 ns</text>
+<line x1="168.0" y1="182.0" x2="224.3" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="224.3" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.06 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="206.0" x2="281.3" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="281.3" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.39 ns</text>
+<line x1="168.0" y1="206.0" x2="282.2" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="282.2" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.62 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="230.0" x2="297.0" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="297.0" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.8 ns</text>
+<line x1="168.0" y1="230.0" x2="297.6" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="297.6" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.1 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="416.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="416.8" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">137 ns</text>
-<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="278.0" x2="421.3" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="421.3" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">150 ns</text>
-<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="302.0" x2="423.2" y2="302.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="423.2" cy="302.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">156 ns</text>
+<line x1="168.0" y1="254.0" x2="416.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="416.5" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">138 ns</text>
+<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
+<line x1="168.0" y1="278.0" x2="421.4" y2="278.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="421.4" cy="278.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">152 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
+<line x1="168.0" y1="302.0" x2="421.4" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="421.4" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">152 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="431.1" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="431.1" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">182 ns</text>
+<line x1="168.0" y1="326.0" x2="431.3" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="431.3" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">185 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="487.4" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="487.4" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">553 ns</text>
+<line x1="168.0" y1="350.0" x2="487.5" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="487.5" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">563 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="498.2" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="498.2" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">685 ns</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="614.9" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="614.9" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.89 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="422.0" x2="654.0" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="654.0" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.9 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="661.5" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="661.5" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">17.3 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="470.0" x2="679.2" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="679.2" cy="470.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">24.6 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">52.9 µs</text>
+<line x1="168.0" y1="374.0" x2="497.9" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="497.9" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">691 ns</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="398.0" x2="581.5" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="581.5" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.62 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
+<line x1="168.0" y1="422.0" x2="614.1" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="614.1" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.92 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
+<line x1="168.0" y1="446.0" x2="622.1" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="622.1" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.11 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
+<line x1="168.0" y1="470.0" x2="629.2" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="629.2" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.32 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
+<line x1="168.0" y1="494.0" x2="654.3" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="654.3" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.4 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="518.0" x2="679.1" y2="518.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="679.1" cy="518.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">25.1 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
+<line x1="168.0" y1="542.0" x2="680.3" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="680.3" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">25.7 µs</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="566.0" x2="687.2" y2="566.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="687.2" cy="566.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">29.5 µs</text>
+<text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="590.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">54.2 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/i32_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i32-div-dark.svg
+++ b/docs/benchmarks/figs/wat-i32-div-dark.svg
@@ -1,89 +1,105 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_div: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 7.54 ns, then wasmtime at 7.55 ns; dewasm-bash is slowest at 67.1 µs, a span of 8890x. The table below carries every number.">
-<title>wat/i32_div: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 7.54 ns, then wasmtime at 7.55 ns; dewasm-bash is slowest at 67.1 µs, a span of 8890x. The table below carries every number.</title>
-<rect width="820" height="536" fill="#1a1a19"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="282.0" y1="68.0" x2="282.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="282.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="395.9" y1="68.0" x2="395.9" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="395.9" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="509.9" y1="68.0" x2="509.9" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="509.9" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="623.8" y1="68.0" x2="623.8" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="623.8" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="86.0" x2="268.0" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="268.0" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.54 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="268.0" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="268.0" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.55 ns</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_div: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 7.66 ns, then wasmer at 7.67 ns; dewasm-bash is slowest at 68.2 µs, a span of 8910x. The table below carries every number.">
+<title>wat/i32_div: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 7.66 ns, then wasmer at 7.67 ns; dewasm-bash is slowest at 68.2 µs, a span of 8910x. The table below carries every number.</title>
+<rect width="820" height="632" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
+<line x1="281.8" y1="68.0" x2="281.8" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="281.8" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="395.6" y1="68.0" x2="395.6" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="395.6" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="509.3" y1="68.0" x2="509.3" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="509.3" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="623.1" y1="68.0" x2="623.1" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="623.1" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="268.6" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="268.6" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.66 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="110.0" x2="268.7" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="268.7" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.67 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="268.2" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="268.2" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.57 ns</text>
+<line x1="168.0" y1="134.0" x2="268.7" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="268.7" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.68 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="268.3" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="268.3" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.59 ns</text>
+<line x1="168.0" y1="158.0" x2="268.7" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="268.7" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.68 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="269.4" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="269.4" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.77 ns</text>
+<line x1="168.0" y1="182.0" x2="270.2" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="270.2" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.90 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="206.0" x2="298.1" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="298.1" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.9 ns</text>
+<line x1="168.0" y1="206.0" x2="299.0" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="299.0" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.2 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="230.0" x2="307.4" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="307.4" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">16.7 ns</text>
+<line x1="168.0" y1="230.0" x2="304.3" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="304.3" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.8 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="427.1" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="427.1" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">188 ns</text>
+<line x1="168.0" y1="254.0" x2="425.0" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="425.0" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">181 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="428.7" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="428.7" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">194 ns</text>
+<line x1="168.0" y1="278.0" x2="426.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="426.5" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">187 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="439.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="439.5" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">241 ns</text>
+<line x1="168.0" y1="302.0" x2="439.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="439.2" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">242 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="460.1" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="460.1" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">366 ns</text>
+<line x1="168.0" y1="326.0" x2="459.8" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="459.8" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">367 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="508.4" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="508.4" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">971 ns</text>
+<line x1="168.0" y1="350.0" x2="508.0" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="508.0" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">974 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="519.3" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="519.3" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.21 µs</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="615.0" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="615.0" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.37 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="422.0" x2="653.0" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="653.0" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">18.0 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="674.3" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="674.3" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">27.8 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="470.0" x2="712.4" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="712.4" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">59.9 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">67.1 µs</text>
+<line x1="168.0" y1="374.0" x2="519.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="519.1" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.22 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="398.0" x2="585.4" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="585.4" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.66 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
+<line x1="168.0" y1="422.0" x2="615.2" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="615.2" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.51 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
+<line x1="168.0" y1="446.0" x2="631.0" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="631.0" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">11.7 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
+<line x1="168.0" y1="470.0" x2="634.4" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="634.4" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.6 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
+<line x1="168.0" y1="494.0" x2="652.9" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="652.9" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">18.3 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
+<line x1="168.0" y1="518.0" x2="679.9" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="679.9" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">31.6 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="542.0" x2="700.1" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="700.1" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">47.5 µs</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="566.0" x2="712.7" y2="566.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="712.7" cy="566.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">61.2 µs</text>
+<text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="590.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">68.2 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/i32_div: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i32-div.svg
+++ b/docs/benchmarks/figs/wat-i32-div.svg
@@ -1,89 +1,105 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_div: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 7.54 ns, then wasmtime at 7.55 ns; dewasm-bash is slowest at 67.1 µs, a span of 8890x. The table below carries every number.">
-<title>wat/i32_div: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 7.54 ns, then wasmtime at 7.55 ns; dewasm-bash is slowest at 67.1 µs, a span of 8890x. The table below carries every number.</title>
-<rect width="820" height="536" fill="#fcfcfb"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="282.0" y1="68.0" x2="282.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="282.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="395.9" y1="68.0" x2="395.9" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="395.9" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="509.9" y1="68.0" x2="509.9" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="509.9" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="623.8" y1="68.0" x2="623.8" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="623.8" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="86.0" x2="268.0" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="268.0" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.54 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="268.0" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="268.0" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.55 ns</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_div: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 7.66 ns, then wasmer at 7.67 ns; dewasm-bash is slowest at 68.2 µs, a span of 8910x. The table below carries every number.">
+<title>wat/i32_div: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 7.66 ns, then wasmer at 7.67 ns; dewasm-bash is slowest at 68.2 µs, a span of 8910x. The table below carries every number.</title>
+<rect width="820" height="632" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
+<line x1="281.8" y1="68.0" x2="281.8" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="281.8" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="395.6" y1="68.0" x2="395.6" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="395.6" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="509.3" y1="68.0" x2="509.3" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="509.3" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="623.1" y1="68.0" x2="623.1" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="623.1" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="268.6" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="268.6" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.66 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="110.0" x2="268.7" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="268.7" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.67 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="268.2" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="268.2" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.57 ns</text>
+<line x1="168.0" y1="134.0" x2="268.7" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="268.7" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.68 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="268.3" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="268.3" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.59 ns</text>
+<line x1="168.0" y1="158.0" x2="268.7" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="268.7" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.68 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="269.4" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="269.4" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.77 ns</text>
+<line x1="168.0" y1="182.0" x2="270.2" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="270.2" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.90 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="206.0" x2="298.1" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="298.1" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.9 ns</text>
+<line x1="168.0" y1="206.0" x2="299.0" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="299.0" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.2 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="230.0" x2="307.4" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="307.4" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">16.7 ns</text>
+<line x1="168.0" y1="230.0" x2="304.3" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="304.3" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.8 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="427.1" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="427.1" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">188 ns</text>
+<line x1="168.0" y1="254.0" x2="425.0" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="425.0" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">181 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="428.7" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="428.7" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">194 ns</text>
+<line x1="168.0" y1="278.0" x2="426.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="426.5" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">187 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="439.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="439.5" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">241 ns</text>
+<line x1="168.0" y1="302.0" x2="439.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="439.2" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">242 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="460.1" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="460.1" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">366 ns</text>
+<line x1="168.0" y1="326.0" x2="459.8" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="459.8" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">367 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="508.4" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="508.4" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">971 ns</text>
+<line x1="168.0" y1="350.0" x2="508.0" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="508.0" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">974 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="519.3" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="519.3" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.21 µs</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="615.0" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="615.0" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.37 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="422.0" x2="653.0" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="653.0" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">18.0 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="674.3" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="674.3" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">27.8 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="470.0" x2="712.4" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="712.4" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">59.9 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="494.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">67.1 µs</text>
+<line x1="168.0" y1="374.0" x2="519.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="519.1" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.22 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="398.0" x2="585.4" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="585.4" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.66 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
+<line x1="168.0" y1="422.0" x2="615.2" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="615.2" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.51 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
+<line x1="168.0" y1="446.0" x2="631.0" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="631.0" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">11.7 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
+<line x1="168.0" y1="470.0" x2="634.4" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="634.4" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.6 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
+<line x1="168.0" y1="494.0" x2="652.9" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="652.9" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">18.3 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
+<line x1="168.0" y1="518.0" x2="679.9" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="679.9" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">31.6 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="542.0" x2="700.1" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="700.1" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">47.5 µs</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="566.0" x2="712.7" y2="566.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="712.7" cy="566.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">61.2 µs</text>
+<text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="590.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">68.2 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/i32_div: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i64-alu-dark.svg
+++ b/docs/benchmarks/figs/wat-i64-alu-dark.svg
@@ -1,91 +1,107 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.30 ns, then wasmtime at 2.30 ns; pywasm-pypy is slowest at 313 µs, a span of 136000x. The table below carries every number.">
-<title>wat/i64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.30 ns, then wasmtime at 2.30 ns; pywasm-pypy is slowest at 313 µs, a span of 136000x. The table below carries every number.</title>
-<rect width="820" height="536" fill="#1a1a19"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="268.1" y1="68.0" x2="268.1" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="268.1" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="368.2" y1="68.0" x2="368.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="368.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="468.2" y1="68.0" x2="468.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="468.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="568.3" y1="68.0" x2="568.3" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="568.3" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="668.4" y1="68.0" x2="668.4" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="668.4" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
-<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="86.0" x2="204.2" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="204.2" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.30 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="204.2" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="204.2" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.30 ns</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_alu: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 2.33 ns, then wasmer at 2.33 ns; pywasm-pypy is slowest at 408 µs, a span of 175000x. The table below carries every number.">
+<title>wat/i64_alu: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 2.33 ns, then wasmer at 2.33 ns; pywasm-pypy is slowest at 408 µs, a span of 175000x. The table below carries every number.</title>
+<rect width="820" height="632" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
+<line x1="266.0" y1="68.0" x2="266.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="266.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="364.0" y1="68.0" x2="364.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="364.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="462.1" y1="68.0" x2="462.1" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="462.1" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="560.1" y1="68.0" x2="560.1" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="560.1" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="658.1" y1="68.0" x2="658.1" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="658.1" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="204.0" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="204.0" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.33 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="110.0" x2="204.0" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="204.0" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.33 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="204.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="204.6" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.32 ns</text>
+<line x1="168.0" y1="134.0" x2="204.4" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="204.4" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.35 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="158.0" x2="209.4" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="209.4" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.59 ns</text>
+<line x1="168.0" y1="158.0" x2="209.0" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="209.0" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.62 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="182.0" x2="209.9" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="209.9" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.62 ns</text>
+<line x1="168.0" y1="182.0" x2="209.8" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="209.8" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.67 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="275.5" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="275.5" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">11.9 ns</text>
+<line x1="168.0" y1="206.0" x2="274.0" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="274.0" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.1 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="230.0" x2="387.2" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="387.2" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">155 ns</text>
+<line x1="168.0" y1="230.0" x2="381.8" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="381.8" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">152 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="254.0" x2="402.3" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="402.3" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">219 ns</text>
+<line x1="168.0" y1="254.0" x2="398.1" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="398.1" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">223 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="278.0" x2="448.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="448.6" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">637 ns</text>
+<line x1="168.0" y1="278.0" x2="441.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="441.5" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">616 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="302.0" x2="465.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="465.6" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">940 ns</text>
+<line x1="168.0" y1="302.0" x2="460.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="460.1" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">954 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="326.0" x2="467.6" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="467.6" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">986 ns</text>
+<line x1="168.0" y1="326.0" x2="462.1" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="462.1" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.00 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="350.0" x2="468.8" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="468.8" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.01 µs</text>
+<line x1="168.0" y1="350.0" x2="463.3" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="463.3" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.03 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="374.0" x2="477.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="477.8" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.25 µs</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="563.6" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="563.6" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.98 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="422.0" x2="589.5" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="589.5" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">16.3 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="446.0" x2="611.6" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="611.6" cy="446.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">27.0 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="470.0" x2="643.9" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="643.9" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">57.0 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">313 µs</text>
+<line x1="168.0" y1="374.0" x2="472.3" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="472.3" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.27 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="398.0" x2="529.9" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="529.9" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.92 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
+<line x1="168.0" y1="422.0" x2="556.7" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="556.7" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.24 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
+<line x1="168.0" y1="446.0" x2="562.3" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="562.3" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.5 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
+<line x1="168.0" y1="470.0" x2="567.5" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="567.5" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">11.9 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
+<line x1="168.0" y1="494.0" x2="581.9" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="581.9" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">16.7 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
+<line x1="168.0" y1="518.0" x2="599.3" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="599.3" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">25.1 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="542.0" x2="603.2" y2="542.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="603.2" cy="542.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">27.6 µs</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="566.0" x2="635.0" y2="566.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="635.0" cy="566.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">58.2 µs</text>
+<text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="590.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">408 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/i64_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i64-alu.svg
+++ b/docs/benchmarks/figs/wat-i64-alu.svg
@@ -1,91 +1,107 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.30 ns, then wasmtime at 2.30 ns; pywasm-pypy is slowest at 313 µs, a span of 136000x. The table below carries every number.">
-<title>wat/i64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.30 ns, then wasmtime at 2.30 ns; pywasm-pypy is slowest at 313 µs, a span of 136000x. The table below carries every number.</title>
-<rect width="820" height="536" fill="#fcfcfb"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="268.1" y1="68.0" x2="268.1" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="268.1" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="368.2" y1="68.0" x2="368.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="368.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="468.2" y1="68.0" x2="468.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="468.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="568.3" y1="68.0" x2="568.3" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="568.3" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="668.4" y1="68.0" x2="668.4" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="668.4" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
-<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="86.0" x2="204.2" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="204.2" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.30 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="204.2" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="204.2" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.30 ns</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_alu: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 2.33 ns, then wasmer at 2.33 ns; pywasm-pypy is slowest at 408 µs, a span of 175000x. The table below carries every number.">
+<title>wat/i64_alu: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 2.33 ns, then wasmer at 2.33 ns; pywasm-pypy is slowest at 408 µs, a span of 175000x. The table below carries every number.</title>
+<rect width="820" height="632" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
+<line x1="266.0" y1="68.0" x2="266.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="266.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="364.0" y1="68.0" x2="364.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="364.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="462.1" y1="68.0" x2="462.1" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="462.1" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="560.1" y1="68.0" x2="560.1" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="560.1" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="658.1" y1="68.0" x2="658.1" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="658.1" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="204.0" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="204.0" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.33 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="110.0" x2="204.0" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="204.0" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.33 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="204.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="204.6" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.32 ns</text>
+<line x1="168.0" y1="134.0" x2="204.4" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="204.4" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.35 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="158.0" x2="209.4" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="209.4" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.59 ns</text>
+<line x1="168.0" y1="158.0" x2="209.0" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="209.0" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.62 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="182.0" x2="209.9" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="209.9" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.62 ns</text>
+<line x1="168.0" y1="182.0" x2="209.8" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="209.8" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.67 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="275.5" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="275.5" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">11.9 ns</text>
+<line x1="168.0" y1="206.0" x2="274.0" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="274.0" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.1 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="230.0" x2="387.2" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="387.2" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">155 ns</text>
+<line x1="168.0" y1="230.0" x2="381.8" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="381.8" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">152 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="254.0" x2="402.3" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="402.3" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">219 ns</text>
+<line x1="168.0" y1="254.0" x2="398.1" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="398.1" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">223 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="278.0" x2="448.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="448.6" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">637 ns</text>
+<line x1="168.0" y1="278.0" x2="441.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="441.5" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">616 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="302.0" x2="465.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="465.6" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">940 ns</text>
+<line x1="168.0" y1="302.0" x2="460.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="460.1" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">954 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="326.0" x2="467.6" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="467.6" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">986 ns</text>
+<line x1="168.0" y1="326.0" x2="462.1" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="462.1" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.00 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="350.0" x2="468.8" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="468.8" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.01 µs</text>
+<line x1="168.0" y1="350.0" x2="463.3" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="463.3" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.03 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="374.0" x2="477.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="477.8" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.25 µs</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="563.6" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="563.6" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.98 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="422.0" x2="589.5" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="589.5" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">16.3 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="446.0" x2="611.6" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="611.6" cy="446.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">27.0 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="470.0" x2="643.9" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="643.9" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">57.0 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">313 µs</text>
+<line x1="168.0" y1="374.0" x2="472.3" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="472.3" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.27 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="398.0" x2="529.9" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="529.9" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.92 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
+<line x1="168.0" y1="422.0" x2="556.7" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="556.7" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.24 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
+<line x1="168.0" y1="446.0" x2="562.3" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="562.3" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.5 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
+<line x1="168.0" y1="470.0" x2="567.5" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="567.5" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">11.9 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
+<line x1="168.0" y1="494.0" x2="581.9" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="581.9" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">16.7 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
+<line x1="168.0" y1="518.0" x2="599.3" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="599.3" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">25.1 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="542.0" x2="603.2" y2="542.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="603.2" cy="542.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">27.6 µs</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="566.0" x2="635.0" y2="566.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="635.0" cy="566.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">58.2 µs</text>
+<text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="590.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">408 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/i64_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i64-div-dark.svg
+++ b/docs/benchmarks/figs/wat-i64-div-dark.svg
@@ -1,83 +1,99 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="488" viewBox="0 0 820 488" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_div: seconds per iteration for 16 runners on a log scale, fastest first. dewasm-go is fastest at 8.15 ns, then wasmer at 8.16 ns; pywasm-pypy is slowest at 233 µs, a span of 28600x. The table below carries every number.">
-<title>wat/i64_div: seconds per iteration for 16 runners on a log scale, fastest first. dewasm-go is fastest at 8.15 ns, then wasmer at 8.16 ns; pywasm-pypy is slowest at 233 µs, a span of 28600x. The table below carries every number.</title>
-<rect width="820" height="488" fill="#1a1a19"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="270.5" y1="68.0" x2="270.5" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="270.5" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="373.0" y1="68.0" x2="373.0" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="373.0" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="475.5" y1="68.0" x2="475.5" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="475.5" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="577.9" y1="68.0" x2="577.9" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="577.9" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="680.4" y1="68.0" x2="680.4" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="680.4" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
-<line x1="168.0" y1="458.0" x2="726.0" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="584" viewBox="0 0 820 584" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_div: seconds per iteration for 20 runners on a log scale, fastest first. dewasm-go is fastest at 8.24 ns, then wasmtime at 8.27 ns; pywasm-pypy is slowest at 419 µs, a span of 50800x. The table below carries every number.">
+<title>wat/i64_div: seconds per iteration for 20 runners on a log scale, fastest first. dewasm-go is fastest at 8.24 ns, then wasmtime at 8.27 ns; pywasm-pypy is slowest at 419 µs, a span of 50800x. The table below carries every number.</title>
+<rect width="820" height="584" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
+<line x1="265.8" y1="68.0" x2="265.8" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="265.8" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="363.7" y1="68.0" x2="363.7" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="363.7" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="461.5" y1="68.0" x2="461.5" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="461.5" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="559.3" y1="68.0" x2="559.3" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="559.3" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="657.1" y1="68.0" x2="657.1" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="657.1" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="168.0" y1="554.0" x2="726.0" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="86.0" x2="261.4" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="261.4" cy="86.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.15 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="261.4" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="261.4" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.16 ns</text>
-<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="134.0" x2="261.5" y2="134.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="261.5" cy="134.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.17 ns</text>
+<line x1="168.0" y1="86.0" x2="257.6" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="257.6" cy="86.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.24 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="110.0" x2="257.7" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="257.7" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.27 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="134.0" x2="257.8" y2="134.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="257.8" cy="134.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.28 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="261.7" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="261.7" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.21 ns</text>
+<line x1="168.0" y1="158.0" x2="258.0" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="258.0" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.32 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="262.9" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="262.9" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.43 ns</text>
+<line x1="168.0" y1="182.0" x2="260.1" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="260.1" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.74 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="291.2" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="291.2" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.9 ns</text>
+<line x1="168.0" y1="206.0" x2="286.2" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="286.2" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">16.2 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="230.0" x2="401.1" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="401.1" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">188 ns</text>
+<line x1="168.0" y1="230.0" x2="388.8" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="388.8" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">181 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="254.0" x2="416.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="416.8" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="254.0" x2="405.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="405.5" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">268 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="278.0" x2="476.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="476.6" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="278.0" x2="462.9" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="462.9" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.03 µs</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="302.0" x2="480.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="480.6" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.12 µs</text>
+<line x1="168.0" y1="302.0" x2="467.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="467.0" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.14 µs</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="326.0" x2="489.8" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="489.8" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.38 µs</text>
+<line x1="168.0" y1="326.0" x2="475.9" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="475.9" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.40 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="350.0" x2="493.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="493.7" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.51 µs</text>
+<line x1="168.0" y1="350.0" x2="479.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="479.1" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.52 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="374.0" x2="498.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="498.0" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.66 µs</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="398.0" x2="661.4" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="661.4" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">65.2 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="422.0" x2="667.9" y2="422.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="667.9" cy="422.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">75.4 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="718.0" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">233 µs</text>
+<line x1="168.0" y1="374.0" x2="484.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="484.0" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.70 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="398.0" x2="540.0" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="540.0" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.35 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
+<line x1="168.0" y1="422.0" x2="571.4" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="571.4" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.3 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
+<line x1="168.0" y1="446.0" x2="588.9" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="588.9" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.1 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
+<line x1="168.0" y1="470.0" x2="606.9" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="606.9" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">30.6 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="494.0" x2="640.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="640.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">66.8 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="518.0" x2="646.1" y2="518.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="646.1" cy="518.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">77.1 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="542.0" x2="718.0" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">419 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/i64_div: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i64-div.svg
+++ b/docs/benchmarks/figs/wat-i64-div.svg
@@ -1,83 +1,99 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="488" viewBox="0 0 820 488" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_div: seconds per iteration for 16 runners on a log scale, fastest first. dewasm-go is fastest at 8.15 ns, then wasmer at 8.16 ns; pywasm-pypy is slowest at 233 µs, a span of 28600x. The table below carries every number.">
-<title>wat/i64_div: seconds per iteration for 16 runners on a log scale, fastest first. dewasm-go is fastest at 8.15 ns, then wasmer at 8.16 ns; pywasm-pypy is slowest at 233 µs, a span of 28600x. The table below carries every number.</title>
-<rect width="820" height="488" fill="#fcfcfb"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="270.5" y1="68.0" x2="270.5" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="270.5" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="373.0" y1="68.0" x2="373.0" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="373.0" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="475.5" y1="68.0" x2="475.5" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="475.5" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="577.9" y1="68.0" x2="577.9" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="577.9" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="680.4" y1="68.0" x2="680.4" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="680.4" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
-<line x1="168.0" y1="458.0" x2="726.0" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="584" viewBox="0 0 820 584" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_div: seconds per iteration for 20 runners on a log scale, fastest first. dewasm-go is fastest at 8.24 ns, then wasmtime at 8.27 ns; pywasm-pypy is slowest at 419 µs, a span of 50800x. The table below carries every number.">
+<title>wat/i64_div: seconds per iteration for 20 runners on a log scale, fastest first. dewasm-go is fastest at 8.24 ns, then wasmtime at 8.27 ns; pywasm-pypy is slowest at 419 µs, a span of 50800x. The table below carries every number.</title>
+<rect width="820" height="584" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
+<line x1="265.8" y1="68.0" x2="265.8" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="265.8" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="363.7" y1="68.0" x2="363.7" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="363.7" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="461.5" y1="68.0" x2="461.5" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="461.5" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="559.3" y1="68.0" x2="559.3" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="559.3" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="657.1" y1="68.0" x2="657.1" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="657.1" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="168.0" y1="554.0" x2="726.0" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="86.0" x2="261.4" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="261.4" cy="86.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.15 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="261.4" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="261.4" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.16 ns</text>
-<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="134.0" x2="261.5" y2="134.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="261.5" cy="134.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.17 ns</text>
+<line x1="168.0" y1="86.0" x2="257.6" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="257.6" cy="86.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.24 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="110.0" x2="257.7" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="257.7" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.27 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="134.0" x2="257.8" y2="134.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="257.8" cy="134.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.28 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="261.7" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="261.7" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.21 ns</text>
+<line x1="168.0" y1="158.0" x2="258.0" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="258.0" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.32 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="262.9" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="262.9" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.43 ns</text>
+<line x1="168.0" y1="182.0" x2="260.1" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="260.1" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.74 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="291.2" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="291.2" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.9 ns</text>
+<line x1="168.0" y1="206.0" x2="286.2" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="286.2" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">16.2 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="230.0" x2="401.1" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="401.1" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">188 ns</text>
+<line x1="168.0" y1="230.0" x2="388.8" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="388.8" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">181 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="254.0" x2="416.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="416.8" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="254.0" x2="405.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="405.5" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">268 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="278.0" x2="476.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="476.6" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="278.0" x2="462.9" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="462.9" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.03 µs</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="302.0" x2="480.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="480.6" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.12 µs</text>
+<line x1="168.0" y1="302.0" x2="467.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="467.0" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.14 µs</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="326.0" x2="489.8" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="489.8" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.38 µs</text>
+<line x1="168.0" y1="326.0" x2="475.9" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="475.9" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.40 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="350.0" x2="493.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="493.7" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.51 µs</text>
+<line x1="168.0" y1="350.0" x2="479.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="479.1" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.52 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="374.0" x2="498.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="498.0" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.66 µs</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="398.0" x2="661.4" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="661.4" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">65.2 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="422.0" x2="667.9" y2="422.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="667.9" cy="422.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">75.4 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="718.0" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">233 µs</text>
+<line x1="168.0" y1="374.0" x2="484.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="484.0" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.70 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="398.0" x2="540.0" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="540.0" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.35 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
+<line x1="168.0" y1="422.0" x2="571.4" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="571.4" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.3 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
+<line x1="168.0" y1="446.0" x2="588.9" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="588.9" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.1 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
+<line x1="168.0" y1="470.0" x2="606.9" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="606.9" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">30.6 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="494.0" x2="640.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="640.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">66.8 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="518.0" x2="646.1" y2="518.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="646.1" cy="518.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">77.1 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="542.0" x2="718.0" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">419 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/i64_div: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-mem-narrow-dark.svg
+++ b/docs/benchmarks/figs/wat-mem-narrow-dark.svg
@@ -1,89 +1,105 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_narrow: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.48 ns, then wasmer at 1.56 ns; pywasm-cpython is slowest at 84.8 µs, a span of 57300x. The table below carries every number.">
-<title>wat/mem_narrow: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.48 ns, then wasmer at 1.56 ns; pywasm-cpython is slowest at 84.8 µs, a span of 57300x. The table below carries every number.</title>
-<rect width="820" height="536" fill="#1a1a19"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="279.6" y1="68.0" x2="279.6" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="279.6" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="391.2" y1="68.0" x2="391.2" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="391.2" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="502.8" y1="68.0" x2="502.8" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="502.8" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="614.4" y1="68.0" x2="614.4" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="614.4" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_narrow: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.58 ns; pywasm-cpython is slowest at 87.8 µs, a span of 58500x. The table below carries every number.">
+<title>wat/mem_narrow: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.58 ns; pywasm-cpython is slowest at 87.8 µs, a span of 58500x. The table below carries every number.</title>
+<rect width="820" height="632" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
+<line x1="279.3" y1="68.0" x2="279.3" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="279.3" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="390.5" y1="68.0" x2="390.5" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="390.5" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="501.8" y1="68.0" x2="501.8" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="501.8" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="613.0" y1="68.0" x2="613.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="613.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="187.0" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="187.0" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.48 ns</text>
+<line x1="168.0" y1="86.0" x2="187.6" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="187.6" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.50 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="189.7" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="189.7" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.56 ns</text>
+<line x1="168.0" y1="110.0" x2="190.0" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="190.0" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.58 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="211.3" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="211.3" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.44 ns</text>
+<line x1="168.0" y1="134.0" x2="212.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="212.1" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.49 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="212.2" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="212.2" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.49 ns</text>
+<line x1="168.0" y1="158.0" x2="212.7" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="212.7" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.52 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="238.5" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="238.5" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.28 ns</text>
+<line x1="168.0" y1="182.0" x2="240.0" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="240.0" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.44 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
 <line x1="168.0" y1="206.0" x2="313.1" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="313.1" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.0 ns</text>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.1 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="374.3" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="374.3" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">70.6 ns</text>
+<line x1="168.0" y1="230.0" x2="375.2" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="375.2" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">72.8 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="437.3" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="437.3" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">259 ns</text>
+<line x1="168.0" y1="254.0" x2="437.0" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="437.0" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">261 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="444.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="444.8" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">303 ns</text>
+<line x1="168.0" y1="278.0" x2="444.9" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="444.9" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">308 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="449.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="449.6" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">334 ns</text>
+<line x1="168.0" y1="302.0" x2="449.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="449.1" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">336 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="461.2" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="461.2" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">424 ns</text>
+<line x1="168.0" y1="326.0" x2="461.4" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="461.4" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">434 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="532.6" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="532.6" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.85 µs</text>
+<line x1="168.0" y1="350.0" x2="533.5" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="533.5" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.93 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="556.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="556.1" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.01 µs</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="632.6" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="632.6" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.6 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="422.0" x2="662.3" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="662.3" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">26.9 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="667.9" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="667.9" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">30.1 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="470.0" x2="691.3" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="691.3" cy="470.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">48.9 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">84.8 µs</text>
+<line x1="168.0" y1="374.0" x2="558.4" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="558.4" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.23 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="398.0" x2="597.3" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="597.3" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.22 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
+<line x1="168.0" y1="422.0" x2="631.7" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="631.7" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.7 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
+<line x1="168.0" y1="446.0" x2="638.2" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="638.2" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">16.8 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
+<line x1="168.0" y1="470.0" x2="647.4" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="647.4" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.4 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
+<line x1="168.0" y1="494.0" x2="663.5" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="663.5" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">28.4 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
+<line x1="168.0" y1="518.0" x2="687.5" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="687.5" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">46.7 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="542.0" x2="688.0" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="688.0" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">47.1 µs</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="566.0" x2="692.5" y2="566.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="692.5" cy="566.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">51.8 µs</text>
+<text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="590.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">87.8 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/mem_narrow: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-mem-narrow.svg
+++ b/docs/benchmarks/figs/wat-mem-narrow.svg
@@ -1,89 +1,105 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_narrow: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.48 ns, then wasmer at 1.56 ns; pywasm-cpython is slowest at 84.8 µs, a span of 57300x. The table below carries every number.">
-<title>wat/mem_narrow: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.48 ns, then wasmer at 1.56 ns; pywasm-cpython is slowest at 84.8 µs, a span of 57300x. The table below carries every number.</title>
-<rect width="820" height="536" fill="#fcfcfb"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="279.6" y1="68.0" x2="279.6" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="279.6" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="391.2" y1="68.0" x2="391.2" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="391.2" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="502.8" y1="68.0" x2="502.8" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="502.8" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="614.4" y1="68.0" x2="614.4" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="614.4" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_narrow: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.58 ns; pywasm-cpython is slowest at 87.8 µs, a span of 58500x. The table below carries every number.">
+<title>wat/mem_narrow: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.58 ns; pywasm-cpython is slowest at 87.8 µs, a span of 58500x. The table below carries every number.</title>
+<rect width="820" height="632" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
+<line x1="279.3" y1="68.0" x2="279.3" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="279.3" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="390.5" y1="68.0" x2="390.5" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="390.5" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="501.8" y1="68.0" x2="501.8" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="501.8" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="613.0" y1="68.0" x2="613.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="613.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="187.0" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="187.0" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.48 ns</text>
+<line x1="168.0" y1="86.0" x2="187.6" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="187.6" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.50 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="189.7" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="189.7" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.56 ns</text>
+<line x1="168.0" y1="110.0" x2="190.0" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="190.0" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.58 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="211.3" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="211.3" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.44 ns</text>
+<line x1="168.0" y1="134.0" x2="212.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="212.1" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.49 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="212.2" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="212.2" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.49 ns</text>
+<line x1="168.0" y1="158.0" x2="212.7" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="212.7" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.52 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="238.5" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="238.5" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.28 ns</text>
+<line x1="168.0" y1="182.0" x2="240.0" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="240.0" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.44 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
 <line x1="168.0" y1="206.0" x2="313.1" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="313.1" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.0 ns</text>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.1 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="374.3" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="374.3" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">70.6 ns</text>
+<line x1="168.0" y1="230.0" x2="375.2" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="375.2" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">72.8 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="437.3" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="437.3" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">259 ns</text>
+<line x1="168.0" y1="254.0" x2="437.0" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="437.0" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">261 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="444.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="444.8" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">303 ns</text>
+<line x1="168.0" y1="278.0" x2="444.9" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="444.9" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">308 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="449.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="449.6" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">334 ns</text>
+<line x1="168.0" y1="302.0" x2="449.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="449.1" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">336 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="461.2" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="461.2" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">424 ns</text>
+<line x1="168.0" y1="326.0" x2="461.4" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="461.4" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">434 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="532.6" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="532.6" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.85 µs</text>
+<line x1="168.0" y1="350.0" x2="533.5" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="533.5" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.93 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="556.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="556.1" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.01 µs</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="632.6" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="632.6" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.6 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="422.0" x2="662.3" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="662.3" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">26.9 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="667.9" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="667.9" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">30.1 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="470.0" x2="691.3" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="691.3" cy="470.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">48.9 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">84.8 µs</text>
+<line x1="168.0" y1="374.0" x2="558.4" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="558.4" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.23 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="398.0" x2="597.3" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="597.3" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.22 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
+<line x1="168.0" y1="422.0" x2="631.7" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="631.7" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.7 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
+<line x1="168.0" y1="446.0" x2="638.2" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="638.2" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">16.8 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
+<line x1="168.0" y1="470.0" x2="647.4" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="647.4" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.4 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
+<line x1="168.0" y1="494.0" x2="663.5" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="663.5" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">28.4 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
+<line x1="168.0" y1="518.0" x2="687.5" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="687.5" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">46.7 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="542.0" x2="688.0" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="688.0" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">47.1 µs</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="566.0" x2="692.5" y2="566.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="692.5" cy="566.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">51.8 µs</text>
+<text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="590.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">87.8 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/mem_narrow: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-mem-rw-dark.svg
+++ b/docs/benchmarks/figs/wat-mem-rw-dark.svg
@@ -1,91 +1,103 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_rw: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 0.99 ns, then wasmer at 0.99 ns; pywasm-cpython is slowest at 38.5 µs, a span of 39000x. The table below carries every number.">
-<title>wat/mem_rw: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 0.99 ns, then wasmer at 0.99 ns; pywasm-cpython is slowest at 38.5 µs, a span of 39000x. The table below carries every number.</title>
-<rect width="820" height="536" fill="#1a1a19"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">0 ns</text>
-<line x1="266.5" y1="68.0" x2="266.5" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="266.5" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="364.9" y1="68.0" x2="364.9" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="364.9" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="463.4" y1="68.0" x2="463.4" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="463.4" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="561.9" y1="68.0" x2="561.9" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="561.9" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="660.4" y1="68.0" x2="660.4" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="660.4" y="522.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="265.9" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="265.9" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.99 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="266.0" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="266.0" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.99 ns</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_rw: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 1.01 ns, then wasmtime at 1.01 ns; pywasm-cpython is slowest at 39.9 µs, a span of 39700x. The table below carries every number.">
+<title>wat/mem_rw: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 1.01 ns, then wasmtime at 1.01 ns; pywasm-cpython is slowest at 39.9 µs, a span of 39700x. The table below carries every number.</title>
+<rect width="820" height="632" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
+<line x1="287.5" y1="68.0" x2="287.5" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="287.5" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="407.1" y1="68.0" x2="407.1" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="407.1" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="526.6" y1="68.0" x2="526.6" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="526.6" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="646.2" y1="68.0" x2="646.2" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="646.2" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<circle cx="168.3" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.01 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<circle cx="168.5" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.01 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="283.7" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="283.7" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.50 ns</text>
+<line x1="168.0" y1="134.0" x2="189.3" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="189.3" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.51 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="284.7" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="284.7" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.53 ns</text>
+<line x1="168.0" y1="158.0" x2="190.8" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="190.8" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.55 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="289.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="289.7" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.72 ns</text>
+<line x1="168.0" y1="182.0" x2="198.2" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="198.2" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.79 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="365.3" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="365.3" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.1 ns</text>
+<line x1="168.0" y1="206.0" x2="287.1" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="287.1" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.91 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="436.4" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="436.4" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">53.1 ns</text>
+<line x1="168.0" y1="230.0" x2="375.5" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="375.5" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">54.4 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="473.4" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="473.4" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">126 ns</text>
+<line x1="168.0" y1="254.0" x2="419.7" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="419.7" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">127 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="475.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="475.1" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">131 ns</text>
+<line x1="168.0" y1="278.0" x2="422.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="422.6" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">135 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="477.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="477.7" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">140 ns</text>
+<line x1="168.0" y1="302.0" x2="425.3" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="425.3" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">142 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="487.4" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="487.4" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">175 ns</text>
+<line x1="168.0" y1="326.0" x2="437.5" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="437.5" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">180 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="549.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="549.2" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">744 ns</text>
+<line x1="168.0" y1="350.0" x2="513.3" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="513.3" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">773 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="560.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="560.1" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">958 ns</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="638.5" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="638.5" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.00 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="422.0" x2="658.7" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="658.7" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.61 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="446.0" x2="670.4" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="670.4" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.6 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="470.0" x2="707.8" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="707.8" cy="470.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">30.3 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">38.5 µs</text>
+<line x1="168.0" y1="374.0" x2="526.7" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="526.7" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.00 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="398.0" x2="586.4" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="586.4" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.16 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
+<line x1="168.0" y1="422.0" x2="618.9" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="618.9" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.92 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
+<line x1="168.0" y1="446.0" x2="622.0" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="622.0" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.27 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
+<line x1="168.0" y1="470.0" x2="634.4" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="634.4" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.97 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="494.0" x2="635.2" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="635.2" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.09 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
+<line x1="168.0" y1="518.0" x2="660.6" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="660.6" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.2 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
+<line x1="168.0" y1="542.0" x2="688.2" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="688.2" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">22.5 µs</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="566.0" x2="706.3" y2="566.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="706.3" cy="566.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">31.9 µs</text>
+<text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="590.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">39.9 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/mem_rw: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-mem-rw.svg
+++ b/docs/benchmarks/figs/wat-mem-rw.svg
@@ -1,91 +1,103 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_rw: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 0.99 ns, then wasmer at 0.99 ns; pywasm-cpython is slowest at 38.5 µs, a span of 39000x. The table below carries every number.">
-<title>wat/mem_rw: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 0.99 ns, then wasmer at 0.99 ns; pywasm-cpython is slowest at 38.5 µs, a span of 39000x. The table below carries every number.</title>
-<rect width="820" height="536" fill="#fcfcfb"/>
-<line x1="168.0" y1="68.0" x2="168.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">0 ns</text>
-<line x1="266.5" y1="68.0" x2="266.5" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="266.5" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="364.9" y1="68.0" x2="364.9" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="364.9" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="463.4" y1="68.0" x2="463.4" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="463.4" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="561.9" y1="68.0" x2="561.9" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="561.9" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="660.4" y1="68.0" x2="660.4" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="660.4" y="522.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="168.0" y1="506.0" x2="726.0" y2="506.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="265.9" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="265.9" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.99 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="266.0" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="266.0" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.99 ns</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_rw: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 1.01 ns, then wasmtime at 1.01 ns; pywasm-cpython is slowest at 39.9 µs, a span of 39700x. The table below carries every number.">
+<title>wat/mem_rw: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 1.01 ns, then wasmtime at 1.01 ns; pywasm-cpython is slowest at 39.9 µs, a span of 39700x. The table below carries every number.</title>
+<rect width="820" height="632" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
+<line x1="287.5" y1="68.0" x2="287.5" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="287.5" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="407.1" y1="68.0" x2="407.1" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="407.1" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="526.6" y1="68.0" x2="526.6" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="526.6" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="646.2" y1="68.0" x2="646.2" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="646.2" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<circle cx="168.3" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.01 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<circle cx="168.5" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.01 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="283.7" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="283.7" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.50 ns</text>
+<line x1="168.0" y1="134.0" x2="189.3" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="189.3" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.51 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="284.7" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="284.7" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.53 ns</text>
+<line x1="168.0" y1="158.0" x2="190.8" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="190.8" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.55 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="289.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="289.7" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.72 ns</text>
+<line x1="168.0" y1="182.0" x2="198.2" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="198.2" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.79 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="365.3" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="365.3" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.1 ns</text>
+<line x1="168.0" y1="206.0" x2="287.1" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="287.1" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.91 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="436.4" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="436.4" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">53.1 ns</text>
+<line x1="168.0" y1="230.0" x2="375.5" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="375.5" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">54.4 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="473.4" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="473.4" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">126 ns</text>
+<line x1="168.0" y1="254.0" x2="419.7" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="419.7" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">127 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="475.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="475.1" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">131 ns</text>
+<line x1="168.0" y1="278.0" x2="422.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="422.6" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">135 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="477.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="477.7" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">140 ns</text>
+<line x1="168.0" y1="302.0" x2="425.3" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="425.3" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">142 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="487.4" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="487.4" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">175 ns</text>
+<line x1="168.0" y1="326.0" x2="437.5" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="437.5" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">180 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="549.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="549.2" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">744 ns</text>
+<line x1="168.0" y1="350.0" x2="513.3" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="513.3" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">773 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="560.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="560.1" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">958 ns</text>
-<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="638.5" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="638.5" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.00 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="422.0" x2="658.7" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="658.7" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.61 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="446.0" x2="670.4" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="670.4" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.6 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="470.0" x2="707.8" y2="470.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="707.8" cy="470.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">30.3 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="494.0" x2="718.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="718.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">38.5 µs</text>
+<line x1="168.0" y1="374.0" x2="526.7" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="526.7" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.00 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="398.0" x2="586.4" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="586.4" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.16 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
+<line x1="168.0" y1="422.0" x2="618.9" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="618.9" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.92 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
+<line x1="168.0" y1="446.0" x2="622.0" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="622.0" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.27 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
+<line x1="168.0" y1="470.0" x2="634.4" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="634.4" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.97 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="494.0" x2="635.2" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="635.2" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.09 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
+<line x1="168.0" y1="518.0" x2="660.6" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="660.6" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.2 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
+<line x1="168.0" y1="542.0" x2="688.2" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="688.2" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">22.5 µs</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="566.0" x2="706.3" y2="566.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="706.3" cy="566.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">31.9 µs</text>
+<text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="590.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">39.9 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/mem_rw: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/results.md
+++ b/docs/benchmarks/results.md
@@ -7,12 +7,12 @@ How to run and read these measurements is [README.md](README.md).
 
 ## Environment
 
-Measured 2026-08-24T23:27:21Z.
+Measured 2026-08-30T05:11:20Z.
 
 | | |
 | --- | --- |
-| OS | macOS 26.5.2 |
-| Kernel | Darwin 25.5.0 |
+| OS | macOS 26.6.2 |
+| Kernel | Darwin 25.6.0 |
 | CPU | Apple M1 Pro |
 | Arch | aarch64 |
 
@@ -21,11 +21,11 @@ A runner missing from this table was unavailable on this host; its cells appear 
 
 | Runner | Version |
 | --- | --- |
-| `wasmtime` | wasmtime 48.0.0 (f1412a598 2026-08-20) |
+| `wasmtime` | wasmtime 48.0.1 (7bac2c277 2026-08-24) |
 | `wasmer` | wasmer 7.3.0 |
 | `wasmedge` | wasmedge version 0.17.1 |
 | `wazero` | 1.12.0 |
-| `wasm3` | Wasm3 v0.5.0 on arm64-v8a |
+| `wasm3` | Wasm3 v0.9.0 on arm64-v8a |
 | `dewasm-ruby` | ruby 4.0.4 (2026-05-12 revision b89eb1bcbf) +PRISM [arm64-darwin25] |
 | `dewasm-ruby-yjit` | ruby 4.0.4 (2026-05-12 revision b89eb1bcbf) +PRISM [arm64-darwin25] |
 | `dewasm-ruby-zjit` | ruby 4.0.4 (2026-05-12 revision b89eb1bcbf) +PRISM [arm64-darwin25] |
@@ -35,6 +35,10 @@ A runner missing from this table was unavailable on this host; its cells appear 
 | `dewasm-go` | go version go1.26.2 darwin/arm64 |
 | `dewasm-java` | java version "25.0.4.1" 2026-08-18 LTS |
 | `dewasm-bash` | 5.3.15(1)-release |
+| `wasm3-ruby` | Wasm3 v0.9.0 on wasm |
+| `wasm3-ruby-yjit` | Wasm3 v0.9.0 on wasm |
+| `wasm3-python` | Wasm3 v0.9.0 on wasm |
+| `wasm3-pypy` | Wasm3 v0.9.0 on wasm |
 | `pywasm-cpython` | pywasm 2.2.3 |
 | `pywasm-pypy` | pywasm 2.2.3 |
 | `wardite` | wardite 0.9.0 |
@@ -54,7 +58,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-br-table-dark.svg">
-  <img alt="wat/br_table: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-go is fastest at 7.60 ns, then wasmtime at 8.52 ns; pywasm-cpython is slowest at 50.0 µs, a span of 6580x. The table below carries every number." src="figs/wat-br-table.svg">
+  <img alt="wat/br_table: seconds per iteration for 22 runners on a log scale, fastest first. dewasm-go is fastest at 7.65 ns, then wasmer at 8.48 ns; pywasm-pypy is slowest at 54.2 µs, a span of 7080x. The table below carries every number." src="figs/wat-br-table.svg">
 </picture>
 
 <details>
@@ -62,24 +66,28 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 35 355 417 | 8.52 | 8.52 | 5.8 ms | 306.9 ms | 1.00x | — |
-| `wasmer` | 35 144 240 | 8.53 | 8.57 | 9.1 ms | 308.8 ms | 1.00x | — |
-| `wasmedge` | 1 349 761 | 222.1 | 222.2 | 16.1 ms | 316.0 ms | 26x | — |
-| `wazero` | 34 048 782 | 8.84 | 8.83 | 5.0 ms | 305.9 ms | 1.04x | — |
-| `wasm3` | 10 952 072 | 26.2 | 26.2 | 4.6 ms | 291.5 ms | 3.08x | — |
-| `dewasm-ruby` | 1 315 136 | 217.0 | 216.9 | 40.3 ms | 325.6 ms | 25x | — |
-| `dewasm-ruby-yjit` | 1 182 148 | 217.8 | 218.8 | 39.6 ms | 297.0 ms | 26x | — |
-| `dewasm-ruby-zjit` | 1 400 375 | 209.1 | 209.3 | 41.0 ms | 333.9 ms | 25x | — |
-| `dewasm-python` | 762 544 | 391.1 | 392.4 | 26.5 ms | 324.8 ms | 46x | — |
-| `dewasm-pypy` | 4 350 118 | 61.0 | 61.0 | 36.7 ms | 301.8 ms | 7.16x | — |
-| `dewasm-perl` | 352 352 | 860.3 | 860.8 | 10.3 ms | 313.4 ms | 101x | — |
-| `dewasm-go` | 39 690 089 | 7.60 | 7.60 | 2.6 ms | 304.1 ms | 0.89x | — |
-| `dewasm-java` | 26 656 189 | 9.68 | 9.67 | 60.6 ms | 318.6 ms | 1.14x | — |
-| `dewasm-bash` | 7 981 | 35705 | 35782 | 11.4 ms | 296.4 ms | 4192x | — |
-| `pywasm-cpython` | 5 891 | 49647 | 50045 | 38.9 ms | 331.4 ms | 5829x | 0.9 ms |
-| `pywasm-pypy` | 4 247 | 42232 | 42176 | 72.1 ms | 251.5 ms | 4959x | 5.2 ms |
-| `wardite` | 15 578 | 20347 | 20372 | 47.1 ms | 364.0 ms | 2389x | 3.5 ms |
-| `wardite-yjit` | 32 468 | 8391 | 8394 | 92.1 ms | 364.6 ms | 985x | 8.5 ms |
+| `wasmtime` | 35 239 116 | 8.44 | 8.50 | 5.8 ms | 303.1 ms | 1.00x | — |
+| `wasmer` | 35 419 097 | 8.46 | 8.48 | 9.0 ms | 308.6 ms | 1.00x | — |
+| `wasmedge` | 1 333 994 | 220.9 | 220.8 | 15.5 ms | 310.1 ms | 26x | — |
+| `wazero` | 34 105 260 | 8.83 | 8.85 | 5.2 ms | 306.5 ms | 1.05x | — |
+| `wasm3` | 11 214 447 | 26.5 | 26.6 | 4.4 ms | 302.1 ms | 3.15x | — |
+| `dewasm-ruby` | 1 166 279 | 217.7 | 216.9 | 38.6 ms | 292.6 ms | 26x | — |
+| `dewasm-ruby-yjit` | 1 121 504 | 218.6 | 220.7 | 38.7 ms | 283.8 ms | 26x | — |
+| `dewasm-ruby-zjit` | 1 295 469 | 216.8 | 216.8 | 40.6 ms | 321.4 ms | 26x | — |
+| `dewasm-python` | 712 829 | 397.0 | 398.9 | 29.2 ms | 312.1 ms | 47x | — |
+| `dewasm-pypy` | 4 049 969 | 62.8 | 63.0 | 40.1 ms | 294.5 ms | 7.44x | — |
+| `dewasm-perl` | 335 558 | 878.3 | 878.3 | 10.2 ms | 305.0 ms | 104x | — |
+| `dewasm-go` | 37 618 165 | 7.62 | 7.65 | 4.8 ms | 291.5 ms | 0.90x | — |
+| `dewasm-java` | 25 986 047 | 9.73 | 9.75 | 66.2 ms | 319.1 ms | 1.15x | — |
+| `dewasm-bash` | 7 275 | 36520 | 36574 | 12.7 ms | 278.4 ms | 4329x | — |
+| `wasm3-ruby` | 37 411 | 8086 | 8134 | 160.3 ms | 462.8 ms | 958x | — |
+| `wasm3-ruby-yjit` | 99 364 | 3123 | 3127 | 271.6 ms | 581.9 ms | 370x | — |
+| `wasm3-python` | 11 875 | 22743 | 23012 | 351.0 ms | 621.1 ms | 2696x | — |
+| `wasm3-pypy` | 22 397 | 8718 | 8754 | 399.6 ms | 594.8 ms | 1033x | — |
+| `pywasm-cpython` | 5 421 | 51427 | 51377 | 44.9 ms | 323.7 ms | 6096x | 0.9 ms |
+| `pywasm-pypy` | 3 527 | 53795 | 54155 | 81.6 ms | 271.4 ms | 6377x | 5.3 ms |
+| `wardite` | 9 046 | 21372 | 21403 | 52.2 ms | 245.5 ms | 2533x | 4.3 ms |
+| `wardite-yjit` | 24 427 | 8854 | 8847 | 102.3 ms | 318.6 ms | 1049x | 10.3 ms |
 
 </details>
 
@@ -87,7 +95,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-call-direct-dark.svg">
-  <img alt="wat/call_direct: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 3.44 ns, then wasmer at 3.44 ns; dewasm-bash is slowest at 54.4 µs, a span of 15800x. The table below carries every number." src="figs/wat-call-direct.svg">
+  <img alt="wat/call_direct: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 3.50 ns, then wasmtime at 3.51 ns; wasm3-python is slowest at 73.3 µs, a span of 21000x. The table below carries every number." src="figs/wat-call-direct.svg">
 </picture>
 
 <details>
@@ -95,24 +103,28 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 87 949 082 | 3.43 | 3.44 | 5.3 ms | 307.4 ms | 1.00x | — |
-| `wasmer` | 87 810 157 | 3.43 | 3.44 | 8.3 ms | 309.5 ms | 1.00x | — |
-| `wasmedge` | 1 431 459 | 201.7 | 202.0 | 14.7 ms | 303.4 ms | 59x | — |
-| `wazero` | 50 672 207 | 5.89 | 5.91 | 4.9 ms | 303.4 ms | 1.72x | — |
-| `wasm3` | 6 403 126 | 48.6 | 48.7 | 4.1 ms | 315.5 ms | 14x | — |
-| `dewasm-ruby` | 1 403 757 | 202.0 | 203.6 | 35.2 ms | 318.8 ms | 59x | — |
-| `dewasm-ruby-yjit` | 2 274 206 | 105.7 | 105.8 | 35.6 ms | 276.0 ms | 31x | — |
-| `dewasm-ruby-zjit` | 2 441 519 | 122.2 | 122.1 | 36.3 ms | 334.6 ms | 36x | — |
-| `dewasm-python` | 728 959 | 414.2 | 412.3 | 26.8 ms | 328.7 ms | 121x | — |
-| `dewasm-pypy` | 2 310 894 | 87.2 | 88.2 | 36.9 ms | 238.4 ms | 25x | — |
-| `dewasm-perl` | 278 822 | 1089 | 1089 | 10.0 ms | 313.6 ms | 317x | — |
-| `dewasm-go` | 73 937 121 | 4.07 | 4.07 | 2.5 ms | 303.2 ms | 1.18x | — |
-| `dewasm-java` | 67 653 439 | 3.53 | 3.55 | 60.3 ms | 299.1 ms | 1.03x | — |
-| `dewasm-bash` | 5 334 | 54397 | 54437 | 11.3 ms | 301.5 ms | 15839x | — |
-| `pywasm-cpython` | 5 384 | 47710 | 47860 | 39.0 ms | 295.9 ms | 13892x | 0.6 ms |
-| `pywasm-pypy` | 30 570 | 8369 | 8555 | 70.9 ms | 326.8 ms | 2437x | 3.4 ms |
-| `wardite` | 15 715 | 17478 | 17332 | 47.7 ms | 322.4 ms | 5089x | 3.4 ms |
-| `wardite-yjit` | 37 188 | 7834 | 7666 | 97.1 ms | 388.4 ms | 2281x | 8.1 ms |
+| `wasmtime` | 85 655 520 | 3.52 | 3.51 | 5.6 ms | 307.1 ms | 1.00x | — |
+| `wasmer` | 84 775 575 | 3.49 | 3.50 | 9.1 ms | 304.6 ms | 0.99x | — |
+| `wasmedge` | 1 447 425 | 204.2 | 204.0 | 16.0 ms | 311.5 ms | 58x | — |
+| `wazero` | 49 851 598 | 6.03 | 6.03 | 5.2 ms | 305.6 ms | 1.71x | — |
+| `wasm3` | 6 364 347 | 44.9 | 44.9 | 4.2 ms | 289.8 ms | 13x | — |
+| `dewasm-ruby` | 1 373 608 | 208.3 | 209.1 | 40.7 ms | 326.8 ms | 59x | — |
+| `dewasm-ruby-yjit` | 3 084 746 | 109.7 | 109.5 | 39.5 ms | 378.0 ms | 31x | — |
+| `dewasm-ruby-zjit` | 1 850 551 | 126.5 | 126.5 | 41.0 ms | 275.0 ms | 36x | — |
+| `dewasm-python` | 707 203 | 423.2 | 424.2 | 29.6 ms | 328.8 ms | 120x | — |
+| `dewasm-pypy` | 2 043 202 | 90.0 | 90.1 | 40.3 ms | 224.1 ms | 26x | — |
+| `dewasm-perl` | 270 353 | 1113 | 1113 | 10.9 ms | 311.7 ms | 316x | — |
+| `dewasm-go` | 67 239 232 | 4.10 | 4.10 | 4.8 ms | 280.7 ms | 1.17x | — |
+| `dewasm-java` | 74 403 853 | 3.59 | 3.61 | 66.4 ms | 333.8 ms | 1.02x | — |
+| `dewasm-bash` | 5 007 | 55811 | 56182 | 12.4 ms | 291.9 ms | 15859x | — |
+| `wasm3-ruby` | 10 010 | 22350 | 22418 | 152.3 ms | 376.0 ms | 6351x | — |
+| `wasm3-ruby-yjit` | 19 045 | 9560 | 9525 | 192.3 ms | 374.3 ms | 2716x | — |
+| `wasm3-python` | 3 614 | 73519 | 73306 | 341.2 ms | 606.9 ms | 20890x | — |
+| `wasm3-pypy` | 11 824 | 17260 | 17352 | 391.1 ms | 595.2 ms | 4904x | — |
+| `pywasm-cpython` | 6 000 | 49558 | 49464 | 43.5 ms | 340.9 ms | 14082x | 0.6 ms |
+| `pywasm-pypy` | 23 314 | 9998 | 10001 | 79.8 ms | 312.9 ms | 2841x | 3.6 ms |
+| `wardite` | 11 302 | 18043 | 18057 | 52.5 ms | 256.4 ms | 5127x | 3.7 ms |
+| `wardite-yjit` | 36 951 | 8328 | 8316 | 102.8 ms | 410.5 ms | 2366x | 9.3 ms |
 
 </details>
 
@@ -120,7 +132,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-call-indirect-dark.svg">
-  <img alt="wat/call_indirect: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 10.3 ns, then wasmer at 10.4 ns; pywasm-cpython is slowest at 80.2 µs, a span of 7790x. The table below carries every number." src="figs/wat-call-indirect.svg">
+  <img alt="wat/call_indirect: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 10.5 ns, then wasmer at 10.5 ns; wasm3-python is slowest at 107 µs, a span of 10200x. The table below carries every number." src="figs/wat-call-indirect.svg">
 </picture>
 
 <details>
@@ -128,24 +140,28 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 33 554 432 | 10.3 | 10.3 | 5.4 ms | 350.5 ms | 1.00x | — |
-| `wasmer` | 33 554 432 | 10.3 | 10.4 | 8.6 ms | 354.1 ms | 1.00x | — |
-| `wasmedge` | 723 169 | 408.8 | 413.2 | 14.5 ms | 310.1 ms | 40x | — |
-| `wazero` | 16 777 216 | 11.6 | 11.6 | 4.9 ms | 198.9 ms | 1.12x | — |
-| `wasm3` | 4 404 301 | 67.2 | 67.9 | 4.2 ms | 300.1 ms | 6.53x | — |
-| `dewasm-ruby` | 424 648 | 651.4 | 658.7 | 35.3 ms | 312.0 ms | 63x | — |
-| `dewasm-ruby-yjit` | 691 248 | 401.0 | 403.1 | 35.7 ms | 312.9 ms | 39x | — |
-| `dewasm-ruby-zjit` | 592 003 | 463.2 | 467.2 | 35.6 ms | 309.8 ms | 45x | — |
-| `dewasm-python` | 390 912 | 770.4 | 774.5 | 26.3 ms | 327.4 ms | 75x | — |
-| `dewasm-pypy` | 2 012 008 | 135.3 | 135.9 | 36.6 ms | 308.9 ms | 13x | — |
-| `dewasm-perl` | 131 072 | 2393 | 2419 | 10.2 ms | 323.9 ms | 233x | — |
-| `dewasm-go` | 33 554 432 | 10.6 | 10.6 | 2.6 ms | 358.9 ms | 1.03x | — |
-| `dewasm-java` | 3 918 198 | 51.6 | 54.2 | 60.3 ms | 262.4 ms | 5.01x | — |
-| `dewasm-bash` | 3 988 | 73183 | 73223 | 11.5 ms | 303.4 ms | 7115x | — |
-| `pywasm-cpython` | 3 709 | 80159 | 80205 | 39.1 ms | 336.4 ms | 7793x | 0.8 ms |
-| `pywasm-pypy` | 6 044 | 30635 | 30687 | 71.0 ms | 256.2 ms | 2978x | 4.0 ms |
-| `wardite` | 9 146 | 27238 | 27264 | 47.2 ms | 296.3 ms | 2648x | 3.5 ms |
-| `wardite-yjit` | 16 413 | 13604 | 13677 | 91.9 ms | 315.2 ms | 1323x | 8.3 ms |
+| `wasmtime` | 33 554 432 | 10.5 | 10.5 | 5.6 ms | 356.9 ms | 1.00x | — |
+| `wasmer` | 33 554 432 | 10.5 | 10.5 | 9.2 ms | 360.5 ms | 1.00x | — |
+| `wasmedge` | 723 435 | 411.9 | 411.7 | 15.7 ms | 313.7 ms | 39x | — |
+| `wazero` | 16 777 216 | 11.8 | 11.9 | 5.2 ms | 203.8 ms | 1.13x | — |
+| `wasm3` | 4 216 115 | 65.9 | 66.7 | 4.1 ms | 281.9 ms | 6.29x | — |
+| `dewasm-ruby` | 435 056 | 665.8 | 668.2 | 40.0 ms | 329.7 ms | 64x | — |
+| `dewasm-ruby-yjit` | 688 799 | 411.5 | 412.1 | 41.1 ms | 324.6 ms | 39x | — |
+| `dewasm-ruby-zjit` | 475 540 | 478.5 | 480.2 | 40.3 ms | 267.8 ms | 46x | — |
+| `dewasm-python` | 374 416 | 787.2 | 791.2 | 29.1 ms | 323.9 ms | 75x | — |
+| `dewasm-pypy` | 1 915 712 | 139.5 | 139.5 | 40.3 ms | 307.5 ms | 13x | — |
+| `dewasm-perl` | 131 072 | 2459 | 2465 | 11.2 ms | 333.5 ms | 235x | — |
+| `dewasm-go` | 25 722 013 | 10.8 | 10.8 | 3.3 ms | 280.2 ms | 1.03x | — |
+| `dewasm-java` | 3 620 267 | 55.5 | 58.2 | 66.2 ms | 267.2 ms | 5.30x | — |
+| `dewasm-bash` | 3 803 | 75121 | 75261 | 12.9 ms | 298.6 ms | 7175x | — |
+| `wasm3-ruby` | 8 331 | 31483 | 31621 | 158.9 ms | 421.1 ms | 3007x | — |
+| `wasm3-ruby-yjit` | 18 069 | 12027 | 12059 | 220.8 ms | 438.1 ms | 1149x | — |
+| `wasm3-python` | 2 638 | 107024 | 106835 | 350.9 ms | 633.2 ms | 10222x | — |
+| `wasm3-pypy` | 6 087 | 32432 | 32404 | 389.7 ms | 587.1 ms | 3097x | — |
+| `pywasm-cpython` | 3 474 | 82644 | 82560 | 43.9 ms | 331.0 ms | 7893x | 0.8 ms |
+| `pywasm-pypy` | 5 128 | 36982 | 36885 | 79.2 ms | 268.8 ms | 3532x | 4.4 ms |
+| `wardite` | 8 924 | 28101 | 28186 | 52.2 ms | 303.0 ms | 2684x | 4.1 ms |
+| `wardite-yjit` | 17 114 | 13997 | 13995 | 102.9 ms | 342.5 ms | 1337x | 9.9 ms |
 
 </details>
 
@@ -153,7 +169,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-conv-dark.svg">
-  <img alt="wat/conv: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 7.53 ns, then wasmtime at 7.55 ns; pywasm-pypy is slowest at 657 µs, a span of 87200x. The table below carries every number." src="figs/wat-conv.svg">
+  <img alt="wat/conv: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 7.64 ns, then wasmtime at 7.67 ns; pywasm-pypy is slowest at 795 µs, a span of 104000x. The table below carries every number." src="figs/wat-conv.svg">
 </picture>
 
 <details>
@@ -161,24 +177,28 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 40 068 914 | 7.55 | 7.55 | 5.3 ms | 307.7 ms | 1.00x | — |
-| `wasmer` | 39 938 607 | 7.53 | 7.53 | 8.1 ms | 308.6 ms | 1.00x | — |
-| `wasmedge` | 1 293 619 | 232.7 | 233.0 | 14.8 ms | 315.8 ms | 31x | — |
-| `wazero` | 4 561 802 | 56.0 | 56.1 | 4.7 ms | 260.0 ms | 7.42x | — |
-| `wasm3` | 14 943 610 | 20.9 | 21.0 | 4.1 ms | 315.8 ms | 2.76x | — |
-| `dewasm-ruby` | 223 519 | 1333 | 1332 | 35.4 ms | 333.3 ms | 177x | — |
-| `dewasm-ruby-yjit` | 320 802 | 855.2 | 876.4 | 35.9 ms | 310.2 ms | 113x | — |
-| `dewasm-ruby-zjit` | 305 592 | 949.3 | 955.3 | 36.9 ms | 327.0 ms | 126x | — |
-| `dewasm-python` | 216 541 | 1367 | 1385 | 26.3 ms | 322.4 ms | 181x | — |
-| `dewasm-pypy` | 698 910 | 254.0 | 254.1 | 36.7 ms | 214.2 ms | 34x | — |
-| `dewasm-perl` | 136 240 | 2206 | 2214 | 13.9 ms | 314.5 ms | 292x | — |
-| `dewasm-go` | 33 554 432 | 10.3 | 10.3 | 2.6 ms | 349.8 ms | 1.37x | — |
-| `dewasm-java` | 10 400 247 | 18.3 | 18.4 | 60.7 ms | 251.1 ms | 2.43x | — |
-| `dewasm-bash` | 593 | 503992 | 504081 | 11.5 ms | 310.3 ms | 66791x | — |
-| `pywasm-cpython` | 3 010 | 98552 | 98578 | 39.0 ms | 335.7 ms | 13061x | 0.6 ms |
-| `pywasm-pypy` | 424 | 648858 | 656723 | 73.0 ms | 348.1 ms | 85989x | 3.7 ms |
-| `wardite` | 12 141 | 25162 | 25147 | 47.5 ms | 353.0 ms | 3335x | 3.6 ms |
-| `wardite-yjit` | 13 824 | 15018 | 15008 | 90.2 ms | 297.8 ms | 1990x | 8.3 ms |
+| `wasmtime` | 39 141 196 | 7.66 | 7.67 | 5.0 ms | 304.9 ms | 1.00x | — |
+| `wasmer` | 39 093 364 | 7.64 | 7.64 | 8.9 ms | 307.6 ms | 1.00x | — |
+| `wasmedge` | 1 317 133 | 228.0 | 228.0 | 15.5 ms | 315.8 ms | 30x | — |
+| `wazero` | 4 458 568 | 57.1 | 57.1 | 4.5 ms | 259.2 ms | 7.46x | — |
+| `wasm3` | 12 272 980 | 21.7 | 21.7 | 4.2 ms | 271.0 ms | 2.84x | — |
+| `dewasm-ruby` | 215 378 | 1367 | 1364 | 39.2 ms | 333.6 ms | 178x | — |
+| `dewasm-ruby-yjit` | 308 833 | 864.4 | 867.5 | 40.9 ms | 307.9 ms | 113x | — |
+| `dewasm-ruby-zjit` | 185 097 | 999.7 | 996.3 | 39.0 ms | 224.0 ms | 130x | — |
+| `dewasm-python` | 203 391 | 1446 | 1447 | 29.5 ms | 323.6 ms | 189x | — |
+| `dewasm-pypy` | 1 123 714 | 257.5 | 256.5 | 40.6 ms | 330.0 ms | 34x | — |
+| `dewasm-perl` | 133 640 | 2242 | 2241 | 14.8 ms | 314.4 ms | 293x | — |
+| `dewasm-go` | 33 554 432 | 10.5 | 10.5 | 2.7 ms | 356.1 ms | 1.37x | — |
+| `dewasm-java` | 10 291 101 | 18.5 | 18.5 | 67.3 ms | 257.6 ms | 2.41x | — |
+| `dewasm-bash` | 567 | 520245 | 521016 | 12.7 ms | 307.7 ms | 67910x | — |
+| `wasm3-ruby` | 22 153 | 17229 | 17444 | 154.6 ms | 536.3 ms | 2249x | — |
+| `wasm3-ruby-yjit` | 22 463 | 9076 | 9027 | 220.8 ms | 424.6 ms | 1185x | — |
+| `wasm3-python` | 5 933 | 41626 | 41317 | 338.0 ms | 585.0 ms | 5434x | — |
+| `wasm3-pypy` | 4 268 | 49354 | 49125 | 389.6 ms | 600.2 ms | 6442x | — |
+| `pywasm-cpython` | 3 083 | 101403 | 101642 | 44.6 ms | 357.2 ms | 13237x | 0.7 ms |
+| `pywasm-pypy` | 321 | 794746 | 795048 | 79.9 ms | 335.0 ms | 103743x | 3.7 ms |
+| `wardite` | 10 468 | 25919 | 26111 | 52.8 ms | 324.2 ms | 3383x | 4.1 ms |
+| `wardite-yjit` | 14 628 | 15296 | 15310 | 102.9 ms | 326.7 ms | 1997x | 9.9 ms |
 
 </details>
 
@@ -186,7 +206,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-eh-throw-dark.svg">
-  <img alt="wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.96 ns, then wasmedge at 115 ns; wasmer is slowest at 10.2 µs, a span of 2060x. The table below carries every number." src="figs/wat-eh-throw.svg">
+  <img alt="wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.61 ns, then wasmedge at 114 ns; wasmer is slowest at 10.2 µs, a span of 2220x. The table below carries every number." src="figs/wat-eh-throw.svg">
 </picture>
 
 <details>
@@ -194,17 +214,17 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 1 364 279 | 219.3 | 222.7 | 5.1 ms | 304.4 ms | 1.00x | — |
-| `wasmer` | 25 160 | 10176 | 10213 | 7.9 ms | 263.9 ms | 46x | — |
-| `wasmedge` | 2 578 268 | 113.8 | 115.4 | 14.5 ms | 308.0 ms | 0.52x | — |
-| `dewasm-ruby` | 475 659 | 616.7 | 614.1 | 35.6 ms | 329.0 ms | 2.81x | — |
-| `dewasm-ruby-yjit` | 478 428 | 460.8 | 460.7 | 35.7 ms | 256.1 ms | 2.10x | — |
-| `dewasm-ruby-zjit` | 488 729 | 588.3 | 597.6 | 35.8 ms | 323.3 ms | 2.68x | — |
-| `dewasm-python` | 453 870 | 650.1 | 653.5 | 26.2 ms | 321.2 ms | 2.96x | — |
-| `dewasm-pypy` | 4 000 000 | 4.62 | 4.96 | 36.4 ms | 54.9 ms | 0.02x | — |
-| `dewasm-perl` | 256 202 | 1150 | 1170 | 10.3 ms | 305.1 ms | 5.25x | — |
-| `dewasm-go` | 1 520 365 | 193.4 | 193.7 | 2.5 ms | 296.5 ms | 0.88x | — |
-| `dewasm-java` | 402 370 | 512.3 | 517.0 | 61.1 ms | 267.3 ms | 2.34x | — |
+| `wasmtime` | 1 321 919 | 221.2 | 221.1 | 5.5 ms | 297.9 ms | 1.00x | — |
+| `wasmer` | 21 505 | 10214 | 10217 | 9.0 ms | 228.7 ms | 46x | — |
+| `wasmedge` | 2 249 852 | 113.9 | 113.8 | 15.6 ms | 271.9 ms | 0.51x | — |
+| `dewasm-ruby` | 400 463 | 630.4 | 634.3 | 39.4 ms | 291.9 ms | 2.85x | — |
+| `dewasm-ruby-yjit` | 430 841 | 462.4 | 471.4 | 40.9 ms | 240.1 ms | 2.09x | — |
+| `dewasm-ruby-zjit` | 455 002 | 608.9 | 610.8 | 39.5 ms | 316.5 ms | 2.75x | — |
+| `dewasm-python` | 442 140 | 668.1 | 668.7 | 28.8 ms | 324.2 ms | 3.02x | — |
+| `dewasm-pypy` | 4 000 000 | 4.75 | 4.61 | 39.3 ms | 58.2 ms | 0.02x | — |
+| `dewasm-perl` | 255 611 | 1177 | 1187 | 11.3 ms | 312.2 ms | 5.32x | — |
+| `dewasm-go` | 1 041 645 | 200.4 | 198.9 | 3.2 ms | 212.0 ms | 0.91x | — |
+| `dewasm-java` | 321 098 | 560.5 | 551.1 | 64.2 ms | 244.2 ms | 2.53x | — |
 
 </details>
 
@@ -212,7 +232,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-eh-try-dark.svg">
-  <img alt="wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.25 ns, then dewasm-java at 1.42 ns; dewasm-perl is slowest at 511 ns, a span of 409x. The table below carries every number." src="figs/wat-eh-try.svg">
+  <img alt="wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.27 ns, then dewasm-java at 1.43 ns; dewasm-perl is slowest at 515 ns, a span of 406x. The table below carries every number." src="figs/wat-eh-try.svg">
 </picture>
 
 <details>
@@ -220,17 +240,17 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 110 065 555 | 2.74 | 2.74 | 5.3 ms | 306.6 ms | 1.00x | — |
-| `wasmer` | 240 488 062 | 1.25 | 1.25 | 8.1 ms | 308.1 ms | 0.46x | — |
-| `wasmedge` | 2 467 650 | 115.4 | 115.6 | 14.8 ms | 299.6 ms | 42x | — |
-| `dewasm-ruby` | 2 501 599 | 119.1 | 119.4 | 35.8 ms | 333.8 ms | 44x | — |
-| `dewasm-ruby-yjit` | 2 406 205 | 120.5 | 120.7 | 35.5 ms | 325.4 ms | 44x | — |
-| `dewasm-ruby-zjit` | 2 413 169 | 120.4 | 120.2 | 35.7 ms | 326.2 ms | 44x | — |
-| `dewasm-python` | 1 495 350 | 198.7 | 197.7 | 28.0 ms | 325.1 ms | 73x | — |
-| `dewasm-pypy` | 92 124 254 | 2.56 | 2.57 | 36.5 ms | 272.2 ms | 0.93x | — |
-| `dewasm-perl` | 597 271 | 509.3 | 510.6 | 10.4 ms | 314.6 ms | 186x | — |
-| `dewasm-go` | 71 700 270 | 4.23 | 4.23 | 2.5 ms | 305.5 ms | 1.54x | — |
-| `dewasm-java` | 243 599 088 | 1.41 | 1.42 | 61.5 ms | 405.0 ms | 0.52x | — |
+| `wasmtime` | 106 710 677 | 2.78 | 2.78 | 5.6 ms | 301.8 ms | 1.00x | — |
+| `wasmer` | 235 152 025 | 1.27 | 1.27 | 9.4 ms | 307.5 ms | 0.46x | — |
+| `wasmedge` | 2 635 760 | 114.8 | 115.1 | 16.0 ms | 318.6 ms | 41x | — |
+| `dewasm-ruby` | 2 284 539 | 121.4 | 121.5 | 39.7 ms | 317.0 ms | 44x | — |
+| `dewasm-ruby-yjit` | 2 223 097 | 121.9 | 122.5 | 39.9 ms | 310.9 ms | 44x | — |
+| `dewasm-ruby-zjit` | 2 771 590 | 121.5 | 121.5 | 40.6 ms | 377.4 ms | 44x | — |
+| `dewasm-python` | 1 439 446 | 197.7 | 197.8 | 29.3 ms | 313.9 ms | 71x | — |
+| `dewasm-pypy` | 103 860 134 | 2.60 | 2.61 | 40.7 ms | 311.1 ms | 0.94x | — |
+| `dewasm-perl` | 577 933 | 515.4 | 515.0 | 10.6 ms | 308.5 ms | 186x | — |
+| `dewasm-go` | 62 254 918 | 4.26 | 4.25 | 3.2 ms | 268.3 ms | 1.53x | — |
+| `dewasm-java` | 232 371 486 | 1.43 | 1.43 | 67.3 ms | 400.0 ms | 0.52x | — |
 
 </details>
 
@@ -238,7 +258,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-f32-alu-dark.svg">
-  <img alt="wat/f32_alu: seconds per iteration for 16 runners on a log scale, fastest first. wazero is fastest at 0.94 ns, then wasmtime at 0.98 ns; dewasm-bash is slowest at 1.18 ms, a span of 1250000x. The table below carries every number." src="figs/wat-f32-alu.svg">
+  <img alt="wat/f32_alu: seconds per iteration for 20 runners on a log scale, fastest first. wazero is fastest at 0.96 ns, then wasmtime at 1.00 ns; dewasm-bash is slowest at 1.21 ms, a span of 1260000x. The table below carries every number." src="figs/wat-f32-alu.svg">
 </picture>
 
 <details>
@@ -246,22 +266,26 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 297 910 004 | 0.98 | 0.98 | 5.1 ms | 298.1 ms | 1.00x | — |
-| `wasmer` | 293 658 788 | 0.98 | 0.98 | 8.0 ms | 296.7 ms | 1.00x | — |
-| `wasmedge` | 3 909 453 | 81.1 | 81.2 | 14.7 ms | 331.9 ms | 82x | — |
-| `wazero` | 319 518 669 | 0.94 | 0.94 | 4.7 ms | 305.7 ms | 0.96x | — |
-| `wasm3` | 45 663 039 | 6.67 | 6.67 | 4.2 ms | 308.7 ms | 6.78x | — |
-| `dewasm-ruby` | 773 262 | 360.4 | 361.3 | 35.5 ms | 314.2 ms | 366x | — |
-| `dewasm-ruby-yjit` | 1 283 321 | 224.3 | 227.1 | 35.5 ms | 323.4 ms | 228x | — |
-| `dewasm-ruby-zjit` | 1 027 353 | 263.8 | 277.3 | 35.5 ms | 306.5 ms | 268x | — |
-| `dewasm-python` | 556 236 | 539.4 | 539.5 | 26.2 ms | 326.2 ms | 548x | — |
-| `dewasm-pypy` | 48 491 264 | 5.44 | 5.47 | 36.5 ms | 300.4 ms | 5.53x | — |
-| `dewasm-perl` | 193 629 | 1536 | 1543 | 10.1 ms | 307.4 ms | 1561x | — |
-| `dewasm-go` | 87 855 884 | 3.43 | 3.44 | 2.6 ms | 304.2 ms | 3.49x | — |
-| `dewasm-java` | 172 820 992 | 1.63 | 1.63 | 60.7 ms | 342.5 ms | 1.66x | — |
-| `dewasm-bash` | 180 | 1174988 | 1176732 | 11.6 ms | 223.1 ms | 1194708x | — |
-| `pywasm-cpython` | 7 643 | 28321 | 28631 | 38.7 ms | 255.2 ms | 28796x | 0.6 ms |
-| `pywasm-pypy` | 27 531 | 6954 | 6967 | 70.7 ms | 262.2 ms | 7071x | 3.2 ms |
+| `wasmtime` | 280 698 883 | 1.00 | 1.00 | 5.2 ms | 286.6 ms | 1.00x | — |
+| `wasmer` | 290 391 634 | 1.00 | 1.00 | 9.0 ms | 299.1 ms | 1.00x | — |
+| `wasmedge` | 3 175 480 | 79.0 | 79.0 | 15.7 ms | 266.6 ms | 79x | — |
+| `wazero` | 303 213 828 | 0.96 | 0.96 | 4.7 ms | 295.4 ms | 0.96x | — |
+| `wasm3` | 42 223 961 | 7.01 | 7.00 | 3.9 ms | 299.9 ms | 6.99x | — |
+| `dewasm-ruby` | 832 283 | 362.2 | 362.9 | 41.0 ms | 342.4 ms | 361x | — |
+| `dewasm-ruby-yjit` | 1 186 483 | 227.1 | 226.9 | 40.1 ms | 309.5 ms | 227x | — |
+| `dewasm-ruby-zjit` | 805 841 | 280.9 | 280.9 | 39.5 ms | 265.9 ms | 280x | — |
+| `dewasm-python` | 530 383 | 541.8 | 541.0 | 29.3 ms | 316.7 ms | 540x | — |
+| `dewasm-pypy` | 49 140 324 | 5.54 | 5.55 | 40.6 ms | 312.8 ms | 5.53x | — |
+| `dewasm-perl` | 191 797 | 1538 | 1532 | 10.4 ms | 305.4 ms | 1534x | — |
+| `dewasm-go` | 76 869 252 | 3.48 | 3.48 | 3.8 ms | 271.6 ms | 3.48x | — |
+| `dewasm-java` | 200 010 216 | 1.64 | 1.64 | 66.4 ms | 394.4 ms | 1.64x | — |
+| `dewasm-bash` | 191 | 1204096 | 1206844 | 12.8 ms | 242.8 ms | 1201098x | — |
+| `wasm3-ruby` | 65 536 | 5356 | 5362 | 153.7 ms | 504.7 ms | 5342x | — |
+| `wasm3-ruby-yjit` | 179 080 | 1856 | 1855 | 209.3 ms | 541.7 ms | 1852x | — |
+| `wasm3-python` | 21 740 | 14043 | 14020 | 336.3 ms | 641.6 ms | 14008x | — |
+| `wasm3-pypy` | 64 624 | 3217 | 3220 | 384.2 ms | 592.1 ms | 3209x | — |
+| `pywasm-cpython` | 9 553 | 29180 | 29245 | 43.2 ms | 322.0 ms | 29108x | 0.7 ms |
+| `pywasm-pypy` | 38 048 | 6158 | 6168 | 78.2 ms | 312.5 ms | 6143x | 3.2 ms |
 
 </details>
 
@@ -269,7 +293,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-f64-alu-dark.svg">
-  <img alt="wat/f64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wazero is fastest at 0.95 ns, then wasmer at 0.96 ns; dewasm-bash is slowest at 566 µs, a span of 594000x. The table below carries every number." src="figs/wat-f64-alu.svg">
+  <img alt="wat/f64_alu: seconds per iteration for 22 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmer at 0.98 ns; dewasm-bash is slowest at 578 µs, a span of 599000x. The table below carries every number." src="figs/wat-f64-alu.svg">
 </picture>
 
 <details>
@@ -277,24 +301,28 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 299 733 643 | 0.96 | 0.96 | 5.3 ms | 293.7 ms | 1.00x | — |
-| `wasmer` | 300 619 813 | 0.96 | 0.96 | 8.3 ms | 297.6 ms | 1.00x | — |
-| `wasmedge` | 3 606 962 | 81.3 | 81.4 | 14.6 ms | 307.9 ms | 85x | — |
-| `wazero` | 315 697 492 | 0.95 | 0.95 | 4.7 ms | 304.9 ms | 0.99x | — |
-| `wasm3` | 56 283 616 | 5.34 | 5.36 | 4.0 ms | 304.4 ms | 5.55x | — |
-| `dewasm-ruby` | 2 789 606 | 100.4 | 101.2 | 35.4 ms | 315.5 ms | 104x | — |
-| `dewasm-ruby-yjit` | 3 948 315 | 74.8 | 75.1 | 35.5 ms | 331.0 ms | 78x | — |
-| `dewasm-ruby-zjit` | 3 642 743 | 81.0 | 81.1 | 35.8 ms | 330.9 ms | 84x | — |
-| `dewasm-python` | 1 970 958 | 150.0 | 150.5 | 26.1 ms | 321.7 ms | 156x | — |
-| `dewasm-pypy` | 136 731 461 | 2.12 | 2.12 | 36.5 ms | 326.1 ms | 2.20x | — |
-| `dewasm-perl` | 359 903 | 814.8 | 817.5 | 13.9 ms | 307.2 ms | 847x | — |
-| `dewasm-go` | 86 481 609 | 3.46 | 3.47 | 2.6 ms | 301.6 ms | 3.59x | — |
-| `dewasm-java` | 178 114 357 | 1.62 | 1.62 | 60.7 ms | 348.4 ms | 1.68x | — |
-| `dewasm-bash` | 527 | 563427 | 565804 | 11.6 ms | 308.5 ms | 585603x | — |
-| `pywasm-cpython` | 9 652 | 28690 | 28740 | 38.6 ms | 315.6 ms | 29820x | 0.6 ms |
-| `pywasm-pypy` | 42 808 | 5436 | 5460 | 70.2 ms | 303.0 ms | 5650x | 3.2 ms |
-| `wardite` | 39 133 | 7392 | 7453 | 47.4 ms | 336.6 ms | 7683x | 3.5 ms |
-| `wardite-yjit` | 84 093 | 3442 | 3441 | 94.6 ms | 384.0 ms | 3578x | 8.1 ms |
+| `wasmtime` | 312 833 484 | 0.98 | 0.98 | 5.4 ms | 311.2 ms | 1.00x | — |
+| `wasmer` | 305 968 246 | 0.98 | 0.98 | 9.0 ms | 308.3 ms | 1.00x | — |
+| `wasmedge` | 3 419 021 | 79.2 | 79.0 | 15.6 ms | 286.3 ms | 81x | — |
+| `wazero` | 302 242 260 | 0.96 | 0.97 | 5.0 ms | 296.4 ms | 0.99x | — |
+| `wasm3` | 55 393 303 | 5.41 | 5.40 | 4.2 ms | 304.1 ms | 5.54x | — |
+| `dewasm-ruby` | 2 939 163 | 102.2 | 102.0 | 39.1 ms | 339.5 ms | 105x | — |
+| `dewasm-ruby-yjit` | 3 893 067 | 75.2 | 75.8 | 40.0 ms | 332.7 ms | 77x | — |
+| `dewasm-ruby-zjit` | 3 808 571 | 81.7 | 82.5 | 40.3 ms | 351.3 ms | 84x | — |
+| `dewasm-python` | 2 355 738 | 151.3 | 151.6 | 30.0 ms | 386.4 ms | 155x | — |
+| `dewasm-pypy` | 127 247 474 | 2.15 | 2.15 | 40.8 ms | 314.9 ms | 2.20x | — |
+| `dewasm-perl` | 357 962 | 831.3 | 830.9 | 14.8 ms | 312.4 ms | 851x | — |
+| `dewasm-go` | 71 050 685 | 3.52 | 3.52 | 2.7 ms | 252.9 ms | 3.60x | — |
+| `dewasm-java` | 104 920 190 | 1.71 | 1.71 | 62.3 ms | 241.7 ms | 1.75x | — |
+| `dewasm-bash` | 516 | 577997 | 578211 | 12.9 ms | 311.2 ms | 591389x | — |
+| `wasm3-ruby` | 65 442 | 4529 | 4570 | 153.1 ms | 449.5 ms | 4634x | — |
+| `wasm3-ruby-yjit` | 114 552 | 1583 | 1593 | 208.7 ms | 390.1 ms | 1620x | — |
+| `wasm3-python` | 23 080 | 12568 | 12557 | 337.6 ms | 627.7 ms | 12860x | — |
+| `wasm3-pypy` | 84 158 | 2694 | 2682 | 386.6 ms | 613.4 ms | 2757x | — |
+| `pywasm-cpython` | 10 149 | 29695 | 29637 | 42.2 ms | 343.6 ms | 30383x | 0.6 ms |
+| `pywasm-pypy` | 24 726 | 7759 | 7719 | 78.2 ms | 270.1 ms | 7939x | 3.6 ms |
+| `wardite` | 42 335 | 7625 | 7640 | 53.0 ms | 375.8 ms | 7802x | 3.9 ms |
+| `wardite-yjit` | 56 468 | 3588 | 3548 | 104.4 ms | 307.0 ms | 3671x | 9.5 ms |
 
 </details>
 
@@ -302,7 +330,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-i32-alu-dark.svg">
-  <img alt="wat/i32_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.29 ns, then wasmtime at 2.29 ns; pywasm-cpython is slowest at 52.9 µs, a span of 23200x. The table below carries every number." src="figs/wat-i32-alu.svg">
+  <img alt="wat/i32_alu: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 2.32 ns, then wasmer at 2.32 ns; pywasm-cpython is slowest at 54.2 µs, a span of 23400x. The table below carries every number." src="figs/wat-i32-alu.svg">
 </picture>
 
 <details>
@@ -310,24 +338,28 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 131 999 693 | 2.29 | 2.29 | 5.3 ms | 307.0 ms | 1.00x | — |
-| `wasmer` | 130 185 171 | 2.29 | 2.29 | 8.2 ms | 306.1 ms | 1.00x | — |
-| `wasmedge` | 2 009 724 | 154.8 | 155.6 | 14.7 ms | 325.9 ms | 68x | — |
-| `wazero` | 113 963 502 | 2.62 | 2.62 | 4.6 ms | 302.8 ms | 1.14x | — |
-| `wasm3` | 16 777 216 | 12.8 | 12.8 | 4.2 ms | 218.3 ms | 5.59x | — |
-| `dewasm-ruby` | 1 373 516 | 181.5 | 181.8 | 35.4 ms | 284.7 ms | 79x | — |
-| `dewasm-ruby-yjit` | 1 613 675 | 137.1 | 137.0 | 35.6 ms | 256.8 ms | 60x | — |
-| `dewasm-ruby-zjit` | 1 918 665 | 149.7 | 149.9 | 35.5 ms | 322.7 ms | 65x | — |
-| `dewasm-python` | 556 420 | 554.4 | 553.3 | 27.1 ms | 335.5 ms | 243x | — |
-| `dewasm-pypy` | 29 501 604 | 9.39 | 9.39 | 36.5 ms | 313.4 ms | 4.11x | — |
-| `dewasm-perl` | 443 819 | 684.2 | 685.5 | 10.2 ms | 313.8 ms | 299x | — |
-| `dewasm-go` | 98 820 377 | 3.02 | 3.02 | 2.5 ms | 301.2 ms | 1.32x | — |
-| `dewasm-java` | 85 831 532 | 2.33 | 2.34 | 61.0 ms | 260.6 ms | 1.02x | — |
-| `dewasm-bash` | 11 899 | 24567 | 24572 | 11.8 ms | 304.1 ms | 10748x | — |
-| `pywasm-cpython` | 5 746 | 52302 | 52929 | 39.1 ms | 339.6 ms | 22881x | 0.6 ms |
-| `pywasm-pypy` | 12 568 | 17299 | 17322 | 72.4 ms | 289.8 ms | 7568x | 3.5 ms |
-| `wardite` | 20 913 | 14810 | 14918 | 47.4 ms | 357.1 ms | 6479x | 3.5 ms |
-| `wardite-yjit` | 27 613 | 6724 | 6885 | 91.2 ms | 276.9 ms | 2942x | 7.8 ms |
+| `wasmtime` | 125 909 648 | 2.32 | 2.32 | 5.1 ms | 297.7 ms | 1.00x | — |
+| `wasmer` | 128 404 565 | 2.32 | 2.32 | 9.2 ms | 307.3 ms | 1.00x | — |
+| `wasmedge` | 1 751 609 | 151.9 | 151.6 | 15.5 ms | 281.6 ms | 65x | — |
+| `wazero` | 112 657 465 | 2.67 | 2.67 | 5.1 ms | 306.1 ms | 1.15x | — |
+| `wasm3` | 15 248 317 | 13.0 | 13.1 | 4.5 ms | 202.5 ms | 5.58x | — |
+| `dewasm-ruby` | 1 602 740 | 184.4 | 184.8 | 39.1 ms | 334.7 ms | 79x | — |
+| `dewasm-ruby-yjit` | 2 365 102 | 137.7 | 137.8 | 41.2 ms | 366.8 ms | 59x | — |
+| `dewasm-ruby-zjit` | 1 702 710 | 151.6 | 151.7 | 39.0 ms | 297.1 ms | 65x | — |
+| `dewasm-python` | 516 029 | 563.3 | 562.5 | 29.5 ms | 320.2 ms | 242x | — |
+| `dewasm-pypy` | 28 507 321 | 9.59 | 9.62 | 40.1 ms | 313.5 ms | 4.13x | — |
+| `dewasm-perl` | 422 668 | 692.0 | 690.8 | 10.6 ms | 303.0 ms | 298x | — |
+| `dewasm-go` | 85 678 303 | 3.05 | 3.06 | 3.7 ms | 265.3 ms | 1.31x | — |
+| `dewasm-java` | 123 953 808 | 2.36 | 2.34 | 65.4 ms | 357.8 ms | 1.01x | — |
+| `dewasm-bash` | 11 609 | 25075 | 25065 | 13.3 ms | 304.4 ms | 10788x | — |
+| `wasm3-ruby` | 31 074 | 9296 | 9322 | 153.2 ms | 442.1 ms | 3999x | — |
+| `wasm3-ruby-yjit` | 75 528 | 3629 | 3625 | 217.7 ms | 491.8 ms | 1561x | — |
+| `wasm3-python` | 9 432 | 25499 | 25663 | 341.0 ms | 581.5 ms | 10970x | — |
+| `wasm3-pypy` | 28 118 | 8073 | 8106 | 386.4 ms | 613.4 ms | 3473x | — |
+| `pywasm-cpython` | 5 206 | 54256 | 54228 | 43.2 ms | 325.6 ms | 23343x | 0.7 ms |
+| `pywasm-pypy` | 6 026 | 29619 | 29477 | 81.9 ms | 260.4 ms | 12743x | 3.9 ms |
+| `wardite` | 15 728 | 15278 | 15355 | 53.1 ms | 293.4 ms | 6573x | 4.6 ms |
+| `wardite-yjit` | 29 146 | 6898 | 6922 | 101.2 ms | 302.2 ms | 2968x | 9.5 ms |
 
 </details>
 
@@ -335,7 +367,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-i32-div-dark.svg">
-  <img alt="wat/i32_div: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 7.54 ns, then wasmtime at 7.55 ns; dewasm-bash is slowest at 67.1 µs, a span of 8890x. The table below carries every number." src="figs/wat-i32-div.svg">
+  <img alt="wat/i32_div: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 7.66 ns, then wasmer at 7.67 ns; dewasm-bash is slowest at 68.2 µs, a span of 8910x. The table below carries every number." src="figs/wat-i32-div.svg">
 </picture>
 
 <details>
@@ -343,24 +375,28 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 39 958 199 | 7.55 | 7.55 | 5.1 ms | 306.7 ms | 1.00x | — |
-| `wasmer` | 39 930 619 | 7.55 | 7.54 | 8.1 ms | 309.5 ms | 1.00x | — |
-| `wasmedge` | 1 612 912 | 187.7 | 187.8 | 14.6 ms | 317.3 ms | 25x | — |
-| `wazero` | 39 981 886 | 7.52 | 7.59 | 4.8 ms | 305.5 ms | 1.00x | — |
-| `wasm3` | 16 777 216 | 16.7 | 16.7 | 4.1 ms | 284.9 ms | 2.22x | — |
-| `dewasm-ruby` | 820 626 | 363.4 | 365.6 | 35.3 ms | 333.5 ms | 48x | — |
-| `dewasm-ruby-yjit` | 1 380 362 | 184.5 | 194.1 | 35.6 ms | 290.3 ms | 24x | — |
-| `dewasm-ruby-zjit` | 1 051 613 | 238.8 | 241.1 | 35.6 ms | 286.7 ms | 32x | — |
-| `dewasm-python` | 305 620 | 970.4 | 970.6 | 26.3 ms | 322.8 ms | 129x | — |
-| `dewasm-pypy` | 16 402 417 | 13.8 | 13.9 | 36.4 ms | 263.5 ms | 1.83x | — |
-| `dewasm-perl` | 252 906 | 1201 | 1211 | 10.1 ms | 313.7 ms | 159x | — |
-| `dewasm-go` | 39 705 014 | 7.56 | 7.57 | 2.5 ms | 302.5 ms | 1.00x | — |
-| `dewasm-java` | 28 410 481 | 7.77 | 7.77 | 61.5 ms | 282.1 ms | 1.03x | — |
-| `dewasm-bash` | 4 352 | 67029 | 67089 | 11.5 ms | 303.2 ms | 8882x | — |
-| `pywasm-cpython` | 4 365 | 60065 | 59948 | 39.0 ms | 301.1 ms | 7959x | 0.6 ms |
-| `pywasm-pypy` | 6 992 | 27262 | 27763 | 71.2 ms | 261.8 ms | 3612x | 3.5 ms |
-| `wardite` | 16 031 | 17937 | 18037 | 47.5 ms | 335.0 ms | 2377x | 3.5 ms |
-| `wardite-yjit` | 27 269 | 8215 | 8371 | 92.7 ms | 316.7 ms | 1089x | 7.9 ms |
+| `wasmtime` | 39 310 654 | 7.65 | 7.66 | 5.5 ms | 306.4 ms | 1.00x | — |
+| `wasmer` | 38 898 318 | 7.64 | 7.67 | 8.8 ms | 306.1 ms | 1.00x | — |
+| `wasmedge` | 1 624 300 | 181.2 | 181.3 | 15.8 ms | 310.2 ms | 24x | — |
+| `wazero` | 39 140 777 | 7.67 | 7.68 | 5.4 ms | 305.7 ms | 1.00x | — |
+| `wasm3` | 13 119 225 | 15.8 | 15.8 | 4.1 ms | 211.4 ms | 2.06x | — |
+| `dewasm-ruby` | 745 314 | 367.2 | 367.1 | 39.7 ms | 313.3 ms | 48x | — |
+| `dewasm-ruby-yjit` | 1 622 501 | 185.7 | 187.2 | 40.7 ms | 342.1 ms | 24x | — |
+| `dewasm-ruby-zjit` | 933 732 | 240.5 | 241.8 | 40.2 ms | 264.7 ms | 31x | — |
+| `dewasm-python` | 304 998 | 973.5 | 974.1 | 30.2 ms | 327.1 ms | 127x | — |
+| `dewasm-pypy` | 12 959 713 | 14.2 | 14.2 | 39.7 ms | 224.1 ms | 1.86x | — |
+| `dewasm-perl` | 246 418 | 1214 | 1218 | 11.6 ms | 310.8 ms | 159x | — |
+| `dewasm-go` | 36 409 793 | 7.68 | 7.68 | 3.4 ms | 283.1 ms | 1.00x | — |
+| `dewasm-java` | 29 107 804 | 7.91 | 7.90 | 67.4 ms | 297.5 ms | 1.03x | — |
+| `dewasm-bash` | 4 203 | 68435 | 68217 | 12.7 ms | 300.4 ms | 8941x | — |
+| `wasm3-ruby` | 17 417 | 11749 | 11727 | 153.5 ms | 358.1 ms | 1535x | — |
+| `wasm3-ruby-yjit` | 56 016 | 4657 | 4663 | 214.3 ms | 475.2 ms | 608x | — |
+| `wasm3-python` | 10 078 | 31240 | 31572 | 340.1 ms | 654.9 ms | 4082x | — |
+| `wasm3-pypy` | 16 576 | 12645 | 12559 | 389.3 ms | 598.9 ms | 1652x | — |
+| `pywasm-cpython` | 4 011 | 61492 | 61234 | 43.6 ms | 290.2 ms | 8034x | 0.7 ms |
+| `pywasm-pypy` | 4 032 | 47605 | 47464 | 78.8 ms | 270.8 ms | 6220x | 3.6 ms |
+| `wardite` | 15 238 | 18102 | 18266 | 52.9 ms | 328.8 ms | 2365x | 3.7 ms |
+| `wardite-yjit` | 32 894 | 8493 | 8514 | 101.3 ms | 380.7 ms | 1110x | 10.0 ms |
 
 </details>
 
@@ -368,7 +404,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-i64-alu-dark.svg">
-  <img alt="wat/i64_alu: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 2.30 ns, then wasmtime at 2.30 ns; pywasm-pypy is slowest at 313 µs, a span of 136000x. The table below carries every number." src="figs/wat-i64-alu.svg">
+  <img alt="wat/i64_alu: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 2.33 ns, then wasmer at 2.33 ns; pywasm-pypy is slowest at 408 µs, a span of 175000x. The table below carries every number." src="figs/wat-i64-alu.svg">
 </picture>
 
 <details>
@@ -376,24 +412,28 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 131 082 244 | 2.29 | 2.30 | 5.3 ms | 305.5 ms | 1.00x | — |
-| `wasmer` | 130 617 898 | 2.30 | 2.30 | 8.1 ms | 308.2 ms | 1.00x | — |
-| `wasmedge` | 1 694 580 | 154.7 | 155.0 | 14.7 ms | 276.9 ms | 68x | — |
-| `wazero` | 115 006 089 | 2.62 | 2.62 | 4.7 ms | 305.7 ms | 1.14x | — |
-| `wasm3` | 16 777 216 | 11.8 | 11.9 | 4.2 ms | 203.0 ms | 5.17x | — |
-| `dewasm-ruby` | 240 784 | 1248 | 1246 | 36.3 ms | 336.7 ms | 545x | — |
-| `dewasm-ruby-yjit` | 300 412 | 930.1 | 940.4 | 35.8 ms | 315.2 ms | 406x | — |
-| `dewasm-ruby-zjit` | 290 472 | 1001 | 1012 | 35.8 ms | 326.6 ms | 437x | — |
-| `dewasm-python` | 482 787 | 625.0 | 636.6 | 26.2 ms | 327.9 ms | 273x | — |
-| `dewasm-pypy` | 927 607 | 218.6 | 219.3 | 37.1 ms | 239.8 ms | 95x | — |
-| `dewasm-perl` | 305 989 | 983.2 | 985.7 | 10.3 ms | 311.1 ms | 429x | — |
-| `dewasm-go` | 115 624 091 | 2.59 | 2.59 | 2.6 ms | 302.0 ms | 1.13x | — |
-| `dewasm-java` | 131 553 348 | 2.32 | 2.32 | 60.2 ms | 364.9 ms | 1.01x | — |
-| `dewasm-bash` | 8 771 | 26955 | 27049 | 12.3 ms | 248.8 ms | 11768x | — |
-| `pywasm-cpython` | 4 981 | 56822 | 56993 | 39.5 ms | 322.6 ms | 24807x | 0.6 ms |
-| `pywasm-pypy` | 608 | 305086 | 313202 | 74.6 ms | 260.1 ms | 133195x | 3.4 ms |
-| `wardite` | 17 916 | 16230 | 16273 | 47.5 ms | 338.3 ms | 7086x | 3.5 ms |
-| `wardite-yjit` | 31 575 | 8790 | 8976 | 90.9 ms | 368.4 ms | 3838x | 8.5 ms |
+| `wasmtime` | 128 742 317 | 2.33 | 2.33 | 5.7 ms | 305.6 ms | 1.00x | — |
+| `wasmer` | 129 557 406 | 2.33 | 2.33 | 9.4 ms | 311.2 ms | 1.00x | — |
+| `wasmedge` | 1 967 678 | 151.8 | 151.8 | 15.6 ms | 314.3 ms | 65x | — |
+| `wazero` | 112 940 596 | 2.67 | 2.67 | 5.1 ms | 306.2 ms | 1.14x | — |
+| `wasm3` | 16 777 216 | 12.1 | 12.1 | 4.5 ms | 207.0 ms | 5.18x | — |
+| `dewasm-ruby` | 235 760 | 1260 | 1273 | 39.8 ms | 336.8 ms | 541x | — |
+| `dewasm-ruby-yjit` | 258 973 | 953.4 | 954.2 | 39.3 ms | 286.2 ms | 409x | — |
+| `dewasm-ruby-zjit` | 266 250 | 1024 | 1029 | 40.8 ms | 313.6 ms | 440x | — |
+| `dewasm-python` | 459 986 | 614.5 | 616.1 | 29.1 ms | 311.8 ms | 264x | — |
+| `dewasm-pypy` | 1 028 338 | 220.3 | 222.7 | 40.2 ms | 266.7 ms | 95x | — |
+| `dewasm-perl` | 299 368 | 1001 | 1001 | 10.9 ms | 310.5 ms | 429x | — |
+| `dewasm-go` | 96 940 225 | 2.63 | 2.62 | 3.7 ms | 258.8 ms | 1.13x | — |
+| `dewasm-java` | 87 673 825 | 2.35 | 2.35 | 67.4 ms | 273.1 ms | 1.01x | — |
+| `dewasm-bash` | 9 690 | 27581 | 27553 | 13.7 ms | 280.9 ms | 11839x | — |
+| `wasm3-ruby` | 28 128 | 10602 | 10531 | 153.3 ms | 451.5 ms | 4551x | — |
+| `wasm3-ruby-yjit` | 48 196 | 4914 | 4924 | 217.3 ms | 454.1 ms | 2109x | — |
+| `wasm3-python` | 9 691 | 25191 | 25094 | 339.8 ms | 583.9 ms | 10813x | — |
+| `wasm3-pypy` | 15 988 | 11941 | 11903 | 390.4 ms | 581.3 ms | 5125x | — |
+| `pywasm-cpython` | 5 260 | 58273 | 58157 | 44.9 ms | 351.4 ms | 25013x | 0.7 ms |
+| `pywasm-pypy` | 455 | 408852 | 408203 | 82.4 ms | 268.5 ms | 175493x | 3.7 ms |
+| `wardite` | 12 205 | 16651 | 16708 | 53.5 ms | 256.7 ms | 7147x | 4.3 ms |
+| `wardite-yjit` | 30 900 | 9208 | 9239 | 101.4 ms | 386.0 ms | 3952x | 9.5 ms |
 
 </details>
 
@@ -401,7 +441,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-i64-div-dark.svg">
-  <img alt="wat/i64_div: seconds per iteration for 16 runners on a log scale, fastest first. dewasm-go is fastest at 8.15 ns, then wasmer at 8.16 ns; pywasm-pypy is slowest at 233 µs, a span of 28600x. The table below carries every number." src="figs/wat-i64-div.svg">
+  <img alt="wat/i64_div: seconds per iteration for 20 runners on a log scale, fastest first. dewasm-go is fastest at 8.24 ns, then wasmtime at 8.27 ns; pywasm-pypy is slowest at 419 µs, a span of 50800x. The table below carries every number." src="figs/wat-i64-div.svg">
 </picture>
 
 <details>
@@ -409,22 +449,26 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 36 825 262 | 8.16 | 8.17 | 5.3 ms | 305.8 ms | 1.00x | — |
-| `wasmer` | 37 065 480 | 8.15 | 8.16 | 8.4 ms | 310.6 ms | 1.00x | — |
-| `wasmedge` | 1 369 333 | 187.9 | 188.0 | 14.7 ms | 272.0 ms | 23x | — |
-| `wazero` | 36 880 330 | 8.16 | 8.21 | 4.7 ms | 305.7 ms | 1.00x | — |
-| `wasm3` | 16 777 216 | 15.9 | 15.9 | 4.0 ms | 271.0 ms | 1.95x | — |
-| `dewasm-ruby` | 169 163 | 1653 | 1660 | 35.3 ms | 314.9 ms | 203x | — |
-| `dewasm-ruby-yjit` | 232 346 | 1119 | 1122 | 35.7 ms | 295.6 ms | 137x | — |
-| `dewasm-ruby-zjit` | 194 831 | 1370 | 1381 | 35.8 ms | 302.8 ms | 168x | — |
-| `dewasm-python` | 289 849 | 1025 | 1026 | 26.6 ms | 323.6 ms | 126x | — |
-| `dewasm-pypy` | 772 592 | 267.0 | 267.5 | 36.5 ms | 242.8 ms | 33x | — |
-| `dewasm-perl` | 200 444 | 1483 | 1508 | 10.2 ms | 307.4 ms | 182x | — |
-| `dewasm-go` | 36 821 131 | 8.13 | 8.15 | 2.6 ms | 302.1 ms | 1.00x | — |
-| `dewasm-java` | 29 158 791 | 8.57 | 8.43 | 56.8 ms | 306.7 ms | 1.05x | — |
-| `dewasm-bash` | 3 863 | 75324 | 75413 | 11.3 ms | 302.3 ms | 9230x | — |
-| `pywasm-cpython` | 4 211 | 64728 | 65187 | 38.8 ms | 311.3 ms | 7931x | 0.6 ms |
-| `pywasm-pypy` | 822 | 233001 | 232582 | 70.5 ms | 262.0 ms | 28550x | 3.4 ms |
+| `wasmtime` | 36 187 407 | 8.29 | 8.27 | 5.2 ms | 305.0 ms | 1.00x | — |
+| `wasmer` | 35 952 591 | 8.28 | 8.28 | 9.2 ms | 307.0 ms | 1.00x | — |
+| `wasmedge` | 1 662 336 | 180.2 | 180.6 | 15.8 ms | 315.3 ms | 22x | — |
+| `wazero` | 36 083 066 | 8.32 | 8.32 | 4.9 ms | 305.2 ms | 1.00x | — |
+| `wasm3` | 14 261 590 | 16.1 | 16.2 | 4.3 ms | 234.2 ms | 1.95x | — |
+| `dewasm-ruby` | 165 828 | 1683 | 1697 | 39.9 ms | 319.0 ms | 203x | — |
+| `dewasm-ruby-yjit` | 183 238 | 1106 | 1139 | 39.6 ms | 242.4 ms | 134x | — |
+| `dewasm-ruby-zjit` | 186 417 | 1401 | 1404 | 40.1 ms | 301.3 ms | 169x | — |
+| `dewasm-python` | 290 159 | 1030 | 1033 | 29.7 ms | 328.6 ms | 124x | — |
+| `dewasm-pypy` | 715 479 | 268.3 | 267.9 | 41.1 ms | 233.1 ms | 32x | — |
+| `dewasm-perl` | 200 301 | 1512 | 1515 | 11.0 ms | 313.9 ms | 183x | — |
+| `dewasm-go` | 33 385 589 | 8.29 | 8.24 | 3.1 ms | 279.8 ms | 1.00x | — |
+| `dewasm-java` | 21 095 517 | 8.78 | 8.74 | 65.5 ms | 250.7 ms | 1.06x | — |
+| `dewasm-bash` | 3 721 | 77143 | 77138 | 12.8 ms | 299.9 ms | 9311x | — |
+| `wasm3-ruby` | 21 976 | 13171 | 13306 | 151.8 ms | 441.2 ms | 1590x | — |
+| `wasm3-ruby-yjit` | 32 021 | 6346 | 6351 | 212.4 ms | 415.6 ms | 766x | — |
+| `wasm3-python` | 11 369 | 30701 | 30627 | 339.4 ms | 688.4 ms | 3705x | — |
+| `wasm3-pypy` | 10 754 | 20119 | 20083 | 387.8 ms | 604.1 ms | 2428x | — |
+| `pywasm-cpython` | 4 194 | 66862 | 66832 | 43.0 ms | 323.5 ms | 8070x | 0.7 ms |
+| `pywasm-pypy` | 463 | 414074 | 418985 | 79.2 ms | 270.9 ms | 49977x | 3.9 ms |
 
 </details>
 
@@ -432,7 +476,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-mem-narrow-dark.svg">
-  <img alt="wat/mem_narrow: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.48 ns, then wasmer at 1.56 ns; pywasm-cpython is slowest at 84.8 µs, a span of 57300x. The table below carries every number." src="figs/wat-mem-narrow.svg">
+  <img alt="wat/mem_narrow: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.58 ns; pywasm-cpython is slowest at 87.8 µs, a span of 58500x. The table below carries every number." src="figs/wat-mem-narrow.svg">
 </picture>
 
 <details>
@@ -440,24 +484,28 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 205 396 532 | 1.48 | 1.48 | 5.2 ms | 308.9 ms | 1.00x | — |
-| `wasmer` | 191 021 914 | 1.55 | 1.56 | 8.1 ms | 303.7 ms | 1.05x | — |
-| `wasmedge` | 1 119 717 | 258.4 | 259.1 | 14.6 ms | 303.9 ms | 175x | — |
-| `wazero` | 121 681 796 | 2.47 | 2.49 | 4.7 ms | 305.6 ms | 1.67x | — |
-| `wasm3` | 15 322 101 | 19.9 | 20.0 | 4.1 ms | 309.1 ms | 13x | — |
-| `dewasm-ruby` | 667 725 | 423.6 | 423.6 | 35.6 ms | 318.4 ms | 286x | — |
-| `dewasm-ruby-yjit` | 889 630 | 297.6 | 302.6 | 35.7 ms | 300.4 ms | 201x | — |
-| `dewasm-ruby-zjit` | 779 199 | 325.5 | 333.7 | 35.5 ms | 289.1 ms | 220x | — |
-| `dewasm-python` | 164 381 | 1847 | 1850 | 26.2 ms | 329.7 ms | 1249x | — |
-| `dewasm-pypy` | 4 001 718 | 70.5 | 70.6 | 37.3 ms | 319.5 ms | 48x | — |
-| `dewasm-perl` | 65 536 | 3005 | 3006 | 10.1 ms | 207.0 ms | 2032x | — |
-| `dewasm-go` | 121 799 829 | 2.44 | 2.44 | 2.5 ms | 299.9 ms | 1.65x | — |
-| `dewasm-java` | 54 783 780 | 4.28 | 4.28 | 60.2 ms | 294.4 ms | 2.89x | — |
-| `dewasm-bash` | 6 213 | 48561 | 48868 | 11.3 ms | 313.1 ms | 32835x | — |
-| `pywasm-cpython` | 3 525 | 84735 | 84839 | 39.0 ms | 337.7 ms | 57295x | 0.7 ms |
-| `pywasm-pypy` | 6 884 | 29800 | 30146 | 71.8 ms | 277.0 ms | 20149x | 4.7 ms |
-| `wardite` | 10 882 | 26793 | 26863 | 47.2 ms | 338.8 ms | 18116x | 3.6 ms |
-| `wardite-yjit` | 13 071 | 14168 | 14573 | 91.6 ms | 276.8 ms | 9580x | 8.0 ms |
+| `wasmtime` | 197 866 562 | 1.50 | 1.50 | 5.3 ms | 301.5 ms | 1.00x | — |
+| `wasmer` | 182 896 153 | 1.58 | 1.58 | 9.0 ms | 297.9 ms | 1.06x | — |
+| `wasmedge` | 1 097 745 | 261.5 | 261.4 | 15.6 ms | 302.6 ms | 175x | — |
+| `wazero` | 120 287 021 | 2.50 | 2.52 | 5.2 ms | 306.4 ms | 1.67x | — |
+| `wasm3` | 14 577 052 | 20.1 | 20.1 | 4.4 ms | 298.1 ms | 13x | — |
+| `dewasm-ruby` | 715 050 | 434.3 | 433.6 | 39.5 ms | 350.1 ms | 290x | — |
+| `dewasm-ruby-yjit` | 839 357 | 308.3 | 308.3 | 39.8 ms | 298.6 ms | 206x | — |
+| `dewasm-ruby-zjit` | 808 241 | 335.2 | 336.2 | 40.3 ms | 311.2 ms | 224x | — |
+| `dewasm-python` | 156 625 | 1908 | 1927 | 29.2 ms | 328.1 ms | 1275x | — |
+| `dewasm-pypy` | 3 203 405 | 73.0 | 72.8 | 40.6 ms | 274.5 ms | 49x | — |
+| `dewasm-perl` | 94 648 | 3224 | 3226 | 10.5 ms | 315.6 ms | 2153x | — |
+| `dewasm-go` | 99 145 868 | 2.49 | 2.49 | 3.4 ms | 250.5 ms | 1.66x | — |
+| `dewasm-java` | 43 951 401 | 4.45 | 4.44 | 65.7 ms | 261.3 ms | 2.97x | — |
+| `dewasm-bash` | 5 861 | 51685 | 51782 | 12.4 ms | 315.4 ms | 34521x | — |
+| `wasm3-ruby` | 12 076 | 16668 | 16831 | 178.9 ms | 380.2 ms | 11133x | — |
+| `wasm3-ruby-yjit` | 33 510 | 7248 | 7224 | 232.4 ms | 475.3 ms | 4841x | — |
+| `wasm3-python` | 5 183 | 46395 | 46694 | 389.1 ms | 629.6 ms | 30988x | — |
+| `wasm3-pypy` | 10 416 | 20379 | 20372 | 386.7 ms | 599.0 ms | 13611x | — |
+| `pywasm-cpython` | 3 599 | 87469 | 87770 | 45.1 ms | 359.9 ms | 58421x | 0.8 ms |
+| `pywasm-pypy` | 4 086 | 47592 | 47138 | 78.9 ms | 273.3 ms | 31788x | 4.8 ms |
+| `wardite` | 9 442 | 28239 | 28399 | 53.5 ms | 320.2 ms | 18861x | 4.4 ms |
+| `wardite-yjit` | 21 940 | 14667 | 14715 | 103.1 ms | 424.9 ms | 9796x | 9.4 ms |
 
 </details>
 
@@ -465,7 +513,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-mem-rw-dark.svg">
-  <img alt="wat/mem_rw: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 0.99 ns, then wasmer at 0.99 ns; pywasm-cpython is slowest at 38.5 µs, a span of 39000x. The table below carries every number." src="figs/wat-mem-rw.svg">
+  <img alt="wat/mem_rw: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 1.01 ns, then wasmtime at 1.01 ns; pywasm-cpython is slowest at 39.9 µs, a span of 39700x. The table below carries every number." src="figs/wat-mem-rw.svg">
 </picture>
 
 <details>
@@ -473,24 +521,28 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 300 641 504 | 0.99 | 0.99 | 5.3 ms | 302.3 ms | 1.00x | — |
-| `wasmer` | 303 482 249 | 0.99 | 0.99 | 8.3 ms | 307.9 ms | 1.00x | — |
-| `wasmedge` | 2 379 605 | 126.1 | 126.3 | 14.7 ms | 314.9 ms | 128x | — |
-| `wazero` | 196 568 970 | 1.53 | 1.53 | 4.8 ms | 305.0 ms | 1.55x | — |
-| `wasm3` | 33 554 432 | 9.97 | 10.1 | 4.1 ms | 338.7 ms | 10x | — |
-| `dewasm-ruby` | 1 742 013 | 174.4 | 175.2 | 35.4 ms | 339.3 ms | 177x | — |
-| `dewasm-ruby-yjit` | 2 155 858 | 131.1 | 131.2 | 35.4 ms | 318.1 ms | 133x | — |
-| `dewasm-ruby-zjit` | 2 048 560 | 139.6 | 139.6 | 35.8 ms | 321.7 ms | 141x | — |
-| `dewasm-python` | 412 851 | 735.7 | 743.7 | 26.2 ms | 329.9 ms | 745x | — |
-| `dewasm-pypy` | 5 702 846 | 52.4 | 53.1 | 37.2 ms | 336.0 ms | 53x | — |
-| `dewasm-perl` | 311 478 | 957.3 | 958.0 | 10.1 ms | 308.2 ms | 969x | — |
-| `dewasm-go` | 200 721 416 | 1.48 | 1.50 | 2.5 ms | 299.5 ms | 1.50x | — |
-| `dewasm-java` | 162 834 081 | 1.72 | 1.72 | 61.0 ms | 341.1 ms | 1.74x | — |
-| `dewasm-bash` | 9 977 | 30119 | 30308 | 11.4 ms | 311.9 ms | 30484x | — |
-| `pywasm-cpython` | 7 462 | 38320 | 38480 | 38.8 ms | 324.8 ms | 38785x | 0.7 ms |
-| `pywasm-pypy` | 17 721 | 9744 | 9615 | 72.1 ms | 244.7 ms | 9862x | 4.3 ms |
-| `wardite` | 18 040 | 12585 | 12631 | 47.3 ms | 274.4 ms | 12738x | 3.5 ms |
-| `wardite-yjit` | 45 282 | 5796 | 6001 | 91.8 ms | 354.3 ms | 5866x | 8.0 ms |
+| `wasmtime` | 284 180 286 | 1.01 | 1.01 | 5.7 ms | 292.3 ms | 1.00x | — |
+| `wasmer` | 286 572 989 | 1.01 | 1.01 | 9.2 ms | 297.4 ms | 1.00x | — |
+| `wasmedge` | 2 246 338 | 127.3 | 127.5 | 15.5 ms | 301.6 ms | 126x | — |
+| `wazero` | 193 108 533 | 1.55 | 1.55 | 4.9 ms | 303.9 ms | 1.54x | — |
+| `wasm3` | 33 554 432 | 9.90 | 9.91 | 4.6 ms | 336.8 ms | 9.82x | — |
+| `dewasm-ruby` | 1 737 235 | 179.6 | 179.6 | 40.1 ms | 352.2 ms | 178x | — |
+| `dewasm-ruby-yjit` | 2 475 521 | 134.6 | 134.9 | 40.3 ms | 373.5 ms | 133x | — |
+| `dewasm-ruby-zjit` | 2 105 621 | 142.2 | 141.9 | 40.3 ms | 339.7 ms | 141x | — |
+| `dewasm-python` | 389 292 | 760.0 | 773.0 | 29.4 ms | 325.3 ms | 754x | — |
+| `dewasm-pypy` | 5 417 848 | 54.6 | 54.4 | 41.0 ms | 336.7 ms | 54x | — |
+| `dewasm-perl` | 295 649 | 1002 | 1002 | 10.3 ms | 306.4 ms | 993x | — |
+| `dewasm-go` | 157 221 506 | 1.50 | 1.51 | 4.1 ms | 240.4 ms | 1.49x | — |
+| `dewasm-java` | 145 104 918 | 1.77 | 1.79 | 66.4 ms | 323.7 ms | 1.76x | — |
+| `dewasm-bash` | 9 223 | 31865 | 31855 | 12.4 ms | 306.3 ms | 31602x | — |
+| `wasm3-ruby` | 44 000 | 7939 | 7974 | 177.3 ms | 526.6 ms | 7873x | — |
+| `wasm3-ruby-yjit` | 89 670 | 3105 | 3161 | 221.1 ms | 499.5 ms | 3079x | — |
+| `wasm3-python` | 12 941 | 22143 | 22456 | 392.4 ms | 679.0 ms | 21960x | — |
+| `wasm3-pypy` | 33 816 | 5857 | 5916 | 389.3 ms | 587.4 ms | 5808x | — |
+| `pywasm-cpython` | 6 069 | 39704 | 39895 | 42.8 ms | 283.7 ms | 39376x | 0.7 ms |
+| `pywasm-pypy` | 30 798 | 8048 | 8090 | 81.2 ms | 329.0 ms | 7981x | 4.8 ms |
+| `wardite` | 26 680 | 13222 | 13201 | 52.3 ms | 405.0 ms | 13113x | 3.9 ms |
+| `wardite-yjit` | 42 768 | 6263 | 6274 | 102.8 ms | 370.7 ms | 6212x | 9.4 ms |
 
 </details>
 
@@ -498,7 +550,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/c-mandelbrot-dark.svg">
-  <img alt="c/mandelbrot: seconds per iteration for 18 runners on a log scale, fastest first. dewasm-java is fastest at 94.3 ns, then wasmer at 94.6 ns; dewasm-bash is slowest at 19.9 ms, a span of 211000x. The table below carries every number." src="figs/c-mandelbrot.svg">
+  <img alt="c/mandelbrot: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 96.4 ns, then wasmer at 96.4 ns; dewasm-bash is slowest at 20.3 ms, a span of 211000x. The table below carries every number." src="figs/c-mandelbrot.svg">
 </picture>
 
 <details>
@@ -506,24 +558,28 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 3 207 439 | 94.5 | 94.7 | 5.4 ms | 308.4 ms | 1.00x | — |
-| `wasmer` | 3 001 362 | 94.6 | 94.6 | 8.6 ms | 292.6 ms | 1.00x | — |
-| `wasmedge` | 65 536 | 3784 | 3787 | 14.6 ms | 262.7 ms | 40x | — |
-| `wazero` | 2 878 998 | 105.3 | 105.5 | 4.8 ms | 307.9 ms | 1.11x | — |
-| `wasm3` | 673 532 | 448.3 | 449.4 | 4.1 ms | 306.1 ms | 4.75x | — |
-| `dewasm-ruby` | 70 224 | 4465 | 4448 | 35.6 ms | 349.1 ms | 47x | — |
-| `dewasm-ruby-yjit` | 180 221 | 1532 | 1534 | 35.6 ms | 311.6 ms | 16x | — |
-| `dewasm-ruby-zjit` | 83 218 | 3470 | 3471 | 36.7 ms | 325.5 ms | 37x | — |
-| `dewasm-python` | 93 710 | 3554 | 3541 | 26.6 ms | 359.6 ms | 38x | — |
-| `dewasm-pypy` | 2 305 546 | 138.9 | 138.7 | 36.6 ms | 356.7 ms | 1.47x | — |
-| `dewasm-perl` | 5 330 | 55309 | 55683 | 10.5 ms | 305.3 ms | 586x | — |
-| `dewasm-go` | 1 274 840 | 231.9 | 231.9 | 2.6 ms | 298.2 ms | 2.45x | — |
-| `dewasm-java` | 2 899 895 | 94.2 | 94.3 | 60.8 ms | 334.0 ms | 1.00x | — |
-| `dewasm-bash` | 186 | 19904774 | 19915374 | 11.9 ms | 3.71 s | 210723x | — |
-| `pywasm-cpython` | 256 | 1461020 | 1461356 | 38.7 ms | 412.8 ms | 15467x | 0.8 ms |
-| `pywasm-pypy` | 158 | 1299710 | 1309364 | 72.4 ms | 277.7 ms | 13759x | 5.0 ms |
-| `wardite` | 793 | 368298 | 368273 | 47.4 ms | 339.4 ms | 3899x | 3.6 ms |
-| `wardite-yjit` | 1 441 | 177917 | 177894 | 91.9 ms | 348.3 ms | 1884x | 9.2 ms |
+| `wasmtime` | 3 075 042 | 96.4 | 96.4 | 5.6 ms | 301.9 ms | 1.00x | — |
+| `wasmer` | 3 070 839 | 96.3 | 96.4 | 9.5 ms | 305.1 ms | 1.00x | — |
+| `wasmedge` | 87 134 | 3700 | 3698 | 15.4 ms | 337.8 ms | 38x | — |
+| `wazero` | 2 465 523 | 107.4 | 107.7 | 4.8 ms | 269.7 ms | 1.12x | — |
+| `wasm3` | 653 731 | 452.6 | 453.0 | 4.4 ms | 300.2 ms | 4.70x | — |
+| `dewasm-ruby` | 65 536 | 4534 | 4533 | 40.9 ms | 338.1 ms | 47x | — |
+| `dewasm-ruby-yjit` | 167 113 | 1555 | 1551 | 39.3 ms | 299.1 ms | 16x | — |
+| `dewasm-ruby-zjit` | 78 988 | 3484 | 3502 | 40.4 ms | 315.6 ms | 36x | — |
+| `dewasm-python` | 95 700 | 3574 | 3577 | 30.3 ms | 372.4 ms | 37x | — |
+| `dewasm-pypy` | 2 027 383 | 142.0 | 142.1 | 40.5 ms | 328.3 ms | 1.47x | — |
+| `dewasm-perl` | 5 352 | 55811 | 56073 | 11.2 ms | 309.9 ms | 579x | — |
+| `dewasm-go` | 923 094 | 235.0 | 233.2 | 3.5 ms | 220.4 ms | 2.44x | — |
+| `dewasm-java` | 2 838 348 | 96.3 | 96.6 | 67.3 ms | 340.7 ms | 1.00x | — |
+| `dewasm-bash` | 111 | 20274933 | 20302567 | 13.4 ms | 2.26 s | 210422x | — |
+| `wasm3-ruby` | 1 211 | 227479 | 227424 | 148.7 ms | 424.2 ms | 2361x | — |
+| `wasm3-ruby-yjit` | 2 059 | 96240 | 96482 | 236.9 ms | 435.0 ms | 999x | — |
+| `wasm3-python` | 512 | 629755 | 631857 | 334.2 ms | 656.6 ms | 6536x | — |
+| `wasm3-pypy` | 1 512 | 180778 | 181513 | 393.2 ms | 666.5 ms | 1876x | — |
+| `pywasm-cpython` | 256 | 1481182 | 1486747 | 44.3 ms | 423.5 ms | 15372x | 0.8 ms |
+| `pywasm-pypy` | 112 | 1835368 | 1847883 | 81.3 ms | 286.9 ms | 19048x | 4.9 ms |
+| `wardite` | 701 | 389068 | 386166 | 51.8 ms | 324.5 ms | 4038x | 4.3 ms |
+| `wardite-yjit` | 1 378 | 184893 | 186030 | 104.3 ms | 359.1 ms | 1919x | 10.4 ms |
 
 </details>
 
@@ -531,7 +587,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/c-sha256-dark.svg">
-  <img alt="c/sha256: seconds per iteration for 18 runners on a log scale, fastest first. wasmer is fastest at 290 ns, then wasmtime at 290 ns; dewasm-bash is slowest at 15.4 ms, a span of 53100x. The table below carries every number." src="figs/c-sha256.svg">
+  <img alt="c/sha256: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 293 ns, then wasmtime at 294 ns; dewasm-bash is slowest at 15.9 ms, a span of 54300x. The table below carries every number." src="figs/c-sha256.svg">
 </picture>
 
 <details>
@@ -539,24 +595,28 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 1 034 887 | 288.6 | 290.0 | 5.2 ms | 303.9 ms | 1.00x | — |
-| `wasmer` | 1 033 724 | 288.1 | 289.7 | 8.3 ms | 306.1 ms | 1.00x | — |
-| `wasmedge` | 7 123 | 41153 | 41266 | 14.6 ms | 307.7 ms | 143x | — |
-| `wazero` | 772 597 | 371.8 | 372.4 | 4.8 ms | 292.1 ms | 1.29x | — |
-| `wasm3` | 41 434 | 4964 | 4977 | 4.5 ms | 210.1 ms | 17x | — |
-| `dewasm-ruby` | 3 743 | 77827 | 77877 | 35.5 ms | 326.8 ms | 270x | — |
-| `dewasm-ruby-yjit` | 10 348 | 33258 | 33311 | 35.9 ms | 380.0 ms | 115x | — |
-| `dewasm-ruby-zjit` | 6 514 | 52256 | 52508 | 36.1 ms | 376.5 ms | 181x | — |
-| `dewasm-python` | 1 105 | 263182 | 266135 | 27.1 ms | 317.9 ms | 912x | — |
-| `dewasm-pypy` | 13 112 | 14196 | 14424 | 37.3 ms | 223.5 ms | 49x | — |
-| `dewasm-perl` | 946 | 312947 | 314047 | 10.3 ms | 306.4 ms | 1084x | — |
-| `dewasm-go` | 880 383 | 342.3 | 342.9 | 2.7 ms | 304.0 ms | 1.19x | — |
-| `dewasm-java` | 434 236 | 499.6 | 499.7 | 60.8 ms | 277.8 ms | 1.73x | — |
-| `dewasm-bash` | 19 | 15306623 | 15390943 | 13.8 ms | 304.6 ms | 53037x | — |
-| `pywasm-cpython` | 20 | 14145473 | 14308729 | 39.9 ms | 322.8 ms | 49014x | 1.3 ms |
-| `pywasm-pypy` | 28 | 6830323 | 6828612 | 79.5 ms | 270.7 ms | 23667x | 7.4 ms |
-| `wardite` | 70 | 4022615 | 4058854 | 47.8 ms | 329.3 ms | 13938x | 3.6 ms |
-| `wardite-yjit` | 119 | 1896622 | 1892230 | 92.3 ms | 318.0 ms | 6572x | 8.9 ms |
+| `wasmtime` | 997 415 | 294.1 | 294.1 | 5.3 ms | 298.7 ms | 1.00x | — |
+| `wasmer` | 962 488 | 293.3 | 293.3 | 8.9 ms | 291.3 ms | 1.00x | — |
+| `wasmedge` | 6 953 | 40643 | 40648 | 15.5 ms | 298.1 ms | 138x | — |
+| `wazero` | 767 517 | 378.7 | 378.5 | 5.0 ms | 295.6 ms | 1.29x | — |
+| `wasm3` | 65 536 | 4916 | 4917 | 4.7 ms | 326.9 ms | 17x | — |
+| `dewasm-ruby` | 3 601 | 79581 | 79260 | 39.2 ms | 325.7 ms | 271x | — |
+| `dewasm-ruby-yjit` | 8 594 | 34055 | 33985 | 40.8 ms | 333.4 ms | 116x | — |
+| `dewasm-ruby-zjit` | 3 285 | 54569 | 54506 | 40.5 ms | 219.8 ms | 186x | — |
+| `dewasm-python` | 1 112 | 267274 | 269116 | 30.1 ms | 327.4 ms | 909x | — |
+| `dewasm-pypy` | 18 529 | 13983 | 14012 | 41.0 ms | 300.1 ms | 48x | — |
+| `dewasm-perl` | 917 | 320255 | 320630 | 10.8 ms | 304.5 ms | 1089x | — |
+| `dewasm-go` | 779 032 | 348.4 | 348.7 | 3.6 ms | 275.0 ms | 1.18x | — |
+| `dewasm-java` | 334 711 | 534.5 | 541.4 | 66.7 ms | 245.5 ms | 1.82x | — |
+| `dewasm-bash` | 18 | 15913394 | 15923049 | 15.0 ms | 301.5 ms | 54101x | — |
+| `wasm3-ruby` | 79 | 3092359 | 3096225 | 150.1 ms | 394.4 ms | 10513x | — |
+| `wasm3-ruby-yjit` | 208 | 1252763 | 1244240 | 249.6 ms | 510.2 ms | 4259x | — |
+| `wasm3-python` | 25 | 8947055 | 8930102 | 339.4 ms | 563.1 ms | 30417x | — |
+| `wasm3-pypy` | 60 | 3822547 | 3807396 | 406.2 ms | 635.6 ms | 12996x | — |
+| `pywasm-cpython` | 19 | 14479471 | 14597695 | 45.0 ms | 320.1 ms | 49226x | 1.2 ms |
+| `pywasm-pypy` | 28 | 7281929 | 7282771 | 88.8 ms | 292.7 ms | 24756x | 8.0 ms |
+| `wardite` | 53 | 4169347 | 4147897 | 53.0 ms | 273.9 ms | 14175x | 4.4 ms |
+| `wardite-yjit` | 135 | 1929772 | 1949294 | 104.7 ms | 365.2 ms | 6561x | 10.3 ms |
 
 </details>
 
@@ -564,7 +624,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/c-wordcount-dark.svg">
-  <img alt="c/wordcount: seconds per iteration for 18 runners on a log scale, fastest first. wasmtime is fastest at 1.53 ns, then wasmer at 1.62 ns; pywasm-cpython is slowest at 58.7 µs, a span of 38300x. The table below carries every number." src="figs/c-wordcount.svg">
+  <img alt="c/wordcount: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.62 ns; pywasm-cpython is slowest at 59.7 µs, a span of 39800x. The table below carries every number." src="figs/c-wordcount.svg">
 </picture>
 
 <details>
@@ -572,24 +632,28 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 194 702 493 | 1.48 | 1.53 | 5.2 ms | 293.2 ms | 1.00x | — |
-| `wasmer` | 173 628 504 | 1.58 | 1.62 | 8.0 ms | 282.4 ms | 1.07x | — |
-| `wasmedge` | 1 514 894 | 202.8 | 203.5 | 15.4 ms | 322.6 ms | 137x | — |
-| `wazero` | 99 771 338 | 2.97 | 2.98 | 5.1 ms | 301.5 ms | 2.01x | — |
-| `wasm3` | 14 605 934 | 20.4 | 20.4 | 4.1 ms | 301.6 ms | 14x | — |
-| `dewasm-ruby` | 744 827 | 401.4 | 402.5 | 37.1 ms | 336.0 ms | 271x | — |
-| `dewasm-ruby-yjit` | 1 063 765 | 271.7 | 272.2 | 37.4 ms | 326.4 ms | 184x | — |
-| `dewasm-ruby-zjit` | 977 196 | 291.4 | 292.5 | 37.7 ms | 322.5 ms | 197x | — |
-| `dewasm-python` | 337 494 | 880.9 | 888.1 | 30.0 ms | 327.3 ms | 595x | — |
-| `dewasm-pypy` | 5 158 992 | 55.0 | 55.6 | 42.1 ms | 325.9 ms | 37x | — |
-| `dewasm-perl` | 204 418 | 1448 | 1461 | 17.5 ms | 313.5 ms | 979x | — |
-| `dewasm-go` | 123 168 302 | 2.44 | 2.45 | 2.5 ms | 303.1 ms | 1.65x | — |
-| `dewasm-java` | 86 552 884 | 3.29 | 3.28 | 61.9 ms | 346.6 ms | 2.22x | — |
-| `dewasm-bash` | 6 206 | 41601 | 42037 | 119.1 ms | 377.2 ms | 28119x | — |
-| `pywasm-cpython` | 4 604 | 58504 | 58701 | 271.0 ms | 540.4 ms | 39545x | 1.3 ms |
-| `pywasm-pypy` | 15 022 | 13669 | 13919 | 180.5 ms | 385.8 ms | 9239x | 7.6 ms |
-| `wardite` | 12 943 | 20128 | 20235 | 113.5 ms | 374.1 ms | 13605x | 3.7 ms |
-| `wardite-yjit` | 30 233 | 9452 | 9442 | 131.7 ms | 417.4 ms | 6389x | 9.1 ms |
+| `wasmtime` | 179 975 764 | 1.46 | 1.50 | 5.4 ms | 267.4 ms | 1.00x | — |
+| `wasmer` | 177 418 041 | 1.62 | 1.62 | 9.2 ms | 296.2 ms | 1.11x | — |
+| `wasmedge` | 1 486 638 | 197.2 | 197.3 | 16.5 ms | 309.7 ms | 135x | — |
+| `wazero` | 99 868 591 | 3.01 | 3.01 | 5.6 ms | 305.8 ms | 2.06x | — |
+| `wasm3` | 11 986 465 | 20.2 | 20.3 | 4.5 ms | 247.2 ms | 14x | — |
+| `dewasm-ruby` | 748 536 | 410.2 | 411.1 | 41.0 ms | 348.1 ms | 282x | — |
+| `dewasm-ruby-yjit` | 958 325 | 273.3 | 273.1 | 41.1 ms | 303.0 ms | 188x | — |
+| `dewasm-ruby-zjit` | 619 243 | 297.4 | 296.2 | 40.7 ms | 224.8 ms | 204x | — |
+| `dewasm-python` | 323 946 | 897.8 | 899.3 | 33.2 ms | 324.0 ms | 617x | — |
+| `dewasm-pypy` | 4 919 747 | 56.8 | 57.0 | 45.5 ms | 324.9 ms | 39x | — |
+| `dewasm-perl` | 200 141 | 1480 | 1482 | 18.7 ms | 314.8 ms | 1016x | — |
+| `dewasm-go` | 92 941 984 | 2.72 | 2.72 | 4.0 ms | 256.6 ms | 1.87x | — |
+| `dewasm-java` | 63 054 338 | 3.49 | 3.52 | 68.7 ms | 288.7 ms | 2.40x | — |
+| `dewasm-bash` | 6 852 | 42404 | 42502 | 125.3 ms | 415.9 ms | 29129x | — |
+| `wasm3-ruby` | 26 095 | 11505 | 11634 | 194.5 ms | 494.7 ms | 7903x | — |
+| `wasm3-ruby-yjit` | 63 553 | 4324 | 4374 | 278.4 ms | 553.2 ms | 2970x | — |
+| `wasm3-python` | 12 444 | 32805 | 33022 | 460.4 ms | 868.6 ms | 22535x | — |
+| `wasm3-pypy` | 20 186 | 10821 | 10850 | 487.4 ms | 705.8 ms | 7434x | — |
+| `pywasm-cpython` | 5 017 | 59457 | 59693 | 281.9 ms | 580.2 ms | 40844x | 1.3 ms |
+| `pywasm-pypy` | 13 376 | 16107 | 16021 | 196.9 ms | 412.3 ms | 11065x | 8.2 ms |
+| `wardite` | 11 545 | 20831 | 20830 | 121.6 ms | 362.0 ms | 14310x | 3.9 ms |
+| `wardite-yjit` | 31 453 | 9728 | 9854 | 144.9 ms | 450.9 ms | 6683x | 10.6 ms |
 
 </details>
 
@@ -602,7 +666,7 @@ Every runner executes the same work, so wall times compare directly.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/app-cowsay-dark.svg">
-  <img alt="app/cowsay: seconds per run for 18 runners on a log scale, fastest first. dewasm-go is fastest at 4.04 ms, then wasm3 at 6.64 ms; dewasm-bash is slowest at 1.27 s, a span of 316x. The table below carries every number." src="figs/app-cowsay.svg">
+  <img alt="app/cowsay: seconds per run for 22 runners on a log scale, fastest first. dewasm-go is fastest at 5.75 ms, then wasm3 at 8.16 ms; wasm3-python is slowest at 3.84 s, a span of 668x. The table below carries every number." src="figs/app-cowsay.svg">
 </picture>
 
 <details>
@@ -610,24 +674,28 @@ Every runner executes the same work, so wall times compare directly.
 
 | Runner | Runs/sample | Wall time (min) | Wall time (median) | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 31 | 9.5 ms | 9.5 ms | 1.00x | — |
-| `wasmer` | 24 | 12.8 ms | 12.8 ms | 1.35x | — |
-| `wasmedge` | 13 | 24.5 ms | 24.7 ms | 2.58x | — |
-| `wazero` | 3 | 101.3 ms | 101.5 ms | 11x | — |
-| `wasm3` | 46 | 6.6 ms | 6.6 ms | 0.70x | — |
-| `dewasm-ruby` | 3 | 134.1 ms | 135.2 ms | 14x | — |
-| `dewasm-ruby-yjit` | 2 | 180.6 ms | 181.1 ms | 19x | — |
-| `dewasm-ruby-zjit` | 2 | 239.0 ms | 241.0 ms | 25x | — |
-| `dewasm-python` | 1 | 400.2 ms | 402.1 ms | 42x | — |
-| `dewasm-pypy` | 1 | 597.6 ms | 602.7 ms | 63x | — |
-| `dewasm-perl` | 3 | 103.8 ms | 104.1 ms | 11x | — |
-| `dewasm-go` | 64 | 4.0 ms | 4.0 ms | 0.42x | — |
-| `dewasm-java` | 3 | 123.3 ms | 124.4 ms | 13x | — |
-| `dewasm-bash` | 1 | 1.27 s | 1.27 s | 134x | — |
-| `pywasm-cpython` | 1 | 476.5 ms | 479.5 ms | 50x | 266.8 ms |
-| `pywasm-pypy` | 1 | 853.3 ms | 857.5 ms | 90x | 445.9 ms |
-| `wardite` | 2 | 222.8 ms | 223.6 ms | 23x | 102.1 ms |
-| `wardite-yjit` | 2 | 245.0 ms | 249.1 ms | 26x | 76.5 ms |
+| `wasmtime` | 25 | 10.3 ms | 10.3 ms | 1.00x | — |
+| `wasmer` | 16 | 14.2 ms | 14.3 ms | 1.39x | — |
+| `wasmedge` | 12 | 26.6 ms | 26.7 ms | 2.59x | — |
+| `wazero` | 3 | 106.6 ms | 107.2 ms | 10x | — |
+| `wasm3` | 39 | 8.1 ms | 8.2 ms | 0.79x | — |
+| `dewasm-ruby` | 3 | 144.5 ms | 146.1 ms | 14x | — |
+| `dewasm-ruby-yjit` | 2 | 198.0 ms | 199.1 ms | 19x | — |
+| `dewasm-ruby-zjit` | 2 | 256.9 ms | 258.2 ms | 25x | — |
+| `dewasm-python` | 1 | 427.8 ms | 428.0 ms | 42x | — |
+| `dewasm-pypy` | 1 | 629.1 ms | 631.1 ms | 61x | — |
+| `dewasm-perl` | 3 | 111.4 ms | 111.8 ms | 11x | — |
+| `dewasm-go` | 1 | 5.1 ms | 5.8 ms | 0.50x | — |
+| `dewasm-java` | 3 | 132.9 ms | 133.8 ms | 13x | — |
+| `dewasm-bash` | 1 | 1.34 s | 1.34 s | 130x | — |
+| `wasm3-ruby` | 1 | 1.56 s | 1.56 s | 152x | — |
+| `wasm3-ruby-yjit` | 1 | 1.25 s | 1.25 s | 122x | — |
+| `wasm3-python` | 1 | 3.84 s | 3.84 s | 374x | — |
+| `wasm3-pypy` | 1 | 1.71 s | 1.72 s | 167x | — |
+| `pywasm-cpython` | 1 | 502.6 ms | 504.2 ms | 49x | 279.0 ms |
+| `pywasm-pypy` | 1 | 891.7 ms | 892.3 ms | 87x | 481.7 ms |
+| `wardite` | 2 | 240.3 ms | 241.1 ms | 23x | 105.8 ms |
+| `wardite-yjit` | 2 | 273.5 ms | 276.2 ms | 27x | 85.4 ms |
 
 </details>
 
@@ -635,7 +703,7 @@ Every runner executes the same work, so wall times compare directly.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/app-sqlite3-query-dark.svg">
-  <img alt="app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 76.7 ms, then wasmer at 85.3 ms; dewasm-ruby is slowest at 18.8 s, a span of 245x. The table below carries every number." src="figs/app-sqlite3-query.svg">
+  <img alt="app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 79.4 ms, then wasmer at 87.5 ms; dewasm-ruby is slowest at 19.3 s, a span of 243x. The table below carries every number." src="figs/app-sqlite3-query.svg">
 </picture>
 
 <details>
@@ -643,17 +711,17 @@ Every runner executes the same work, so wall times compare directly.
 
 | Runner | Runs/sample | Wall time (min) | Wall time (median) | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 4 | 76.4 ms | 76.7 ms | 1.00x | — |
-| `wasmer` | 4 | 83.8 ms | 85.3 ms | 1.10x | — |
-| `wasmedge` | 1 | 9.53 s | 9.56 s | 125x | — |
-| `wazero` | 1 | 614.9 ms | 615.8 ms | 8.04x | — |
-| `wasm3` | 1 | 1.06 s | 1.07 s | 14x | — |
-| `dewasm-ruby` | 1 | 18.75 s | 18.82 s | 245x | — |
-| `dewasm-ruby-yjit` | 1 | 8.95 s | 8.99 s | 117x | — |
-| `dewasm-ruby-zjit` | 1 | 13.53 s | 13.58 s | 177x | — |
-| `dewasm-pypy` | 1 | 11.24 s | 11.30 s | 147x | — |
-| `dewasm-go` | 2 | 169.0 ms | 169.2 ms | 2.21x | — |
-| `dewasm-java` | 1 | 2.34 s | 2.35 s | 31x | — |
+| `wasmtime` | 4 | 79.1 ms | 79.4 ms | 1.00x | — |
+| `wasmer` | 4 | 87.2 ms | 87.5 ms | 1.10x | — |
+| `wasmedge` | 1 | 9.61 s | 9.61 s | 121x | — |
+| `wazero` | 1 | 647.9 ms | 648.5 ms | 8.19x | — |
+| `wasm3` | 1 | 1.13 s | 1.13 s | 14x | — |
+| `dewasm-ruby` | 1 | 19.29 s | 19.31 s | 244x | — |
+| `dewasm-ruby-yjit` | 1 | 9.27 s | 9.32 s | 117x | — |
+| `dewasm-ruby-zjit` | 1 | 14.04 s | 14.04 s | 177x | — |
+| `dewasm-pypy` | 1 | 11.98 s | 12.01 s | 151x | — |
+| `dewasm-go` | 1 | 169.8 ms | 170.4 ms | 2.15x | — |
+| `dewasm-java` | 1 | 2.35 s | 2.37 s | 30x | — |
 
 </details>
 
@@ -661,7 +729,7 @@ Every runner executes the same work, so wall times compare directly.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/app-sqlite3-mod-query-dark.svg">
-  <img alt="app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 84.5 ms, then wasmer at 87.1 ms; dewasm-ruby is slowest at 19.9 s, a span of 236x. The table below carries every number." src="figs/app-sqlite3-mod-query.svg">
+  <img alt="app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 85.8 ms, then wasmer at 90.0 ms; dewasm-ruby is slowest at 20.3 s, a span of 236x. The table below carries every number." src="figs/app-sqlite3-mod-query.svg">
 </picture>
 
 <details>
@@ -669,17 +737,17 @@ Every runner executes the same work, so wall times compare directly.
 
 | Runner | Runs/sample | Wall time (min) | Wall time (median) | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 4 | 84.4 ms | 84.5 ms | 1.00x | — |
-| `wasmer` | 4 | 87.0 ms | 87.1 ms | 1.03x | — |
-| `wasmedge` | 1 | 9.93 s | 9.94 s | 118x | — |
-| `wazero` | 1 | 608.3 ms | 608.6 ms | 7.21x | — |
-| `wasm3` | 1 | 1.15 s | 1.15 s | 14x | — |
-| `dewasm-ruby` | 1 | 19.81 s | 19.90 s | 235x | — |
-| `dewasm-ruby-yjit` | 1 | 8.11 s | 8.11 s | 96x | — |
-| `dewasm-ruby-zjit` | 1 | 14.03 s | 14.03 s | 166x | — |
-| `dewasm-pypy` | 1 | 12.08 s | 12.11 s | 143x | — |
-| `dewasm-go` | 3 | 124.3 ms | 124.5 ms | 1.47x | — |
-| `dewasm-java` | 1 | 5.37 s | 5.39 s | 64x | — |
+| `wasmtime` | 3 | 85.7 ms | 85.8 ms | 1.00x | — |
+| `wasmer` | 3 | 89.9 ms | 90.0 ms | 1.05x | — |
+| `wasmedge` | 1 | 9.94 s | 9.97 s | 116x | — |
+| `wazero` | 1 | 631.4 ms | 633.9 ms | 7.37x | — |
+| `wasm3` | 1 | 1.19 s | 1.20 s | 14x | — |
+| `dewasm-ruby` | 1 | 20.24 s | 20.27 s | 236x | — |
+| `dewasm-ruby-yjit` | 1 | 8.28 s | 8.31 s | 97x | — |
+| `dewasm-ruby-zjit` | 1 | 14.54 s | 14.55 s | 170x | — |
+| `dewasm-pypy` | 1 | 12.91 s | 13.07 s | 151x | — |
+| `dewasm-go` | 1 | 126.8 ms | 127.0 ms | 1.48x | — |
+| `dewasm-java` | 1 | 5.50 s | 5.55 s | 64x | — |
 
 </details>
 
@@ -687,7 +755,7 @@ Every runner executes the same work, so wall times compare directly.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/app-minigzip-dark.svg">
-  <img alt="app/minigzip: seconds per run for 13 runners on a log scale, fastest first. wasmtime is fastest at 42.9 ms, then wasmer at 49.4 ms; pywasm-pypy is slowest at 78.6 s, a span of 1830x. The table below carries every number." src="figs/app-minigzip.svg">
+  <img alt="app/minigzip: seconds per run for 15 runners on a log scale, fastest first. wasmtime is fastest at 45.0 ms, then wasmer at 53.0 ms; pywasm-pypy is slowest at 81.3 s, a span of 1810x. The table below carries every number." src="figs/app-minigzip.svg">
 </picture>
 
 <details>
@@ -695,19 +763,21 @@ Every runner executes the same work, so wall times compare directly.
 
 | Runner | Runs/sample | Wall time (min) | Wall time (median) | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 7 | 42.9 ms | 42.9 ms | 1.00x | — |
-| `wasmer` | 7 | 49.2 ms | 49.4 ms | 1.15x | — |
-| `wasmedge` | 1 | 2.21 s | 2.21 s | 52x | — |
-| `wazero` | 4 | 84.9 ms | 85.3 ms | 1.98x | — |
-| `dewasm-ruby` | 1 | 5.17 s | 5.17 s | 121x | — |
-| `dewasm-ruby-yjit` | 1 | 1.57 s | 1.58 s | 37x | — |
-| `dewasm-ruby-zjit` | 1 | 3.22 s | 3.22 s | 75x | — |
-| `dewasm-python` | 1 | 14.95 s | 15.06 s | 349x | — |
-| `dewasm-pypy` | 1 | 2.71 s | 2.71 s | 63x | — |
-| `dewasm-perl` | 1 | 23.78 s | 23.79 s | 554x | — |
-| `dewasm-go` | 6 | 56.0 ms | 56.4 ms | 1.31x | — |
-| `dewasm-java` | 1 | 487.0 ms | 546.8 ms | 11x | — |
-| `pywasm-pypy` | 1 | 78.34 s | 78.63 s | 1826x | 303.6 ms |
+| `wasmtime` | 7 | 45.0 ms | 45.0 ms | 1.00x | — |
+| `wasmer` | 6 | 52.9 ms | 53.0 ms | 1.18x | — |
+| `wasmedge` | 1 | 2.19 s | 2.20 s | 49x | — |
+| `wazero` | 4 | 88.6 ms | 88.6 ms | 1.97x | — |
+| `wasm3` | 2 | 256.0 ms | 256.6 ms | 5.69x | — |
+| `dewasm-ruby` | 1 | 5.28 s | 5.29 s | 117x | — |
+| `dewasm-ruby-yjit` | 1 | 1.63 s | 1.63 s | 36x | — |
+| `dewasm-ruby-zjit` | 1 | 3.31 s | 3.31 s | 73x | — |
+| `dewasm-python` | 1 | 15.32 s | 15.33 s | 341x | — |
+| `dewasm-pypy` | 1 | 2.76 s | 2.76 s | 61x | — |
+| `dewasm-perl` | 1 | 24.25 s | 24.42 s | 539x | — |
+| `dewasm-go` | 1 | 58.1 ms | 58.2 ms | 1.29x | — |
+| `dewasm-java` | 1 | 523.4 ms | 524.1 ms | 12x | — |
+| `wasm3-ruby-yjit` | 1 | 51.57 s | 51.67 s | 1146x | — |
+| `pywasm-pypy` | 1 | 80.55 s | 81.32 s | 1791x | 332.6 ms |
 
 </details>
 
@@ -719,15 +789,23 @@ A missing runner or an unbuilt module is stated here rather than left as a gap i
 | Workload | Runner | Reason |
 | --- | --- | --- |
 | `wat/eh_throw` | `wazero` | excluded: wazero 1.12.0 rejects the module: "tag section not supported as feature \"exception-handling\" is disabled" |
-| `wat/eh_throw` | `wasm3` | excluded: wasm3 0.5.0 fails to load it: "out of order Wasm section" (the tag section is unknown to it) |
+| `wat/eh_throw` | `wasm3` | excluded: wasm3 0.9.0 fails to load it: "out of order Wasm section" (the tag section is unknown to it) |
 | `wat/eh_throw` | `dewasm-bash` | excluded: the bash backend has no exception-handling lowering and rejects the module at conversion time with "unsupported (exception-handling): tag, exnref value, or try_table/throw/throw_ref instruction" (see docs/support.md) |
+| `wat/eh_throw` | `wasm3-ruby` | excluded: the converted wasm3 0.9.0 fails to load it like the native one, "out of order Wasm section" (the tag section is unknown to it), measured through the converted interpreter |
+| `wat/eh_throw` | `wasm3-ruby-yjit` | excluded: the converted wasm3 0.9.0 fails to load it like the native one, "out of order Wasm section" (the tag section is unknown to it), measured through the converted interpreter |
+| `wat/eh_throw` | `wasm3-python` | excluded: the converted wasm3 0.9.0 fails to load it like the native one, "out of order Wasm section" (the tag section is unknown to it), measured through the converted interpreter |
+| `wat/eh_throw` | `wasm3-pypy` | excluded: the converted wasm3 0.9.0 fails to load it like the native one, "out of order Wasm section" (the tag section is unknown to it), measured through the converted interpreter |
 | `wat/eh_throw` | `pywasm-cpython` | excluded: pywasm 2.2.3 has no exception-handling opcodes; decoding dies with AssertionError on the throw/try_table opcode (pywasm/core.py, from_reader) |
 | `wat/eh_throw` | `pywasm-pypy` | excluded: pywasm 2.2.3 has no exception-handling opcodes; decoding dies with AssertionError on the throw/try_table opcode (pywasm/core.py, from_reader) |
 | `wat/eh_throw` | `wardite` | excluded: wardite 0.9.0 fails to load the tag section: Wardite::LoadError "unknown code: 13" |
 | `wat/eh_throw` | `wardite-yjit` | excluded: wardite 0.9.0 fails to load the tag section: Wardite::LoadError "unknown code: 13" |
 | `wat/eh_try` | `wazero` | excluded: wazero 1.12.0 rejects the module: "tag section not supported as feature \"exception-handling\" is disabled" |
-| `wat/eh_try` | `wasm3` | excluded: wasm3 0.5.0 fails to load it: "out of order Wasm section" (the tag section is unknown to it) |
+| `wat/eh_try` | `wasm3` | excluded: wasm3 0.9.0 fails to load it: "out of order Wasm section" (the tag section is unknown to it) |
 | `wat/eh_try` | `dewasm-bash` | excluded: the bash backend has no exception-handling lowering and rejects the module at conversion time with "unsupported (exception-handling): tag, exnref value, or try_table/throw/throw_ref instruction" (see docs/support.md) |
+| `wat/eh_try` | `wasm3-ruby` | excluded: the converted wasm3 0.9.0 fails to load it like the native one, "out of order Wasm section" (the tag section is unknown to it), measured through the converted interpreter |
+| `wat/eh_try` | `wasm3-ruby-yjit` | excluded: the converted wasm3 0.9.0 fails to load it like the native one, "out of order Wasm section" (the tag section is unknown to it), measured through the converted interpreter |
+| `wat/eh_try` | `wasm3-python` | excluded: the converted wasm3 0.9.0 fails to load it like the native one, "out of order Wasm section" (the tag section is unknown to it), measured through the converted interpreter |
+| `wat/eh_try` | `wasm3-pypy` | excluded: the converted wasm3 0.9.0 fails to load it like the native one, "out of order Wasm section" (the tag section is unknown to it), measured through the converted interpreter |
 | `wat/eh_try` | `pywasm-cpython` | excluded: pywasm 2.2.3 has no exception-handling opcodes; decoding dies with AssertionError on the throw/try_table opcode (pywasm/core.py, from_reader) |
 | `wat/eh_try` | `pywasm-pypy` | excluded: pywasm 2.2.3 has no exception-handling opcodes; decoding dies with AssertionError on the throw/try_table opcode (pywasm/core.py, from_reader) |
 | `wat/eh_try` | `wardite` | excluded: wardite 0.9.0 fails to load the tag section: Wardite::LoadError "unknown code: 13" |
@@ -739,6 +817,10 @@ A missing runner or an unbuilt module is stated here rather than left as a gap i
 | `app/sqlite3_query` | `dewasm-python` | excluded on cost, not capability: dewasm-python runs this program correctly but at 56 s and 57 s per run (median, sqlite3_query and sqlite3_mod_query), costing roughly 9 minutes of the roughly 65 minute full suite; dewasm-python stays measured on the other app cases and the microbenchmarks |
 | `app/sqlite3_query` | `dewasm-perl` | excluded on cost, not capability: dewasm-perl runs this program correctly but at 113 s and 115 s per run (median, sqlite3_query and sqlite3_mod_query), so one warmup plus the timed repetitions across both cases alone cost roughly 19 minutes of the roughly 65 minute full suite; dewasm-perl stays measured on the other app cases and the microbenchmarks |
 | `app/sqlite3_query` | `dewasm-bash` | excluded: bash runs ~10000x slower than wasmtime on compute, so 100k SQL inserts do not finish in a practical time |
+| `app/sqlite3_query` | `wasm3-ruby` | excluded on cost, not capability: the converted wasm3 runs this program correctly (stdout matching the oracle) at 160 s per run on wasm3-ruby-yjit, the fastest of the four wasm3-* runners, so one warmup plus the timed repetitions across both query cases and all four runners would add hours to the suite |
+| `app/sqlite3_query` | `wasm3-ruby-yjit` | excluded on cost, not capability: the converted wasm3 runs this program correctly (stdout matching the oracle) at 160 s per run on wasm3-ruby-yjit, the fastest of the four wasm3-* runners, so one warmup plus the timed repetitions across both query cases and all four runners would add hours to the suite |
+| `app/sqlite3_query` | `wasm3-python` | excluded on cost, not capability: the converted wasm3 runs this program correctly (stdout matching the oracle) at 160 s per run on wasm3-ruby-yjit, the fastest of the four wasm3-* runners, so one warmup plus the timed repetitions across both query cases and all four runners would add hours to the suite |
+| `app/sqlite3_query` | `wasm3-pypy` | excluded on cost, not capability: the converted wasm3 runs this program correctly (stdout matching the oracle) at 160 s per run on wasm3-ruby-yjit, the fastest of the four wasm3-* runners, so one warmup plus the timed repetitions across both query cases and all four runners would add hours to the suite |
 | `app/sqlite3_query` | `pywasm-cpython` | excluded on cost, not capability: pywasm runs this program correctly (byte-identical to wasmtime under -batch) at ~17.9 ms/row: measured 358 s at 20k rows, so the 100k-row script needs roughly half an hour per sample |
 | `app/sqlite3_query` | `pywasm-pypy` | excluded on cost, not capability: pywasm runs this program correctly (byte-identical to wasmtime under -batch) at ~17.9 ms/row: measured 358 s at 20k rows, so the 100k-row script needs roughly half an hour per sample |
 | `app/sqlite3_query` | `wardite` | excluded: wardite loads the sqlite3 shell but cannot execute a query, raising Wardite::EvalError ("maybe empty or invalid stack", convert.generated.rb:200) as soon as any SQL runs |
@@ -746,12 +828,18 @@ A missing runner or an unbuilt module is stated here rather than left as a gap i
 | `app/sqlite3_mod_query` | `dewasm-python` | excluded on cost, not capability: dewasm-python runs this program correctly but at 56 s and 57 s per run (median, sqlite3_query and sqlite3_mod_query), costing roughly 9 minutes of the roughly 65 minute full suite; dewasm-python stays measured on the other app cases and the microbenchmarks |
 | `app/sqlite3_mod_query` | `dewasm-perl` | excluded on cost, not capability: dewasm-perl runs this program correctly but at 113 s and 115 s per run (median, sqlite3_query and sqlite3_mod_query), so one warmup plus the timed repetitions across both cases alone cost roughly 19 minutes of the roughly 65 minute full suite; dewasm-perl stays measured on the other app cases and the microbenchmarks |
 | `app/sqlite3_mod_query` | `dewasm-bash` | excluded: bash runs ~10000x slower than wasmtime on compute, so 100k SQL inserts do not finish in a practical time |
+| `app/sqlite3_mod_query` | `wasm3-ruby` | excluded on cost, not capability: the converted wasm3 runs this program correctly (stdout matching the oracle) at 160 s per run on wasm3-ruby-yjit, the fastest of the four wasm3-* runners, so one warmup plus the timed repetitions across both query cases and all four runners would add hours to the suite |
+| `app/sqlite3_mod_query` | `wasm3-ruby-yjit` | excluded on cost, not capability: the converted wasm3 runs this program correctly (stdout matching the oracle) at 160 s per run on wasm3-ruby-yjit, the fastest of the four wasm3-* runners, so one warmup plus the timed repetitions across both query cases and all four runners would add hours to the suite |
+| `app/sqlite3_mod_query` | `wasm3-python` | excluded on cost, not capability: the converted wasm3 runs this program correctly (stdout matching the oracle) at 160 s per run on wasm3-ruby-yjit, the fastest of the four wasm3-* runners, so one warmup plus the timed repetitions across both query cases and all four runners would add hours to the suite |
+| `app/sqlite3_mod_query` | `wasm3-pypy` | excluded on cost, not capability: the converted wasm3 runs this program correctly (stdout matching the oracle) at 160 s per run on wasm3-ruby-yjit, the fastest of the four wasm3-* runners, so one warmup plus the timed repetitions across both query cases and all four runners would add hours to the suite |
 | `app/sqlite3_mod_query` | `pywasm-cpython` | excluded on cost, not capability: pywasm runs this program correctly (byte-identical to wasmtime under -batch) at ~17.9 ms/row: measured 358 s at 20k rows, so the 100k-row script needs roughly half an hour per sample |
 | `app/sqlite3_mod_query` | `pywasm-pypy` | excluded on cost, not capability: pywasm runs this program correctly (byte-identical to wasmtime under -batch) at ~17.9 ms/row: measured 358 s at 20k rows, so the 100k-row script needs roughly half an hour per sample |
 | `app/sqlite3_mod_query` | `wardite` | excluded: wardite loads the sqlite3 shell but cannot execute a query, raising Wardite::EvalError ("maybe empty or invalid stack", convert.generated.rb:200) as soon as any SQL runs |
 | `app/sqlite3_mod_query` | `wardite-yjit` | excluded: wardite loads the sqlite3 shell but cannot execute a query, raising Wardite::EvalError ("maybe empty or invalid stack", convert.generated.rb:200) as soon as any SQL runs |
-| `app/minigzip` | `wasm3` | excluded: wasm3's WASI does not provide fd_tell, which minigzip's stdio imports, so the module fails before running ("missing imported function ('wasi_snapshot_preview1.fd_tell')") |
 | `app/minigzip` | `dewasm-bash` | excluded on cost, not capability: bash compresses this workload's generated text at ~0.61 ms/byte (measured 30.6 s on a 50000-byte prefix), so the full 1.2 MB input needs roughly 12 minutes per run |
+| `app/minigzip` | `wasm3-ruby` | excluded on cost, not capability: the converted wasm3 compresses the full 1.2 MB input correctly (byte-identical to wasmtime) but at 149 s per run on plain ruby and 301 s on pypy, both measured, and roughly 7 minutes on cpython (measured 107 s on a 300000-byte prefix); wasm3-ruby-yjit runs it at 54 s and stays measured |
+| `app/minigzip` | `wasm3-python` | excluded on cost, not capability: the converted wasm3 compresses the full 1.2 MB input correctly (byte-identical to wasmtime) but at 149 s per run on plain ruby and 301 s on pypy, both measured, and roughly 7 minutes on cpython (measured 107 s on a 300000-byte prefix); wasm3-ruby-yjit runs it at 54 s and stays measured |
+| `app/minigzip` | `wasm3-pypy` | excluded on cost, not capability: the converted wasm3 compresses the full 1.2 MB input correctly (byte-identical to wasmtime) but at 149 s per run on plain ruby and 301 s on pypy, both measured, and roughly 7 minutes on cpython (measured 107 s on a 300000-byte prefix); wasm3-ruby-yjit runs it at 54 s and stays measured |
 | `app/minigzip` | `pywasm-cpython` | excluded on cost, not capability: pywasm under CPython compresses this workload's generated text at ~0.46 ms/byte (measured 9.2 s on a 20000-byte prefix), so the full 1.2 MB input needs roughly 9 minutes per run |
 | `app/minigzip` | `wardite` | excluded: wardite computes the correct compressed output but its driver crashes on exit (IOError: closed stream at wardite.rb:40) because minigzip closes stdout itself and wardite's fd_close closes the real fd under it, so the driver's own trailing flush fails and the process exits 1 |
 | `app/minigzip` | `wardite-yjit` | excluded: wardite computes the correct compressed output but its driver crashes on exit (IOError: closed stream at wardite.rb:40) because minigzip closes stdout itself and wardite's fd_close closes the real fd under it, so the driver's own trailing flush fails and the process exits 1 |

--- a/records/2026-08-30T05-11-20Z-speed.json
+++ b/records/2026-08-30T05-11-20Z-speed.json
@@ -1,0 +1,12627 @@
+{
+  "schema": 1,
+  "generated_at": "2026-08-30T05:11:20Z",
+  "host": {
+    "os": "macOS 26.6.2",
+    "arch": "aarch64",
+    "kernel": "Darwin 25.6.0",
+    "cpu": "Apple M1 Pro"
+  },
+  "settings": {
+    "reps": 3,
+    "target_ms": 300,
+    "timeout_s": 900,
+    "filter": null
+  },
+  "runtimes": [
+    {
+      "runner": "wasmtime",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "wasmtime 48.0.1 (7bac2c277 2026-08-24)"
+    },
+    {
+      "runner": "wasmer",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "wasmer 7.3.0"
+    },
+    {
+      "runner": "wasmedge",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "wasmedge version 0.17.1"
+    },
+    {
+      "runner": "wazero",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "1.12.0"
+    },
+    {
+      "runner": "wasm3",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "Wasm3 v0.9.0 on arm64-v8a"
+    },
+    {
+      "runner": "dewasm-ruby",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "ruby 4.0.4 (2026-05-12 revision b89eb1bcbf) +PRISM [arm64-darwin25]"
+    },
+    {
+      "runner": "dewasm-ruby-yjit",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "ruby 4.0.4 (2026-05-12 revision b89eb1bcbf) +PRISM [arm64-darwin25]"
+    },
+    {
+      "runner": "dewasm-ruby-zjit",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "ruby 4.0.4 (2026-05-12 revision b89eb1bcbf) +PRISM [arm64-darwin25]"
+    },
+    {
+      "runner": "dewasm-python",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "Python 3.14.7 (main, Aug  5 2026, 10:29:49) [Clang 21.0.0 (clang-2100.1.1.101)]"
+    },
+    {
+      "runner": "dewasm-pypy",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "Python 3.11.15 (194f9f44b505, Aug 22 2026, 08:59:40)"
+    },
+    {
+      "runner": "dewasm-perl",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "v5.44.0"
+    },
+    {
+      "runner": "dewasm-go",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "go version go1.26.2 darwin/arm64"
+    },
+    {
+      "runner": "dewasm-java",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "java version \"25.0.4.1\" 2026-08-18 LTS"
+    },
+    {
+      "runner": "dewasm-bash",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "5.3.15(1)-release"
+    },
+    {
+      "runner": "wasm3-ruby",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "Wasm3 v0.9.0 on wasm"
+    },
+    {
+      "runner": "wasm3-ruby-yjit",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "Wasm3 v0.9.0 on wasm"
+    },
+    {
+      "runner": "wasm3-python",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "Wasm3 v0.9.0 on wasm"
+    },
+    {
+      "runner": "wasm3-pypy",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "Wasm3 v0.9.0 on wasm"
+    },
+    {
+      "runner": "pywasm-cpython",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "pywasm 2.2.3"
+    },
+    {
+      "runner": "pywasm-pypy",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "pywasm 2.2.3"
+    },
+    {
+      "runner": "wardite",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "wardite 0.9.0"
+    },
+    {
+      "runner": "wardite-yjit",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "wardite 0.9.0"
+    }
+  ],
+  "results": [
+    {
+      "workload": "wat/br_table",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 35239116,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005826209,
+        "median_s": 0.005843542,
+        "samples_s": [
+          0.005826209,
+          0.006021625,
+          0.005843542
+        ]
+      },
+      "total": {
+        "min_s": 0.303113917,
+        "median_s": 0.305447167,
+        "samples_s": [
+          0.306203458,
+          0.305447167,
+          0.303113917
+        ]
+      },
+      "compute_s": 0.297287708,
+      "ns_per_op_min": 8.436298685812664,
+      "ns_per_op_median": 8.502018750981156,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 35419097,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009003208,
+        "median_s": 0.009616041,
+        "samples_s": [
+          0.009616041,
+          0.009003208,
+          0.009801791
+        ]
+      },
+      "total": {
+        "min_s": 0.308633917,
+        "median_s": 0.309803333,
+        "samples_s": [
+          0.309803333,
+          0.308633917,
+          0.31059275
+        ]
+      },
+      "compute_s": 0.299630709,
+      "ns_per_op_min": 8.459580688914796,
+      "ns_per_op_median": 8.47529489529335,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1333994,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.01546525,
+        "median_s": 0.015867083,
+        "samples_s": [
+          0.015867083,
+          0.01546525,
+          0.016148625
+        ]
+      },
+      "total": {
+        "min_s": 0.310121958,
+        "median_s": 0.310356791,
+        "samples_s": [
+          0.310627625,
+          0.310121958,
+          0.310356791
+        ]
+      },
+      "compute_s": 0.294656708,
+      "ns_per_op_min": 220.88308343215937,
+      "ns_per_op_median": 220.7578954627982,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 34105260,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005238666,
+        "median_s": 0.005348083,
+        "samples_s": [
+          0.005348083,
+          0.0058045,
+          0.005238666
+        ]
+      },
+      "total": {
+        "min_s": 0.30651825,
+        "median_s": 0.307343167,
+        "samples_s": [
+          0.307343167,
+          0.30651825,
+          0.309158667
+        ]
+      },
+      "compute_s": 0.301279584,
+      "ns_per_op_min": 8.833815780908868,
+      "ns_per_op_median": 8.85479494951805,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 11214447,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004414917,
+        "median_s": 0.004421333,
+        "samples_s": [
+          0.004414917,
+          0.004421333,
+          0.004601375
+        ]
+      },
+      "total": {
+        "min_s": 0.302104917,
+        "median_s": 0.302376833,
+        "samples_s": [
+          0.302104917,
+          0.303962542,
+          0.302376833
+        ]
+      },
+      "compute_s": 0.29768999999999995,
+      "ns_per_op_min": 26.545223317743616,
+      "ns_per_op_median": 26.568898136484126,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 1166279,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.038632458,
+        "median_s": 0.039791417,
+        "samples_s": [
+          0.039839125,
+          0.038632458,
+          0.039791417
+        ]
+      },
+      "total": {
+        "min_s": 0.29256425,
+        "median_s": 0.292782167,
+        "samples_s": [
+          0.292782167,
+          0.293186416,
+          0.29256425
+        ]
+      },
+      "compute_s": 0.25393179200000005,
+      "ns_per_op_min": 217.72816967466622,
+      "ns_per_op_median": 216.921294132879,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 1121504,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.038661417,
+        "median_s": 0.039237625,
+        "samples_s": [
+          0.038661417,
+          0.040535333,
+          0.039237625
+        ]
+      },
+      "total": {
+        "min_s": 0.283819875,
+        "median_s": 0.286781417,
+        "samples_s": [
+          0.286924,
+          0.283819875,
+          0.286781417
+        ]
+      },
+      "compute_s": 0.245158458,
+      "ns_per_op_min": 218.59793455930608,
+      "ns_per_op_median": 220.7248409278968,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 1295469,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040622625,
+        "median_s": 0.040954,
+        "samples_s": [
+          0.040622625,
+          0.041814667,
+          0.040954
+        ]
+      },
+      "total": {
+        "min_s": 0.3214355,
+        "median_s": 0.321841958,
+        "samples_s": [
+          0.3214355,
+          0.324138083,
+          0.321841958
+        ]
+      },
+      "compute_s": 0.28081287499999996,
+      "ns_per_op_min": 216.76541468765362,
+      "ns_per_op_median": 216.82337284798015,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 712829,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.029162708,
+        "median_s": 0.029543,
+        "samples_s": [
+          0.029543,
+          0.029927833,
+          0.029162708
+        ]
+      },
+      "total": {
+        "min_s": 0.312120417,
+        "median_s": 0.313861125,
+        "samples_s": [
+          0.314328042,
+          0.313861125,
+          0.312120417
+        ]
+      },
+      "compute_s": 0.282957709,
+      "ns_per_op_min": 396.9503331093432,
+      "ns_per_op_median": 398.8588076523262,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 4049969,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040133334,
+        "median_s": 0.040271708,
+        "samples_s": [
+          0.040271708,
+          0.04059225,
+          0.040133334
+        ]
+      },
+      "total": {
+        "min_s": 0.294489791,
+        "median_s": 0.295526834,
+        "samples_s": [
+          0.294489791,
+          0.297850292,
+          0.295526834
+        ]
+      },
+      "compute_s": 0.254356457,
+      "ns_per_op_min": 62.804544182930776,
+      "ns_per_op_median": 63.026439461635384,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 335558,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0102455,
+        "median_s": 0.011123208,
+        "samples_s": [
+          0.0102455,
+          0.011123208,
+          0.011369292
+        ]
+      },
+      "total": {
+        "min_s": 0.304966167,
+        "median_s": 0.30583775,
+        "samples_s": [
+          0.304966167,
+          0.306013334,
+          0.30583775
+        ]
+      },
+      "compute_s": 0.294720667,
+      "ns_per_op_min": 878.300225296372,
+      "ns_per_op_median": 878.2819721180839,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 37618165,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004844666,
+        "median_s": 0.0052595,
+        "samples_s": [
+          0.005712792,
+          0.0052595,
+          0.004844666
+        ]
+      },
+      "total": {
+        "min_s": 0.291502166,
+        "median_s": 0.292898166,
+        "samples_s": [
+          0.291502166,
+          0.292898166,
+          0.293878459
+        ]
+      },
+      "compute_s": 0.2866575,
+      "ns_per_op_min": 7.620188278721198,
+      "ns_per_op_median": 7.646270518511469,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 25986047,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.066246042,
+        "median_s": 0.067022416,
+        "samples_s": [
+          0.067022416,
+          0.066246042,
+          0.0674495
+        ]
+      },
+      "total": {
+        "min_s": 0.31914475,
+        "median_s": 0.320474917,
+        "samples_s": [
+          0.321036208,
+          0.320474917,
+          0.31914475
+        ]
+      },
+      "compute_s": 0.25289870799999997,
+      "ns_per_op_min": 9.732096151446196,
+      "ns_per_op_median": 9.75340731893543,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 7275,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.012676792,
+        "median_s": 0.012685542,
+        "samples_s": [
+          0.012685542,
+          0.0128695,
+          0.012676792
+        ]
+      },
+      "total": {
+        "min_s": 0.278357667,
+        "median_s": 0.278763625,
+        "samples_s": [
+          0.278763625,
+          0.278357667,
+          0.280681083
+        ]
+      },
+      "compute_s": 0.265680875,
+      "ns_per_op_min": 36519.707903780065,
+      "ns_per_op_median": 36574.30694158076,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": 37411,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.160346584,
+        "median_s": 0.160981417,
+        "samples_s": [
+          0.166367208,
+          0.160981417,
+          0.160346584
+        ]
+      },
+      "total": {
+        "min_s": 0.462838208,
+        "median_s": 0.465297583,
+        "samples_s": [
+          0.467729917,
+          0.462838208,
+          0.465297583
+        ]
+      },
+      "compute_s": 0.30249162399999996,
+      "ns_per_op_min": 8085.63320948384,
+      "ns_per_op_median": 8134.403410761541,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": 99364,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.271550167,
+        "median_s": 0.275520458,
+        "samples_s": [
+          0.276967,
+          0.275520458,
+          0.271550167
+        ]
+      },
+      "total": {
+        "min_s": 0.581908792,
+        "median_s": 0.586227292,
+        "samples_s": [
+          0.586227292,
+          0.588458541,
+          0.581908792
+        ]
+      },
+      "compute_s": 0.310358625,
+      "ns_per_op_min": 3123.451400909786,
+      "ns_per_op_median": 3126.9557787528684,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": 11875,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.351031208,
+        "median_s": 0.352356958,
+        "samples_s": [
+          0.351031208,
+          0.352447666,
+          0.352356958
+        ]
+      },
+      "total": {
+        "min_s": 0.621107542,
+        "median_s": 0.625624584,
+        "samples_s": [
+          0.626185333,
+          0.621107542,
+          0.625624584
+        ]
+      },
+      "compute_s": 0.270076334,
+      "ns_per_op_min": 22743.270231578947,
+      "ns_per_op_median": 23012.010610526315,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": 22397,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.399555834,
+        "median_s": 0.401873584,
+        "samples_s": [
+          0.399555834,
+          0.404621791,
+          0.401873584
+        ]
+      },
+      "total": {
+        "min_s": 0.594802875,
+        "median_s": 0.597933792,
+        "samples_s": [
+          0.594802875,
+          0.59806075,
+          0.597933792
+        ]
+      },
+      "compute_s": 0.19524704099999995,
+      "ns_per_op_min": 8717.553288386835,
+      "ns_per_op_median": 8753.860249140509,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 5421,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.044947209,
+        "median_s": 0.045528292,
+        "samples_s": [
+          0.04565475,
+          0.044947209,
+          0.045528292
+        ]
+      },
+      "total": {
+        "min_s": 0.323731625,
+        "median_s": 0.324043541,
+        "samples_s": [
+          0.323731625,
+          0.324043541,
+          0.324169708
+        ]
+      },
+      "compute_s": 0.27878441600000003,
+      "ns_per_op_min": 51426.7507839882,
+      "ns_per_op_median": 51377.098136875116,
+      "load_ms": 0.93,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 3527,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.081628625,
+        "median_s": 0.082001584,
+        "samples_s": [
+          0.082105167,
+          0.081628625,
+          0.082001584
+        ]
+      },
+      "total": {
+        "min_s": 0.27136325,
+        "median_s": 0.273007667,
+        "samples_s": [
+          0.27136325,
+          0.273422208,
+          0.273007667
+        ]
+      },
+      "compute_s": 0.189734625,
+      "ns_per_op_min": 53794.90360079388,
+      "ns_per_op_median": 54155.396370853414,
+      "load_ms": 5.275,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 9046,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.052215375,
+        "median_s": 0.053883458,
+        "samples_s": [
+          0.052215375,
+          0.053910125,
+          0.053883458
+        ]
+      },
+      "total": {
+        "min_s": 0.245546584,
+        "median_s": 0.247493584,
+        "samples_s": [
+          0.247493584,
+          0.2479815,
+          0.245546584
+        ]
+      },
+      "compute_s": 0.193331209,
+      "ns_per_op_min": 21372.010722971478,
+      "ns_per_op_median": 21402.843908910014,
+      "load_ms": 4.254,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 24427,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.102281291,
+        "median_s": 0.103896417,
+        "samples_s": [
+          0.102281291,
+          0.103896417,
+          0.104838042
+        ]
+      },
+      "total": {
+        "min_s": 0.318551083,
+        "median_s": 0.319994958,
+        "samples_s": [
+          0.322356625,
+          0.319994958,
+          0.318551083
+        ]
+      },
+      "compute_s": 0.21626979200000002,
+      "ns_per_op_min": 8853.718917591192,
+      "ns_per_op_median": 8846.708191755024,
+      "load_ms": 10.257,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 85655520,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005641291,
+        "median_s": 0.006176625,
+        "samples_s": [
+          0.005641291,
+          0.006291667,
+          0.006176625
+        ]
+      },
+      "total": {
+        "min_s": 0.307089375,
+        "median_s": 0.307154167,
+        "samples_s": [
+          0.307154167,
+          0.307089375,
+          0.30931275
+        ]
+      },
+      "compute_s": 0.301448084,
+      "ns_per_op_min": 3.5193071503155897,
+      "ns_per_op_median": 3.5138137273581433,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 84775575,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009052958,
+        "median_s": 0.009630708,
+        "samples_s": [
+          0.010036208,
+          0.009630708,
+          0.009052958
+        ]
+      },
+      "total": {
+        "min_s": 0.304649625,
+        "median_s": 0.306041583,
+        "samples_s": [
+          0.304649625,
+          0.306185917,
+          0.306041583
+        ]
+      },
+      "compute_s": 0.295596667,
+      "ns_per_op_min": 3.4868140617152994,
+      "ns_per_op_median": 3.496418337475151,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1447425,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015973125,
+        "median_s": 0.01660975,
+        "samples_s": [
+          0.015973125,
+          0.01660975,
+          0.017029958
+        ]
+      },
+      "total": {
+        "min_s": 0.311500125,
+        "median_s": 0.311817167,
+        "samples_s": [
+          0.312617125,
+          0.311500125,
+          0.311817167
+        ]
+      },
+      "compute_s": 0.29552700000000004,
+      "ns_per_op_min": 204.17430954971763,
+      "ns_per_op_median": 203.95351538076238,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 49851598,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005159417,
+        "median_s": 0.005243917,
+        "samples_s": [
+          0.005159417,
+          0.005383375,
+          0.005243917
+        ]
+      },
+      "total": {
+        "min_s": 0.305553791,
+        "median_s": 0.306090208,
+        "samples_s": [
+          0.306090208,
+          0.305553791,
+          0.306107667
+        ]
+      },
+      "compute_s": 0.300394374,
+      "ns_per_op_min": 6.025772212958951,
+      "ns_per_op_median": 6.034837458971727,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 6364347,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004195291,
+        "median_s": 0.004472167,
+        "samples_s": [
+          0.004965958,
+          0.004472167,
+          0.004195291
+        ]
+      },
+      "total": {
+        "min_s": 0.289775416,
+        "median_s": 0.289962208,
+        "samples_s": [
+          0.289962208,
+          0.291937875,
+          0.289775416
+        ]
+      },
+      "compute_s": 0.285580125,
+      "ns_per_op_min": 44.871865880348764,
+      "ns_per_op_median": 44.85771140385651,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 1373608,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040677292,
+        "median_s": 0.040827417,
+        "samples_s": [
+          0.04104475,
+          0.040677292,
+          0.040827417
+        ]
+      },
+      "total": {
+        "min_s": 0.326805708,
+        "median_s": 0.327984041,
+        "samples_s": [
+          0.326805708,
+          0.3320085,
+          0.327984041
+        ]
+      },
+      "compute_s": 0.286128416,
+      "ns_per_op_min": 208.30427312595734,
+      "ns_per_op_median": 209.0528185625011,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 3084746,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039465625,
+        "median_s": 0.040224166,
+        "samples_s": [
+          0.040754833,
+          0.039465625,
+          0.040224166
+        ]
+      },
+      "total": {
+        "min_s": 0.377972667,
+        "median_s": 0.378067666,
+        "samples_s": [
+          0.377972667,
+          0.378067666,
+          0.379553583
+        ]
+      },
+      "compute_s": 0.338507042,
+      "ns_per_op_min": 109.73579088845564,
+      "ns_per_op_median": 109.52068663027686,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 1850551,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040950917,
+        "median_s": 0.041575042,
+        "samples_s": [
+          0.041893208,
+          0.040950917,
+          0.041575042
+        ]
+      },
+      "total": {
+        "min_s": 0.274975,
+        "median_s": 0.275683542,
+        "samples_s": [
+          0.274975,
+          0.27615225,
+          0.275683542
+        ]
+      },
+      "compute_s": 0.23402408300000002,
+      "ns_per_op_min": 126.46183920356695,
+      "ns_per_op_median": 126.5074564278423,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 707203,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.02957175,
+        "median_s": 0.029595042,
+        "samples_s": [
+          0.029595042,
+          0.030115666,
+          0.02957175
+        ]
+      },
+      "total": {
+        "min_s": 0.328840625,
+        "median_s": 0.329596125,
+        "samples_s": [
+          0.328840625,
+          0.329596125,
+          0.33535725
+        ]
+      },
+      "compute_s": 0.299268875,
+      "ns_per_op_min": 423.17251906454015,
+      "ns_per_op_median": 424.20787666341914,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 2043202,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040337625,
+        "median_s": 0.040983333,
+        "samples_s": [
+          0.040337625,
+          0.040983333,
+          0.041270792
+        ]
+      },
+      "total": {
+        "min_s": 0.224144291,
+        "median_s": 0.225089833,
+        "samples_s": [
+          0.225852875,
+          0.225089833,
+          0.224144291
+        ]
+      },
+      "compute_s": 0.183806666,
+      "ns_per_op_min": 89.96010477671811,
+      "ns_per_op_median": 90.10685189227497,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 270353,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010875292,
+        "median_s": 0.010937791,
+        "samples_s": [
+          0.010875292,
+          0.011312125,
+          0.010937791
+        ]
+      },
+      "total": {
+        "min_s": 0.311655042,
+        "median_s": 0.311946375,
+        "samples_s": [
+          0.312248375,
+          0.311655042,
+          0.311946375
+        ]
+      },
+      "compute_s": 0.30077975,
+      "ns_per_op_min": 1112.5445251208605,
+      "ns_per_op_median": 1113.390951829645,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 67239232,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004766333,
+        "median_s": 0.005374458,
+        "samples_s": [
+          0.006848792,
+          0.005374458,
+          0.004766333
+        ]
+      },
+      "total": {
+        "min_s": 0.280727375,
+        "median_s": 0.280752,
+        "samples_s": [
+          0.280752,
+          0.281218666,
+          0.280727375
+        ]
+      },
+      "compute_s": 0.275961042,
+      "ns_per_op_min": 4.1041670731753745,
+      "ns_per_op_median": 4.095489103742292,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 74403853,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.066433542,
+        "median_s": 0.066581459,
+        "samples_s": [
+          0.066433542,
+          0.066581459,
+          0.066863292
+        ]
+      },
+      "total": {
+        "min_s": 0.333822708,
+        "median_s": 0.335468625,
+        "samples_s": [
+          0.335468625,
+          0.333822708,
+          0.337747708
+        ]
+      },
+      "compute_s": 0.267389166,
+      "ns_per_op_min": 3.5937542911924196,
+      "ns_per_op_median": 3.6138876571351757,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 5007,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.01243675,
+        "median_s": 0.012790709,
+        "samples_s": [
+          0.01243675,
+          0.012895167,
+          0.012790709
+        ]
+      },
+      "total": {
+        "min_s": 0.291883167,
+        "median_s": 0.294093583,
+        "samples_s": [
+          0.294434083,
+          0.294093583,
+          0.291883167
+        ]
+      },
+      "compute_s": 0.279446417,
+      "ns_per_op_min": 55811.14779308967,
+      "ns_per_op_median": 56181.92011184342,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": 10010,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.152313625,
+        "median_s": 0.153918208,
+        "samples_s": [
+          0.152313625,
+          0.156701916,
+          0.153918208
+        ]
+      },
+      "total": {
+        "min_s": 0.37603675,
+        "median_s": 0.37832025,
+        "samples_s": [
+          0.37832025,
+          0.378642625,
+          0.37603675
+        ]
+      },
+      "compute_s": 0.22372312499999997,
+      "ns_per_op_min": 22349.962537462536,
+      "ns_per_op_median": 22417.78641358642,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": 19045,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.19227475,
+        "median_s": 0.194923292,
+        "samples_s": [
+          0.194923292,
+          0.19637725,
+          0.19227475
+        ]
+      },
+      "total": {
+        "min_s": 0.374338083,
+        "median_s": 0.376324583,
+        "samples_s": [
+          0.374338083,
+          0.376324583,
+          0.378081667
+        ]
+      },
+      "compute_s": 0.182063333,
+      "ns_per_op_min": 9559.639432922027,
+      "ns_per_op_median": 9524.87744814912,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": 3614,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.341241625,
+        "median_s": 0.342142333,
+        "samples_s": [
+          0.343068333,
+          0.341241625,
+          0.342142333
+        ]
+      },
+      "total": {
+        "min_s": 0.606937625,
+        "median_s": 0.607069875,
+        "samples_s": [
+          0.607069875,
+          0.6104115,
+          0.606937625
+        ]
+      },
+      "compute_s": 0.26569600000000004,
+      "ns_per_op_min": 73518.5390149419,
+      "ns_per_op_median": 73305.90536801328,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": 11824,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.391081583,
+        "median_s": 0.391301458,
+        "samples_s": [
+          0.391301458,
+          0.392052083,
+          0.391081583
+        ]
+      },
+      "total": {
+        "min_s": 0.595168125,
+        "median_s": 0.596474041,
+        "samples_s": [
+          0.597313125,
+          0.595168125,
+          0.596474041
+        ]
+      },
+      "compute_s": 0.20408654200000004,
+      "ns_per_op_min": 17260.363836265227,
+      "ns_per_op_median": 17352.214394451963,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 6000,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.043526667,
+        "median_s": 0.044348666,
+        "samples_s": [
+          0.043526667,
+          0.044348666,
+          0.044557625
+        ]
+      },
+      "total": {
+        "min_s": 0.340873791,
+        "median_s": 0.34113075,
+        "samples_s": [
+          0.34113075,
+          0.340873791,
+          0.343977541
+        ]
+      },
+      "compute_s": 0.29734712399999996,
+      "ns_per_op_min": 49557.85399999999,
+      "ns_per_op_median": 49463.68066666667,
+      "load_ms": 0.644,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 23314,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.079833459,
+        "median_s": 0.080336791,
+        "samples_s": [
+          0.079833459,
+          0.080336791,
+          0.080660542
+        ]
+      },
+      "total": {
+        "min_s": 0.312932792,
+        "median_s": 0.313510584,
+        "samples_s": [
+          0.312932792,
+          0.314275959,
+          0.313510584
+        ]
+      },
+      "compute_s": 0.23309933300000002,
+      "ns_per_op_min": 9998.255683280433,
+      "ns_per_op_median": 10001.449472420003,
+      "load_ms": 3.588,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 11302,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.052488792,
+        "median_s": 0.052888875,
+        "samples_s": [
+          0.052888875,
+          0.052488792,
+          0.05348
+        ]
+      },
+      "total": {
+        "min_s": 0.256414916,
+        "median_s": 0.256970583,
+        "samples_s": [
+          0.256414916,
+          0.258085875,
+          0.256970583
+        ]
+      },
+      "compute_s": 0.203926124,
+      "ns_per_op_min": 18043.366129888516,
+      "ns_per_op_median": 18057.132188993095,
+      "load_ms": 3.696,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 36951,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.10275925,
+        "median_s": 0.105281166,
+        "samples_s": [
+          0.105281166,
+          0.10275925,
+          0.105749167
+        ]
+      },
+      "total": {
+        "min_s": 0.410483625,
+        "median_s": 0.412568375,
+        "samples_s": [
+          0.413598292,
+          0.410483625,
+          0.412568375
+        ]
+      },
+      "compute_s": 0.30772437500000005,
+      "ns_per_op_min": 8327.903845633407,
+      "ns_per_op_median": 8316.072880300939,
+      "load_ms": 9.343,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 33554432,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005626084,
+        "median_s": 0.0058855,
+        "samples_s": [
+          0.006310166,
+          0.005626084,
+          0.0058855
+        ]
+      },
+      "total": {
+        "min_s": 0.356949708,
+        "median_s": 0.357265375,
+        "samples_s": [
+          0.357265375,
+          0.356949708,
+          0.357880958
+        ]
+      },
+      "compute_s": 0.351323624,
+      "ns_per_op_min": 10.47025990486145,
+      "ns_per_op_median": 10.47193631529808,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 33554432,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009159166,
+        "median_s": 0.009345291,
+        "samples_s": [
+          0.009345291,
+          0.009159166,
+          0.009765083
+        ]
+      },
+      "total": {
+        "min_s": 0.360516666,
+        "median_s": 0.360828417,
+        "samples_s": [
+          0.360828417,
+          0.361133542,
+          0.360516666
+        ]
+      },
+      "compute_s": 0.3513575,
+      "ns_per_op_min": 10.471269488334656,
+      "ns_per_op_median": 10.475013434886934,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 723435,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.01567675,
+        "median_s": 0.015977458,
+        "samples_s": [
+          0.015977458,
+          0.01567675,
+          0.016057
+        ]
+      },
+      "total": {
+        "min_s": 0.31369175,
+        "median_s": 0.313821,
+        "samples_s": [
+          0.316615625,
+          0.31369175,
+          0.313821
+        ]
+      },
+      "compute_s": 0.298015,
+      "ns_per_op_min": 411.94440412753045,
+      "ns_per_op_median": 411.70739872967164,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 16777216,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.00521,
+        "median_s": 0.005224667,
+        "samples_s": [
+          0.005224667,
+          0.005315625,
+          0.00521
+        ]
+      },
+      "total": {
+        "min_s": 0.203802625,
+        "median_s": 0.204330042,
+        "samples_s": [
+          0.203802625,
+          0.204330042,
+          0.206341167
+        ]
+      },
+      "compute_s": 0.198592625,
+      "ns_per_op_min": 11.83704286813736,
+      "ns_per_op_median": 11.867605149745941,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 4216115,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004125625,
+        "median_s": 0.004912791,
+        "samples_s": [
+          0.004125625,
+          0.005109083,
+          0.004912791
+        ]
+      },
+      "total": {
+        "min_s": 0.281884584,
+        "median_s": 0.286032209,
+        "samples_s": [
+          0.288284333,
+          0.286032209,
+          0.281884584
+        ]
+      },
+      "compute_s": 0.27775895899999997,
+      "ns_per_op_min": 65.880309004854,
+      "ns_per_op_median": 66.67736008149681,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 435056,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040044083,
+        "median_s": 0.040151542,
+        "samples_s": [
+          0.040151542,
+          0.041073,
+          0.040044083
+        ]
+      },
+      "total": {
+        "min_s": 0.32971925,
+        "median_s": 0.330836625,
+        "samples_s": [
+          0.330836625,
+          0.32971925,
+          0.331051167
+        ]
+      },
+      "compute_s": 0.289675167,
+      "ns_per_op_min": 665.8342075502924,
+      "ns_per_op_median": 668.1555546872127,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 688799,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.041135584,
+        "median_s": 0.041269125,
+        "samples_s": [
+          0.041269125,
+          0.041492084,
+          0.041135584
+        ]
+      },
+      "total": {
+        "min_s": 0.32455775,
+        "median_s": 0.325123375,
+        "samples_s": [
+          0.326629625,
+          0.325123375,
+          0.32455775
+        ]
+      },
+      "compute_s": 0.283422166,
+      "ns_per_op_min": 411.4729638109231,
+      "ns_per_op_median": 412.10026437320613,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 475540,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040266291,
+        "median_s": 0.040317833,
+        "samples_s": [
+          0.040317833,
+          0.040266291,
+          0.041620417
+        ]
+      },
+      "total": {
+        "min_s": 0.267809667,
+        "median_s": 0.268653542,
+        "samples_s": [
+          0.268911708,
+          0.267809667,
+          0.268653542
+        ]
+      },
+      "compute_s": 0.22754337599999996,
+      "ns_per_op_min": 478.49471337847496,
+      "ns_per_op_median": 480.16088867392864,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 374416,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.029134084,
+        "median_s": 0.029165375,
+        "samples_s": [
+          0.029134084,
+          0.030233167,
+          0.029165375
+        ]
+      },
+      "total": {
+        "min_s": 0.323881125,
+        "median_s": 0.325403625,
+        "samples_s": [
+          0.325403625,
+          0.323881125,
+          0.333987292
+        ]
+      },
+      "compute_s": 0.294747041,
+      "ns_per_op_min": 787.2180702747746,
+      "ns_per_op_median": 791.200830092731,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 1915712,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040310334,
+        "median_s": 0.040351291,
+        "samples_s": [
+          0.040310334,
+          0.041914792,
+          0.040351291
+        ]
+      },
+      "total": {
+        "min_s": 0.3074655,
+        "median_s": 0.307681958,
+        "samples_s": [
+          0.307681958,
+          0.3074655,
+          0.30805275
+        ]
+      },
+      "compute_s": 0.267155166,
+      "ns_per_op_min": 139.4547645992717,
+      "ns_per_op_median": 139.54637596883038,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 131072,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.011233625,
+        "median_s": 0.011567417,
+        "samples_s": [
+          0.011233625,
+          0.01182425,
+          0.011567417
+        ]
+      },
+      "total": {
+        "min_s": 0.333489708,
+        "median_s": 0.334722917,
+        "samples_s": [
+          0.334722917,
+          0.335902458,
+          0.333489708
+        ]
+      },
+      "compute_s": 0.32225608299999997,
+      "ns_per_op_min": 2458.618797302246,
+      "ns_per_op_median": 2465.4808044433594,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 25722013,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.003329,
+        "median_s": 0.003728208,
+        "samples_s": [
+          0.003728208,
+          0.003329,
+          0.004681084
+        ]
+      },
+      "total": {
+        "min_s": 0.280155708,
+        "median_s": 0.28113775,
+        "samples_s": [
+          0.280155708,
+          0.28113775,
+          0.281326417
+        ]
+      },
+      "compute_s": 0.276826708,
+      "ns_per_op_min": 10.762248973282146,
+      "ns_per_op_median": 10.784907930806193,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 3620267,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.066242,
+        "median_s": 0.066329333,
+        "samples_s": [
+          0.066753083,
+          0.066242,
+          0.066329333
+        ]
+      },
+      "total": {
+        "min_s": 0.2671755,
+        "median_s": 0.27685025,
+        "samples_s": [
+          0.2671755,
+          0.27685025,
+          0.278586291
+        ]
+      },
+      "compute_s": 0.20093350000000001,
+      "ns_per_op_min": 55.5023980275488,
+      "ns_per_op_median": 58.1506604347138,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 3803,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.012878292,
+        "median_s": 0.013151667,
+        "samples_s": [
+          0.012878292,
+          0.013870584,
+          0.013151667
+        ]
+      },
+      "total": {
+        "min_s": 0.298565042,
+        "median_s": 0.299370541,
+        "samples_s": [
+          0.298565042,
+          0.299724875,
+          0.299370541
+        ]
+      },
+      "compute_s": 0.28568675,
+      "ns_per_op_min": 75121.41730212989,
+      "ns_per_op_median": 75261.3394688404,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": 8331,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.158858208,
+        "median_s": 0.159114709,
+        "samples_s": [
+          0.158858208,
+          0.159114709,
+          0.159340417
+        ]
+      },
+      "total": {
+        "min_s": 0.421144375,
+        "median_s": 0.422549208,
+        "samples_s": [
+          0.422549208,
+          0.421144375,
+          0.422881125
+        ]
+      },
+      "compute_s": 0.262286167,
+      "ns_per_op_min": 31483.155323490577,
+      "ns_per_op_median": 31620.993758252313,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": 18069,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.2208055,
+        "median_s": 0.223511542,
+        "samples_s": [
+          0.223735541,
+          0.2208055,
+          0.223511542
+        ]
+      },
+      "total": {
+        "min_s": 0.43811475,
+        "median_s": 0.441414041,
+        "samples_s": [
+          0.445418208,
+          0.43811475,
+          0.441414041
+        ]
+      },
+      "compute_s": 0.21730925,
+      "ns_per_op_min": 12026.634014057225,
+      "ns_per_op_median": 12059.466434224361,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": 2638,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.350917458,
+        "median_s": 0.351596375,
+        "samples_s": [
+          0.3532715,
+          0.350917458,
+          0.351596375
+        ]
+      },
+      "total": {
+        "min_s": 0.633246334,
+        "median_s": 0.633428333,
+        "samples_s": [
+          0.63564525,
+          0.633428333,
+          0.633246334
+        ]
+      },
+      "compute_s": 0.28232887599999995,
+      "ns_per_op_min": 107023.83472327518,
+      "ns_per_op_median": 106835.46550416983,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": 6087,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.389709333,
+        "median_s": 0.390213291,
+        "samples_s": [
+          0.389709333,
+          0.390213291,
+          0.39235775
+        ]
+      },
+      "total": {
+        "min_s": 0.587120291,
+        "median_s": 0.587457875,
+        "samples_s": [
+          0.587120291,
+          0.587457875,
+          0.587834334
+        ]
+      },
+      "compute_s": 0.19741095799999997,
+      "ns_per_op_min": 32431.568588795788,
+      "ns_per_op_median": 32404.235912600623,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 3474,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.043891708,
+        "median_s": 0.044596333,
+        "samples_s": [
+          0.045542167,
+          0.043891708,
+          0.044596333
+        ]
+      },
+      "total": {
+        "min_s": 0.330997375,
+        "median_s": 0.331408792,
+        "samples_s": [
+          0.331925083,
+          0.330997375,
+          0.331408792
+        ]
+      },
+      "compute_s": 0.28710566699999995,
+      "ns_per_op_min": 82644.11830742659,
+      "ns_per_op_median": 82559.71761658031,
+      "load_ms": 0.765,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 5128,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.07920275,
+        "median_s": 0.080006417,
+        "samples_s": [
+          0.07920275,
+          0.080631375,
+          0.080006417
+        ]
+      },
+      "total": {
+        "min_s": 0.268847042,
+        "median_s": 0.269151667,
+        "samples_s": [
+          0.268847042,
+          0.269151667,
+          0.271009209
+        ]
+      },
+      "compute_s": 0.189644292,
+      "ns_per_op_min": 36982.116224648984,
+      "ns_per_op_median": 36884.799141965676,
+      "load_ms": 4.383,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 8924,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.052210458,
+        "median_s": 0.053294042,
+        "samples_s": [
+          0.052210458,
+          0.054710041,
+          0.053294042
+        ]
+      },
+      "total": {
+        "min_s": 0.302980875,
+        "median_s": 0.304829708,
+        "samples_s": [
+          0.302980875,
+          0.306404208,
+          0.304829708
+        ]
+      },
+      "compute_s": 0.25077041699999997,
+      "ns_per_op_min": 28100.674249215594,
+      "ns_per_op_median": 28186.42604213357,
+      "load_ms": 4.105,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 17114,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.102924583,
+        "median_s": 0.104342417,
+        "samples_s": [
+          0.104342417,
+          0.105319542,
+          0.102924583
+        ]
+      },
+      "total": {
+        "min_s": 0.342466584,
+        "median_s": 0.343859375,
+        "samples_s": [
+          0.343859375,
+          0.342466584,
+          0.344953416
+        ]
+      },
+      "compute_s": 0.239542001,
+      "ns_per_op_min": 13996.844746990768,
+      "ns_per_op_median": 13995.381442094193,
+      "load_ms": 9.911,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 39141196,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005047875,
+        "median_s": 0.005571583,
+        "samples_s": [
+          0.006005416,
+          0.005571583,
+          0.005047875
+        ]
+      },
+      "total": {
+        "min_s": 0.304899084,
+        "median_s": 0.305650333,
+        "samples_s": [
+          0.305650333,
+          0.30627125,
+          0.304899084
+        ]
+      },
+      "compute_s": 0.299851209,
+      "ns_per_op_min": 7.660757453604637,
+      "ns_per_op_median": 7.666570791551694,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 39093364,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.008929792,
+        "median_s": 0.009266583,
+        "samples_s": [
+          0.009966042,
+          0.008929792,
+          0.009266583
+        ]
+      },
+      "total": {
+        "min_s": 0.307598417,
+        "median_s": 0.307920333,
+        "samples_s": [
+          0.308308709,
+          0.307920333,
+          0.307598417
+        ]
+      },
+      "compute_s": 0.298668625,
+      "ns_per_op_min": 7.639880389930117,
+      "ns_per_op_median": 7.639499890569663,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1317133,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015483083,
+        "median_s": 0.015651875,
+        "samples_s": [
+          0.015651875,
+          0.015483083,
+          0.016589208
+        ]
+      },
+      "total": {
+        "min_s": 0.315770833,
+        "median_s": 0.316004459,
+        "samples_s": [
+          0.316004459,
+          0.315770833,
+          0.31641525
+        ]
+      },
+      "compute_s": 0.30028774999999996,
+      "ns_per_op_min": 227.98589815910765,
+      "ns_per_op_median": 228.0351217378959,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 4458568,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004511875,
+        "median_s": 0.004865,
+        "samples_s": [
+          0.005673,
+          0.004865,
+          0.004511875
+        ]
+      },
+      "total": {
+        "min_s": 0.259151375,
+        "median_s": 0.259435333,
+        "samples_s": [
+          0.259151375,
+          0.259548125,
+          0.259435333
+        ]
+      },
+      "compute_s": 0.2546395,
+      "ns_per_op_min": 57.11239572885286,
+      "ns_per_op_median": 57.096882451944204,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 12272980,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004188792,
+        "median_s": 0.00439075,
+        "samples_s": [
+          0.00439075,
+          0.004792167,
+          0.004188792
+        ]
+      },
+      "total": {
+        "min_s": 0.271022834,
+        "median_s": 0.271167208,
+        "samples_s": [
+          0.271022834,
+          0.271167208,
+          0.276177709
+        ]
+      },
+      "compute_s": 0.266834042,
+      "ns_per_op_min": 21.741585336242707,
+      "ns_per_op_median": 21.73689340323214,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 215378,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039219708,
+        "median_s": 0.040101875,
+        "samples_s": [
+          0.040101875,
+          0.041135708,
+          0.039219708
+        ]
+      },
+      "total": {
+        "min_s": 0.333620333,
+        "median_s": 0.333777875,
+        "samples_s": [
+          0.333977791,
+          0.333620333,
+          0.333777875
+        ]
+      },
+      "compute_s": 0.29440062499999997,
+      "ns_per_op_min": 1366.9020280622906,
+      "ns_per_op_median": 1363.5375943689698,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 308833,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.04090175,
+        "median_s": 0.041321625,
+        "samples_s": [
+          0.04090175,
+          0.041385458,
+          0.041321625
+        ]
+      },
+      "total": {
+        "min_s": 0.307871875,
+        "median_s": 0.309238,
+        "samples_s": [
+          0.3095835,
+          0.309238,
+          0.307871875
+        ]
+      },
+      "compute_s": 0.266970125,
+      "ns_per_op_min": 864.4481807319813,
+      "ns_per_op_median": 867.5121343897833,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 185097,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0389535,
+        "median_s": 0.040505708,
+        "samples_s": [
+          0.040505708,
+          0.0389535,
+          0.041631916
+        ]
+      },
+      "total": {
+        "min_s": 0.223999166,
+        "median_s": 0.224922208,
+        "samples_s": [
+          0.223999166,
+          0.224922208,
+          0.226378833
+        ]
+      },
+      "compute_s": 0.185045666,
+      "ns_per_op_min": 999.7226643327552,
+      "ns_per_op_median": 996.3235492741644,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 203391,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.029493084,
+        "median_s": 0.029514542,
+        "samples_s": [
+          0.029493084,
+          0.029514542,
+          0.030604584
+        ]
+      },
+      "total": {
+        "min_s": 0.323585667,
+        "median_s": 0.323782417,
+        "samples_s": [
+          0.323585667,
+          0.323782417,
+          0.325721
+        ]
+      },
+      "compute_s": 0.294092583,
+      "ns_per_op_min": 1445.946885555408,
+      "ns_per_op_median": 1446.808732933119,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 1123714,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040606167,
+        "median_s": 0.041744209,
+        "samples_s": [
+          0.040606167,
+          0.041744209,
+          0.042313583
+        ]
+      },
+      "total": {
+        "min_s": 0.330016042,
+        "median_s": 0.330022333,
+        "samples_s": [
+          0.330022333,
+          0.332043083,
+          0.330016042
+        ]
+      },
+      "compute_s": 0.28940987500000004,
+      "ns_per_op_min": 257.5476277771747,
+      "ns_per_op_median": 256.54047560144306,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 133640,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.014820709,
+        "median_s": 0.015234291,
+        "samples_s": [
+          0.015234291,
+          0.014820709,
+          0.015882
+        ]
+      },
+      "total": {
+        "min_s": 0.31438875,
+        "median_s": 0.314712834,
+        "samples_s": [
+          0.31438875,
+          0.314712834,
+          0.316146209
+        ]
+      },
+      "compute_s": 0.299568041,
+      "ns_per_op_min": 2241.604616881173,
+      "ns_per_op_median": 2240.9349221789885,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 33554432,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002656625,
+        "median_s": 0.002793,
+        "samples_s": [
+          0.003043042,
+          0.002793,
+          0.002656625
+        ]
+      },
+      "total": {
+        "min_s": 0.356075375,
+        "median_s": 0.356186417,
+        "samples_s": [
+          0.356075375,
+          0.356186417,
+          0.357181667
+        ]
+      },
+      "compute_s": 0.35341875,
+      "ns_per_op_min": 10.532699525356293,
+      "ns_per_op_median": 10.531944543123245,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 10291101,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.067252,
+        "median_s": 0.067709834,
+        "samples_s": [
+          0.067709834,
+          0.068234291,
+          0.067252
+        ]
+      },
+      "total": {
+        "min_s": 0.257561333,
+        "median_s": 0.258041333,
+        "samples_s": [
+          0.257561333,
+          0.258451583,
+          0.258041333
+        ]
+      },
+      "compute_s": 0.190309333,
+      "ns_per_op_min": 18.49261152912599,
+      "ns_per_op_median": 18.494765428888513,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 567,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.012747334,
+        "median_s": 0.012927,
+        "samples_s": [
+          0.012927,
+          0.013145875,
+          0.012747334
+        ]
+      },
+      "total": {
+        "min_s": 0.307726167,
+        "median_s": 0.308343208,
+        "samples_s": [
+          0.310562791,
+          0.307726167,
+          0.308343208
+        ]
+      },
+      "compute_s": 0.294978833,
+      "ns_per_op_min": 520244.8553791887,
+      "ns_per_op_median": 521016.2398589064,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": 22153,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.154631292,
+        "median_s": 0.155151208,
+        "samples_s": [
+          0.155182125,
+          0.154631292,
+          0.155151208
+        ]
+      },
+      "total": {
+        "min_s": 0.536311583,
+        "median_s": 0.541591917,
+        "samples_s": [
+          0.541591917,
+          0.541754042,
+          0.536311583
+        ]
+      },
+      "compute_s": 0.381680291,
+      "ns_per_op_min": 17229.282309393762,
+      "ns_per_op_median": 17444.170496095336,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": 22463,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.220750417,
+        "median_s": 0.22288725,
+        "samples_s": [
+          0.22288725,
+          0.220750417,
+          0.223515375
+        ]
+      },
+      "total": {
+        "min_s": 0.424618,
+        "median_s": 0.425668625,
+        "samples_s": [
+          0.424618,
+          0.425668625,
+          0.427122708
+        ]
+      },
+      "compute_s": 0.203867583,
+      "ns_per_op_min": 9075.705960913503,
+      "ns_per_op_median": 9027.350531985932,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": 5933,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.338000916,
+        "median_s": 0.340785125,
+        "samples_s": [
+          0.338000916,
+          0.343000416,
+          0.340785125
+        ]
+      },
+      "total": {
+        "min_s": 0.584970208,
+        "median_s": 0.585918334,
+        "samples_s": [
+          0.589863541,
+          0.585918334,
+          0.584970208
+        ]
+      },
+      "compute_s": 0.246969292,
+      "ns_per_op_min": 41626.37653800775,
+      "ns_per_op_median": 41316.90696106524,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": 4268,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.38958625,
+        "median_s": 0.393473417,
+        "samples_s": [
+          0.393473417,
+          0.38958625,
+          0.394658667
+        ]
+      },
+      "total": {
+        "min_s": 0.60022825,
+        "median_s": 0.603140792,
+        "samples_s": [
+          0.603740917,
+          0.603140792,
+          0.60022825
+        ]
+      },
+      "compute_s": 0.210642,
+      "ns_per_op_min": 49353.79568884723,
+      "ns_per_op_median": 49125.439315838805,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 3083,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.044616916,
+        "median_s": 0.044818458,
+        "samples_s": [
+          0.044616916,
+          0.044945208,
+          0.044818458
+        ]
+      },
+      "total": {
+        "min_s": 0.357242041,
+        "median_s": 0.358181,
+        "samples_s": [
+          0.358181,
+          0.359556542,
+          0.357242041
+        ]
+      },
+      "compute_s": 0.312625125,
+      "ns_per_op_min": 101402.89490755758,
+      "ns_per_op_median": 101642.0830360039,
+      "load_ms": 0.682,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 321,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.079932917,
+        "median_s": 0.080086958,
+        "samples_s": [
+          0.080242417,
+          0.080086958,
+          0.079932917
+        ]
+      },
+      "total": {
+        "min_s": 0.3350465,
+        "median_s": 0.335297458,
+        "samples_s": [
+          0.335297458,
+          0.33736875,
+          0.3350465
+        ]
+      },
+      "compute_s": 0.25511358300000003,
+      "ns_per_op_min": 794746.3644859814,
+      "ns_per_op_median": 795048.2866043614,
+      "load_ms": 3.701,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 10468,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.052849917,
+        "median_s": 0.053522792,
+        "samples_s": [
+          0.054711458,
+          0.053522792,
+          0.052849917
+        ]
+      },
+      "total": {
+        "min_s": 0.324167375,
+        "median_s": 0.326852833,
+        "samples_s": [
+          0.327243083,
+          0.326852833,
+          0.324167375
+        ]
+      },
+      "compute_s": 0.27131745799999996,
+      "ns_per_op_min": 25918.74837600305,
+      "ns_per_op_median": 26111.008884218572,
+      "load_ms": 4.135,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 14628,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.102915541,
+        "median_s": 0.103645875,
+        "samples_s": [
+          0.102915541,
+          0.103645875,
+          0.10380225
+        ]
+      },
+      "total": {
+        "min_s": 0.326672334,
+        "median_s": 0.327601416,
+        "samples_s": [
+          0.327601416,
+          0.331617125,
+          0.326672334
+        ]
+      },
+      "compute_s": 0.223756793,
+      "ns_per_op_min": 15296.472039923434,
+      "ns_per_op_median": 15310.05885972108,
+      "load_ms": 9.921,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 1321919,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005518667,
+        "median_s": 0.005738583,
+        "samples_s": [
+          0.005518667,
+          0.005738583,
+          0.005757084
+        ]
+      },
+      "total": {
+        "min_s": 0.297940416,
+        "median_s": 0.298032958,
+        "samples_s": [
+          0.298032958,
+          0.297940416,
+          0.300244958
+        ]
+      },
+      "compute_s": 0.292421749,
+      "ns_per_op_min": 221.21003556193685,
+      "ns_per_op_median": 221.11368018766657,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 21505,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009025834,
+        "median_s": 0.009074833,
+        "samples_s": [
+          0.009074833,
+          0.009633083,
+          0.009025834
+        ]
+      },
+      "total": {
+        "min_s": 0.228685333,
+        "median_s": 0.228784875,
+        "samples_s": [
+          0.228685333,
+          0.231761667,
+          0.228784875
+        ]
+      },
+      "compute_s": 0.21965949899999998,
+      "ns_per_op_min": 10214.345454545453,
+      "ns_per_op_median": 10216.69574517554,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 2249852,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.01564125,
+        "median_s": 0.016109417,
+        "samples_s": [
+          0.016570625,
+          0.016109417,
+          0.01564125
+        ]
+      },
+      "total": {
+        "min_s": 0.271939875,
+        "median_s": 0.272070583,
+        "samples_s": [
+          0.271939875,
+          0.272070583,
+          0.27294425
+        ]
+      },
+      "compute_s": 0.256298625,
+      "ns_per_op_min": 113.91799327244637,
+      "ns_per_op_median": 113.76800162855156,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wazero",
+      "status": "skipped",
+      "reason": "excluded: wazero 1.12.0 rejects the module: \"tag section not supported as feature \\\"exception-handling\\\" is disabled\""
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wasm3",
+      "status": "skipped",
+      "reason": "excluded: wasm3 0.9.0 fails to load it: \"out of order Wasm section\" (the tag section is unknown to it)"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 400463,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039411125,
+        "median_s": 0.03974075,
+        "samples_s": [
+          0.03974075,
+          0.039411125,
+          0.040106125
+        ]
+      },
+      "total": {
+        "min_s": 0.291872708,
+        "median_s": 0.293740292,
+        "samples_s": [
+          0.293740292,
+          0.291872708,
+          0.293878125
+        ]
+      },
+      "compute_s": 0.252461583,
+      "ns_per_op_min": 630.4242414405326,
+      "ns_per_op_median": 634.2646936171383,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 430841,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040870042,
+        "median_s": 0.041050584,
+        "samples_s": [
+          0.040870042,
+          0.041234833,
+          0.041050584
+        ]
+      },
+      "total": {
+        "min_s": 0.240092791,
+        "median_s": 0.244167917,
+        "samples_s": [
+          0.240092791,
+          0.246173833,
+          0.244167917
+        ]
+      },
+      "compute_s": 0.199222749,
+      "ns_per_op_min": 462.40434174092064,
+      "ns_per_op_median": 471.4438342683264,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 455002,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.03950175,
+        "median_s": 0.0405395,
+        "samples_s": [
+          0.040599792,
+          0.03950175,
+          0.0405395
+        ]
+      },
+      "total": {
+        "min_s": 0.316535459,
+        "median_s": 0.318471583,
+        "samples_s": [
+          0.3192695,
+          0.316535459,
+          0.318471583
+        ]
+      },
+      "compute_s": 0.277033709,
+      "ns_per_op_min": 608.8626181862937,
+      "ns_per_op_median": 610.8370578590864,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 442140,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.028760625,
+        "median_s": 0.029109167,
+        "samples_s": [
+          0.02993775,
+          0.029109167,
+          0.028760625
+        ]
+      },
+      "total": {
+        "min_s": 0.324173834,
+        "median_s": 0.324788792,
+        "samples_s": [
+          0.324173834,
+          0.324788792,
+          0.325488583
+        ]
+      },
+      "compute_s": 0.295413209,
+      "ns_per_op_min": 668.1440471343918,
+      "ns_per_op_median": 668.7466074094178,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 4000000,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039260292,
+        "median_s": 0.0408645,
+        "samples_s": [
+          0.0408645,
+          0.039260292,
+          0.040931167
+        ]
+      },
+      "total": {
+        "min_s": 0.058243833,
+        "median_s": 0.059293209,
+        "samples_s": [
+          0.058243833,
+          0.059293209,
+          0.059744958
+        ]
+      },
+      "compute_s": 0.018983541,
+      "ns_per_op_min": 4.74588525,
+      "ns_per_op_median": 4.60717725,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 255611,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.011304417,
+        "median_s": 0.011464125,
+        "samples_s": [
+          0.011469792,
+          0.011464125,
+          0.011304417
+        ]
+      },
+      "total": {
+        "min_s": 0.312183375,
+        "median_s": 0.314846708,
+        "samples_s": [
+          0.314846708,
+          0.317667,
+          0.312183375
+        ]
+      },
+      "compute_s": 0.300878958,
+      "ns_per_op_min": 1177.097065462754,
+      "ns_per_op_median": 1186.891733923814,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 1041645,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.003195708,
+        "median_s": 0.0051505,
+        "samples_s": [
+          0.003195708,
+          0.0051505,
+          0.005204417
+        ]
+      },
+      "total": {
+        "min_s": 0.211972,
+        "median_s": 0.212310583,
+        "samples_s": [
+          0.211972,
+          0.214453375,
+          0.212310583
+        ]
+      },
+      "compute_s": 0.208776292,
+      "ns_per_op_min": 200.42940925171243,
+      "ns_per_op_median": 198.87781633857983,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 321098,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.06423375,
+        "median_s": 0.0678875,
+        "samples_s": [
+          0.06423375,
+          0.0678875,
+          0.068314
+        ]
+      },
+      "total": {
+        "min_s": 0.244207334,
+        "median_s": 0.244859292,
+        "samples_s": [
+          0.244859292,
+          0.24636225,
+          0.244207334
+        ]
+      },
+      "compute_s": 0.179973584,
+      "ns_per_op_min": 560.4942540906515,
+      "ns_per_op_median": 551.1457312097865,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-bash",
+      "status": "skipped",
+      "reason": "excluded: the bash backend has no exception-handling lowering and rejects the module at conversion time with \"unsupported (exception-handling): tag, exnref value, or try_table/throw/throw_ref instruction\" (see docs/support.md)"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wasm3-ruby",
+      "status": "skipped",
+      "reason": "excluded: the converted wasm3 0.9.0 fails to load it like the native one, \"out of order Wasm section\" (the tag section is unknown to it), measured through the converted interpreter"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wasm3-ruby-yjit",
+      "status": "skipped",
+      "reason": "excluded: the converted wasm3 0.9.0 fails to load it like the native one, \"out of order Wasm section\" (the tag section is unknown to it), measured through the converted interpreter"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wasm3-python",
+      "status": "skipped",
+      "reason": "excluded: the converted wasm3 0.9.0 fails to load it like the native one, \"out of order Wasm section\" (the tag section is unknown to it), measured through the converted interpreter"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wasm3-pypy",
+      "status": "skipped",
+      "reason": "excluded: the converted wasm3 0.9.0 fails to load it like the native one, \"out of order Wasm section\" (the tag section is unknown to it), measured through the converted interpreter"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "pywasm-cpython",
+      "status": "skipped",
+      "reason": "excluded: pywasm 2.2.3 has no exception-handling opcodes; decoding dies with AssertionError on the throw/try_table opcode (pywasm/core.py, from_reader)"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "pywasm-pypy",
+      "status": "skipped",
+      "reason": "excluded: pywasm 2.2.3 has no exception-handling opcodes; decoding dies with AssertionError on the throw/try_table opcode (pywasm/core.py, from_reader)"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wardite",
+      "status": "skipped",
+      "reason": "excluded: wardite 0.9.0 fails to load the tag section: Wardite::LoadError \"unknown code: 13\""
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wardite-yjit",
+      "status": "skipped",
+      "reason": "excluded: wardite 0.9.0 fails to load the tag section: Wardite::LoadError \"unknown code: 13\""
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 106710677,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.00556575,
+        "median_s": 0.005650084,
+        "samples_s": [
+          0.006136458,
+          0.005650084,
+          0.00556575
+        ]
+      },
+      "total": {
+        "min_s": 0.301839208,
+        "median_s": 0.302605458,
+        "samples_s": [
+          0.302605458,
+          0.30525525,
+          0.301839208
+        ]
+      },
+      "compute_s": 0.29627345800000005,
+      "ns_per_op_min": 2.7764181273069806,
+      "ns_per_op_median": 2.782808453178495,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 235152025,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009404333,
+        "median_s": 0.0095035,
+        "samples_s": [
+          0.009404333,
+          0.0095035,
+          0.010135541
+        ]
+      },
+      "total": {
+        "min_s": 0.307523708,
+        "median_s": 0.308073875,
+        "samples_s": [
+          0.310015542,
+          0.308073875,
+          0.307523708
+        ]
+      },
+      "compute_s": 0.298119375,
+      "ns_per_op_min": 1.2677729439072447,
+      "ns_per_op_median": 1.2696908521200274,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 2635760,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.01595125,
+        "median_s": 0.01636475,
+        "samples_s": [
+          0.016619208,
+          0.01595125,
+          0.01636475
+        ]
+      },
+      "total": {
+        "min_s": 0.31860375,
+        "median_s": 0.319839583,
+        "samples_s": [
+          0.319839583,
+          0.31860375,
+          0.319845625
+        ]
+      },
+      "compute_s": 0.3026525,
+      "ns_per_op_min": 114.82551522141621,
+      "ns_per_op_median": 115.13750607035541,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wazero",
+      "status": "skipped",
+      "reason": "excluded: wazero 1.12.0 rejects the module: \"tag section not supported as feature \\\"exception-handling\\\" is disabled\""
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wasm3",
+      "status": "skipped",
+      "reason": "excluded: wasm3 0.9.0 fails to load it: \"out of order Wasm section\" (the tag section is unknown to it)"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 2284539,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039708583,
+        "median_s": 0.039939792,
+        "samples_s": [
+          0.039939792,
+          0.039708583,
+          0.041116375
+        ]
+      },
+      "total": {
+        "min_s": 0.317005125,
+        "median_s": 0.317545333,
+        "samples_s": [
+          0.317545333,
+          0.317005125,
+          0.318758583
+        ]
+      },
+      "compute_s": 0.277296542,
+      "ns_per_op_min": 121.37964902328216,
+      "ns_per_op_median": 121.51490563304019,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 2223097,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039855875,
+        "median_s": 0.040514417,
+        "samples_s": [
+          0.040514417,
+          0.039855875,
+          0.041038041
+        ]
+      },
+      "total": {
+        "min_s": 0.310944708,
+        "median_s": 0.31291675,
+        "samples_s": [
+          0.31291675,
+          0.310944708,
+          0.314162166
+        ]
+      },
+      "compute_s": 0.27108883300000003,
+      "ns_per_op_min": 121.94197239256766,
+      "ns_per_op_median": 122.53281480745108,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 2771590,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040587292,
+        "median_s": 0.040901917,
+        "samples_s": [
+          0.040901917,
+          0.040996625,
+          0.040587292
+        ]
+      },
+      "total": {
+        "min_s": 0.37739425,
+        "median_s": 0.377701583,
+        "samples_s": [
+          0.37739425,
+          0.380130125,
+          0.377701583
+        ]
+      },
+      "compute_s": 0.336806958,
+      "ns_per_op_min": 121.52120551741058,
+      "ns_per_op_median": 121.51857453663781,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 1439446,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.029347708,
+        "median_s": 0.029926583,
+        "samples_s": [
+          0.030302792,
+          0.029347708,
+          0.029926583
+        ]
+      },
+      "total": {
+        "min_s": 0.3138845,
+        "median_s": 0.31463025,
+        "samples_s": [
+          0.3138845,
+          0.322088208,
+          0.31463025
+        ]
+      },
+      "compute_s": 0.28453679200000004,
+      "ns_per_op_min": 197.67104288733307,
+      "ns_per_op_median": 197.78697290485368,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 103860134,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040727208,
+        "median_s": 0.041151833,
+        "samples_s": [
+          0.040727208,
+          0.041939417,
+          0.041151833
+        ]
+      },
+      "total": {
+        "min_s": 0.311065292,
+        "median_s": 0.312486041,
+        "samples_s": [
+          0.312486041,
+          0.311065292,
+          0.313423291
+        ]
+      },
+      "compute_s": 0.270338084,
+      "ns_per_op_min": 2.602905210963814,
+      "ns_per_op_median": 2.6124962249711707,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 577933,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010636292,
+        "median_s": 0.0110795,
+        "samples_s": [
+          0.0110795,
+          0.010636292,
+          0.011295209
+        ]
+      },
+      "total": {
+        "min_s": 0.308529292,
+        "median_s": 0.30873,
+        "samples_s": [
+          0.30873,
+          0.308529292,
+          0.309440958
+        ]
+      },
+      "compute_s": 0.297893,
+      "ns_per_op_min": 515.4455620288165,
+      "ns_per_op_median": 515.0259632171895,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 62254918,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.003243,
+        "median_s": 0.003696791,
+        "samples_s": [
+          0.003779791,
+          0.003243,
+          0.003696791
+        ]
+      },
+      "total": {
+        "min_s": 0.268311,
+        "median_s": 0.268325125,
+        "samples_s": [
+          0.268311,
+          0.268325125,
+          0.270757375
+        ]
+      },
+      "compute_s": 0.265068,
+      "ns_per_op_min": 4.257784099884286,
+      "ns_per_op_median": 4.2507217502077514,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 232371486,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.067295208,
+        "median_s": 0.067608375,
+        "samples_s": [
+          0.068395,
+          0.067295208,
+          0.067608375
+        ]
+      },
+      "total": {
+        "min_s": 0.400027292,
+        "median_s": 0.400891375,
+        "samples_s": [
+          0.400027292,
+          0.400891375,
+          0.402140792
+        ]
+      },
+      "compute_s": 0.332732084,
+      "ns_per_op_min": 1.4318972165113235,
+      "ns_per_op_median": 1.4342680581730238,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-bash",
+      "status": "skipped",
+      "reason": "excluded: the bash backend has no exception-handling lowering and rejects the module at conversion time with \"unsupported (exception-handling): tag, exnref value, or try_table/throw/throw_ref instruction\" (see docs/support.md)"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wasm3-ruby",
+      "status": "skipped",
+      "reason": "excluded: the converted wasm3 0.9.0 fails to load it like the native one, \"out of order Wasm section\" (the tag section is unknown to it), measured through the converted interpreter"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wasm3-ruby-yjit",
+      "status": "skipped",
+      "reason": "excluded: the converted wasm3 0.9.0 fails to load it like the native one, \"out of order Wasm section\" (the tag section is unknown to it), measured through the converted interpreter"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wasm3-python",
+      "status": "skipped",
+      "reason": "excluded: the converted wasm3 0.9.0 fails to load it like the native one, \"out of order Wasm section\" (the tag section is unknown to it), measured through the converted interpreter"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wasm3-pypy",
+      "status": "skipped",
+      "reason": "excluded: the converted wasm3 0.9.0 fails to load it like the native one, \"out of order Wasm section\" (the tag section is unknown to it), measured through the converted interpreter"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "pywasm-cpython",
+      "status": "skipped",
+      "reason": "excluded: pywasm 2.2.3 has no exception-handling opcodes; decoding dies with AssertionError on the throw/try_table opcode (pywasm/core.py, from_reader)"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "pywasm-pypy",
+      "status": "skipped",
+      "reason": "excluded: pywasm 2.2.3 has no exception-handling opcodes; decoding dies with AssertionError on the throw/try_table opcode (pywasm/core.py, from_reader)"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wardite",
+      "status": "skipped",
+      "reason": "excluded: wardite 0.9.0 fails to load the tag section: Wardite::LoadError \"unknown code: 13\""
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wardite-yjit",
+      "status": "skipped",
+      "reason": "excluded: wardite 0.9.0 fails to load the tag section: Wardite::LoadError \"unknown code: 13\""
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 280698883,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005161584,
+        "median_s": 0.005821333,
+        "samples_s": [
+          0.005821333,
+          0.005892375,
+          0.005161584
+        ]
+      },
+      "total": {
+        "min_s": 0.28656125,
+        "median_s": 0.286599,
+        "samples_s": [
+          0.286599,
+          0.28656125,
+          0.28997825
+        ]
+      },
+      "compute_s": 0.281399666,
+      "ns_per_op_min": 1.0024965649756432,
+      "ns_per_op_median": 1.00028067087107,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 290391634,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.008968125,
+        "median_s": 0.009295708,
+        "samples_s": [
+          0.008968125,
+          0.010057291,
+          0.009295708
+        ]
+      },
+      "total": {
+        "min_s": 0.299131917,
+        "median_s": 0.299781041,
+        "samples_s": [
+          0.300219166,
+          0.299131917,
+          0.299781041
+        ]
+      },
+      "compute_s": 0.29016379200000003,
+      "ns_per_op_min": 0.9992153975069408,
+      "ns_per_op_median": 1.0003226642541638,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 3175480,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015701583,
+        "median_s": 0.015934542,
+        "samples_s": [
+          0.016717458,
+          0.015701583,
+          0.015934542
+        ]
+      },
+      "total": {
+        "min_s": 0.266602292,
+        "median_s": 0.266688167,
+        "samples_s": [
+          0.266688167,
+          0.266602292,
+          0.266747584
+        ]
+      },
+      "compute_s": 0.250900709,
+      "ns_per_op_min": 79.01190024815146,
+      "ns_per_op_median": 78.96558158136722,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 303213828,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004680041,
+        "median_s": 0.00493325,
+        "samples_s": [
+          0.004680041,
+          0.00493325,
+          0.005286167
+        ]
+      },
+      "total": {
+        "min_s": 0.295441292,
+        "median_s": 0.295809542,
+        "samples_s": [
+          0.295441292,
+          0.295809542,
+          0.296555084
+        ]
+      },
+      "compute_s": 0.290761251,
+      "ns_per_op_min": 0.9589313683939243,
+      "ns_per_op_median": 0.9593107739136488,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 42223961,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.003896709,
+        "median_s": 0.004417792,
+        "samples_s": [
+          0.003896709,
+          0.004417792,
+          0.005019708
+        ]
+      },
+      "total": {
+        "min_s": 0.299938583,
+        "median_s": 0.300190791,
+        "samples_s": [
+          0.300190791,
+          0.299938583,
+          0.304077291
+        ]
+      },
+      "compute_s": 0.296041874,
+      "ns_per_op_min": 7.0112293349266785,
+      "ns_per_op_median": 7.004861505058705,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 832283,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.04099375,
+        "median_s": 0.0412915,
+        "samples_s": [
+          0.041919292,
+          0.0412915,
+          0.04099375
+        ]
+      },
+      "total": {
+        "min_s": 0.342416875,
+        "median_s": 0.343328208,
+        "samples_s": [
+          0.342416875,
+          0.343328208,
+          0.344059583
+        ]
+      },
+      "compute_s": 0.301423125,
+      "ns_per_op_min": 362.164221785138,
+      "ns_per_op_median": 362.9014505883216,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 1186483,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040093417,
+        "median_s": 0.040822041,
+        "samples_s": [
+          0.041115833,
+          0.040093417,
+          0.040822041
+        ]
+      },
+      "total": {
+        "min_s": 0.3095255,
+        "median_s": 0.309988541,
+        "samples_s": [
+          0.3095255,
+          0.309988541,
+          0.31185025
+        ]
+      },
+      "compute_s": 0.269432083,
+      "ns_per_op_min": 227.08465523736962,
+      "ns_per_op_median": 226.86081469351015,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 805841,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039488666,
+        "median_s": 0.040289708,
+        "samples_s": [
+          0.04127875,
+          0.040289708,
+          0.039488666
+        ]
+      },
+      "total": {
+        "min_s": 0.265875334,
+        "median_s": 0.2666715,
+        "samples_s": [
+          0.2666715,
+          0.265875334,
+          0.267872459
+        ]
+      },
+      "compute_s": 0.226386668,
+      "ns_per_op_min": 280.9321789285976,
+      "ns_per_op_median": 280.92612810715764,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 530383,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.029326292,
+        "median_s": 0.029899708,
+        "samples_s": [
+          0.030301792,
+          0.029326292,
+          0.029899708
+        ]
+      },
+      "total": {
+        "min_s": 0.316667917,
+        "median_s": 0.316824542,
+        "samples_s": [
+          0.316667917,
+          0.317004875,
+          0.316824542
+        ]
+      },
+      "compute_s": 0.28734162500000004,
+      "ns_per_op_min": 541.7625093564463,
+      "ns_per_op_median": 540.9766791167891,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 49140324,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040569042,
+        "median_s": 0.040760917,
+        "samples_s": [
+          0.041369333,
+          0.040760917,
+          0.040569042
+        ]
+      },
+      "total": {
+        "min_s": 0.312756916,
+        "median_s": 0.313540375,
+        "samples_s": [
+          0.313540375,
+          0.314905791,
+          0.312756916
+        ]
+      },
+      "compute_s": 0.272187874,
+      "ns_per_op_min": 5.538992254100726,
+      "ns_per_op_median": 5.551030921163646,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 191797,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010424834,
+        "median_s": 0.011933667,
+        "samples_s": [
+          0.011933667,
+          0.010424834,
+          0.0122145
+        ]
+      },
+      "total": {
+        "min_s": 0.305399917,
+        "median_s": 0.305856041,
+        "samples_s": [
+          0.307355291,
+          0.305856041,
+          0.305399917
+        ]
+      },
+      "compute_s": 0.294975083,
+      "ns_per_op_min": 1537.9546238992268,
+      "ns_per_op_median": 1532.4659614071131,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 76869252,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.003837792,
+        "median_s": 0.004033167,
+        "samples_s": [
+          0.005707667,
+          0.003837792,
+          0.004033167
+        ]
+      },
+      "total": {
+        "min_s": 0.271639167,
+        "median_s": 0.271852958,
+        "samples_s": [
+          0.272103584,
+          0.271639167,
+          0.271852958
+        ]
+      },
+      "compute_s": 0.267801375,
+      "ns_per_op_min": 3.48385561238452,
+      "ns_per_op_median": 3.4840951880213424,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 200010216,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.066384042,
+        "median_s": 0.068002917,
+        "samples_s": [
+          0.068002917,
+          0.066384042,
+          0.07003325
+        ]
+      },
+      "total": {
+        "min_s": 0.394433833,
+        "median_s": 0.395745167,
+        "samples_s": [
+          0.394433833,
+          0.395745167,
+          0.397914333
+        ]
+      },
+      "compute_s": 0.328049791,
+      "ns_per_op_min": 1.6401651753628426,
+      "ns_per_op_median": 1.638627548904802,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 191,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.012827167,
+        "median_s": 0.012944917,
+        "samples_s": [
+          0.013862417,
+          0.012827167,
+          0.012944917
+        ]
+      },
+      "total": {
+        "min_s": 0.242809583,
+        "median_s": 0.243452042,
+        "samples_s": [
+          0.243452042,
+          0.244493708,
+          0.242809583
+        ]
+      },
+      "compute_s": 0.229982416,
+      "ns_per_op_min": 1204096.4188481676,
+      "ns_per_op_median": 1206843.5863874345,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": 65536,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.153722834,
+        "median_s": 0.154608583,
+        "samples_s": [
+          0.154933833,
+          0.153722834,
+          0.154608583
+        ]
+      },
+      "total": {
+        "min_s": 0.50471,
+        "median_s": 0.506001458,
+        "samples_s": [
+          0.50471,
+          0.508503125,
+          0.506001458
+        ]
+      },
+      "compute_s": 0.350987166,
+      "ns_per_op_min": 5355.639129638672,
+      "ns_per_op_median": 5361.829757690429,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": 179080,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.209308084,
+        "median_s": 0.211258,
+        "samples_s": [
+          0.211933459,
+          0.209308084,
+          0.211258
+        ]
+      },
+      "total": {
+        "min_s": 0.541737958,
+        "median_s": 0.543508084,
+        "samples_s": [
+          0.557920209,
+          0.543508084,
+          0.541737958
+        ]
+      },
+      "compute_s": 0.332429874,
+      "ns_per_op_min": 1856.32049363413,
+      "ns_per_op_median": 1855.3165289256194,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": 21740,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.336340792,
+        "median_s": 0.337194208,
+        "samples_s": [
+          0.337194208,
+          0.336340792,
+          0.33798425
+        ]
+      },
+      "total": {
+        "min_s": 0.641641166,
+        "median_s": 0.641981083,
+        "samples_s": [
+          0.641641166,
+          0.641981083,
+          0.642065875
+        ]
+      },
+      "compute_s": 0.305300374,
+      "ns_per_op_min": 14043.25547378105,
+      "ns_per_op_median": 14019.635464581417,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": 64624,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.384173959,
+        "median_s": 0.386498834,
+        "samples_s": [
+          0.387434666,
+          0.384173959,
+          0.386498834
+        ]
+      },
+      "total": {
+        "min_s": 0.592052375,
+        "median_s": 0.594602125,
+        "samples_s": [
+          0.598754625,
+          0.594602125,
+          0.592052375
+        ]
+      },
+      "compute_s": 0.20787841599999995,
+      "ns_per_op_min": 3216.7370636296105,
+      "ns_per_op_median": 3220.2168079970284,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 9553,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.043236959,
+        "median_s": 0.043755792,
+        "samples_s": [
+          0.043755792,
+          0.043236959,
+          0.045605833
+        ]
+      },
+      "total": {
+        "min_s": 0.321998,
+        "median_s": 0.323131042,
+        "samples_s": [
+          0.323528875,
+          0.321998,
+          0.323131042
+        ]
+      },
+      "compute_s": 0.278761041,
+      "ns_per_op_min": 29180.471160891866,
+      "ns_per_op_median": 29244.766042081017,
+      "load_ms": 0.669,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 38048,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.078199834,
+        "median_s": 0.0784065,
+        "samples_s": [
+          0.078199834,
+          0.078847708,
+          0.0784065
+        ]
+      },
+      "total": {
+        "min_s": 0.312516333,
+        "median_s": 0.313102875,
+        "samples_s": [
+          0.313102875,
+          0.312516333,
+          0.313658208
+        ]
+      },
+      "compute_s": 0.23431649899999998,
+      "ns_per_op_min": 6158.44457001682,
+      "ns_per_op_median": 6168.428695332212,
+      "load_ms": 3.246,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wardite",
+      "status": "skipped",
+      "reason": "excluded: wardite 0.9.0 does not re-round f32 arithmetic to single precision, so a dependent operation chain diverges from wasmtime (1232349357 vs 1232349355 at 10000 iterations) and the byte-for-byte verification would fail the whole run"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wardite-yjit",
+      "status": "skipped",
+      "reason": "excluded: wardite 0.9.0 does not re-round f32 arithmetic to single precision, so a dependent operation chain diverges from wasmtime (1232349357 vs 1232349355 at 10000 iterations) and the byte-for-byte verification would fail the whole run"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 312833484,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005444917,
+        "median_s": 0.005684625,
+        "samples_s": [
+          0.005684625,
+          0.006035709,
+          0.005444917
+        ]
+      },
+      "total": {
+        "min_s": 0.311194584,
+        "median_s": 0.3117755,
+        "samples_s": [
+          0.3117755,
+          0.311194584,
+          0.312554917
+        ]
+      },
+      "compute_s": 0.305749667,
+      "ns_per_op_min": 0.9773559501706026,
+      "ns_per_op_median": 0.978446651829636,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 305968246,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009044542,
+        "median_s": 0.00937175,
+        "samples_s": [
+          0.009044542,
+          0.009652583,
+          0.00937175
+        ]
+      },
+      "total": {
+        "min_s": 0.308277833,
+        "median_s": 0.308465125,
+        "samples_s": [
+          0.308277833,
+          0.309142167,
+          0.308465125
+        ]
+      },
+      "compute_s": 0.299233291,
+      "ns_per_op_min": 0.9779880589307951,
+      "ns_per_op_median": 0.9775307696472528,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 3419021,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015634541,
+        "median_s": 0.0164045,
+        "samples_s": [
+          0.015634541,
+          0.0164045,
+          0.01667275
+        ]
+      },
+      "total": {
+        "min_s": 0.2863015,
+        "median_s": 0.286654417,
+        "samples_s": [
+          0.2863015,
+          0.286654417,
+          0.286760917
+        ]
+      },
+      "compute_s": 0.270666959,
+      "ns_per_op_min": 79.16504724598065,
+      "ns_per_op_median": 79.04307022390327,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 302242260,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004978542,
+        "median_s": 0.005148959,
+        "samples_s": [
+          0.005148959,
+          0.004978542,
+          0.005239833
+        ]
+      },
+      "total": {
+        "min_s": 0.296385,
+        "median_s": 0.297057958,
+        "samples_s": [
+          0.298520792,
+          0.297057958,
+          0.296385
+        ]
+      },
+      "compute_s": 0.29140645800000003,
+      "ns_per_op_min": 0.9641486203815445,
+      "ns_per_op_median": 0.9658113296267703,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 55393303,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004167708,
+        "median_s": 0.00468925,
+        "samples_s": [
+          0.00468925,
+          0.004710708,
+          0.004167708
+        ]
+      },
+      "total": {
+        "min_s": 0.304051708,
+        "median_s": 0.304079667,
+        "samples_s": [
+          0.304079667,
+          0.304141584,
+          0.304051708
+        ]
+      },
+      "compute_s": 0.299884,
+      "ns_per_op_min": 5.413723027131998,
+      "ns_per_op_median": 5.404812509555533,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 2939163,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039062417,
+        "median_s": 0.040218833,
+        "samples_s": [
+          0.040238375,
+          0.040218833,
+          0.039062417
+        ]
+      },
+      "total": {
+        "min_s": 0.339456959,
+        "median_s": 0.339976917,
+        "samples_s": [
+          0.343149458,
+          0.339976917,
+          0.339456959
+        ]
+      },
+      "compute_s": 0.300394542,
+      "ns_per_op_min": 102.20411117042505,
+      "ns_per_op_median": 101.98756720875977,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 3893067,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040018917,
+        "median_s": 0.040937875,
+        "samples_s": [
+          0.041516125,
+          0.040018917,
+          0.040937875
+        ]
+      },
+      "total": {
+        "min_s": 0.332662792,
+        "median_s": 0.336175417,
+        "samples_s": [
+          0.336175417,
+          0.336968167,
+          0.332662792
+        ]
+      },
+      "compute_s": 0.292643875,
+      "ns_per_op_min": 75.17052108273502,
+      "ns_per_op_median": 75.83674825015854,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 3808571,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.04027375,
+        "median_s": 0.040744042,
+        "samples_s": [
+          0.040744042,
+          0.040913125,
+          0.04027375
+        ]
+      },
+      "total": {
+        "min_s": 0.351324125,
+        "median_s": 0.3550885,
+        "samples_s": [
+          0.351324125,
+          0.3550885,
+          0.355578
+        ]
+      },
+      "compute_s": 0.311050375,
+      "ns_per_op_min": 81.6711504131077,
+      "ns_per_op_median": 82.5360635261887,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 2355738,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.030006208,
+        "median_s": 0.030038,
+        "samples_s": [
+          0.030006208,
+          0.030460833,
+          0.030038
+        ]
+      },
+      "total": {
+        "min_s": 0.386443,
+        "median_s": 0.387164167,
+        "samples_s": [
+          0.386443,
+          0.387779167,
+          0.387164167
+        ]
+      },
+      "compute_s": 0.356436792,
+      "ns_per_op_min": 151.3057869763106,
+      "ns_per_op_median": 151.59842350889616,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 127247474,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040777333,
+        "median_s": 0.042111917,
+        "samples_s": [
+          0.040777333,
+          0.042334791,
+          0.042111917
+        ]
+      },
+      "total": {
+        "min_s": 0.314886292,
+        "median_s": 0.315109333,
+        "samples_s": [
+          0.314886292,
+          0.315109333,
+          0.317447166
+        ]
+      },
+      "compute_s": 0.274108959,
+      "ns_per_op_min": 2.154140670800271,
+      "ns_per_op_median": 2.1454053854145663,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 357962,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.014847875,
+        "median_s": 0.015172625,
+        "samples_s": [
+          0.014847875,
+          0.015225167,
+          0.015172625
+        ]
+      },
+      "total": {
+        "min_s": 0.312409375,
+        "median_s": 0.31258775,
+        "samples_s": [
+          0.31537675,
+          0.312409375,
+          0.31258775
+        ]
+      },
+      "compute_s": 0.2975615,
+      "ns_per_op_min": 831.2656091987418,
+      "ns_per_op_median": 830.8566970795782,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 71050685,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002650042,
+        "median_s": 0.002675583,
+        "samples_s": [
+          0.002816416,
+          0.002650042,
+          0.002675583
+        ]
+      },
+      "total": {
+        "min_s": 0.252858292,
+        "median_s": 0.252935833,
+        "samples_s": [
+          0.252858292,
+          0.253001583,
+          0.252935833
+        ]
+      },
+      "compute_s": 0.25020824999999997,
+      "ns_per_op_min": 3.5215459217599374,
+      "ns_per_op_median": 3.52227779366237,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 104920190,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.062331583,
+        "median_s": 0.063026125,
+        "samples_s": [
+          0.063026125,
+          0.066902583,
+          0.062331583
+        ]
+      },
+      "total": {
+        "min_s": 0.241700125,
+        "median_s": 0.242495875,
+        "samples_s": [
+          0.242882959,
+          0.242495875,
+          0.241700125
+        ]
+      },
+      "compute_s": 0.179368542,
+      "ns_per_op_min": 1.7095712655495572,
+      "ns_per_op_median": 1.7105358844660876,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 516,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.01293575,
+        "median_s": 0.013205209,
+        "samples_s": [
+          0.0134335,
+          0.013205209,
+          0.01293575
+        ]
+      },
+      "total": {
+        "min_s": 0.311182333,
+        "median_s": 0.311561959,
+        "samples_s": [
+          0.311561959,
+          0.311182333,
+          0.311830125
+        ]
+      },
+      "compute_s": 0.29824658299999995,
+      "ns_per_op_min": 577997.2538759689,
+      "ns_per_op_median": 578210.7558139535,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": 65442,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.1530895,
+        "median_s": 0.15389475,
+        "samples_s": [
+          0.15572975,
+          0.1530895,
+          0.15389475
+        ]
+      },
+      "total": {
+        "min_s": 0.44947875,
+        "median_s": 0.452963708,
+        "samples_s": [
+          0.452963708,
+          0.44947875,
+          0.455196333
+        ]
+      },
+      "compute_s": 0.29638925,
+      "ns_per_op_min": 4529.037162678403,
+      "ns_per_op_median": 4569.984994346139,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": 114552,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.208707709,
+        "median_s": 0.208746459,
+        "samples_s": [
+          0.208819709,
+          0.208746459,
+          0.208707709
+        ]
+      },
+      "total": {
+        "min_s": 0.390054875,
+        "median_s": 0.391214666,
+        "samples_s": [
+          0.391877583,
+          0.390054875,
+          0.391214666
+        ]
+      },
+      "compute_s": 0.18134716600000003,
+      "ns_per_op_min": 1583.0990816397796,
+      "ns_per_op_median": 1592.885388295272,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": 23080,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.337642792,
+        "median_s": 0.338955583,
+        "samples_s": [
+          0.339479959,
+          0.337642792,
+          0.338955583
+        ]
+      },
+      "total": {
+        "min_s": 0.627720375,
+        "median_s": 0.628767083,
+        "samples_s": [
+          0.628767083,
+          0.633395167,
+          0.627720375
+        ]
+      },
+      "compute_s": 0.29007758299999997,
+      "ns_per_op_min": 12568.35281629116,
+      "ns_per_op_median": 12556.824090121314,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": 84158,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.386606583,
+        "median_s": 0.388628708,
+        "samples_s": [
+          0.392496792,
+          0.386606583,
+          0.388628708
+        ]
+      },
+      "total": {
+        "min_s": 0.6133605,
+        "median_s": 0.61430675,
+        "samples_s": [
+          0.615948375,
+          0.6133605,
+          0.61430675
+        ]
+      },
+      "compute_s": 0.22675391699999997,
+      "ns_per_op_min": 2694.383386012025,
+      "ns_per_op_median": 2681.599396373488,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 10149,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.042176042,
+        "median_s": 0.0435835,
+        "samples_s": [
+          0.044581166,
+          0.042176042,
+          0.0435835
+        ]
+      },
+      "total": {
+        "min_s": 0.343553709,
+        "median_s": 0.344365,
+        "samples_s": [
+          0.343553709,
+          0.344365,
+          0.346389084
+        ]
+      },
+      "compute_s": 0.301377667,
+      "ns_per_op_min": 29695.30663119519,
+      "ns_per_op_median": 29636.565178835353,
+      "load_ms": 0.632,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 24726,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.078223291,
+        "median_s": 0.079408208,
+        "samples_s": [
+          0.080509167,
+          0.078223291,
+          0.079408208
+        ]
+      },
+      "total": {
+        "min_s": 0.270067625,
+        "median_s": 0.270272875,
+        "samples_s": [
+          0.270067625,
+          0.270272875,
+          0.273072583
+        ]
+      },
+      "compute_s": 0.19184433399999998,
+      "ns_per_op_min": 7758.809916686887,
+      "ns_per_op_median": 7719.188991345144,
+      "load_ms": 3.574,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 42335,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.052952333,
+        "median_s": 0.053259042,
+        "samples_s": [
+          0.053259042,
+          0.055695834,
+          0.052952333
+        ]
+      },
+      "total": {
+        "min_s": 0.375767125,
+        "median_s": 0.37671775,
+        "samples_s": [
+          0.377809625,
+          0.375767125,
+          0.37671775
+        ]
+      },
+      "compute_s": 0.32281479199999996,
+      "ns_per_op_min": 7625.246061178693,
+      "ns_per_op_median": 7640.456076532421,
+      "load_ms": 3.864,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 56468,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.104419958,
+        "median_s": 0.1071955,
+        "samples_s": [
+          0.10776325,
+          0.1071955,
+          0.104419958
+        ]
+      },
+      "total": {
+        "min_s": 0.307011708,
+        "median_s": 0.307560208,
+        "samples_s": [
+          0.307560208,
+          0.307011708,
+          0.310812875
+        ]
+      },
+      "compute_s": 0.20259175000000001,
+      "ns_per_op_min": 3587.726677056032,
+      "ns_per_op_median": 3548.28766735142,
+      "load_ms": 9.517,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 125909648,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005071125,
+        "median_s": 0.005839416,
+        "samples_s": [
+          0.005071125,
+          0.005839416,
+          0.00606125
+        ]
+      },
+      "total": {
+        "min_s": 0.297729792,
+        "median_s": 0.298201916,
+        "samples_s": [
+          0.298344,
+          0.298201916,
+          0.297729792
+        ]
+      },
+      "compute_s": 0.292658667,
+      "ns_per_op_min": 2.3243545800398078,
+      "ns_per_op_median": 2.3220023615664465,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 128404565,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009236458,
+        "median_s": 0.009427875,
+        "samples_s": [
+          0.009725875,
+          0.009427875,
+          0.009236458
+        ]
+      },
+      "total": {
+        "min_s": 0.30727,
+        "median_s": 0.307766208,
+        "samples_s": [
+          0.30727,
+          0.307766208,
+          0.309101292
+        ]
+      },
+      "compute_s": 0.298033542,
+      "ns_per_op_min": 2.3210509844412464,
+      "ns_per_op_median": 2.3234246617322367,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1751609,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015512625,
+        "median_s": 0.016005875,
+        "samples_s": [
+          0.016275625,
+          0.016005875,
+          0.015512625
+        ]
+      },
+      "total": {
+        "min_s": 0.281581084,
+        "median_s": 0.28158675,
+        "samples_s": [
+          0.281581084,
+          0.282468833,
+          0.28158675
+        ]
+      },
+      "compute_s": 0.266068459,
+      "ns_per_op_min": 151.89945872623397,
+      "ns_per_op_median": 151.6210952330115,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 112657465,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005140833,
+        "median_s": 0.005188083,
+        "samples_s": [
+          0.00556775,
+          0.005140833,
+          0.005188083
+        ]
+      },
+      "total": {
+        "min_s": 0.306073167,
+        "median_s": 0.306219083,
+        "samples_s": [
+          0.306219083,
+          0.306276709,
+          0.306073167
+        ]
+      },
+      "compute_s": 0.30093233399999997,
+      "ns_per_op_min": 2.6712152097510797,
+      "ns_per_op_median": 2.6720910150073056,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 15248317,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004545125,
+        "median_s": 0.004622083,
+        "samples_s": [
+          0.004545125,
+          0.004622083,
+          0.004817708
+        ]
+      },
+      "total": {
+        "min_s": 0.202465708,
+        "median_s": 0.203641917,
+        "samples_s": [
+          0.202465708,
+          0.203641917,
+          0.2037955
+        ]
+      },
+      "compute_s": 0.19792058299999998,
+      "ns_per_op_min": 12.979831347944824,
+      "ns_per_op_median": 13.051921336630134,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 1602740,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039146334,
+        "median_s": 0.039420125,
+        "samples_s": [
+          0.039420125,
+          0.039146334,
+          0.040171292
+        ]
+      },
+      "total": {
+        "min_s": 0.334706709,
+        "median_s": 0.335633084,
+        "samples_s": [
+          0.335633084,
+          0.339098209,
+          0.334706709
+        ]
+      },
+      "compute_s": 0.295560375,
+      "ns_per_op_min": 184.4094332206097,
+      "ns_per_op_median": 184.81660094588017,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 2365102,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.041178625,
+        "median_s": 0.041612,
+        "samples_s": [
+          0.041612,
+          0.042092791,
+          0.041178625
+        ]
+      },
+      "total": {
+        "min_s": 0.366777125,
+        "median_s": 0.367465708,
+        "samples_s": [
+          0.366777125,
+          0.368474292,
+          0.367465708
+        ]
+      },
+      "compute_s": 0.32559849999999996,
+      "ns_per_op_min": 137.66784688355932,
+      "ns_per_op_median": 137.7757525891061,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 1702710,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039009334,
+        "median_s": 0.039061042,
+        "samples_s": [
+          0.039061042,
+          0.0409215,
+          0.039009334
+        ]
+      },
+      "total": {
+        "min_s": 0.297070792,
+        "median_s": 0.297399541,
+        "samples_s": [
+          0.298045459,
+          0.297399541,
+          0.297070792
+        ]
+      },
+      "compute_s": 0.25806145799999997,
+      "ns_per_op_min": 151.55925436510032,
+      "ns_per_op_median": 151.72196028683686,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 516029,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.029523542,
+        "median_s": 0.02997625,
+        "samples_s": [
+          0.02997625,
+          0.029523542,
+          0.030329166
+        ]
+      },
+      "total": {
+        "min_s": 0.320195667,
+        "median_s": 0.320246917,
+        "samples_s": [
+          0.323399042,
+          0.320195667,
+          0.320246917
+        ]
+      },
+      "compute_s": 0.290672125,
+      "ns_per_op_min": 563.2864141356397,
+      "ns_per_op_median": 562.5084384792328,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 28507321,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.04011725,
+        "median_s": 0.040843334,
+        "samples_s": [
+          0.040843334,
+          0.04011725,
+          0.041100459
+        ]
+      },
+      "total": {
+        "min_s": 0.313484375,
+        "median_s": 0.315073584,
+        "samples_s": [
+          0.315073584,
+          0.316104833,
+          0.313484375
+        ]
+      },
+      "compute_s": 0.273367125,
+      "ns_per_op_min": 9.589365658035703,
+      "ns_per_op_median": 9.619642968204554,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 422668,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010550125,
+        "median_s": 0.011403125,
+        "samples_s": [
+          0.011403125,
+          0.010550125,
+          0.011762708
+        ]
+      },
+      "total": {
+        "min_s": 0.3030475,
+        "median_s": 0.303391125,
+        "samples_s": [
+          0.303391125,
+          0.304041333,
+          0.3030475
+        ]
+      },
+      "compute_s": 0.292497375,
+      "ns_per_op_min": 692.026306699348,
+      "ns_per_op_median": 690.8211646020043,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 85678303,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.003656583,
+        "median_s": 0.004876833,
+        "samples_s": [
+          0.006161833,
+          0.004876833,
+          0.003656583
+        ]
+      },
+      "total": {
+        "min_s": 0.265303625,
+        "median_s": 0.266641708,
+        "samples_s": [
+          0.265303625,
+          0.266641708,
+          0.268651417
+        ]
+      },
+      "compute_s": 0.261647042,
+      "ns_per_op_min": 3.0538308164203487,
+      "ns_per_op_median": 3.0552061121005156,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 123953808,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.065413375,
+        "median_s": 0.067990333,
+        "samples_s": [
+          0.065413375,
+          0.067990333,
+          0.068626917
+        ]
+      },
+      "total": {
+        "min_s": 0.357767375,
+        "median_s": 0.357940666,
+        "samples_s": [
+          0.358230667,
+          0.357940666,
+          0.357767375
+        ]
+      },
+      "compute_s": 0.292354,
+      "ns_per_op_min": 2.358572154556155,
+      "ns_per_op_median": 2.3391805195690316,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 11609,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.013310917,
+        "median_s": 0.013811291,
+        "samples_s": [
+          0.014215709,
+          0.013811291,
+          0.013310917
+        ]
+      },
+      "total": {
+        "min_s": 0.304410209,
+        "median_s": 0.304789125,
+        "samples_s": [
+          0.304410209,
+          0.304798916,
+          0.304789125
+        ]
+      },
+      "compute_s": 0.291099292,
+      "ns_per_op_min": 25075.31156861056,
+      "ns_per_op_median": 25064.849168748384,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": 31074,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.153239208,
+        "median_s": 0.15351875,
+        "samples_s": [
+          0.154287708,
+          0.153239208,
+          0.15351875
+        ]
+      },
+      "total": {
+        "min_s": 0.442109084,
+        "median_s": 0.443181208,
+        "samples_s": [
+          0.442109084,
+          0.446239375,
+          0.443181208
+        ]
+      },
+      "compute_s": 0.288869876,
+      "ns_per_op_min": 9296.19218639377,
+      "ns_per_op_median": 9321.6984617365,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": 75528,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.217687,
+        "median_s": 0.218912959,
+        "samples_s": [
+          0.218912959,
+          0.217687,
+          0.221092375
+        ]
+      },
+      "total": {
+        "min_s": 0.491808333,
+        "median_s": 0.4926735,
+        "samples_s": [
+          0.496756833,
+          0.491808333,
+          0.4926735
+        ]
+      },
+      "compute_s": 0.27412133299999997,
+      "ns_per_op_min": 3629.400129753203,
+      "ns_per_op_median": 3624.62319934329,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": 9432,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.340998917,
+        "median_s": 0.3410835,
+        "samples_s": [
+          0.34228775,
+          0.340998917,
+          0.3410835
+        ]
+      },
+      "total": {
+        "min_s": 0.581508458,
+        "median_s": 0.583141,
+        "samples_s": [
+          0.583847792,
+          0.583141,
+          0.581508458
+        ]
+      },
+      "compute_s": 0.24050954099999994,
+      "ns_per_op_min": 25499.315203562335,
+      "ns_per_op_median": 25663.43299406277,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": 28118,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.386359042,
+        "median_s": 0.386777,
+        "samples_s": [
+          0.390154291,
+          0.386359042,
+          0.386777
+        ]
+      },
+      "total": {
+        "min_s": 0.613364375,
+        "median_s": 0.6147035,
+        "samples_s": [
+          0.614932458,
+          0.6147035,
+          0.613364375
+        ]
+      },
+      "compute_s": 0.22700533299999998,
+      "ns_per_op_min": 8073.310086065864,
+      "ns_per_op_median": 8106.070844299024,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 5206,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.043183708,
+        "median_s": 0.044027125,
+        "samples_s": [
+          0.044027125,
+          0.044860541,
+          0.043183708
+        ]
+      },
+      "total": {
+        "min_s": 0.325642708,
+        "median_s": 0.326336292,
+        "samples_s": [
+          0.326336292,
+          0.326755833,
+          0.325642708
+        ]
+      },
+      "compute_s": 0.282459,
+      "ns_per_op_min": 54256.4348828275,
+      "ns_per_op_median": 54227.65405301575,
+      "load_ms": 0.651,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 6026,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.081920875,
+        "median_s": 0.082873708,
+        "samples_s": [
+          0.081920875,
+          0.082873708,
+          0.082993
+        ]
+      },
+      "total": {
+        "min_s": 0.2604075,
+        "median_s": 0.260504209,
+        "samples_s": [
+          0.260504209,
+          0.264208875,
+          0.2604075
+        ]
+      },
+      "compute_s": 0.178486625,
+      "ns_per_op_min": 29619.420013275805,
+      "ns_per_op_median": 29477.348323929637,
+      "load_ms": 3.901,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 15728,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.053114875,
+        "median_s": 0.053119,
+        "samples_s": [
+          0.053114875,
+          0.054438084,
+          0.053119
+        ]
+      },
+      "total": {
+        "min_s": 0.293403,
+        "median_s": 0.294616833,
+        "samples_s": [
+          0.293403,
+          0.294616833,
+          0.296124083
+        ]
+      },
+      "compute_s": 0.24028812500000002,
+      "ns_per_op_min": 15277.729209053918,
+      "ns_per_op_median": 15354.64350203459,
+      "load_ms": 4.59,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 29146,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.101177125,
+        "median_s": 0.101541166,
+        "samples_s": [
+          0.101177125,
+          0.101541166,
+          0.10184375
+        ]
+      },
+      "total": {
+        "min_s": 0.302233083,
+        "median_s": 0.303284875,
+        "samples_s": [
+          0.302233083,
+          0.3120145,
+          0.303284875
+        ]
+      },
+      "compute_s": 0.201055958,
+      "ns_per_op_min": 6898.235023673918,
+      "ns_per_op_median": 6921.831777945516,
+      "load_ms": 9.494,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 39310654,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005485,
+        "median_s": 0.005534625,
+        "samples_s": [
+          0.005534625,
+          0.005485,
+          0.0057995
+        ]
+      },
+      "total": {
+        "min_s": 0.306360209,
+        "median_s": 0.306514334,
+        "samples_s": [
+          0.306360209,
+          0.306514334,
+          0.307195375
+        ]
+      },
+      "compute_s": 0.300875209,
+      "ns_per_op_min": 7.653782839634263,
+      "ns_per_op_median": 7.656441152060203,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 38898318,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.008825709,
+        "median_s": 0.009415208,
+        "samples_s": [
+          0.008825709,
+          0.009415208,
+          0.009439292
+        ]
+      },
+      "total": {
+        "min_s": 0.306097458,
+        "median_s": 0.307741,
+        "samples_s": [
+          0.308446958,
+          0.306097458,
+          0.307741
+        ]
+      },
+      "compute_s": 0.297271749,
+      "ns_per_op_min": 7.6422777200803385,
+      "ns_per_op_median": 7.6693751128262155,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1624300,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015814083,
+        "median_s": 0.016181917,
+        "samples_s": [
+          0.016220292,
+          0.016181917,
+          0.015814083
+        ]
+      },
+      "total": {
+        "min_s": 0.3101675,
+        "median_s": 0.310711458,
+        "samples_s": [
+          0.3101675,
+          0.312811334,
+          0.310711458
+        ]
+      },
+      "compute_s": 0.294353417,
+      "ns_per_op_min": 181.21862771655483,
+      "ns_per_op_median": 181.32705842516776,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 39140777,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005390708,
+        "median_s": 0.00547975,
+        "samples_s": [
+          0.00547975,
+          0.005594708,
+          0.005390708
+        ]
+      },
+      "total": {
+        "min_s": 0.305705959,
+        "median_s": 0.306065875,
+        "samples_s": [
+          0.305705959,
+          0.306065875,
+          0.307159333
+        ]
+      },
+      "compute_s": 0.300315251,
+      "ns_per_op_min": 7.672695179250018,
+      "ns_per_op_median": 7.679615685708027,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 13119225,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.00409225,
+        "median_s": 0.004594083,
+        "samples_s": [
+          0.004594083,
+          0.004636042,
+          0.00409225
+        ]
+      },
+      "total": {
+        "min_s": 0.211361291,
+        "median_s": 0.211424459,
+        "samples_s": [
+          0.211424459,
+          0.211606916,
+          0.211361291
+        ]
+      },
+      "compute_s": 0.20726904100000001,
+      "ns_per_op_min": 15.798878439846868,
+      "ns_per_op_median": 15.7654416324135,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 745314,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039651375,
+        "median_s": 0.040112292,
+        "samples_s": [
+          0.039651375,
+          0.040112292,
+          0.040770542
+        ]
+      },
+      "total": {
+        "min_s": 0.313329917,
+        "median_s": 0.313733167,
+        "samples_s": [
+          0.313733167,
+          0.313329917,
+          0.314610541
+        ]
+      },
+      "compute_s": 0.273678542,
+      "ns_per_op_min": 367.1989819056129,
+      "ns_per_op_median": 367.1216091472856,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 1622501,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040723125,
+        "median_s": 0.040748375,
+        "samples_s": [
+          0.040748375,
+          0.040723125,
+          0.0411325
+        ]
+      },
+      "total": {
+        "min_s": 0.342075583,
+        "median_s": 0.344510666,
+        "samples_s": [
+          0.342075583,
+          0.358197,
+          0.344510666
+        ]
+      },
+      "compute_s": 0.301352458,
+      "ns_per_op_min": 185.73329569596567,
+      "ns_per_op_median": 187.21855394850297,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 933732,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040202042,
+        "median_s": 0.040344666,
+        "samples_s": [
+          0.040979833,
+          0.040202042,
+          0.040344666
+        ]
+      },
+      "total": {
+        "min_s": 0.264732625,
+        "median_s": 0.266144459,
+        "samples_s": [
+          0.266144459,
+          0.264732625,
+          0.266718542
+        ]
+      },
+      "compute_s": 0.224530583,
+      "ns_per_op_min": 240.46576855029065,
+      "ns_per_op_median": 241.82505579759504,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 304998,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.030208583,
+        "median_s": 0.030537209,
+        "samples_s": [
+          0.030208583,
+          0.030668208,
+          0.030537209
+        ]
+      },
+      "total": {
+        "min_s": 0.327111584,
+        "median_s": 0.327649416,
+        "samples_s": [
+          0.327649416,
+          0.331110959,
+          0.327111584
+        ]
+      },
+      "compute_s": 0.296903001,
+      "ns_per_op_min": 973.4588456317746,
+      "ns_per_op_median": 974.1447714411242,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 12959713,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039669166,
+        "median_s": 0.041265375,
+        "samples_s": [
+          0.041265375,
+          0.041412625,
+          0.039669166
+        ]
+      },
+      "total": {
+        "min_s": 0.224090292,
+        "median_s": 0.224906833,
+        "samples_s": [
+          0.224090292,
+          0.224906833,
+          0.225345875
+        ]
+      },
+      "compute_s": 0.184421126,
+      "ns_per_op_min": 14.230340286085038,
+      "ns_per_op_median": 14.170179385916956,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 246418,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.011573958,
+        "median_s": 0.01172425,
+        "samples_s": [
+          0.0119165,
+          0.01172425,
+          0.011573958
+        ]
+      },
+      "total": {
+        "min_s": 0.310788417,
+        "median_s": 0.31176925,
+        "samples_s": [
+          0.31176925,
+          0.312263916,
+          0.310788417
+        ]
+      },
+      "compute_s": 0.299214459,
+      "ns_per_op_min": 1214.255691548507,
+      "ns_per_op_median": 1217.6261474405278,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 36409793,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.003360167,
+        "median_s": 0.003819459,
+        "samples_s": [
+          0.003360167,
+          0.006238875,
+          0.003819459
+        ]
+      },
+      "total": {
+        "min_s": 0.283096417,
+        "median_s": 0.283323334,
+        "samples_s": [
+          0.283323334,
+          0.283096417,
+          0.284018
+        ]
+      },
+      "compute_s": 0.27973624999999996,
+      "ns_per_op_min": 7.68299479208794,
+      "ns_per_op_median": 7.676612580576878,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 29107804,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.067351917,
+        "median_s": 0.067833625,
+        "samples_s": [
+          0.067351917,
+          0.067841625,
+          0.067833625
+        ]
+      },
+      "total": {
+        "min_s": 0.297507791,
+        "median_s": 0.297883958,
+        "samples_s": [
+          0.297883958,
+          0.297507791,
+          0.299396708
+        ]
+      },
+      "compute_s": 0.23015587400000004,
+      "ns_per_op_min": 7.9070160703294565,
+      "ns_per_op_median": 7.9033902042215205,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 4203,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.01272025,
+        "median_s": 0.013778583,
+        "samples_s": [
+          0.013811667,
+          0.013778583,
+          0.01272025
+        ]
+      },
+      "total": {
+        "min_s": 0.300354291,
+        "median_s": 0.3004955,
+        "samples_s": [
+          0.300354291,
+          0.301364875,
+          0.3004955
+        ]
+      },
+      "compute_s": 0.287634041,
+      "ns_per_op_min": 68435.41303830597,
+      "ns_per_op_median": 68217.2060433024,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": 17417,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.153475459,
+        "median_s": 0.155174833,
+        "samples_s": [
+          0.155174833,
+          0.155614792,
+          0.153475459
+        ]
+      },
+      "total": {
+        "min_s": 0.358105875,
+        "median_s": 0.35942425,
+        "samples_s": [
+          0.35942425,
+          0.358105875,
+          0.359516209
+        ]
+      },
+      "compute_s": 0.204630416,
+      "ns_per_op_min": 11748.889935120858,
+      "ns_per_op_median": 11727.014813113625,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": 56016,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.214333042,
+        "median_s": 0.215410291,
+        "samples_s": [
+          0.214333042,
+          0.215410291,
+          0.215977708
+        ]
+      },
+      "total": {
+        "min_s": 0.475199625,
+        "median_s": 0.476613792,
+        "samples_s": [
+          0.476613792,
+          0.475199625,
+          0.47812875
+        ]
+      },
+      "compute_s": 0.260866583,
+      "ns_per_op_min": 4657.001267495001,
+      "ns_per_op_median": 4663.01594187375,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": 10078,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.340082375,
+        "median_s": 0.340177167,
+        "samples_s": [
+          0.340082375,
+          0.342233166,
+          0.340177167
+        ]
+      },
+      "total": {
+        "min_s": 0.654923792,
+        "median_s": 0.658360458,
+        "samples_s": [
+          0.654923792,
+          0.658360458,
+          0.659759458
+        ]
+      },
+      "compute_s": 0.31484141699999996,
+      "ns_per_op_min": 31240.46606469537,
+      "ns_per_op_median": 31572.066977574916,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": 16576,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.389291334,
+        "median_s": 0.392967333,
+        "samples_s": [
+          0.394059125,
+          0.392967333,
+          0.389291334
+        ]
+      },
+      "total": {
+        "min_s": 0.598902875,
+        "median_s": 0.60114325,
+        "samples_s": [
+          0.598902875,
+          0.60114325,
+          0.602899916
+        ]
+      },
+      "compute_s": 0.20961154099999996,
+      "ns_per_op_min": 12645.483892374516,
+      "ns_per_op_median": 12558.875301640928,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 4011,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.043578625,
+        "median_s": 0.04525575,
+        "samples_s": [
+          0.04525575,
+          0.043578625,
+          0.045597125
+        ]
+      },
+      "total": {
+        "min_s": 0.290222167,
+        "median_s": 0.290865042,
+        "samples_s": [
+          0.290222167,
+          0.290865042,
+          0.292649625
+        ]
+      },
+      "compute_s": 0.24664354199999997,
+      "ns_per_op_min": 61491.78309648466,
+      "ns_per_op_median": 61233.929693343314,
+      "load_ms": 0.731,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 4032,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.078822833,
+        "median_s": 0.079669917,
+        "samples_s": [
+          0.078822833,
+          0.081059916,
+          0.079669917
+        ]
+      },
+      "total": {
+        "min_s": 0.270767833,
+        "median_s": 0.27104675,
+        "samples_s": [
+          0.270767833,
+          0.271387959,
+          0.27104675
+        ]
+      },
+      "compute_s": 0.19194500000000003,
+      "ns_per_op_min": 47605.40674603175,
+      "ns_per_op_median": 47464.49231150794,
+      "load_ms": 3.615,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 15238,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.052914959,
+        "median_s": 0.053077958,
+        "samples_s": [
+          0.053653625,
+          0.053077958,
+          0.052914959
+        ]
+      },
+      "total": {
+        "min_s": 0.328753916,
+        "median_s": 0.331409583,
+        "samples_s": [
+          0.331409583,
+          0.331553667,
+          0.328753916
+        ]
+      },
+      "compute_s": 0.275838957,
+      "ns_per_op_min": 18102.044690904317,
+      "ns_per_op_median": 18265.627050794068,
+      "load_ms": 3.669,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 32894,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.101324708,
+        "median_s": 0.104021,
+        "samples_s": [
+          0.104080292,
+          0.101324708,
+          0.104021
+        ]
+      },
+      "total": {
+        "min_s": 0.380706125,
+        "median_s": 0.384064667,
+        "samples_s": [
+          0.384064667,
+          0.380706125,
+          0.385568833
+        ]
+      },
+      "compute_s": 0.279381417,
+      "ns_per_op_min": 8493.38532863136,
+      "ns_per_op_median": 8513.518179607225,
+      "load_ms": 10.047,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 128742317,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005711875,
+        "median_s": 0.005993291,
+        "samples_s": [
+          0.006087,
+          0.005711875,
+          0.005993291
+        ]
+      },
+      "total": {
+        "min_s": 0.305646708,
+        "median_s": 0.305869542,
+        "samples_s": [
+          0.305869542,
+          0.306385791,
+          0.305646708
+        ]
+      },
+      "compute_s": 0.299934833,
+      "ns_per_op_min": 2.3297299597303347,
+      "ns_per_op_median": 2.3292749267515513,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 129557406,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009394292,
+        "median_s": 0.009413042,
+        "samples_s": [
+          0.010128542,
+          0.009413042,
+          0.009394292
+        ]
+      },
+      "total": {
+        "min_s": 0.311199042,
+        "median_s": 0.311331291,
+        "samples_s": [
+          0.311331291,
+          0.311199042,
+          0.3127745
+        ]
+      },
+      "compute_s": 0.30180474999999996,
+      "ns_per_op_min": 2.3295059643290474,
+      "ns_per_op_median": 2.3303820161388535,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1967678,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015599917,
+        "median_s": 0.016211958,
+        "samples_s": [
+          0.016211958,
+          0.016865833,
+          0.015599917
+        ]
+      },
+      "total": {
+        "min_s": 0.314266042,
+        "median_s": 0.314935,
+        "samples_s": [
+          0.314935,
+          0.315223666,
+          0.314266042
+        ]
+      },
+      "compute_s": 0.298666125,
+      "ns_per_op_min": 151.7860772951672,
+      "ns_per_op_median": 151.8150032678111,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 112940596,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005138083,
+        "median_s": 0.005283,
+        "samples_s": [
+          0.005612083,
+          0.005138083,
+          0.005283
+        ]
+      },
+      "total": {
+        "min_s": 0.306239292,
+        "median_s": 0.306881083,
+        "samples_s": [
+          0.306957583,
+          0.306239292,
+          0.306881083
+        ]
+      },
+      "compute_s": 0.301101209,
+      "ns_per_op_min": 2.666013990221904,
+      "ns_per_op_median": 2.670413418041463,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 16777216,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004549584,
+        "median_s": 0.004573708,
+        "samples_s": [
+          0.004549584,
+          0.004801542,
+          0.004573708
+        ]
+      },
+      "total": {
+        "min_s": 0.206976958,
+        "median_s": 0.206991875,
+        "samples_s": [
+          0.206976958,
+          0.206991875,
+          0.207067209
+        ]
+      },
+      "compute_s": 0.202427374,
+      "ns_per_op_min": 12.065611720085144,
+      "ns_per_op_median": 12.065062940120695,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 235760,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039765833,
+        "median_s": 0.04011025,
+        "samples_s": [
+          0.040317958,
+          0.039765833,
+          0.04011025
+        ]
+      },
+      "total": {
+        "min_s": 0.336812041,
+        "median_s": 0.340155125,
+        "samples_s": [
+          0.336812041,
+          0.340946917,
+          0.340155125
+        ]
+      },
+      "compute_s": 0.29704620800000003,
+      "ns_per_op_min": 1259.9516796742453,
+      "ns_per_op_median": 1272.6708305055988,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 258973,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039258583,
+        "median_s": 0.040182375,
+        "samples_s": [
+          0.039258583,
+          0.040529292,
+          0.040182375
+        ]
+      },
+      "total": {
+        "min_s": 0.286175708,
+        "median_s": 0.287292875,
+        "samples_s": [
+          0.288117791,
+          0.287292875,
+          0.286175708
+        ]
+      },
+      "compute_s": 0.24691712499999996,
+      "ns_per_op_min": 953.4473671000451,
+      "ns_per_op_median": 954.1940665629236,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 266250,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040828667,
+        "median_s": 0.041041,
+        "samples_s": [
+          0.040828667,
+          0.042689125,
+          0.041041
+        ]
+      },
+      "total": {
+        "min_s": 0.313575,
+        "median_s": 0.315077,
+        "samples_s": [
+          0.313575,
+          0.316702167,
+          0.315077
+        ]
+      },
+      "compute_s": 0.272746333,
+      "ns_per_op_min": 1024.399372769953,
+      "ns_per_op_median": 1029.2431924882628,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 459986,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.029082125,
+        "median_s": 0.0298765,
+        "samples_s": [
+          0.029082125,
+          0.029978542,
+          0.0298765
+        ]
+      },
+      "total": {
+        "min_s": 0.311758292,
+        "median_s": 0.313286292,
+        "samples_s": [
+          0.313286292,
+          0.313914,
+          0.311758292
+        ]
+      },
+      "compute_s": 0.282676167,
+      "ns_per_op_min": 614.5321096729031,
+      "ns_per_op_median": 616.1269951694184,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 1028338,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040231334,
+        "median_s": 0.040431875,
+        "samples_s": [
+          0.040231334,
+          0.040675458,
+          0.040431875
+        ]
+      },
+      "total": {
+        "min_s": 0.266724541,
+        "median_s": 0.269436916,
+        "samples_s": [
+          0.27043475,
+          0.269436916,
+          0.266724541
+        ]
+      },
+      "compute_s": 0.22649320699999997,
+      "ns_per_op_min": 220.25171393063368,
+      "ns_per_op_median": 222.6943291019101,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 299368,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010920084,
+        "median_s": 0.01114275,
+        "samples_s": [
+          0.010920084,
+          0.012103833,
+          0.01114275
+        ]
+      },
+      "total": {
+        "min_s": 0.310468,
+        "median_s": 0.310920167,
+        "samples_s": [
+          0.311485666,
+          0.310920167,
+          0.310468
+        ]
+      },
+      "compute_s": 0.299547916,
+      "ns_per_op_min": 1000.6009860773363,
+      "ns_per_op_median": 1001.3676044199783,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 96940225,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.003707708,
+        "median_s": 0.004956791,
+        "samples_s": [
+          0.006145583,
+          0.004956791,
+          0.003707708
+        ]
+      },
+      "total": {
+        "min_s": 0.258844042,
+        "median_s": 0.258888,
+        "samples_s": [
+          0.259551833,
+          0.258888,
+          0.258844042
+        ]
+      },
+      "compute_s": 0.255136334,
+      "ns_per_op_min": 2.6318933548998884,
+      "ns_per_op_median": 2.6194617249959964,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 87673825,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.067396708,
+        "median_s": 0.067639042,
+        "samples_s": [
+          0.067639042,
+          0.067716125,
+          0.067396708
+        ]
+      },
+      "total": {
+        "min_s": 0.27311325,
+        "median_s": 0.273699167,
+        "samples_s": [
+          0.273699167,
+          0.275696833,
+          0.27311325
+        ]
+      },
+      "compute_s": 0.20571654199999997,
+      "ns_per_op_min": 2.3463849330173514,
+      "ns_per_op_median": 2.350303810743971,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 9690,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.013686583,
+        "median_s": 0.014496334,
+        "samples_s": [
+          0.014555791,
+          0.013686583,
+          0.014496334
+        ]
+      },
+      "total": {
+        "min_s": 0.280947334,
+        "median_s": 0.281486041,
+        "samples_s": [
+          0.282482375,
+          0.281486041,
+          0.280947334
+        ]
+      },
+      "compute_s": 0.267260751,
+      "ns_per_op_min": 27581.088854489168,
+      "ns_per_op_median": 27553.117337461303,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": 28128,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.153332875,
+        "median_s": 0.155830667,
+        "samples_s": [
+          0.155830667,
+          0.159999875,
+          0.153332875
+        ]
+      },
+      "total": {
+        "min_s": 0.451545458,
+        "median_s": 0.452055209,
+        "samples_s": [
+          0.452055209,
+          0.451545458,
+          0.452373666
+        ]
+      },
+      "compute_s": 0.298212583,
+      "ns_per_op_min": 10601.983184015928,
+      "ns_per_op_median": 10531.304820819114,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": 48196,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.217278708,
+        "median_s": 0.2187325,
+        "samples_s": [
+          0.220735834,
+          0.217278708,
+          0.2187325
+        ]
+      },
+      "total": {
+        "min_s": 0.454112875,
+        "median_s": 0.456046083,
+        "samples_s": [
+          0.456192792,
+          0.454112875,
+          0.456046083
+        ]
+      },
+      "compute_s": 0.23683416700000004,
+      "ns_per_op_min": 4913.979728608184,
+      "ns_per_op_median": 4923.926944144742,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": 9691,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.339762666,
+        "median_s": 0.34147475,
+        "samples_s": [
+          0.345277125,
+          0.34147475,
+          0.339762666
+        ]
+      },
+      "total": {
+        "min_s": 0.583886375,
+        "median_s": 0.584659625,
+        "samples_s": [
+          0.583886375,
+          0.584659625,
+          0.588194167
+        ]
+      },
+      "compute_s": 0.24412370899999997,
+      "ns_per_op_min": 25190.765555670205,
+      "ns_per_op_median": 25093.888659581058,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": 15988,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.390437208,
+        "median_s": 0.392473666,
+        "samples_s": [
+          0.390437208,
+          0.392473666,
+          0.392630333
+        ]
+      },
+      "total": {
+        "min_s": 0.581344084,
+        "median_s": 0.582772666,
+        "samples_s": [
+          0.581344084,
+          0.589169084,
+          0.582772666
+        ]
+      },
+      "compute_s": 0.19090687600000006,
+      "ns_per_op_min": 11940.63522641982,
+      "ns_per_op_median": 11902.614460845634,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 5260,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.044898083,
+        "median_s": 0.04583925,
+        "samples_s": [
+          0.04583925,
+          0.046731208,
+          0.044898083
+        ]
+      },
+      "total": {
+        "min_s": 0.35141525,
+        "median_s": 0.351743625,
+        "samples_s": [
+          0.35141525,
+          0.351743625,
+          0.352679875
+        ]
+      },
+      "compute_s": 0.30651716700000003,
+      "ns_per_op_min": 58273.22566539925,
+      "ns_per_op_median": 58156.7252851711,
+      "load_ms": 0.721,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 455,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.082430209,
+        "median_s": 0.083598167,
+        "samples_s": [
+          0.083727625,
+          0.083598167,
+          0.082430209
+        ]
+      },
+      "total": {
+        "min_s": 0.268457792,
+        "median_s": 0.269330667,
+        "samples_s": [
+          0.269330667,
+          0.270230875,
+          0.268457792
+        ]
+      },
+      "compute_s": 0.18602758299999997,
+      "ns_per_op_min": 408851.8307692307,
+      "ns_per_op_median": 408203.2967032968,
+      "load_ms": 3.66,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 12205,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.05350825,
+        "median_s": 0.053564542,
+        "samples_s": [
+          0.05350825,
+          0.053564542,
+          0.053904917
+        ]
+      },
+      "total": {
+        "min_s": 0.256731167,
+        "median_s": 0.257481583,
+        "samples_s": [
+          0.258173792,
+          0.257481583,
+          0.256731167
+        ]
+      },
+      "compute_s": 0.20322291699999998,
+      "ns_per_op_min": 16650.792052437522,
+      "ns_per_op_median": 16707.664154035236,
+      "load_ms": 4.268,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 30900,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.101438041,
+        "median_s": 0.101927833,
+        "samples_s": [
+          0.101928,
+          0.101927833,
+          0.101438041
+        ]
+      },
+      "total": {
+        "min_s": 0.385970292,
+        "median_s": 0.387419084,
+        "samples_s": [
+          0.385970292,
+          0.387419084,
+          0.387799583
+        ]
+      },
+      "compute_s": 0.284532251,
+      "ns_per_op_min": 9208.163462783172,
+      "ns_per_op_median": 9239.199061488674,
+      "load_ms": 9.481,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 36187407,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005183834,
+        "median_s": 0.005830792,
+        "samples_s": [
+          0.005183834,
+          0.005830792,
+          0.006319667
+        ]
+      },
+      "total": {
+        "min_s": 0.305004083,
+        "median_s": 0.305008542,
+        "samples_s": [
+          0.305004083,
+          0.305008542,
+          0.305177584
+        ]
+      },
+      "compute_s": 0.299820249,
+      "ns_per_op_min": 8.285209520538457,
+      "ns_per_op_median": 8.267454752975254,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 35952591,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009161583,
+        "median_s": 0.0093475,
+        "samples_s": [
+          0.0093475,
+          0.009605416,
+          0.009161583
+        ]
+      },
+      "total": {
+        "min_s": 0.307011167,
+        "median_s": 0.307081416,
+        "samples_s": [
+          0.310064916,
+          0.307011167,
+          0.307081416
+        ]
+      },
+      "compute_s": 0.297849584,
+      "ns_per_op_min": 8.28450956427591,
+      "ns_per_op_median": 8.281292327443104,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1662336,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.01579575,
+        "median_s": 0.016286416,
+        "samples_s": [
+          0.016687041,
+          0.016286416,
+          0.01579575
+        ]
+      },
+      "total": {
+        "min_s": 0.315300625,
+        "median_s": 0.316561875,
+        "samples_s": [
+          0.316916208,
+          0.315300625,
+          0.316561875
+        ]
+      },
+      "compute_s": 0.299504875,
+      "ns_per_op_min": 180.17108153826905,
+      "ns_per_op_median": 180.6346364393239,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 36083066,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004856542,
+        "median_s": 0.005273583,
+        "samples_s": [
+          0.004856542,
+          0.005273583,
+          0.005656709
+        ]
+      },
+      "total": {
+        "min_s": 0.305205375,
+        "median_s": 0.30555525,
+        "samples_s": [
+          0.305205375,
+          0.30555525,
+          0.305827917
+        ]
+      },
+      "compute_s": 0.300348833,
+      "ns_per_op_min": 8.323816856361375,
+      "ns_per_op_median": 8.321955429175558,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 14261590,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004291166,
+        "median_s": 0.004458583,
+        "samples_s": [
+          0.004458583,
+          0.004291166,
+          0.004478917
+        ]
+      },
+      "total": {
+        "min_s": 0.234227416,
+        "median_s": 0.234942917,
+        "samples_s": [
+          0.234227416,
+          0.234942917,
+          0.235360375
+        ]
+      },
+      "compute_s": 0.22993624999999998,
+      "ns_per_op_min": 16.122764011586362,
+      "ns_per_op_median": 16.161194789641268,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 165828,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039949542,
+        "median_s": 0.040259334,
+        "samples_s": [
+          0.039949542,
+          0.040259334,
+          0.041329042
+        ]
+      },
+      "total": {
+        "min_s": 0.319037416,
+        "median_s": 0.321744291,
+        "samples_s": [
+          0.325851375,
+          0.319037416,
+          0.321744291
+        ]
+      },
+      "compute_s": 0.279087874,
+      "ns_per_op_min": 1682.9960802759485,
+      "ns_per_op_median": 1697.4513170272817,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 183238,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039640834,
+        "median_s": 0.039980041,
+        "samples_s": [
+          0.040278,
+          0.039640834,
+          0.039980041
+        ]
+      },
+      "total": {
+        "min_s": 0.242375292,
+        "median_s": 0.248737542,
+        "samples_s": [
+          0.248737542,
+          0.242375292,
+          0.249690167
+        ]
+      },
+      "compute_s": 0.202734458,
+      "ns_per_op_min": 1106.3996441786092,
+      "ns_per_op_median": 1139.2696984249992,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 186417,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040132292,
+        "median_s": 0.040641292,
+        "samples_s": [
+          0.04174125,
+          0.040641292,
+          0.040132292
+        ]
+      },
+      "total": {
+        "min_s": 0.301268292,
+        "median_s": 0.302397458,
+        "samples_s": [
+          0.301268292,
+          0.303101917,
+          0.302397458
+        ]
+      },
+      "compute_s": 0.261136,
+      "ns_per_op_min": 1400.8164491435866,
+      "ns_per_op_median": 1404.1432165521385,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 290159,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.029721208,
+        "median_s": 0.030101625,
+        "samples_s": [
+          0.030101625,
+          0.029721208,
+          0.031205
+        ]
+      },
+      "total": {
+        "min_s": 0.328600834,
+        "median_s": 0.329965458,
+        "samples_s": [
+          0.329965458,
+          0.332621917,
+          0.328600834
+        ]
+      },
+      "compute_s": 0.298879626,
+      "ns_per_op_min": 1030.0546459010404,
+      "ns_per_op_median": 1033.44660341399,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 715479,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.041084541,
+        "median_s": 0.041598792,
+        "samples_s": [
+          0.041598792,
+          0.041084541,
+          0.041761334
+        ]
+      },
+      "total": {
+        "min_s": 0.233071,
+        "median_s": 0.233252666,
+        "samples_s": [
+          0.234729459,
+          0.233252666,
+          0.233071
+        ]
+      },
+      "compute_s": 0.191986459,
+      "ns_per_op_min": 268.33276588131866,
+      "ns_per_op_median": 267.8679234470893,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 200301,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010990541,
+        "median_s": 0.011196875,
+        "samples_s": [
+          0.011630916,
+          0.011196875,
+          0.010990541
+        ]
+      },
+      "total": {
+        "min_s": 0.313943667,
+        "median_s": 0.314665,
+        "samples_s": [
+          0.316549708,
+          0.313943667,
+          0.314665
+        ]
+      },
+      "compute_s": 0.30295312599999996,
+      "ns_per_op_min": 1512.4893335530023,
+      "ns_per_op_median": 1515.0604590091912,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 33385589,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.00305875,
+        "median_s": 0.004620166,
+        "samples_s": [
+          0.00305875,
+          0.004620166,
+          0.004632291
+        ]
+      },
+      "total": {
+        "min_s": 0.279835042,
+        "median_s": 0.279858458,
+        "samples_s": [
+          0.279835042,
+          0.279858458,
+          0.280406042
+        ]
+      },
+      "compute_s": 0.276776292,
+      "ns_per_op_min": 8.290292317442715,
+      "ns_per_op_median": 8.244224536520832,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 21095517,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.065511333,
+        "median_s": 0.066640875,
+        "samples_s": [
+          0.066640875,
+          0.067066792,
+          0.065511333
+        ]
+      },
+      "total": {
+        "min_s": 0.250703958,
+        "median_s": 0.251088792,
+        "samples_s": [
+          0.250703958,
+          0.251088792,
+          0.253244417
+        ]
+      },
+      "compute_s": 0.185192625,
+      "ns_per_op_min": 8.778766834678667,
+      "ns_per_op_median": 8.743465116308837,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 3721,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.012820416,
+        "median_s": 0.013169875,
+        "samples_s": [
+          0.013169875,
+          0.012820416,
+          0.013389917
+        ]
+      },
+      "total": {
+        "min_s": 0.299869959,
+        "median_s": 0.3001995,
+        "samples_s": [
+          0.299869959,
+          0.3001995,
+          0.301451042
+        ]
+      },
+      "compute_s": 0.287049543,
+      "ns_per_op_min": 77143.11824778286,
+      "ns_per_op_median": 77137.76538564902,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": 21976,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.151776834,
+        "median_s": 0.153203958,
+        "samples_s": [
+          0.151776834,
+          0.153203958,
+          0.153434625
+        ]
+      },
+      "total": {
+        "min_s": 0.441212209,
+        "median_s": 0.445617167,
+        "samples_s": [
+          0.445617167,
+          0.441212209,
+          0.446080667
+        ]
+      },
+      "compute_s": 0.28943537500000005,
+      "ns_per_op_min": 13170.521250455045,
+      "ns_per_op_median": 13306.025163815071,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": 32021,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.21238075,
+        "median_s": 0.213861708,
+        "samples_s": [
+          0.216835667,
+          0.21238075,
+          0.213861708
+        ]
+      },
+      "total": {
+        "min_s": 0.415572541,
+        "median_s": 0.417211333,
+        "samples_s": [
+          0.419396667,
+          0.417211333,
+          0.415572541
+        ]
+      },
+      "compute_s": 0.203191791,
+      "ns_per_op_min": 6345.579182411542,
+      "ns_per_op_median": 6350.508260204241,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": 11369,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.339408583,
+        "median_s": 0.340768417,
+        "samples_s": [
+          0.341198458,
+          0.339408583,
+          0.340768417
+        ]
+      },
+      "total": {
+        "min_s": 0.688442666,
+        "median_s": 0.688963042,
+        "samples_s": [
+          0.688442666,
+          0.688963042,
+          0.693090458
+        ]
+      },
+      "compute_s": 0.34903408300000005,
+      "ns_per_op_min": 30700.50866391064,
+      "ns_per_op_median": 30626.671211188324,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": 10754,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.387778209,
+        "median_s": 0.388300041,
+        "samples_s": [
+          0.387778209,
+          0.388300041,
+          0.3904245
+        ]
+      },
+      "total": {
+        "min_s": 0.604135083,
+        "median_s": 0.604269458,
+        "samples_s": [
+          0.613623167,
+          0.604135083,
+          0.604269458
+        ]
+      },
+      "compute_s": 0.21635687399999998,
+      "ns_per_op_min": 20118.734796354842,
+      "ns_per_op_median": 20082.70569090571,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 4194,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.043038042,
+        "median_s": 0.04477975,
+        "samples_s": [
+          0.044994333,
+          0.043038042,
+          0.04477975
+        ]
+      },
+      "total": {
+        "min_s": 0.323459167,
+        "median_s": 0.325072,
+        "samples_s": [
+          0.323459167,
+          0.325072,
+          0.326822625
+        ]
+      },
+      "compute_s": 0.280421125,
+      "ns_per_op_min": 66862.45231282785,
+      "ns_per_op_median": 66831.72389127324,
+      "load_ms": 0.698,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 463,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.079158583,
+        "median_s": 0.080209167,
+        "samples_s": [
+          0.081803916,
+          0.079158583,
+          0.080209167
+        ]
+      },
+      "total": {
+        "min_s": 0.270874708,
+        "median_s": 0.274199208,
+        "samples_s": [
+          0.274199208,
+          0.276454958,
+          0.270874708
+        ]
+      },
+      "compute_s": 0.19171612500000001,
+      "ns_per_op_min": 414073.7041036718,
+      "ns_per_op_median": 418984.96976241906,
+      "load_ms": 3.941,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wardite",
+      "status": "skipped",
+      "reason": "excluded: wardite 0.9.0 computes i64.div_s at f64 precision, wrong for operands beyond 2^53: i64.div_s(0x8000000000000000, 3) gives -3074457345618258432 where -3074457345618258602 is correct"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wardite-yjit",
+      "status": "skipped",
+      "reason": "excluded: wardite 0.9.0 computes i64.div_s at f64 precision, wrong for operands beyond 2^53: i64.div_s(0x8000000000000000, 3) gives -3074457345618258432 where -3074457345618258602 is correct"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 197866562,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005288125,
+        "median_s": 0.00589075,
+        "samples_s": [
+          0.00589075,
+          0.005288125,
+          0.006040834
+        ]
+      },
+      "total": {
+        "min_s": 0.301534417,
+        "median_s": 0.302737166,
+        "samples_s": [
+          0.301534417,
+          0.303160708,
+          0.302737166
+        ]
+      },
+      "compute_s": 0.296246292,
+      "ns_per_op_min": 1.49720240249588,
+      "ns_per_op_median": 1.5002353757983626,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 182896153,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009005959,
+        "median_s": 0.009767708,
+        "samples_s": [
+          0.009767708,
+          0.010069875,
+          0.009005959
+        ]
+      },
+      "total": {
+        "min_s": 0.297908959,
+        "median_s": 0.298304,
+        "samples_s": [
+          0.297908959,
+          0.29883975,
+          0.298304
+        ]
+      },
+      "compute_s": 0.28890299999999997,
+      "ns_per_op_min": 1.579601294292942,
+      "ns_per_op_median": 1.5775962876594785,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1097745,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015558,
+        "median_s": 0.016013333,
+        "samples_s": [
+          0.016013333,
+          0.016746,
+          0.015558
+        ]
+      },
+      "total": {
+        "min_s": 0.302564708,
+        "median_s": 0.302979458,
+        "samples_s": [
+          0.302979458,
+          0.302564708,
+          0.303222417
+        ]
+      },
+      "compute_s": 0.287006708,
+      "ns_per_op_min": 261.4511639770621,
+      "ns_per_op_median": 261.41419455337984,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 120287021,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005209292,
+        "median_s": 0.005377792,
+        "samples_s": [
+          0.005377792,
+          0.005724875,
+          0.005209292
+        ]
+      },
+      "total": {
+        "min_s": 0.306354834,
+        "median_s": 0.3088145,
+        "samples_s": [
+          0.309477334,
+          0.306354834,
+          0.3088145
+        ]
+      },
+      "compute_s": 0.30114554200000004,
+      "ns_per_op_min": 2.5035580688293884,
+      "ns_per_op_median": 2.5226055602457724,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 14577052,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.00441275,
+        "median_s": 0.00454875,
+        "samples_s": [
+          0.004608583,
+          0.00454875,
+          0.00441275
+        ]
+      },
+      "total": {
+        "min_s": 0.298055541,
+        "median_s": 0.298117292,
+        "samples_s": [
+          0.298117292,
+          0.298055541,
+          0.298223375
+        ]
+      },
+      "compute_s": 0.29364279099999996,
+      "ns_per_op_min": 20.144182170715997,
+      "ns_per_op_median": 20.139088616820466,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 715050,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039532167,
+        "median_s": 0.040457375,
+        "samples_s": [
+          0.039532167,
+          0.041156875,
+          0.040457375
+        ]
+      },
+      "total": {
+        "min_s": 0.350107,
+        "median_s": 0.350476541,
+        "samples_s": [
+          0.351013208,
+          0.350107,
+          0.350476541
+        ]
+      },
+      "compute_s": 0.310574833,
+      "ns_per_op_min": 434.3400223760576,
+      "ns_per_op_median": 433.5629200755191,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 839357,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039783541,
+        "median_s": 0.040366916,
+        "samples_s": [
+          0.041254208,
+          0.040366916,
+          0.039783541
+        ]
+      },
+      "total": {
+        "min_s": 0.298573917,
+        "median_s": 0.299128541,
+        "samples_s": [
+          0.299128541,
+          0.298573917,
+          0.299348416
+        ]
+      },
+      "compute_s": 0.25879037600000004,
+      "ns_per_op_min": 308.3197924125253,
+      "ns_per_op_median": 308.2855388112567,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 808241,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.04028575,
+        "median_s": 0.041039584,
+        "samples_s": [
+          0.04028575,
+          0.041039584,
+          0.041183
+        ]
+      },
+      "total": {
+        "min_s": 0.311223416,
+        "median_s": 0.312749875,
+        "samples_s": [
+          0.311223416,
+          0.315744167,
+          0.312749875
+        ]
+      },
+      "compute_s": 0.27093766599999997,
+      "ns_per_op_min": 335.2189087165832,
+      "ns_per_op_median": 336.17484265212977,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 156625,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.02922225,
+        "median_s": 0.0294465,
+        "samples_s": [
+          0.0294465,
+          0.029536166,
+          0.02922225
+        ]
+      },
+      "total": {
+        "min_s": 0.328136042,
+        "median_s": 0.331259958,
+        "samples_s": [
+          0.331259958,
+          0.331991958,
+          0.328136042
+        ]
+      },
+      "compute_s": 0.298913792,
+      "ns_per_op_min": 1908.4679457302475,
+      "ns_per_op_median": 1926.9813758978455,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 3203405,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040648167,
+        "median_s": 0.041901542,
+        "samples_s": [
+          0.040648167,
+          0.041901542,
+          0.041974625
+        ]
+      },
+      "total": {
+        "min_s": 0.274535625,
+        "median_s": 0.275064167,
+        "samples_s": [
+          0.274535625,
+          0.275064167,
+          0.275584792
+        ]
+      },
+      "compute_s": 0.233887458,
+      "ns_per_op_min": 73.01214114356442,
+      "ns_per_op_median": 72.78587159600488,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 94648,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010462333,
+        "median_s": 0.010595042,
+        "samples_s": [
+          0.010462333,
+          0.010595042,
+          0.010994666
+        ]
+      },
+      "total": {
+        "min_s": 0.315582,
+        "median_s": 0.315907042,
+        "samples_s": [
+          0.315907042,
+          0.316154333,
+          0.315582
+        ]
+      },
+      "compute_s": 0.305119667,
+      "ns_per_op_min": 3223.7307391598342,
+      "ns_per_op_median": 3225.7628264728255,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 99145868,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.003444709,
+        "median_s": 0.004391958,
+        "samples_s": [
+          0.004391958,
+          0.004434875,
+          0.003444709
+        ]
+      },
+      "total": {
+        "min_s": 0.250514791,
+        "median_s": 0.251153792,
+        "samples_s": [
+          0.251153792,
+          0.251384375,
+          0.250514791
+        ]
+      },
+      "compute_s": 0.24707008200000002,
+      "ns_per_op_min": 2.4919856670174094,
+      "ns_per_op_median": 2.4888766317523188,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 43951401,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.065710833,
+        "median_s": 0.066855333,
+        "samples_s": [
+          0.066855333,
+          0.0675915,
+          0.065710833
+        ]
+      },
+      "total": {
+        "min_s": 0.261305208,
+        "median_s": 0.261999791,
+        "samples_s": [
+          0.261305208,
+          0.263935083,
+          0.261999791
+        ]
+      },
+      "compute_s": 0.19559437500000001,
+      "ns_per_op_min": 4.450242098084655,
+      "ns_per_op_median": 4.440005405060921,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 5861,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.012444209,
+        "median_s": 0.012472334,
+        "samples_s": [
+          0.012444209,
+          0.012658667,
+          0.012472334
+        ]
+      },
+      "total": {
+        "min_s": 0.315369584,
+        "median_s": 0.315964083,
+        "samples_s": [
+          0.316504458,
+          0.315964083,
+          0.315369584
+        ]
+      },
+      "compute_s": 0.302925375,
+      "ns_per_op_min": 51684.930046067224,
+      "ns_per_op_median": 51781.56440880397,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": 12076,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.178927,
+        "median_s": 0.179322625,
+        "samples_s": [
+          0.179322625,
+          0.178927,
+          0.18003625
+        ]
+      },
+      "total": {
+        "min_s": 0.380206542,
+        "median_s": 0.382577209,
+        "samples_s": [
+          0.383685,
+          0.382577209,
+          0.380206542
+        ]
+      },
+      "compute_s": 0.20127954199999998,
+      "ns_per_op_min": 16667.732858562435,
+      "ns_per_op_median": 16831.283868830735,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": 33510,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.232409542,
+        "median_s": 0.235454292,
+        "samples_s": [
+          0.232409542,
+          0.236555709,
+          0.235454292
+        ]
+      },
+      "total": {
+        "min_s": 0.475282209,
+        "median_s": 0.477529958,
+        "samples_s": [
+          0.479260125,
+          0.475282209,
+          0.477529958
+        ]
+      },
+      "compute_s": 0.24287266700000001,
+      "ns_per_op_min": 7247.766845717696,
+      "ns_per_op_median": 7223.982870784839,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": 5183,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.389138958,
+        "median_s": 0.391994625,
+        "samples_s": [
+          0.389138958,
+          0.391994625,
+          0.395296958
+        ]
+      },
+      "total": {
+        "min_s": 0.629606125,
+        "median_s": 0.634011584,
+        "samples_s": [
+          0.634011584,
+          0.639185833,
+          0.629606125
+        ]
+      },
+      "compute_s": 0.24046716700000004,
+      "ns_per_op_min": 46395.36311016786,
+      "ns_per_op_median": 46694.37758055181,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": 10416,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.38670075,
+        "median_s": 0.386836334,
+        "samples_s": [
+          0.386836334,
+          0.38670075,
+          0.388737875
+        ]
+      },
+      "total": {
+        "min_s": 0.598963958,
+        "median_s": 0.599030167,
+        "samples_s": [
+          0.604965583,
+          0.599030167,
+          0.598963958
+        ]
+      },
+      "compute_s": 0.21226320800000004,
+      "ns_per_op_min": 20378.572196620586,
+      "ns_per_op_median": 20371.9117703533,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 3599,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.045053,
+        "median_s": 0.045475041,
+        "samples_s": [
+          0.0457585,
+          0.045475041,
+          0.045053
+        ]
+      },
+      "total": {
+        "min_s": 0.359852833,
+        "median_s": 0.361360875,
+        "samples_s": [
+          0.361360875,
+          0.359852833,
+          0.361646625
+        ]
+      },
+      "compute_s": 0.314799833,
+      "ns_per_op_min": 87468.69491525424,
+      "ns_per_op_median": 87770.4456793554,
+      "load_ms": 0.762,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 4086,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.078859625,
+        "median_s": 0.081558959,
+        "samples_s": [
+          0.078859625,
+          0.082152875,
+          0.081558959
+        ]
+      },
+      "total": {
+        "min_s": 0.273322375,
+        "median_s": 0.274166208,
+        "samples_s": [
+          0.274166208,
+          0.273322375,
+          0.274211541
+        ]
+      },
+      "compute_s": 0.19446275000000002,
+      "ns_per_op_min": 47592.44982868332,
+      "ns_per_op_median": 47138.337983357815,
+      "load_ms": 4.813,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 9442,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.053537833,
+        "median_s": 0.053748209,
+        "samples_s": [
+          0.054453292,
+          0.053537833,
+          0.053748209
+        ]
+      },
+      "total": {
+        "min_s": 0.320172917,
+        "median_s": 0.321895834,
+        "samples_s": [
+          0.321895834,
+          0.322700708,
+          0.320172917
+        ]
+      },
+      "compute_s": 0.266635084,
+      "ns_per_op_min": 28239.2590552849,
+      "ns_per_op_median": 28399.451916966744,
+      "load_ms": 4.384,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 21940,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.103073917,
+        "median_s": 0.10341325,
+        "samples_s": [
+          0.103539334,
+          0.103073917,
+          0.10341325
+        ]
+      },
+      "total": {
+        "min_s": 0.424861292,
+        "median_s": 0.426254042,
+        "samples_s": [
+          0.426254042,
+          0.426486292,
+          0.424861292
+        ]
+      },
+      "compute_s": 0.321787375,
+      "ns_per_op_min": 14666.698951686418,
+      "ns_per_op_median": 14714.712488605288,
+      "load_ms": 9.354,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 284180286,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005734916,
+        "median_s": 0.005927084,
+        "samples_s": [
+          0.005734916,
+          0.005927084,
+          0.005976458
+        ]
+      },
+      "total": {
+        "min_s": 0.29227975,
+        "median_s": 0.292774875,
+        "samples_s": [
+          0.292774875,
+          0.29227975,
+          0.294689083
+        ]
+      },
+      "compute_s": 0.286544834,
+      "ns_per_op_min": 1.0083205912460795,
+      "ns_per_op_median": 1.0093866644922722,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 286572989,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009160084,
+        "median_s": 0.009172083,
+        "samples_s": [
+          0.009819333,
+          0.009160084,
+          0.009172083
+        ]
+      },
+      "total": {
+        "min_s": 0.297449584,
+        "median_s": 0.297492542,
+        "samples_s": [
+          0.298600708,
+          0.297492542,
+          0.297449584
+        ]
+      },
+      "compute_s": 0.2882895,
+      "ns_per_op_min": 1.005989786427499,
+      "ns_per_op_median": 1.0060978182420395,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 2246338,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015545167,
+        "median_s": 0.015572667,
+        "samples_s": [
+          0.016402375,
+          0.015545167,
+          0.015572667
+        ]
+      },
+      "total": {
+        "min_s": 0.301589958,
+        "median_s": 0.301945708,
+        "samples_s": [
+          0.301945708,
+          0.301589958,
+          0.302278959
+        ]
+      },
+      "compute_s": 0.28604479099999996,
+      "ns_per_op_min": 127.33826832827471,
+      "ns_per_op_median": 127.4843950465157,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 193108533,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004891917,
+        "median_s": 0.005427792,
+        "samples_s": [
+          0.005427792,
+          0.004891917,
+          0.005637542
+        ]
+      },
+      "total": {
+        "min_s": 0.303891333,
+        "median_s": 0.305305083,
+        "samples_s": [
+          0.305445417,
+          0.303891333,
+          0.305305083
+        ]
+      },
+      "compute_s": 0.29899941599999996,
+      "ns_per_op_min": 1.548349062337913,
+      "ns_per_op_median": 1.5528950810267923,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 33554432,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004647584,
+        "median_s": 0.004723417,
+        "samples_s": [
+          0.004918292,
+          0.004723417,
+          0.004647584
+        ]
+      },
+      "total": {
+        "min_s": 0.336834834,
+        "median_s": 0.337407041,
+        "samples_s": [
+          0.338226083,
+          0.336834834,
+          0.337407041
+        ]
+      },
+      "compute_s": 0.33218725000000004,
+      "ns_per_op_min": 9.899951517581941,
+      "ns_per_op_median": 9.91474461555481,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 1737235,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040112125,
+        "median_s": 0.040540666,
+        "samples_s": [
+          0.040112125,
+          0.040774583,
+          0.040540666
+        ]
+      },
+      "total": {
+        "min_s": 0.352155708,
+        "median_s": 0.352495042,
+        "samples_s": [
+          0.352495042,
+          0.352155708,
+          0.353098041
+        ]
+      },
+      "compute_s": 0.312043583,
+      "ns_per_op_min": 179.62082447107042,
+      "ns_per_op_median": 179.569474481,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 2475521,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.04032175,
+        "median_s": 0.040818208,
+        "samples_s": [
+          0.040818208,
+          0.04032175,
+          0.041096958
+        ]
+      },
+      "total": {
+        "min_s": 0.373454125,
+        "median_s": 0.374722875,
+        "samples_s": [
+          0.373454125,
+          0.375517833,
+          0.374722875
+        ]
+      },
+      "compute_s": 0.33313237500000004,
+      "ns_per_op_min": 134.57061160054795,
+      "ns_per_op_median": 134.8825831006887,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 2105621,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040316875,
+        "median_s": 0.04094775,
+        "samples_s": [
+          0.040316875,
+          0.04094775,
+          0.041064625
+        ]
+      },
+      "total": {
+        "min_s": 0.339703125,
+        "median_s": 0.33979775,
+        "samples_s": [
+          0.339703125,
+          0.33979775,
+          0.342800792
+        ]
+      },
+      "compute_s": 0.29938624999999996,
+      "ns_per_op_min": 142.18430097344202,
+      "ns_per_op_median": 141.92962551190362,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 389292,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.029400167,
+        "median_s": 0.029722208,
+        "samples_s": [
+          0.029722208,
+          0.030101709,
+          0.029400167
+        ]
+      },
+      "total": {
+        "min_s": 0.32525325,
+        "median_s": 0.330642625,
+        "samples_s": [
+          0.331298959,
+          0.32525325,
+          0.330642625
+        ]
+      },
+      "compute_s": 0.295853083,
+      "ns_per_op_min": 759.9772998160763,
+      "ns_per_op_median": 772.9940944072831,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 5417848,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040998875,
+        "median_s": 0.04182675,
+        "samples_s": [
+          0.042076417,
+          0.040998875,
+          0.04182675
+        ]
+      },
+      "total": {
+        "min_s": 0.336687584,
+        "median_s": 0.336707542,
+        "samples_s": [
+          0.336687584,
+          0.34058475,
+          0.336707542
+        ]
+      },
+      "compute_s": 0.295688709,
+      "ns_per_op_min": 54.576781962137,
+      "ns_per_op_median": 54.42766057667177,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 295649,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010304375,
+        "median_s": 0.010325833,
+        "samples_s": [
+          0.010696833,
+          0.010304375,
+          0.010325833
+        ]
+      },
+      "total": {
+        "min_s": 0.306445625,
+        "median_s": 0.306632167,
+        "samples_s": [
+          0.306445625,
+          0.310940167,
+          0.306632167
+        ]
+      },
+      "compute_s": 0.29614125,
+      "ns_per_op_min": 1001.6649811093561,
+      "ns_per_op_median": 1002.223359456653,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 157221506,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004086875,
+        "median_s": 0.004151708,
+        "samples_s": [
+          0.006111084,
+          0.004086875,
+          0.004151708
+        ]
+      },
+      "total": {
+        "min_s": 0.240369833,
+        "median_s": 0.240931584,
+        "samples_s": [
+          0.240931584,
+          0.240369833,
+          0.242043208
+        ]
+      },
+      "compute_s": 0.23628295800000002,
+      "ns_per_op_min": 1.502866649808074,
+      "ns_per_op_median": 1.5060272733935012,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 145104918,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.066408708,
+        "median_s": 0.066568292,
+        "samples_s": [
+          0.066408708,
+          0.066568292,
+          0.068080084
+        ]
+      },
+      "total": {
+        "min_s": 0.323686708,
+        "median_s": 0.325959,
+        "samples_s": [
+          0.326100709,
+          0.323686708,
+          0.325959
+        ]
+      },
+      "compute_s": 0.257278,
+      "ns_per_op_min": 1.7730481057850844,
+      "ns_per_op_median": 1.787607970668506,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 9223,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.012371667,
+        "median_s": 0.012840708,
+        "samples_s": [
+          0.012371667,
+          0.012840708,
+          0.012950708
+        ]
+      },
+      "total": {
+        "min_s": 0.306261625,
+        "median_s": 0.306638084,
+        "samples_s": [
+          0.306261625,
+          0.306638084,
+          0.3070985
+        ]
+      },
+      "compute_s": 0.293889958,
+      "ns_per_op_min": 31864.898406158518,
+      "ns_per_op_median": 31854.86024070259,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": 44000,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.17732325,
+        "median_s": 0.177515542,
+        "samples_s": [
+          0.177515542,
+          0.17732325,
+          0.180754583
+        ]
+      },
+      "total": {
+        "min_s": 0.526634625,
+        "median_s": 0.528387833,
+        "samples_s": [
+          0.53193925,
+          0.528387833,
+          0.526634625
+        ]
+      },
+      "compute_s": 0.34931137500000004,
+      "ns_per_op_min": 7938.894886363638,
+      "ns_per_op_median": 7974.370250000002,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": 89670,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.221085,
+        "median_s": 0.222517583,
+        "samples_s": [
+          0.221085,
+          0.224422042,
+          0.222517583
+        ]
+      },
+      "total": {
+        "min_s": 0.499515083,
+        "median_s": 0.506000791,
+        "samples_s": [
+          0.499515083,
+          0.51175525,
+          0.506000791
+        ]
+      },
+      "compute_s": 0.27843008300000005,
+      "ns_per_op_min": 3105.052782424446,
+      "ns_per_op_median": 3161.405241440838,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": 12941,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.392412916,
+        "median_s": 0.393015709,
+        "samples_s": [
+          0.392412916,
+          0.393180458,
+          0.393015709
+        ]
+      },
+      "total": {
+        "min_s": 0.67896825,
+        "median_s": 0.683618625,
+        "samples_s": [
+          0.686243875,
+          0.67896825,
+          0.683618625
+        ]
+      },
+      "compute_s": 0.28655533400000005,
+      "ns_per_op_min": 22143.214125647173,
+      "ns_per_op_median": 22455.986090719423,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": 33816,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.38931425,
+        "median_s": 0.391840667,
+        "samples_s": [
+          0.38931425,
+          0.391840667,
+          0.394455458
+        ]
+      },
+      "total": {
+        "min_s": 0.587360916,
+        "median_s": 0.59190275,
+        "samples_s": [
+          0.592981125,
+          0.59190275,
+          0.587360916
+        ]
+      },
+      "compute_s": 0.19804666599999998,
+      "ns_per_op_min": 5856.59646321268,
+      "ns_per_op_median": 5916.1959723207965,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 6069,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.042769541,
+        "median_s": 0.04404675,
+        "samples_s": [
+          0.042769541,
+          0.04404675,
+          0.044537375
+        ]
+      },
+      "total": {
+        "min_s": 0.283730333,
+        "median_s": 0.286167416,
+        "samples_s": [
+          0.289115333,
+          0.286167416,
+          0.283730333
+        ]
+      },
+      "compute_s": 0.240960792,
+      "ns_per_op_min": 39703.541275333664,
+      "ns_per_op_median": 39894.65579172846,
+      "load_ms": 0.691,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 30798,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.081179459,
+        "median_s": 0.08142,
+        "samples_s": [
+          0.08142,
+          0.081179459,
+          0.081863083
+        ]
+      },
+      "total": {
+        "min_s": 0.329030042,
+        "median_s": 0.330583959,
+        "samples_s": [
+          0.329030042,
+          0.332288167,
+          0.330583959
+        ]
+      },
+      "compute_s": 0.247850583,
+      "ns_per_op_min": 8047.619423339178,
+      "ns_per_op_median": 8090.2642704071695,
+      "load_ms": 4.789,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 26680,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.052269166,
+        "median_s": 0.052822334,
+        "samples_s": [
+          0.052269166,
+          0.053106209,
+          0.052822334
+        ]
+      },
+      "total": {
+        "min_s": 0.405024208,
+        "median_s": 0.40503625,
+        "samples_s": [
+          0.409436875,
+          0.40503625,
+          0.405024208
+        ]
+      },
+      "compute_s": 0.352755042,
+      "ns_per_op_min": 13221.703223388306,
+      "ns_per_op_median": 13201.421139430282,
+      "load_ms": 3.935,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 42768,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.10279275,
+        "median_s": 0.103285625,
+        "samples_s": [
+          0.103285625,
+          0.103957542,
+          0.10279275
+        ]
+      },
+      "total": {
+        "min_s": 0.370663416,
+        "median_s": 0.371614833,
+        "samples_s": [
+          0.370663416,
+          0.371614833,
+          0.372523333
+        ]
+      },
+      "compute_s": 0.26787066600000004,
+      "ns_per_op_min": 6263.343294051628,
+      "ns_per_op_median": 6274.064908342686,
+      "load_ms": 9.384,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 3075042,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005586625,
+        "median_s": 0.005853541,
+        "samples_s": [
+          0.005853541,
+          0.005586625,
+          0.006026791
+        ]
+      },
+      "total": {
+        "min_s": 0.301878041,
+        "median_s": 0.30214425,
+        "samples_s": [
+          0.301878041,
+          0.30214425,
+          0.302374958
+        ]
+      },
+      "compute_s": 0.296291416,
+      "ns_per_op_min": 96.35361598313129,
+      "ns_per_op_median": 96.35338606757242,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 3070839,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009455916,
+        "median_s": 0.009559958,
+        "samples_s": [
+          0.009559958,
+          0.01016425,
+          0.009455916
+        ]
+      },
+      "total": {
+        "min_s": 0.305106416,
+        "median_s": 0.305521167,
+        "samples_s": [
+          0.305106416,
+          0.305678458,
+          0.305521167
+        ]
+      },
+      "compute_s": 0.2956505,
+      "ns_per_op_min": 96.27678298992555,
+      "ns_per_op_median": 96.37796348164133,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 87134,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015389041,
+        "median_s": 0.015783417,
+        "samples_s": [
+          0.015783417,
+          0.016179334,
+          0.015389041
+        ]
+      },
+      "total": {
+        "min_s": 0.337788,
+        "median_s": 0.338009666,
+        "samples_s": [
+          0.340925208,
+          0.337788,
+          0.338009666
+        ]
+      },
+      "compute_s": 0.322398959,
+      "ns_per_op_min": 3700.0362545045564,
+      "ns_per_op_median": 3698.054135010443,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 2465523,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004829792,
+        "median_s": 0.00496775,
+        "samples_s": [
+          0.005635875,
+          0.00496775,
+          0.004829792
+        ]
+      },
+      "total": {
+        "min_s": 0.269712541,
+        "median_s": 0.27046025,
+        "samples_s": [
+          0.269712541,
+          0.27087725,
+          0.27046025
+        ]
+      },
+      "compute_s": 0.264882749,
+      "ns_per_op_min": 107.4347102014461,
+      "ns_per_op_median": 107.68202121821619,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 653731,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004362709,
+        "median_s": 0.004580917,
+        "samples_s": [
+          0.004697292,
+          0.004580917,
+          0.004362709
+        ]
+      },
+      "total": {
+        "min_s": 0.300247334,
+        "median_s": 0.300737667,
+        "samples_s": [
+          0.300737667,
+          0.300738041,
+          0.300247334
+        ]
+      },
+      "compute_s": 0.29588462499999996,
+      "ns_per_op_min": 452.6091389271733,
+      "ns_per_op_median": 453.02540341516607,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 65536,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040927667,
+        "median_s": 0.041059458,
+        "samples_s": [
+          0.041158625,
+          0.040927667,
+          0.041059458
+        ]
+      },
+      "total": {
+        "min_s": 0.338078,
+        "median_s": 0.338102959,
+        "samples_s": [
+          0.339113833,
+          0.338102959,
+          0.338078
+        ]
+      },
+      "compute_s": 0.297150333,
+      "ns_per_op_min": 4534.154251098633,
+      "ns_per_op_median": 4532.524124145508,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 167113,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039330417,
+        "median_s": 0.040350875,
+        "samples_s": [
+          0.040350875,
+          0.040893917,
+          0.039330417
+        ]
+      },
+      "total": {
+        "min_s": 0.299124375,
+        "median_s": 0.299564875,
+        "samples_s": [
+          0.299937042,
+          0.299564875,
+          0.299124375
+        ]
+      },
+      "compute_s": 0.259793958,
+      "ns_per_op_min": 1554.6005277865875,
+      "ns_per_op_median": 1551.130073662731,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 78988,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040421542,
+        "median_s": 0.040733917,
+        "samples_s": [
+          0.040421542,
+          0.040733917,
+          0.042114542
+        ]
+      },
+      "total": {
+        "min_s": 0.315580167,
+        "median_s": 0.317376458,
+        "samples_s": [
+          0.317376458,
+          0.315580167,
+          0.318117833
+        ]
+      },
+      "compute_s": 0.27515862500000005,
+      "ns_per_op_min": 3483.5497164126205,
+      "ns_per_op_median": 3502.3363169088966,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 95700,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.030334458,
+        "median_s": 0.030337583,
+        "samples_s": [
+          0.030831917,
+          0.030334458,
+          0.030337583
+        ]
+      },
+      "total": {
+        "min_s": 0.372392708,
+        "median_s": 0.37260925,
+        "samples_s": [
+          0.372392708,
+          0.37260925,
+          0.373950958
+        ]
+      },
+      "compute_s": 0.34205825,
+      "ns_per_op_min": 3574.276384535005,
+      "ns_per_op_median": 3576.50644723093,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 2027383,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040492917,
+        "median_s": 0.040607333,
+        "samples_s": [
+          0.04151625,
+          0.040607333,
+          0.040492917
+        ]
+      },
+      "total": {
+        "min_s": 0.328305584,
+        "median_s": 0.32863525,
+        "samples_s": [
+          0.328305584,
+          0.329178875,
+          0.32863525
+        ]
+      },
+      "compute_s": 0.28781266699999997,
+      "ns_per_op_min": 141.96265185216603,
+      "ns_per_op_median": 142.0688232070605,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 5352,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.011243083,
+        "median_s": 0.011328875,
+        "samples_s": [
+          0.011342417,
+          0.011243083,
+          0.011328875
+        ]
+      },
+      "total": {
+        "min_s": 0.309942917,
+        "median_s": 0.311429583,
+        "samples_s": [
+          0.311429583,
+          0.309942917,
+          0.31321025
+        ]
+      },
+      "compute_s": 0.298699834,
+      "ns_per_op_min": 55810.8807922272,
+      "ns_per_op_median": 56072.62855007474,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 923094,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.003472917,
+        "median_s": 0.005317875,
+        "samples_s": [
+          0.006129584,
+          0.005317875,
+          0.003472917
+        ]
+      },
+      "total": {
+        "min_s": 0.220401,
+        "median_s": 0.220538208,
+        "samples_s": [
+          0.220401,
+          0.220538208,
+          0.220657208
+        ]
+      },
+      "compute_s": 0.21692808300000002,
+      "ns_per_op_min": 235.00107573009902,
+      "ns_per_op_median": 233.15104745562206,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 2838348,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.067269042,
+        "median_s": 0.067446042,
+        "samples_s": [
+          0.067446042,
+          0.067269042,
+          0.068548375
+        ]
+      },
+      "total": {
+        "min_s": 0.340725709,
+        "median_s": 0.341663834,
+        "samples_s": [
+          0.343641417,
+          0.340725709,
+          0.341663834
+        ]
+      },
+      "compute_s": 0.273456667,
+      "ns_per_op_min": 96.34360092560884,
+      "ns_per_op_median": 96.61175867088885,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 111,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0133805,
+        "median_s": 0.013883333,
+        "samples_s": [
+          0.013994,
+          0.0133805,
+          0.013883333
+        ]
+      },
+      "total": {
+        "min_s": 2.263898042,
+        "median_s": 2.267468292,
+        "samples_s": [
+          2.267468292,
+          2.263898042,
+          2.267721708
+        ]
+      },
+      "compute_s": 2.2505175420000003,
+      "ns_per_op_min": 20274932.810810816,
+      "ns_per_op_median": 20302567.198198203,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": 1211,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.14869625,
+        "median_s": 0.150540334,
+        "samples_s": [
+          0.150795792,
+          0.14869625,
+          0.150540334
+        ]
+      },
+      "total": {
+        "min_s": 0.424172833,
+        "median_s": 0.425950958,
+        "samples_s": [
+          0.425950958,
+          0.424172833,
+          0.4273835
+        ]
+      },
+      "compute_s": 0.275476583,
+      "ns_per_op_min": 227478.59867877787,
+      "ns_per_op_median": 227424.13212221305,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": 2059,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.236869583,
+        "median_s": 0.238946375,
+        "samples_s": [
+          0.238946375,
+          0.236869583,
+          0.2393675
+        ]
+      },
+      "total": {
+        "min_s": 0.435027875,
+        "median_s": 0.437603208,
+        "samples_s": [
+          0.438648833,
+          0.435027875,
+          0.437603208
+        ]
+      },
+      "compute_s": 0.198158292,
+      "ns_per_op_min": 96240.06410879067,
+      "ns_per_op_median": 96482.19184069938,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": 512,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.3342065,
+        "median_s": 0.336385125,
+        "samples_s": [
+          0.336828,
+          0.3342065,
+          0.336385125
+        ]
+      },
+      "total": {
+        "min_s": 0.656641166,
+        "median_s": 0.659896083,
+        "samples_s": [
+          0.659896083,
+          0.656641166,
+          0.659997333
+        ]
+      },
+      "compute_s": 0.322434666,
+      "ns_per_op_min": 629755.20703125,
+      "ns_per_op_median": 631857.33984375,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": 1512,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.393204708,
+        "median_s": 0.394487958,
+        "samples_s": [
+          0.393204708,
+          0.394487958,
+          0.39800525
+        ]
+      },
+      "total": {
+        "min_s": 0.66654175,
+        "median_s": 0.668934875,
+        "samples_s": [
+          0.673092125,
+          0.668934875,
+          0.66654175
+        ]
+      },
+      "compute_s": 0.27333704200000003,
+      "ns_per_op_min": 180778.46693121697,
+      "ns_per_op_median": 181512.51124338625,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 256,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.044288708,
+        "median_s": 0.04442425,
+        "samples_s": [
+          0.045426333,
+          0.04442425,
+          0.044288708
+        ]
+      },
+      "total": {
+        "min_s": 0.42347125,
+        "median_s": 0.425031459,
+        "samples_s": [
+          0.428691458,
+          0.42347125,
+          0.425031459
+        ]
+      },
+      "compute_s": 0.379182542,
+      "ns_per_op_min": 1481181.8046875,
+      "ns_per_op_median": 1486746.91015625,
+      "load_ms": 0.845,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 112,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.081337583,
+        "median_s": 0.081349917,
+        "samples_s": [
+          0.082564167,
+          0.081349917,
+          0.081337583
+        ]
+      },
+      "total": {
+        "min_s": 0.28689875,
+        "median_s": 0.288312791,
+        "samples_s": [
+          0.288655958,
+          0.288312791,
+          0.28689875
+        ]
+      },
+      "compute_s": 0.205561167,
+      "ns_per_op_min": 1835367.5625,
+      "ns_per_op_median": 1847882.8035714289,
+      "load_ms": 4.924,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 701,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.051767334,
+        "median_s": 0.053817167,
+        "samples_s": [
+          0.054221834,
+          0.053817167,
+          0.051767334
+        ]
+      },
+      "total": {
+        "min_s": 0.324503875,
+        "median_s": 0.324519792,
+        "samples_s": [
+          0.325962333,
+          0.324519792,
+          0.324503875
+        ]
+      },
+      "compute_s": 0.272736541,
+      "ns_per_op_min": 389067.8188302425,
+      "ns_per_op_median": 386166.3694721826,
+      "load_ms": 4.336,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 1378,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.104304917,
+        "median_s": 0.104667875,
+        "samples_s": [
+          0.104304917,
+          0.104667875,
+          0.106987042
+        ]
+      },
+      "total": {
+        "min_s": 0.359087417,
+        "median_s": 0.361016584,
+        "samples_s": [
+          0.362891541,
+          0.361016584,
+          0.359087417
+        ]
+      },
+      "compute_s": 0.2547825,
+      "ns_per_op_min": 184892.96081277216,
+      "ns_per_op_median": 186029.54208998545,
+      "load_ms": 10.436,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 997415,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005340541,
+        "median_s": 0.00567925,
+        "samples_s": [
+          0.005340541,
+          0.0059055,
+          0.00567925
+        ]
+      },
+      "total": {
+        "min_s": 0.29872375,
+        "median_s": 0.2990535,
+        "samples_s": [
+          0.2990535,
+          0.299533958,
+          0.29872375
+        ]
+      },
+      "compute_s": 0.29338320900000003,
+      "ns_per_op_min": 294.143570128783,
+      "ns_per_op_median": 294.1345879097467,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 962488,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.008947625,
+        "median_s": 0.009405417,
+        "samples_s": [
+          0.0096635,
+          0.008947625,
+          0.009405417
+        ]
+      },
+      "total": {
+        "min_s": 0.291265125,
+        "median_s": 0.29166925,
+        "samples_s": [
+          0.291265125,
+          0.292000167,
+          0.29166925
+        ]
+      },
+      "compute_s": 0.2823175,
+      "ns_per_op_min": 293.32054010024024,
+      "ns_per_op_median": 293.2647814829899,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 6953,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.015474709,
+        "median_s": 0.015646792,
+        "samples_s": [
+          0.015849167,
+          0.015474709,
+          0.015646792
+        ]
+      },
+      "total": {
+        "min_s": 0.298067459,
+        "median_s": 0.298271042,
+        "samples_s": [
+          0.298067459,
+          0.298271042,
+          0.30001325
+        ]
+      },
+      "compute_s": 0.28259275,
+      "ns_per_op_min": 40643.2834747591,
+      "ns_per_op_median": 40647.81389328346,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 767517,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0050045,
+        "median_s": 0.005294292,
+        "samples_s": [
+          0.0050045,
+          0.005629125,
+          0.005294292
+        ]
+      },
+      "total": {
+        "min_s": 0.2956315,
+        "median_s": 0.295767875,
+        "samples_s": [
+          0.2956315,
+          0.297142125,
+          0.295767875
+        ]
+      },
+      "compute_s": 0.29062699999999997,
+      "ns_per_op_min": 378.6587137483599,
+      "ns_per_op_median": 378.4588263191565,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 65536,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004712792,
+        "median_s": 0.004853833,
+        "samples_s": [
+          0.004853833,
+          0.00487325,
+          0.004712792
+        ]
+      },
+      "total": {
+        "min_s": 0.326862875,
+        "median_s": 0.327072541,
+        "samples_s": [
+          0.327942333,
+          0.326862875,
+          0.327072541
+        ]
+      },
+      "compute_s": 0.322150083,
+      "ns_per_op_min": 4915.620162963867,
+      "ns_per_op_median": 4916.667297363281,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 3601,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039173208,
+        "median_s": 0.040861292,
+        "samples_s": [
+          0.041113708,
+          0.039173208,
+          0.040861292
+        ]
+      },
+      "total": {
+        "min_s": 0.325744166,
+        "median_s": 0.326278125,
+        "samples_s": [
+          0.3264185,
+          0.325744166,
+          0.326278125
+        ]
+      },
+      "compute_s": 0.286570958,
+      "ns_per_op_min": 79580.93807275756,
+      "ns_per_op_median": 79260.4368231047,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 8594,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0407785,
+        "median_s": 0.041437958,
+        "samples_s": [
+          0.041437958,
+          0.0407785,
+          0.042150125
+        ]
+      },
+      "total": {
+        "min_s": 0.333448416,
+        "median_s": 0.333505417,
+        "samples_s": [
+          0.333448416,
+          0.333751584,
+          0.333505417
+        ]
+      },
+      "compute_s": 0.29266991600000003,
+      "ns_per_op_min": 34055.14498487317,
+      "ns_per_op_median": 33985.04293693275,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 3285,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040518375,
+        "median_s": 0.041023583,
+        "samples_s": [
+          0.041023583,
+          0.040518375,
+          0.041447416
+        ]
+      },
+      "total": {
+        "min_s": 0.219777334,
+        "median_s": 0.220077083,
+        "samples_s": [
+          0.219777334,
+          0.221479625,
+          0.220077083
+        ]
+      },
+      "compute_s": 0.179258959,
+      "ns_per_op_min": 54568.937290715374,
+      "ns_per_op_median": 54506.39269406393,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 1112,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.030146041,
+        "median_s": 0.031171416,
+        "samples_s": [
+          0.030146041,
+          0.031171416,
+          0.031826
+        ]
+      },
+      "total": {
+        "min_s": 0.327354583,
+        "median_s": 0.330428583,
+        "samples_s": [
+          0.327354583,
+          0.330428583,
+          0.330476959
+        ]
+      },
+      "compute_s": 0.29720854199999996,
+      "ns_per_op_min": 267273.86870503594,
+      "ns_per_op_median": 269116.1573741007,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 18529,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.041048625,
+        "median_s": 0.041312875,
+        "samples_s": [
+          0.041048625,
+          0.042321541,
+          0.041312875
+        ]
+      },
+      "total": {
+        "min_s": 0.300145167,
+        "median_s": 0.300935459,
+        "samples_s": [
+          0.30168625,
+          0.300145167,
+          0.300935459
+        ]
+      },
+      "compute_s": 0.259096542,
+      "ns_per_op_min": 13983.298720923956,
+      "ns_per_op_median": 14011.688920071243,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 917,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010849375,
+        "median_s": 0.011196542,
+        "samples_s": [
+          0.011531542,
+          0.010849375,
+          0.011196542
+        ]
+      },
+      "total": {
+        "min_s": 0.304523416,
+        "median_s": 0.305214625,
+        "samples_s": [
+          0.306329583,
+          0.304523416,
+          0.305214625
+        ]
+      },
+      "compute_s": 0.293674041,
+      "ns_per_op_min": 320255.2246455834,
+      "ns_per_op_median": 320630.4067611778,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 779032,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.00358625,
+        "median_s": 0.003664583,
+        "samples_s": [
+          0.003664583,
+          0.00358625,
+          0.003732625
+        ]
+      },
+      "total": {
+        "min_s": 0.275033166,
+        "median_s": 0.27533075,
+        "samples_s": [
+          0.27533075,
+          0.275033166,
+          0.275526833
+        ]
+      },
+      "compute_s": 0.271446916,
+      "ns_per_op_min": 348.44129124349195,
+      "ns_per_op_median": 348.722731543762,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 334711,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.066652416,
+        "median_s": 0.067098584,
+        "samples_s": [
+          0.067098584,
+          0.066652416,
+          0.06755425
+        ]
+      },
+      "total": {
+        "min_s": 0.24554975,
+        "median_s": 0.24831575,
+        "samples_s": [
+          0.24831575,
+          0.24554975,
+          0.270089167
+        ]
+      },
+      "compute_s": 0.17889733400000002,
+      "ns_per_op_min": 534.4829838278396,
+      "ns_per_op_median": 541.4138346215092,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 18,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0150195,
+        "median_s": 0.0151295,
+        "samples_s": [
+          0.015241625,
+          0.0151295,
+          0.0150195
+        ]
+      },
+      "total": {
+        "min_s": 0.301460584,
+        "median_s": 0.301744375,
+        "samples_s": [
+          0.301744375,
+          0.302117667,
+          0.301460584
+        ]
+      },
+      "compute_s": 0.28644108399999996,
+      "ns_per_op_min": 15913393.555555552,
+      "ns_per_op_median": 15923048.611111112,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": 79,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.150148125,
+        "median_s": 0.151298,
+        "samples_s": [
+          0.151531125,
+          0.151298,
+          0.150148125
+        ]
+      },
+      "total": {
+        "min_s": 0.394444459,
+        "median_s": 0.395899792,
+        "samples_s": [
+          0.394444459,
+          0.399162666,
+          0.395899792
+        ]
+      },
+      "compute_s": 0.24429633400000003,
+      "ns_per_op_min": 3092358.6582278484,
+      "ns_per_op_median": 3096225.2151898732,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": 208,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.249631709,
+        "median_s": 0.251759,
+        "samples_s": [
+          0.249631709,
+          0.252587916,
+          0.251759
+        ]
+      },
+      "total": {
+        "min_s": 0.510206333,
+        "median_s": 0.510560917,
+        "samples_s": [
+          0.512042916,
+          0.510206333,
+          0.510560917
+        ]
+      },
+      "compute_s": 0.260574624,
+      "ns_per_op_min": 1252762.6153846153,
+      "ns_per_op_median": 1244239.9855769228,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": 25,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.339386625,
+        "median_s": 0.340153291,
+        "samples_s": [
+          0.340721958,
+          0.340153291,
+          0.339386625
+        ]
+      },
+      "total": {
+        "min_s": 0.563063,
+        "median_s": 0.563405833,
+        "samples_s": [
+          0.563405833,
+          0.563063,
+          0.564451167
+        ]
+      },
+      "compute_s": 0.22367637499999998,
+      "ns_per_op_min": 8947054.999999998,
+      "ns_per_op_median": 8930101.68,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": 60,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.406247875,
+        "median_s": 0.407472375,
+        "samples_s": [
+          0.409036041,
+          0.407472375,
+          0.406247875
+        ]
+      },
+      "total": {
+        "min_s": 0.635600708,
+        "median_s": 0.635916125,
+        "samples_s": [
+          0.635600708,
+          0.635916125,
+          0.63742125
+        ]
+      },
+      "compute_s": 0.22935283300000003,
+      "ns_per_op_min": 3822547.2166666673,
+      "ns_per_op_median": 3807395.8333333344,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 19,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.04500575,
+        "median_s": 0.045490417,
+        "samples_s": [
+          0.04500575,
+          0.046115541,
+          0.045490417
+        ]
+      },
+      "total": {
+        "min_s": 0.320115708,
+        "median_s": 0.322846625,
+        "samples_s": [
+          0.320115708,
+          0.322846625,
+          0.323091417
+        ]
+      },
+      "compute_s": 0.275109958,
+      "ns_per_op_min": 14479471.47368421,
+      "ns_per_op_median": 14597695.157894736,
+      "load_ms": 1.212,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 28,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.088832459,
+        "median_s": 0.089554416,
+        "samples_s": [
+          0.090467209,
+          0.088832459,
+          0.089554416
+        ]
+      },
+      "total": {
+        "min_s": 0.292726459,
+        "median_s": 0.293472,
+        "samples_s": [
+          0.298423792,
+          0.292726459,
+          0.293472
+        ]
+      },
+      "compute_s": 0.203894,
+      "ns_per_op_min": 7281928.571428572,
+      "ns_per_op_median": 7282770.857142857,
+      "load_ms": 8.008,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 53,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.052972375,
+        "median_s": 0.054535416,
+        "samples_s": [
+          0.052972375,
+          0.054535416,
+          0.055183459
+        ]
+      },
+      "total": {
+        "min_s": 0.27394775,
+        "median_s": 0.274373959,
+        "samples_s": [
+          0.27394775,
+          0.276254833,
+          0.274373959
+        ]
+      },
+      "compute_s": 0.22097537499999997,
+      "ns_per_op_min": 4169346.698113207,
+      "ns_per_op_median": 4147897.037735849,
+      "load_ms": 4.384,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 135,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.104673,
+        "median_s": 0.104960416,
+        "samples_s": [
+          0.104960416,
+          0.104673,
+          0.105024792
+        ]
+      },
+      "total": {
+        "min_s": 0.365192209,
+        "median_s": 0.368115042,
+        "samples_s": [
+          0.369280166,
+          0.368115042,
+          0.365192209
+        ]
+      },
+      "compute_s": 0.260519209,
+      "ns_per_op_min": 1929771.9185185183,
+      "ns_per_op_median": 1949293.525925926,
+      "load_ms": 10.305,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 179975764,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005390958,
+        "median_s": 0.005824666,
+        "samples_s": [
+          0.005824666,
+          0.005390958,
+          0.005875583
+        ]
+      },
+      "total": {
+        "min_s": 0.267383625,
+        "median_s": 0.2754585,
+        "samples_s": [
+          0.2754585,
+          0.267383625,
+          0.276844916
+        ]
+      },
+      "compute_s": 0.261992667,
+      "ns_per_op_min": 1.455710820041303,
+      "ns_per_op_median": 1.4981674643703693,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 177418041,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009208334,
+        "median_s": 0.009749041,
+        "samples_s": [
+          0.009208334,
+          0.009920541,
+          0.009749041
+        ]
+      },
+      "total": {
+        "min_s": 0.296228125,
+        "median_s": 0.296802417,
+        "samples_s": [
+          0.297925541,
+          0.296228125,
+          0.296802417
+        ]
+      },
+      "compute_s": 0.287019791,
+      "ns_per_op_min": 1.6177598928623047,
+      "ns_per_op_median": 1.6179491915368405,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1486638,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.01647075,
+        "median_s": 0.016776333,
+        "samples_s": [
+          0.016776333,
+          0.0168275,
+          0.01647075
+        ]
+      },
+      "total": {
+        "min_s": 0.309693791,
+        "median_s": 0.310024458,
+        "samples_s": [
+          0.312498041,
+          0.310024458,
+          0.309693791
+        ]
+      },
+      "compute_s": 0.293223041,
+      "ns_per_op_min": 197.23903263605533,
+      "ns_per_op_median": 197.2559056071485,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 99868591,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.00562425,
+        "median_s": 0.005651625,
+        "samples_s": [
+          0.00562425,
+          0.005651625,
+          0.006041791
+        ]
+      },
+      "total": {
+        "min_s": 0.305800292,
+        "median_s": 0.306619416,
+        "samples_s": [
+          0.305800292,
+          0.306823958,
+          0.306619416
+        ]
+      },
+      "compute_s": 0.300176042,
+      "ns_per_op_min": 3.0057101937084503,
+      "ns_per_op_median": 3.013638101693054,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 11986465,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004510583,
+        "median_s": 0.004696084,
+        "samples_s": [
+          0.004696084,
+          0.004940125,
+          0.004510583
+        ]
+      },
+      "total": {
+        "min_s": 0.247151958,
+        "median_s": 0.2479555,
+        "samples_s": [
+          0.248175875,
+          0.247151958,
+          0.2479555
+        ]
+      },
+      "compute_s": 0.242641375,
+      "ns_per_op_min": 20.24294694057005,
+      "ns_per_op_median": 20.294508514395194,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 748536,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040996833,
+        "median_s": 0.041325167,
+        "samples_s": [
+          0.041325167,
+          0.042192416,
+          0.040996833
+        ]
+      },
+      "total": {
+        "min_s": 0.348056458,
+        "median_s": 0.349024459,
+        "samples_s": [
+          0.349987334,
+          0.348056458,
+          0.349024459
+        ]
+      },
+      "compute_s": 0.307059625,
+      "ns_per_op_min": 410.2135702224075,
+      "ns_per_op_median": 411.06812765184304,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 958325,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.041067958,
+        "median_s": 0.041923209,
+        "samples_s": [
+          0.041067958,
+          0.041923209,
+          0.042147917
+        ]
+      },
+      "total": {
+        "min_s": 0.303008666,
+        "median_s": 0.303616916,
+        "samples_s": [
+          0.303616916,
+          0.303008666,
+          0.303638833
+        ]
+      },
+      "compute_s": 0.26194070799999997,
+      "ns_per_op_min": 273.33181123314114,
+      "ns_per_op_median": 273.0740688179897,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 619243,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.040661625,
+        "median_s": 0.042770292,
+        "samples_s": [
+          0.040661625,
+          0.043030208,
+          0.042770292
+        ]
+      },
+      "total": {
+        "min_s": 0.224808125,
+        "median_s": 0.226178666,
+        "samples_s": [
+          0.226378084,
+          0.226178666,
+          0.224808125
+        ]
+      },
+      "compute_s": 0.1841465,
+      "ns_per_op_min": 297.3735674040724,
+      "ns_per_op_median": 296.18158622705465,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 323946,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.033195417,
+        "median_s": 0.033758958,
+        "samples_s": [
+          0.033195417,
+          0.034098834,
+          0.033758958
+        ]
+      },
+      "total": {
+        "min_s": 0.32403175,
+        "median_s": 0.325072625,
+        "samples_s": [
+          0.325072625,
+          0.32403175,
+          0.325262083
+        ]
+      },
+      "compute_s": 0.290836333,
+      "ns_per_op_min": 897.7926351922852,
+      "ns_per_op_median": 899.2661338618165,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 4919747,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.045452083,
+        "median_s": 0.046155167,
+        "samples_s": [
+          0.047340584,
+          0.045452083,
+          0.046155167
+        ]
+      },
+      "total": {
+        "min_s": 0.32486975,
+        "median_s": 0.326387084,
+        "samples_s": [
+          0.326607291,
+          0.32486975,
+          0.326387084
+        ]
+      },
+      "compute_s": 0.27941766700000004,
+      "ns_per_op_min": 56.79512930238081,
+      "ns_per_op_median": 56.96063578066108,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 200141,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.01870075,
+        "median_s": 0.01871225,
+        "samples_s": [
+          0.01870075,
+          0.019169667,
+          0.01871225
+        ]
+      },
+      "total": {
+        "min_s": 0.314848042,
+        "median_s": 0.31526425,
+        "samples_s": [
+          0.314848042,
+          0.31526425,
+          0.316649542
+        ]
+      },
+      "compute_s": 0.296147292,
+      "ns_per_op_min": 1479.6932762402507,
+      "ns_per_op_median": 1481.7153906495923,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 92941984,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004011416,
+        "median_s": 0.004526,
+        "samples_s": [
+          0.004526,
+          0.004011416,
+          0.004975416
+        ]
+      },
+      "total": {
+        "min_s": 0.256639625,
+        "median_s": 0.257361625,
+        "samples_s": [
+          0.257361625,
+          0.256639625,
+          0.25825575
+        ]
+      },
+      "compute_s": 0.252628209,
+      "ns_per_op_min": 2.718127999075208,
+      "ns_per_op_median": 2.7203596708243283,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 63054338,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.068684166,
+        "median_s": 0.068700375,
+        "samples_s": [
+          0.068700375,
+          0.068684166,
+          0.06886875
+        ]
+      },
+      "total": {
+        "min_s": 0.288686,
+        "median_s": 0.290604667,
+        "samples_s": [
+          0.290604667,
+          0.288686,
+          0.291669959
+        ]
+      },
+      "compute_s": 0.220001834,
+      "ns_per_op_min": 3.4890832411879416,
+      "ns_per_op_median": 3.519254963869417,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 6852,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.12534825,
+        "median_s": 0.125607542,
+        "samples_s": [
+          0.125607542,
+          0.126033667,
+          0.12534825
+        ]
+      },
+      "total": {
+        "min_s": 0.415899042,
+        "median_s": 0.416832,
+        "samples_s": [
+          0.417470708,
+          0.416832,
+          0.415899042
+        ]
+      },
+      "compute_s": 0.290550792,
+      "ns_per_op_min": 42403.79334500876,
+      "ns_per_op_median": 42502.110040863976,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": 26095,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.194456834,
+        "median_s": 0.194675792,
+        "samples_s": [
+          0.196249583,
+          0.194456834,
+          0.194675792
+        ]
+      },
+      "total": {
+        "min_s": 0.494674333,
+        "median_s": 0.498270542,
+        "samples_s": [
+          0.498270542,
+          0.500223833,
+          0.494674333
+        ]
+      },
+      "compute_s": 0.30021749900000005,
+      "ns_per_op_min": 11504.790151369996,
+      "ns_per_op_median": 11634.211534776778,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": 63553,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.278367041,
+        "median_s": 0.28203575,
+        "samples_s": [
+          0.278367041,
+          0.28203575,
+          0.2850005
+        ]
+      },
+      "total": {
+        "min_s": 0.553166042,
+        "median_s": 0.560025625,
+        "samples_s": [
+          0.560025625,
+          0.560069958,
+          0.553166042
+        ]
+      },
+      "compute_s": 0.274799001,
+      "ns_per_op_min": 4323.934369738643,
+      "ns_per_op_median": 4374.142448035498,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": 12444,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.460356458,
+        "median_s": 0.460485,
+        "samples_s": [
+          0.460485,
+          0.46212075,
+          0.460356458
+        ]
+      },
+      "total": {
+        "min_s": 0.868578084,
+        "median_s": 0.871408041,
+        "samples_s": [
+          0.871408041,
+          0.868578084,
+          0.874930375
+        ]
+      },
+      "compute_s": 0.408221626,
+      "ns_per_op_min": 32804.695114111215,
+      "ns_per_op_median": 33021.78085824494,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": 20186,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.487382,
+        "median_s": 0.488006083,
+        "samples_s": [
+          0.488006083,
+          0.487382,
+          0.488933833
+        ]
+      },
+      "total": {
+        "min_s": 0.705818791,
+        "median_s": 0.707019625,
+        "samples_s": [
+          0.705818791,
+          0.712962583,
+          0.707019625
+        ]
+      },
+      "compute_s": 0.21843679100000002,
+      "ns_per_op_min": 10821.202367977809,
+      "ns_per_op_median": 10849.774199940555,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 5017,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.28192775,
+        "median_s": 0.283217125,
+        "samples_s": [
+          0.283217125,
+          0.2837505,
+          0.28192775
+        ]
+      },
+      "total": {
+        "min_s": 0.580221916,
+        "median_s": 0.582696958,
+        "samples_s": [
+          0.580221916,
+          0.585030291,
+          0.582696958
+        ]
+      },
+      "compute_s": 0.29829416599999997,
+      "ns_per_op_min": 59456.68048634642,
+      "ns_per_op_median": 59693.010364759815,
+      "load_ms": 1.307,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 13376,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.196864708,
+        "median_s": 0.198497417,
+        "samples_s": [
+          0.198602417,
+          0.196864708,
+          0.198497417
+        ]
+      },
+      "total": {
+        "min_s": 0.412313291,
+        "median_s": 0.412796417,
+        "samples_s": [
+          0.422084667,
+          0.412313291,
+          0.412796417
+        ]
+      },
+      "compute_s": 0.21544858300000003,
+      "ns_per_op_min": 16107.10100179426,
+      "ns_per_op_median": 16021.15729665072,
+      "load_ms": 8.233,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 11545,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.121552,
+        "median_s": 0.122643125,
+        "samples_s": [
+          0.122643125,
+          0.121552,
+          0.122708041
+        ]
+      },
+      "total": {
+        "min_s": 0.36204725,
+        "median_s": 0.363120583,
+        "samples_s": [
+          0.363120583,
+          0.363810917,
+          0.36204725
+        ]
+      },
+      "compute_s": 0.24049525,
+      "ns_per_op_min": 20831.117366825467,
+      "ns_per_op_median": 20829.576266782155,
+      "load_ms": 3.921,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 31453,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.144931583,
+        "median_s": 0.145215666,
+        "samples_s": [
+          0.146225041,
+          0.145215666,
+          0.144931583
+        ]
+      },
+      "total": {
+        "min_s": 0.450901417,
+        "median_s": 0.455145834,
+        "samples_s": [
+          0.450901417,
+          0.455145834,
+          0.46092125
+        ]
+      },
+      "compute_s": 0.305969834,
+      "ns_per_op_min": 9727.842622325374,
+      "ns_per_op_median": 9853.755381044735,
+      "load_ms": 10.615,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 25,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.01025918336,
+        "median_s": 0.010280408240000004,
+        "samples_s": [
+          0.01025918336,
+          0.010481349999999999,
+          0.010280408240000004
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 16,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.014214836125000001,
+        "median_s": 0.0142763621875,
+        "samples_s": [
+          0.014214836125000001,
+          0.0142763621875,
+          0.01433349725
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 12,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.02658748966666667,
+        "median_s": 0.026746062416666664,
+        "samples_s": [
+          0.026746062416666664,
+          0.02658748966666667,
+          0.026790621583333327
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 3,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.10658687466666668,
+        "median_s": 0.10716690266666666,
+        "samples_s": [
+          0.10716690266666666,
+          0.10745165266666667,
+          0.10658687466666668
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 39,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.008139096128205129,
+        "median_s": 0.008155101461538465,
+        "samples_s": [
+          0.008155101461538465,
+          0.008233206153846153,
+          0.008139096128205129
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 3,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.14451236133333334,
+        "median_s": 0.146057722,
+        "samples_s": [
+          0.146057722,
+          0.14618329166666666,
+          0.14451236133333334
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 2,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.19800266700000002,
+        "median_s": 0.19912154199999998,
+        "samples_s": [
+          0.200560479,
+          0.19800266700000002,
+          0.19912154199999998
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 2,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.256912479,
+        "median_s": 0.258188146,
+        "samples_s": [
+          0.25836468749999997,
+          0.258188146,
+          0.256912479
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.42777375,
+        "median_s": 0.427987333,
+        "samples_s": [
+          0.430705666,
+          0.42777375,
+          0.427987333
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.629119667,
+        "median_s": 0.631101208,
+        "samples_s": [
+          0.629119667,
+          0.631101208,
+          0.632939625
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 3,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.11137945833333333,
+        "median_s": 0.11179741666666666,
+        "samples_s": [
+          0.11137945833333333,
+          0.11179741666666666,
+          0.11241374999999999
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.005094917,
+        "median_s": 0.005754916,
+        "samples_s": [
+          0.007037667,
+          0.005094917,
+          0.005754916
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 3,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.132926417,
+        "median_s": 0.13384712466666668,
+        "samples_s": [
+          0.13384712466666668,
+          0.134671028,
+          0.132926417
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 1.337952667,
+        "median_s": 1.338316958,
+        "samples_s": [
+          1.337952667,
+          1.338316958,
+          1.344851083
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 1.555327833,
+        "median_s": 1.556399459,
+        "samples_s": [
+          1.556399459,
+          1.565256666,
+          1.555327833
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 1.248821958,
+        "median_s": 1.252479666,
+        "samples_s": [
+          1.252479666,
+          1.253665542,
+          1.248821958
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 3.8412754590000002,
+        "median_s": 3.841542042,
+        "samples_s": [
+          3.942733417,
+          3.8412754590000002,
+          3.841542042
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 1.7117770829999999,
+        "median_s": 1.7198709170000002,
+        "samples_s": [
+          1.7278164999999999,
+          1.7117770829999999,
+          1.7198709170000002
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.502570083,
+        "median_s": 0.504216542,
+        "samples_s": [
+          0.504216542,
+          0.502570083,
+          0.505450458
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": 278.965,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.891662167,
+        "median_s": 0.892348125,
+        "samples_s": [
+          0.891662167,
+          0.892348125,
+          0.90051025
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": 481.749,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 2,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.2402608745,
+        "median_s": 0.2411354585,
+        "samples_s": [
+          0.2402608745,
+          0.2424966455,
+          0.2411354585
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": 105.841,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 2,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.273508563,
+        "median_s": 0.2762142085,
+        "samples_s": [
+          0.273508563,
+          0.2762142085,
+          0.2771249995
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": 85.364,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 4,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.07914266675000001,
+        "median_s": 0.0794484685,
+        "samples_s": [
+          0.0794484685,
+          0.079449729,
+          0.07914266675000001
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 4,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.08724968749999999,
+        "median_s": 0.08749334375000001,
+        "samples_s": [
+          0.08724968749999999,
+          0.08749334375000001,
+          0.0875504375
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 9.606249708,
+        "median_s": 9.609799709,
+        "samples_s": [
+          9.609799709,
+          9.614307958,
+          9.606249708
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.647856041,
+        "median_s": 0.6485365,
+        "samples_s": [
+          0.6485365,
+          0.649501792,
+          0.647856041
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 1.126757709,
+        "median_s": 1.132086625,
+        "samples_s": [
+          1.132086625,
+          1.126757709,
+          1.1331315
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 19.292105834,
+        "median_s": 19.306646042,
+        "samples_s": [
+          19.306646042,
+          19.311445167,
+          19.292105834
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 9.267006542,
+        "median_s": 9.32228825,
+        "samples_s": [
+          9.32228825,
+          9.267006542,
+          9.34430825
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 14.038493542,
+        "median_s": 14.042138833,
+        "samples_s": [
+          14.05405125,
+          14.042138833,
+          14.038493542
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-python",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: dewasm-python runs this program correctly but at 56 s and 57 s per run (median, sqlite3_query and sqlite3_mod_query), costing roughly 9 minutes of the roughly 65 minute full suite; dewasm-python stays measured on the other app cases and the microbenchmarks"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 11.981554958,
+        "median_s": 12.013413916,
+        "samples_s": [
+          12.013413916,
+          12.071049833,
+          11.981554958
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-perl",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: dewasm-perl runs this program correctly but at 113 s and 115 s per run (median, sqlite3_query and sqlite3_mod_query), so one warmup plus the timed repetitions across both cases alone cost roughly 19 minutes of the roughly 65 minute full suite; dewasm-perl stays measured on the other app cases and the microbenchmarks"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.169805,
+        "median_s": 0.170420458,
+        "samples_s": [
+          0.169805,
+          0.170420458,
+          0.17063
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 2.351580167,
+        "median_s": 2.371863458,
+        "samples_s": [
+          2.373826375,
+          2.371863458,
+          2.351580167
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-bash",
+      "status": "skipped",
+      "reason": "excluded: bash runs ~10000x slower than wasmtime on compute, so 100k SQL inserts do not finish in a practical time"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wasm3-ruby",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: the converted wasm3 runs this program correctly (stdout matching the oracle) at 160 s per run on wasm3-ruby-yjit, the fastest of the four wasm3-* runners, so one warmup plus the timed repetitions across both query cases and all four runners would add hours to the suite"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wasm3-ruby-yjit",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: the converted wasm3 runs this program correctly (stdout matching the oracle) at 160 s per run on wasm3-ruby-yjit, the fastest of the four wasm3-* runners, so one warmup plus the timed repetitions across both query cases and all four runners would add hours to the suite"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wasm3-python",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: the converted wasm3 runs this program correctly (stdout matching the oracle) at 160 s per run on wasm3-ruby-yjit, the fastest of the four wasm3-* runners, so one warmup plus the timed repetitions across both query cases and all four runners would add hours to the suite"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wasm3-pypy",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: the converted wasm3 runs this program correctly (stdout matching the oracle) at 160 s per run on wasm3-ruby-yjit, the fastest of the four wasm3-* runners, so one warmup plus the timed repetitions across both query cases and all four runners would add hours to the suite"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "pywasm-cpython",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: pywasm runs this program correctly (byte-identical to wasmtime under -batch) at ~17.9 ms/row: measured 358 s at 20k rows, so the 100k-row script needs roughly half an hour per sample"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "pywasm-pypy",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: pywasm runs this program correctly (byte-identical to wasmtime under -batch) at ~17.9 ms/row: measured 358 s at 20k rows, so the 100k-row script needs roughly half an hour per sample"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wardite",
+      "status": "skipped",
+      "reason": "excluded: wardite loads the sqlite3 shell but cannot execute a query, raising Wardite::EvalError (\"maybe empty or invalid stack\", convert.generated.rb:200) as soon as any SQL runs"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wardite-yjit",
+      "status": "skipped",
+      "reason": "excluded: wardite loads the sqlite3 shell but cannot execute a query, raising Wardite::EvalError (\"maybe empty or invalid stack\", convert.generated.rb:200) as soon as any SQL runs"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 3,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.085699625,
+        "median_s": 0.085831472,
+        "samples_s": [
+          0.08749412499999999,
+          0.085831472,
+          0.085699625
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 3,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.08987205566666667,
+        "median_s": 0.08999716666666667,
+        "samples_s": [
+          0.08999716666666667,
+          0.08987205566666667,
+          0.09000473633333334
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 9.941833708,
+        "median_s": 9.968452,
+        "samples_s": [
+          9.993034666,
+          9.968452,
+          9.941833708
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.631356292,
+        "median_s": 0.633859792,
+        "samples_s": [
+          0.633859792,
+          0.634783208,
+          0.631356292
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 1.1923958749999999,
+        "median_s": 1.195795708,
+        "samples_s": [
+          1.1923958749999999,
+          1.195795708,
+          1.214039667
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 20.236633125,
+        "median_s": 20.274460625,
+        "samples_s": [
+          20.328477791,
+          20.274460625,
+          20.236633125
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 8.276897583,
+        "median_s": 8.313910875,
+        "samples_s": [
+          8.329254333,
+          8.313910875,
+          8.276897583
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 14.536682292,
+        "median_s": 14.545641334,
+        "samples_s": [
+          14.536682292,
+          14.545641334,
+          14.578478875
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-python",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: dewasm-python runs this program correctly but at 56 s and 57 s per run (median, sqlite3_query and sqlite3_mod_query), costing roughly 9 minutes of the roughly 65 minute full suite; dewasm-python stays measured on the other app cases and the microbenchmarks"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 12.914670917,
+        "median_s": 13.067916084,
+        "samples_s": [
+          13.1259575,
+          12.914670917,
+          13.067916084
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-perl",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: dewasm-perl runs this program correctly but at 113 s and 115 s per run (median, sqlite3_query and sqlite3_mod_query), so one warmup plus the timed repetitions across both cases alone cost roughly 19 minutes of the roughly 65 minute full suite; dewasm-perl stays measured on the other app cases and the microbenchmarks"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.126833292,
+        "median_s": 0.127045333,
+        "samples_s": [
+          0.127045333,
+          0.126833292,
+          0.127210917
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 5.499059,
+        "median_s": 5.550753875,
+        "samples_s": [
+          5.550753875,
+          5.5584505,
+          5.499059
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-bash",
+      "status": "skipped",
+      "reason": "excluded: bash runs ~10000x slower than wasmtime on compute, so 100k SQL inserts do not finish in a practical time"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wasm3-ruby",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: the converted wasm3 runs this program correctly (stdout matching the oracle) at 160 s per run on wasm3-ruby-yjit, the fastest of the four wasm3-* runners, so one warmup plus the timed repetitions across both query cases and all four runners would add hours to the suite"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wasm3-ruby-yjit",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: the converted wasm3 runs this program correctly (stdout matching the oracle) at 160 s per run on wasm3-ruby-yjit, the fastest of the four wasm3-* runners, so one warmup plus the timed repetitions across both query cases and all four runners would add hours to the suite"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wasm3-python",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: the converted wasm3 runs this program correctly (stdout matching the oracle) at 160 s per run on wasm3-ruby-yjit, the fastest of the four wasm3-* runners, so one warmup plus the timed repetitions across both query cases and all four runners would add hours to the suite"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wasm3-pypy",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: the converted wasm3 runs this program correctly (stdout matching the oracle) at 160 s per run on wasm3-ruby-yjit, the fastest of the four wasm3-* runners, so one warmup plus the timed repetitions across both query cases and all four runners would add hours to the suite"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "pywasm-cpython",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: pywasm runs this program correctly (byte-identical to wasmtime under -batch) at ~17.9 ms/row: measured 358 s at 20k rows, so the 100k-row script needs roughly half an hour per sample"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "pywasm-pypy",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: pywasm runs this program correctly (byte-identical to wasmtime under -batch) at ~17.9 ms/row: measured 358 s at 20k rows, so the 100k-row script needs roughly half an hour per sample"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wardite",
+      "status": "skipped",
+      "reason": "excluded: wardite loads the sqlite3 shell but cannot execute a query, raising Wardite::EvalError (\"maybe empty or invalid stack\", convert.generated.rb:200) as soon as any SQL runs"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wardite-yjit",
+      "status": "skipped",
+      "reason": "excluded: wardite loads the sqlite3 shell but cannot execute a query, raising Wardite::EvalError (\"maybe empty or invalid stack\", convert.generated.rb:200) as soon as any SQL runs"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 7,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.04498392285714286,
+        "median_s": 0.04499852985714286,
+        "samples_s": [
+          0.04499852985714286,
+          0.04498392285714286,
+          0.04542476185714285
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 6,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.052906652500000005,
+        "median_s": 0.05295918066666666,
+        "samples_s": [
+          0.05295918066666666,
+          0.052906652500000005,
+          0.053171069499999994
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 2.194391417,
+        "median_s": 2.196633125,
+        "samples_s": [
+          2.200763292,
+          2.194391417,
+          2.196633125
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 4,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.08858412525,
+        "median_s": 0.08859050025,
+        "samples_s": [
+          0.08858412525,
+          0.08885915624999999,
+          0.08859050025
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 2,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.256045417,
+        "median_s": 0.25662491649999997,
+        "samples_s": [
+          0.256045417,
+          0.2566333545,
+          0.25662491649999997
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 5.2806935,
+        "median_s": 5.287249458,
+        "samples_s": [
+          5.2806935,
+          5.287541834,
+          5.287249458
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 1.630144917,
+        "median_s": 1.632419375,
+        "samples_s": [
+          1.630144917,
+          1.632419375,
+          1.6380018330000001
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 3.30613975,
+        "median_s": 3.306269292,
+        "samples_s": [
+          3.315810834,
+          3.30613975,
+          3.306269292
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 15.323792208,
+        "median_s": 15.330825458,
+        "samples_s": [
+          15.330825458,
+          15.46251075,
+          15.323792208
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 2.759619916,
+        "median_s": 2.760715125,
+        "samples_s": [
+          2.759619916,
+          2.760715125,
+          2.762327417
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 24.249065875,
+        "median_s": 24.424935167,
+        "samples_s": [
+          24.424935167,
+          24.442200333,
+          24.249065875
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.058129167,
+        "median_s": 0.05820025,
+        "samples_s": [
+          0.058247292,
+          0.058129167,
+          0.05820025
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.523385625,
+        "median_s": 0.524134958,
+        "samples_s": [
+          0.523385625,
+          0.54074775,
+          0.524134958
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-bash",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: bash compresses this workload's generated text at ~0.61 ms/byte (measured 30.6 s on a 50000-byte prefix), so the full 1.2 MB input needs roughly 12 minutes per run"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wasm3-ruby",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: the converted wasm3 compresses the full 1.2 MB input correctly (byte-identical to wasmtime) but at 149 s per run on plain ruby and 301 s on pypy, both measured, and roughly 7 minutes on cpython (measured 107 s on a 300000-byte prefix); wasm3-ruby-yjit runs it at 54 s and stays measured"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 51.56998025,
+        "median_s": 51.673209709,
+        "samples_s": [
+          51.785436792,
+          51.673209709,
+          51.56998025
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wasm3-python",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: the converted wasm3 compresses the full 1.2 MB input correctly (byte-identical to wasmtime) but at 149 s per run on plain ruby and 301 s on pypy, both measured, and roughly 7 minutes on cpython (measured 107 s on a 300000-byte prefix); wasm3-ruby-yjit runs it at 54 s and stays measured"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wasm3-pypy",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: the converted wasm3 compresses the full 1.2 MB input correctly (byte-identical to wasmtime) but at 149 s per run on plain ruby and 301 s on pypy, both measured, and roughly 7 minutes on cpython (measured 107 s on a 300000-byte prefix); wasm3-ruby-yjit runs it at 54 s and stays measured"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "pywasm-cpython",
+      "status": "skipped",
+      "reason": "excluded on cost, not capability: pywasm under CPython compresses this workload's generated text at ~0.46 ms/byte (measured 9.2 s on a 20000-byte prefix), so the full 1.2 MB input needs roughly 9 minutes per run"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 80.554237625,
+        "median_s": 81.31739075,
+        "samples_s": [
+          80.554237625,
+          81.31739075,
+          81.641067333
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": 332.633,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wardite",
+      "status": "skipped",
+      "reason": "excluded: wardite computes the correct compressed output but its driver crashes on exit (IOError: closed stream at wardite.rb:40) because minigzip closes stdout itself and wardite's fd_close closes the real fd under it, so the driver's own trailing flush fails and the process exits 1"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wardite-yjit",
+      "status": "skipped",
+      "reason": "excluded: wardite computes the correct compressed output but its driver crashes on exit (IOError: closed stream at wardite.rb:40) because minigzip closes stdout itself and wardite's fd_close closes the real fd under it, so the driver's own trailing flush fails and the process exits 1"
+    }
+  ]
+}

--- a/records/README.md
+++ b/records/README.md
@@ -19,7 +19,7 @@ A run appends its line with a `TODO`; fill it in when committing the record.
 - `2026-08-22T08-27-05Z-speed.json`: re-baseline after the f32 rounding change (#268).
 - `2026-08-24T22-56-29Z-speed.json`: TODO: describe the occasion.
 - `2026-08-24T23-27-21Z-speed.json`: TODO: describe the occasion.
-- `2026-08-30T05-11-20Z-speed.json`: TODO: describe the occasion.
+- `2026-08-30T05-11-20Z-speed.json`: the first record with the converted-wasm3 runners (#279) on the wasm3 v0.9.0 pin (#278).
 
 ## Size records
 

--- a/records/README.md
+++ b/records/README.md
@@ -19,6 +19,7 @@ A run appends its line with a `TODO`; fill it in when committing the record.
 - `2026-08-22T08-27-05Z-speed.json`: re-baseline after the f32 rounding change (#268).
 - `2026-08-24T22-56-29Z-speed.json`: TODO: describe the occasion.
 - `2026-08-24T23-27-21Z-speed.json`: TODO: describe the occasion.
+- `2026-08-30T05-11-20Z-speed.json`: TODO: describe the occasion.
 
 ## Size records
 


### PR DESCRIPTION
The first full-suite measurement since the converted-wasm3 runners (#279) and the wasm3 v0.9.0 pin (#278) landed: one dated record plus the rendered `docs/benchmarks/results.md` and its charts.

- Full matrix (462 workload x runner pairs), every cell byte-verified against wasmtime; no failed cells.
- Measured on AC power, Apple M1 Pro, the same discipline as previous records.
- Same-language pairings against the hand-written interpreters go 50/56 to the converted wasm3 (1.6x to 3.6x on `wat/i32_alu`); the six losses are all on `wat/call_direct` / `wat/call_indirect`, where wasm3 spends its own C-stack recursion per guest call.
- Apps split as the shapes predict: cowsay's startup-dominated wall time goes to the hand-written interpreters (one interpretation layer fewer to boot), minigzip's sustained compression to the converted side (wasm3-ruby-yjit 51.7 s vs pywasm-pypy 81.3 s, the only two interpreter-family cells that run it).