### PR TITLE
Run the Java wasm3 glue's instance on a 64 MB thread

### DIFF
--- a/crates/dewasm-backend-java/tests/e2e.rs
+++ b/crates/dewasm-backend-java/tests/e2e.rs
@@ -341,12 +341,24 @@ const JAVA_TOYWASM_GLUE: &str = r#"public class Main {
 "#;
 
 /// Like the toywasm glue; wasm3's CLI takes the guest module directly (its meta-WASI build always forwards the guest's WASI).
+/// wasm3's dispatch nests one JVM frame per guest opcode, deeper than the JVM main thread's default stack on the Linux CI host, so the instance runs on a 64 MB thread like the standalone wrapper's guest thread.
+/// The rethrow is what makes a guest failure a nonzero exit: an uncaught exception on a non-main thread does not change the exit status.
 const JAVA_WASM3_GLUE: &str = r#"public class Main {
     public static void main(String[] a) throws Exception {
-        Wasm3 inst = new Wasm3(null, new String[]{"wasm3", "/apps/cowsay.wasm", "Hello", "from", "dewasm!"}, null, java.util.Map.of("/apps", "{cache}"));
-        try {
-            ((Wasm3.Rt.Fn) inst.Exports.get("_start")).invoke(new Object[]{});
-        } catch (Wasm3.Rt.Exit e) {
+        Throwable[] failure = new Throwable[1];
+        Thread guest = new Thread(null, () -> {
+            try {
+                Wasm3 inst = new Wasm3(null, new String[]{"wasm3", "/apps/cowsay.wasm", "Hello", "from", "dewasm!"}, null, java.util.Map.of("/apps", "{cache}"));
+                ((Wasm3.Rt.Fn) inst.Exports.get("_start")).invoke(new Object[]{});
+            } catch (Wasm3.Rt.Exit e) {
+            } catch (Throwable e) {
+                failure[0] = e;
+            }
+        }, "guest", 64L << 20);
+        guest.start();
+        guest.join();
+        if (failure[0] != null) {
+            throw new RuntimeException(failure[0]);
         }
     }
 }


### PR DESCRIPTION
Fixes #285.

CI on main fails since #278 merged: the Java job's `wasm3_cowsay` e2e case dies with `java.lang.StackOverflowError` (run 33296994212).
wasm3's dispatch nests one JVM frame per guest opcode, and the library-mode glue ran the instance on the JVM main thread, whose default stack on the Linux CI host is smaller than what the cowsay guest's startup needs.
The case passed on the macOS host where it was authored, so the gap reached main unnoticed.

The fix gives the glue the shape the standalone wrapper already generates: the guest runs on a dedicated thread with a 64 MB stack, and a failure is rethrown on the main thread because an uncaught exception on a non-main thread does not change the exit status.
This matches how the Ruby glue raises `RUBY_THREAD_VM_STACK_SIZE` and the Python glue raises the recursion limit for the same case.

Verification: the failure reproduces locally by running the compiled glue with `java -Xss1m` (the same trace as CI); with the fix the same invocation prints the cowsay output and exits 0.
`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, and `cargo test -p dewasm-backend-java --test e2e --features slow_test wasm3_cowsay` all pass.

