### PR TITLE
Keep Go arithmetic between two constants out of constant evaluation

### DIFF
--- a/crates/dewasm-backend-go/src/lib.rs
+++ b/crates/dewasm-backend-go/src/lib.rs
@@ -523,6 +523,12 @@ fn ty_suffix(ty: ValType) -> &'static str {
     }
 }
 
+/// Whether `expr` renders as a Go integer constant, which makes any operation over two of them a compile-time constant expression.
+/// Float constants render as calls (`f32_from_bits`), so they are never constant to Go.
+fn int_const(expr: &Expr) -> bool {
+    matches!(expr, Expr::I32Const(_) | Expr::I64Const(_))
+}
+
 fn zero_value(ty: ValType) -> &'static str {
     match ty {
         ValType::FuncRef | ValType::ExnRef => "nil",
@@ -1726,6 +1732,15 @@ impl<'a> Gen<'a> {
         }
     }
 
+    /// The same constant, always laundered through the identity call, so the expression holding it is not a Go constant expression.
+    fn laundered_const(&self, expr: &Expr) -> String {
+        match expr {
+            Expr::I32Const(v) => format!("{}(0x{v:x})", self.rt("i32c")),
+            Expr::I64Const(v) => format!("{}(0x{v:x})", self.rt("i64c")),
+            other => self.expr(other),
+        }
+    }
+
     fn expr(&self, expr: &Expr) -> String {
         match expr {
             // A folded constant may land directly inside a signed cast (int32/int64); Go rejects that conversion for a compile-time constant beyond the signed range, so launder large values through a call to keep the conversion a runtime one.
@@ -1750,6 +1765,11 @@ impl<'a> Gen<'a> {
             Expr::LocalGet(idx) => format!("l{idx}"),
             Expr::GlobalGet(idx) => format!("p.g{idx}.value"),
             Expr::Un(op, a) => self.un(*op, &self.expr(a)),
+            // Go computes an operation between two constants at arbitrary precision and rejects a result outside the type, where wasm wraps; laundering one operand makes the operation a runtime one, which wraps.
+            // Applied to every operator rather than the ones known to overflow today (`+`, `-`, `*`, `<<`), because the rule is about the operands being constants at all, and `bin` is free to lower an operator into arithmetic that overflows where the operator itself would not.
+            Expr::Bin(op, a, b) if int_const(a) && int_const(b) => {
+                self.bin(*op, &self.laundered_const(a), &self.expr(b))
+            }
             Expr::Bin(op, a, b) => self.bin(*op, &self.expr(a), &self.expr(b)),
             Expr::Load { op, addr, offset } => {
                 format!(

--- a/crates/dewasm-backend-go/tests/vet.rs
+++ b/crates/dewasm-backend-go/tests/vet.rs
@@ -84,6 +84,22 @@ const PRUNED_TAIL_WAT: &str = r#"(module
     (i32.const 3)))
 "#;
 
+/// Go computes an operation between two constants at arbitrary precision and rejects a result outside the type, where wasm wraps, so the emitter has to keep such an operation from being a Go constant expression at all.
+/// The spec testsuite passes its operands in at each `invoke`, so no `.wast` file produces this shape; it reached the emitter through the official wasm3 build (issue #289), whose PRNG multiplies two constants.
+const CONST_ARITHMETIC_WAT: &str = r#"(module
+  (func (export "mul") (result i32) (i32.mul (i32.const 20152) (i32.const 1103515245)))
+  (func (export "sub") (result i32) (i32.sub (i32.const 0) (i32.const 1)))
+  (func (export "shl") (result i32) (i32.shl (i32.const 3) (i32.const 31)))
+  (func (export "add64") (result i64) (i64.add (i64.const 9223372036854775807) (i64.const 1))))
+"#;
+
+#[test]
+fn arithmetic_between_two_constants_wraps_instead_of_overflowing_the_compiler() {
+    let bytes = wat::parse_str(CONST_ARITHMETIC_WAT).expect("parse wat");
+    let src = dewasm_test_helper::convert_bytes(&GoBackend, &bytes, Mode::Library, "constarith");
+    assert_vet_clean("constarith", &src);
+}
+
 #[test]
 fn a_pruned_tail_takes_its_label_and_local_reads_with_it() {
     let bytes = wat::parse_str(PRUNED_TAIL_WAT).expect("parse wat");


### PR DESCRIPTION
Fixes #289.

Go computes a constant expression at arbitrary precision and rejects a result outside the type, where wasm wraps.
Three shapes fail to compile today:

```wat
(func (export "mul") (result i32) (i32.mul (i32.const 20152) (i32.const 1103515245)))
(func (export "sub") (result i32) (i32.sub (i32.const 0) (i32.const 1)))
(func (export "shl") (result i32) (i32.shl (i32.const 3) (i32.const 31)))
```

```
./main.go:78:10: uint32(20152) * uint32(1103515245) (constant 22238039217240 of type uint32) overflows uint32
./main.go:82:10: uint32(0) - uint32(1) (constant -1 of type uint32) overflows uint32
./main.go:86:10: uint32(3) << (uint32(31) & 31) (constant 6442450944 of type uint32) overflows uint32
```

The emitter already launders a large constant through `Rt.i32c` to keep a signed cast a runtime conversion, but that rule looks at one constant at a time and says nothing about what an operation over two of them evaluates to.
This launders one operand whenever both are integer constants, which makes the operation a runtime one, and a runtime one wraps.

The rule covers every operator rather than the three known to overflow today, because what makes the expression constant is the operands being constants at all, and `bin` is free to lower an operator into arithmetic that overflows where the operator itself would not.

## Verification

- Pinned in `vet.rs`, where `go vet` compiles the artifact, alongside the existing inline-`.wat` case.
  The spec testsuite passes its operands in at each `invoke`, so no `.wast` file produces this shape; it reached the emitter through the official wasm3 build (#287), whose PRNG multiplies two constants.
- The wrapped value is checked at runtime, not just the compile: a standalone artifact exiting with `i32.mul(20152, 1103515245) - 0xb26d9458` exits 0, so the product wraps exactly as wasm requires.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` all pass.