### PR TITLE
Pin wasm3 to its official release asset

### DIFF
--- a/agents/apps-audit.md
+++ b/agents/apps-audit.md
@@ -31,7 +31,7 @@ The same verdict covers an app with no artifact to run the audit tool on at all:
 | Lua 5.4.7 | see below | no artifact to audit (SjLj build crashes wasm-ld, prebuilts broken) | ⛔ deferred |
 | PHP | see below | no artifact to audit (no maintained wasm32-wasip1 build) | ⛔ deferred |
 | toywasm 76.0.0 | pinned in `setup.sh` | reference-types *encoding only*¹ | ✅ in scope (shipping, **executes on every backend**¹⁵) |
-| wasm3 0.9.0 | pinned-source zig build in `setup.sh` | none (baseline after the wasm-opt pass)¹¹ | ✅ in scope (shipping, **executes on every backend**¹⁶) |
+| wasm3 0.9.0 | official `wasm3-wasi.wasm` release asset, pinned in `setup.sh` | **tail calls** (accepted input¹⁶) | ✅ in scope (shipping, **executes on every backend but Bash**¹⁶) |
 
 ¹ **Reference-types encoding tolerance.**
 LLVM-based toolchains (clang/wasi-sdk, zig, rustc) emit `call_indirect` type/table-index immediates as padded, overlong LEBs when the `reference-types` target feature is enabled, the default since LLVM 19.
@@ -160,21 +160,16 @@ The case therefore has no wasmtime freshness run and adds no snapshot file.
 An earlier entry deferred wasm3 on evidence measured against its 2026-08 master snapshot, whose whole dispatch is `M3_MUSTTAIL return nextOpImpl()`: the stock build demands the tail-call proposal, and its `-DM3_HAS_TAIL_CALL=0` escape was measured growing the C stack once per *executed* opcode (issue #101 records both).
 The promotion first landed on v0.5.0 (2021-06), which predates that dispatch; upstream then resumed releases with v0.9.0 (2026-08-24) and the pin moved there.
 
-v0.9.0 keeps the musttail dispatch by default, so the official `wasm3-wasi.wasm` release asset needs the tail-call proposal, and `scripts/wasm3.sh` builds the pinned source tarball with `-DM3_HAS_TAIL_CALL=0` in the meta-WASI configuration (`-Dd_m3HasMetaWASI`), which forwards the guest's WASI calls straight to the outer host: exactly the shape a converted interpreter needs.
-Re-measured 2026-08-30, once the tail-call proposal became accepted input: tail calls are the *only* thing the asset needs beyond the baseline (it carries the reference-types bit for overlong `call_indirect` immediates but uses no construct, and it builds into the IR unchanged).
-Converted to Ruby it runs the cowsay guest in under a second on a stock `ruby` with no stack workaround, and on Java it runs on a default JVM stack.
-Every backend but Bash lowers the proposal (decision 88), and this case runs on all six, so the pin cannot move to the asset while Bash is among them; Go additionally cannot build the asset yet for an unrelated emission bug (issue #289).
-The old per-opcode stack growth does not reproduce on that build: dispatch frames unwind at loops and returns, and one million `wat/i32_alu` iterations (15M+ guest opcodes) complete byte-identical to wasmtime both under wasmtime itself and under the Ruby conversion, the same bounded behavior v0.5.0 showed.
-The wasi-libc compatibility fixes the v0.5.0 build carried as a patch are upstream in v0.9.0, so nothing is patched, and its meta-WASI layer serves 38 WASI functions where v0.5.0 served 28 (fd_tell among the additions: minigzip round-trips through it, measured).
-Conversion cost and speed are at parity with the v0.5.0 build (about 3.5 us per `wat/i32_alu` iteration on ruby+yjit against v0.5.0's 3.6).
-Audit: pure baseline after the `wasm-opt` pass¹¹.
+Between 2026-08-29 and 2026-08-31 the pin was a local `-DM3_HAS_TAIL_CALL=0` source build, the only way to get a baseline module out of that dispatch; once the tail-call proposal became accepted input (decision 88) the pin moved to the official `wasm3-wasi.wasm` release asset, which is what `scripts/wasm3.sh` fetches now.
+The asset is the meta-WASI build (`-Dd_m3HasMetaWASI`), which forwards the guest's WASI calls straight to the outer host: exactly the shape a converted interpreter needs, and the reason this app takes the guest module directly with no `--wasi` flag.
+Audit: baseline plus tail calls, and nothing else (it carries the reference-types bit for overlong `call_indirect` immediates but uses no construct).
+
+Every backend but Bash lowers the proposal, so Bash is the one backend whose e2e case is commented out; its `convert` manifest entry declares the requirement, which asserts that Bash refuses the module with the attributed error and every other backend converts it.
+The old per-opcode stack growth is gone with the source build that caused it: the asset's dispatch is a tail call, so each backend's trampoline runs the whole chain in one host frame, and the glue on every backend is now plain.
+The wasi-libc compatibility fixes the v0.5.0 build carried as a patch are upstream in v0.9.0, and its meta-WASI layer serves 38 WASI functions where v0.5.0 served 28 (fd_tell among the additions: minigzip round-trips through it, measured).
 
 The case (`WASM3_COWSAY`, `wasm3_cowsay_e2e!`) mirrors `TOYWASM_COWSAY`¹⁵: the converted interpreter runs the cached `cowsay.wasm` out of the app cache preopened at `/apps`, against the `cowsay_args` snapshot.
 Two differences from toywasm: wasm3's CLI takes the guest module directly (no `--wasi` flag; the meta-WASI build always wires the guest's WASI), and the artifact runs under wasmtime, so the `fs_apps` freshness run cross-checks the case against a live engine, the ground truth the toywasm case cannot have.
-
-What remains of the old finding, shrunk: the dispatch nests one host-language call per guest opcode until a loop or return unwinds it, so a guest whose startup runs deep (cowsay) exceeds Ruby's default VM stack and CPython's default recursion limit.
-Each affected glue self-serves the raise, the same pattern as the CPython-on-Bash glue's `ulimit -s`⁵: the Ruby glue re-execs itself once with `RUBY_THREAD_VM_STACK_SIZE` raised (Ruby cannot grow that stack after boot), the Python glue raises `sys.setrecursionlimit`, and the Java glue runs the instance on a 64 MB thread the way the standalone wrapper already does (the JVM main thread's default stack is smaller on the Linux CI host than on macOS, so this one reached main as a CI failure before it was found); Perl and Go need nothing, and the Bash glue raises `ulimit -s`.
-Accepting the tail-call proposal (decision 88) is what removes this class of workaround at its source rather than per backend.
 
 Why a second interpreter next to toywasm¹⁵: wasm3 natively interprets roughly 6x slower than wasmtime where toywasm sits near 300x, which makes converted wasm3 the carrier that keeps a converted interpreter competitive with the wasm interpreters hand-written in the target languages (wardite, pywasm); the speed benchmark suite measures that comparison.
 

--- a/agents/decisions/88-tail-calls-accepted-input.md
+++ b/agents/decisions/88-tail-calls-accepted-input.md
@@ -14,7 +14,7 @@ That is what the glue stack workarounds on Ruby, Python, Java, and Bash exist fo
 Accepting the proposal removes the workarounds at their source and lets the pinned app be the official asset rather than a source build.
 
 Measured on the v0.9.0 asset: with the proposal accepted, the module validates and builds into the IR, and the only thing left rejecting it is the per-backend declaration.
-Nothing else about it is out of scope.
+Nothing else about it is out of scope, so accepting the proposal is also what lets the pin be upstream's own asset instead of a local build.
 
 ## Decision
 
@@ -58,8 +58,9 @@ Code this governs: `crates/dewasm-core/src/{ir,func,module}.rs` (the two stateme
 
 - Positive: the official `wasm3-wasi.wasm` asset converts and runs the cowsay guest with no stack workaround at all: under a second on a stock `ruby` where the `-DM3_HAS_TAIL_CALL=0` build needs `RUBY_THREAD_VM_STACK_SIZE` raised, and on a default JVM stack where the same build needed the glue's own 64 MB thread.
 - Positive: `docs/support.md` gains a tail-call row, the second feature row that differs per backend.
-- Negative: the pinned app cannot move to the official asset while the case still runs under Bash, so the source build and the Bash `ulimit -s` raise stay; what the other five backends gain is that their own workarounds become unnecessary once it does move.
+- Positive: the pinned wasm3 is upstream's own release asset rather than a local build with the dispatch turned off, and every stack workaround this app needed is gone: the glue is plain on all five backends that run it.
+- Negative: Bash loses the case entirely, since the module it now converts is one Bash refuses; its `e2e.rs` callsite is commented out with that reason, and the convert manifest asserts the refusal so the loss cannot pass silently.
 - Carry-over: a tail-calling function allocates one thunk per hop and pays a wrapper frame even when called normally, the cost decision 18 already recorded.
   In converted wasm3 that hop is the guest opcode dispatch, so the allocation sits in the hottest loop there is; whether it costs more than the stack growth it replaces is a measurement the benchmark suite should make once the app moves.
 - Carry-over: converting the official asset to Go exposed an unrelated emission bug (issue #289): a constant `i32.mul` renders as a Go constant expression, which Go rejects for overflow instead of wrapping.
-  Go therefore cannot build that asset yet, though its tail-call lowering passes the conformance suite.
+  Fixed separately; the asset is what found it, since the spec testsuite passes its operands in at each `invoke` and so never produces the shape.

--- a/crates/dewasm-backend-bash/tests/e2e.rs
+++ b/crates/dewasm-backend-bash/tests/e2e.rs
@@ -273,17 +273,6 @@ toywasm_invoke '_start'
 exit 0
 "#;
 
-/// Like the toywasm glue; wasm3's CLI takes the guest module directly (its meta-WASI build always forwards the guest's WASI).
-/// Raises the stack rlimit for the same reason [`BASH_CPYTHON_GLUE`] does: wasm3's dispatch nests one native bash call per executed guest opcode until a loop or return unwinds it, deep enough to exhaust the default process stack.
-const BASH_WASM3_GLUE: &str = r#"ulimit -s unlimited 2>/dev/null || ulimit -s "$(ulimit -Hs)" 2>/dev/null || true
-WASI_ARGS=(wasm3 /apps/cowsay.wasm Hello from 'dewasm!')
-WASI_ENV=()
-WASI_DIRS=('{cache}::/apps')
-wasm3_init || { echo "init failed" >&2; exit 1; }
-wasm3_invoke '_start'
-exit 0
-"#;
-
 /// CPython reading its stdlib from the cache-preopened tree at `/lib`; `WASI_ENV` carries `PYTHONHOME`/`PYTHONPATH` as the `NAME=value` strings the standalone main also builds.
 ///
 /// The leading `ulimit` is the one thing these two interpreters need that the smaller filesystem apps do not.
@@ -765,9 +754,9 @@ dewasm_test_helper::cruby_packed_hello_e2e!(Bash, ultra);
 // Ultra: interpreting the cowsay guest through the converted interpreter measured 697 s, the same order as the language-runtime giants above (an interpreter's dispatch loop is one bash function call per executed guest instruction).
 // It runs at `slow` on every other backend, so the case itself stays CI-covered.
 dewasm_test_helper::toywasm_cowsay_e2e!(Bash, BASH_TOYWASM_GLUE, ultra);
-// Ultra for the same reason as the toywasm case above; wasm3 interprets the same cowsay guest one bash function call at a time.
-// It runs at `slow` on every other backend, so the case itself stays CI-covered.
-dewasm_test_helper::wasm3_cowsay_e2e!(Bash, BASH_WASM3_GLUE, ultra);
+// REASON: the pinned wasm3 is upstream's official asset, whose dispatch is a musttail chain, so the module needs the tail-call proposal; Bash is the one backend that does not lower it, and `check_module_support` refuses the module before any of this runs.
+// The convert suite asserts that refusal (its manifest entry declares the requirement), and every other backend runs the case, so the app itself stays covered.
+// dewasm_test_helper::wasm3_cowsay_e2e!(Bash, BASH_WASM3_GLUE, ultra);
 
 dewasm_test_helper::doom_frame_e2e!(Bash, BASH_DOOM_FRAME_GLUE, ultra);
 // Ultra-slow category: tens of seconds per tick locally (mem_init's own copy loop over the 41 KB ROM, then agnes's per-frame interpretation), ~20 min for the full 40-frame run, well past the ~1-minute CI-runner line, like the DOOM case above. (It was ~25 min before issue #117 moved the per-pixel frame composition out of the guest.)

--- a/crates/dewasm-backend-java/tests/e2e.rs
+++ b/crates/dewasm-backend-java/tests/e2e.rs
@@ -341,24 +341,13 @@ const JAVA_TOYWASM_GLUE: &str = r#"public class Main {
 "#;
 
 /// Like the toywasm glue; wasm3's CLI takes the guest module directly (its meta-WASI build always forwards the guest's WASI).
-/// wasm3's dispatch nests one JVM frame per guest opcode, deeper than the JVM main thread's default stack on the Linux CI host, so the instance runs on a 64 MB thread like the standalone wrapper's guest thread.
-/// The rethrow is what makes a guest failure a nonzero exit: an uncaught exception on a non-main thread does not change the exit status.
+/// Plain glue on the main thread, unlike every other converted-interpreter case here: the official asset's dispatch is a tail call, so the trampoline runs the whole chain in one JVM frame and the default stack is enough.
 const JAVA_WASM3_GLUE: &str = r#"public class Main {
     public static void main(String[] a) throws Exception {
-        Throwable[] failure = new Throwable[1];
-        Thread guest = new Thread(null, () -> {
-            try {
-                Wasm3 inst = new Wasm3(null, new String[]{"wasm3", "/apps/cowsay.wasm", "Hello", "from", "dewasm!"}, null, java.util.Map.of("/apps", "{cache}"));
-                ((Wasm3.Rt.Fn) inst.Exports.get("_start")).invoke(new Object[]{});
-            } catch (Wasm3.Rt.Exit e) {
-            } catch (Throwable e) {
-                failure[0] = e;
-            }
-        }, "guest", 64L << 20);
-        guest.start();
-        guest.join();
-        if (failure[0] != null) {
-            throw new RuntimeException(failure[0]);
+        Wasm3 inst = new Wasm3(null, new String[]{"wasm3", "/apps/cowsay.wasm", "Hello", "from", "dewasm!"}, null, java.util.Map.of("/apps", "{cache}"));
+        try {
+            ((Wasm3.Rt.Fn) inst.Exports.get("_start")).invoke(new Object[]{});
+        } catch (Wasm3.Rt.Exit e) {
         }
     }
 }

--- a/crates/dewasm-backend-python/tests/e2e.rs
+++ b/crates/dewasm-backend-python/tests/e2e.rs
@@ -235,11 +235,8 @@ except ToywasmRt.Exit:
 "#;
 
 /// Like the toywasm glue; wasm3's CLI takes the guest module directly (its meta-WASI build always forwards the guest's WASI).
-/// wasm3's continuation-passing dispatch nests one Python call per guest opcode until a loop or return unwinds it, and cowsay's startup runs deeper than the default recursion limit, so the glue raises it (the Python analog of the Ruby glue's re-exec).
-const PYTHON_WASM3_GLUE: &str = r#"import sys
-
-sys.setrecursionlimit(200000)
-inst = Wasm3({}, args=["wasm3", "/apps/cowsay.wasm", "Hello", "from", "dewasm!"], env={}, preopens={"/apps": "{cache}"})
+/// Plain glue, unlike every other converted-interpreter case here: the official asset's dispatch is a tail call, so the trampoline runs the whole chain in one Python frame and no recursion limit is raised.
+const PYTHON_WASM3_GLUE: &str = r#"inst = Wasm3({}, args=["wasm3", "/apps/cowsay.wasm", "Hello", "from", "dewasm!"], env={}, preopens={"/apps": "{cache}"})
 try:
     inst.invoke("_start")
 except Wasm3Rt.Exit:

--- a/crates/dewasm-backend-ruby/tests/e2e.rs
+++ b/crates/dewasm-backend-ruby/tests/e2e.rs
@@ -231,12 +231,8 @@ end
 "#;
 
 /// Like the toywasm glue; wasm3's CLI takes the guest module directly (its meta-WASI build always forwards the guest's WASI).
-/// wasm3's continuation-passing dispatch nests one Ruby call per guest opcode until a loop or return unwinds it, and cowsay's startup runs deeper than the default VM stack; Ruby cannot raise that stack after boot, so the glue re-execs itself once with it raised (the Ruby analog of the `ulimit -s` the CPython-on-Bash glue needs).
-const RUBY_WASM3_GLUE: &str = r#"if ENV["RUBY_THREAD_VM_STACK_SIZE"].to_i < 64 * 1024 * 1024
-  require "rbconfig"
-  exec({ "RUBY_THREAD_VM_STACK_SIZE" => (64 * 1024 * 1024).to_s }, RbConfig.ruby, __FILE__, *ARGV)
-end
-inst = Wasm3.new({}, args: ["wasm3", "/apps/cowsay.wasm", "Hello", "from", "dewasm!"], env: {}, preopens: {"/apps" => "{cache}"})
+/// Plain glue, unlike every other converted-interpreter case here: the official asset's dispatch is a tail call, so the trampoline runs the whole chain in one Ruby frame and no stack is raised.
+const RUBY_WASM3_GLUE: &str = r#"inst = Wasm3.new({}, args: ["wasm3", "/apps/cowsay.wasm", "Hello", "from", "dewasm!"], env: {}, preopens: {"/apps" => "{cache}"})
 begin
   inst.invoke("_start")
 rescue Wasm3::Rt::Exit

--- a/crates/dewasm-test-helper/src/apps_convert.rs
+++ b/crates/dewasm-test-helper/src/apps_convert.rs
@@ -116,7 +116,7 @@ const MANIFEST: &[AppConvert] = &[
         stem: "wasm3",
         mode: Mode::Standalone,
         heavy: false,
-        requires: None,
+        requires: Some(Feature::TailCall),
     },
     AppConvert {
         stem: "doom",

--- a/crates/xtask/src/bench/runner.rs
+++ b/crates/xtask/src/bench/runner.rs
@@ -445,7 +445,7 @@ impl Workshop {
     }
 
     /// The converted wasm3 on `target`'s host, told to run `wasm`: the interpreter artifact's launch plus `--dir <wasm's dir>::/work` and the module's guest path, so the caller-appended guest arguments reach the module one interpretation layer down.
-    /// The Ruby hosts get `RUBY_THREAD_VM_STACK_SIZE` raised: wasm3's dispatch nests one host call per guest opcode until a loop or return unwinds it, deeper than the default VM stack for guests with a deep startup, and Ruby cannot raise that stack after boot.
+    /// No host stack is raised: the pinned asset's dispatch is a tail call, so the trampoline runs the whole chain in one host frame.
     fn converted_interpreter_launch(&mut self, target: Target, wasm: &Path) -> Result<Launch> {
         let interpreter = converted_wasm3()
             .context("examples/apps/cache/wasm3.wasm missing: run examples/apps/setup.sh")?;
@@ -453,12 +453,6 @@ impl Workshop {
             .with_context(|| format!("failed to read {}", interpreter.display()))?;
         let artifact = self.artifact_for(target, &bytes)?;
         let mut launch = host_launch(target, artifact)?;
-        if let Target::Ruby(_) = target {
-            launch.env.push((
-                "RUBY_THREAD_VM_STACK_SIZE".to_string(),
-                (64 << 20).to_string(),
-            ));
-        }
         let dir = wasm
             .parent()
             .with_context(|| format!("{} has no parent directory", wasm.display()))?;

--- a/examples/apps/scripts/wasm3.sh
+++ b/examples/apps/scripts/wasm3.sh
@@ -2,69 +2,12 @@
 # shellcheck source-path=SCRIPTDIR
 # shellcheck source=common.sh
 
-# wasm3: a WebAssembly interpreter written in C, built from the pinned v0.9.0 source release with zig.
-# The official wasm3-wasi.wasm release asset needs the tail-call proposal (the default dispatch is a musttail chain), which is outside the accepted input, so it is compiled locally with that dispatch off; the build then audits as baseline wasm.
-# The meta-WASI configuration (-Dd_m3HasMetaWASI) forwards the guest's WASI calls to the outer host: the shape a converted interpreter needs.
+# wasm3: a WebAssembly interpreter written in C, from its official wasm32-wasi release asset.
+# The asset is the meta-WASI build, which forwards the guest's WASI calls to the outer host: the shape a converted interpreter needs, and the reason this app takes the module directly with no `--wasi` flag.
+# Its dispatch is a musttail chain, so it needs the tail-call proposal; every backend but Bash lowers that, and Bash's e2e case is the one that stays commented out.
 
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 
-WASM3_URL="https://github.com/wasm3/wasm3/archive/refs/tags/v0.9.0.tar.gz"
-WASM3_SHA256="cab79ce74bcac25bbf80b5ebe14af9795b9bac30b05ee8f620a3bc8002f3b8e6"
-WASM3_DIR="wasm3-0.9.0"
-# The interpreter core plus the libc/meta-WASI/tracer API layers and the CLI main.
-# The other two WASI variants (m3_api_wasi.c, m3_api_uvwasi.c) stay out: their defines are off anyway, and excluding them keeps the build's WASI surface unambiguous.
-WASM3_SRCS=(
-  source/m3_api_libc.c source/m3_api_meta_wasi.c source/m3_api_tracer.c
-  source/m3_bind.c source/m3_code.c source/m3_compile.c source/m3_core.c
-  source/m3_env.c source/m3_exec.c source/m3_function.c
-  source/m3_info.c source/m3_module.c source/m3_parse.c source/m3_validate.c
-  platforms/app/main.c
-)
-
-wasm3_stamp="cache/wasm3.src-sha256"
-wasm3_key="$(printf '%s wasm-opt:%s' "$WASM3_SHA256" "$(wasm_opt_version)")"
-if is_cached "$wasm3_stamp" "$wasm3_key" cache/wasm3.wasm; then
-  echo "wasm3: cached"
-  exit 0
-fi
-
-require_tool wasm3 zig "install zig (e.g. brew install zig) to build the wasm3 app"
-require_tool wasm3 wasm-opt "install binaryen (e.g. brew install binaryen) to preprocess the wasm3 app"
-
-echo "wasm3: fetching $WASM3_URL"
-new_tmpdir
-fetch_verified "$WASM3_URL" "$WASM3_SHA256" "$tmp/wasm3.tar.gz"
-tar xzf "$tmp/wasm3.tar.gz" -C "$tmp"
-echo "wasm3: building wasm3.wasm (zig cc)"
-srcs=()
-for s in "${WASM3_SRCS[@]}"; do srcs+=("$tmp/$WASM3_DIR/$s"); done
-# Flag notes:
-# -DM3_HAS_TAIL_CALL=0
-# the default dispatch is `M3_MUSTTAIL return nextOpImpl()`, which
-# wasm32 can only compile with the tail-call proposal; with the knob
-# off the chain compiles to plain calls whose frames unwind at loops
-# and returns, so flat guest loops interpret in bounded stack
-# (measured: one million wat/i32_alu iterations complete under
-# wasmtime's default stack limits).
-# -w              keep upstream's warnings out of the build output;
-# they are third-party C's, not ours.
-# -mno-*          keep the output inside the suite's baseline feature set (see
-# benchmarks/c/build.sh for the per-flag reasons).
-# -fomit-frame-pointer -fno-stack-protector
-# upstream's own release flags for the WASI build (CMakeLists.txt).
-# stack-size      upstream's WASI build links an 8 MiB C stack; guest calls
-# recurse on it, so keep upstream's headroom.
-# --strip-debug   drops the DWARF wasm-opt cannot parse.
-zig_cc_wasi -O3 \
-  -Dd_m3HasMetaWASI -DM3_HAS_TAIL_CALL=0 \
-  -I "$tmp/$WASM3_DIR/source" -w \
-  -mno-bulk-memory -mno-bulk-memory-opt -mno-nontrapping-fptoint -mno-multivalue -mno-reference-types \
-  -fomit-frame-pointer -fno-stack-protector \
-  -Wl,-z,stack-size=8388608 -Wl,--strip-debug \
-  "${srcs[@]}" \
-  -o cache/wasm3.wasm
-echo "wasm3: wasm-opt -O2"
-wasm_opt_inplace cache/wasm3.wasm
-
-write_stamp "$wasm3_stamp" "$wasm3_key"
-echo "wasm3: -> cache/wasm3.wasm"
+fetch_app wasm3 \
+  "https://github.com/wasm3/wasm3/releases/download/v0.9.0/wasm3-wasi.wasm" \
+  b8d07723d7c09516360a6196bdf6265d47f48cd7766fff7a92e68dd4854159e8


### PR DESCRIPTION
Closes #287.

**Stacked on #288** (tail-call support), which is what makes the asset convertible at all.
#290, the Go constant-overflow fix the asset also needed, is merged; this branch is rebased onto it, so the diff below is the re-pin alone.

## Why

The local build existed for one reason: wasm3's dispatch is a musttail chain, so upstream's own wasm32-wasi asset needs the tail-call proposal, and building with `-DM3_HAS_TAIL_CALL=0` was the only way to get a baseline module out of it.
Every backend but Bash lowers the proposal now, so the pin can be upstream's asset.

`scripts/wasm3.sh` shrinks from a 70-line zig build with its flag notes to a `fetch_app` call, and the app no longer needs zig at all.

## What the source build cost, now gone

Turning the macro off made the dispatch an ordinary call, and whatever LLVM did not turn back into a tail call became real stack growth, one frame per executed guest opcode.
Every backend running this app carried its own workaround for that. The asset's dispatch is a tail call, so each backend's trampoline runs the whole chain in one host frame, and all of them go away:

| Where | Was | Now |
| --- | --- | --- |
| Ruby glue | re-execs itself with `RUBY_THREAD_VM_STACK_SIZE` raised to 64 MB | plain |
| Python glue | `sys.setrecursionlimit(200000)` | plain |
| Java glue | runs the instance on its own 64 MB thread, with a rethrow to keep the exit status (#286) | plain, on the main thread |
| Benchmark runner | raises `RUBY_THREAD_VM_STACK_SIZE` for the Ruby hosts | plain |

## Bash

Bash is the one backend that does not lower the proposal, so its `wasm3_cowsay_e2e!` callsite is commented out with that reason.
Its convert manifest entry declares `requires: Some(Feature::TailCall)`, which asserts both directions: Bash refuses the module with the attributed error, and every other backend converts it.
So the case is not silently dropped, and the app stays covered on the other five.

## Verification

- `wasm3_cowsay` passes on Ruby, Python, Perl, Go, and Java against the official asset, with the plain glue above.
- `cargo test -p dewasm-backend-bash --test convert wasm3` passes, which is the refusal assertion.
- `--features slow_test` e2e passes for Ruby (40 cases) and Bash (28 passed, 9 ignored).
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` all pass.

The speed record is not regenerated here: the runners now convert a different module, so the numbers want their own measured run rather than a claim in this change.
