### PR TITLE
Add the wat/tail_call microbenchmark

### DIFF
--- a/benchmarks/wat/build.sh
+++ b/benchmarks/wat/build.sh
@@ -23,9 +23,10 @@ require_tool wat2wasm "install wabt (brew install wabt / apt install wabt)"
 
 for src in wat/*.wat; do
   id=$(basename "$src" .wat)
-  # eh_throw and eh_try are the only cases allowed past wasm 1.0, so the exception-handling proposal is enabled for them alone: any other case that reaches for a post-1.0 instruction fails to assemble here.
+  # A case is allowed past wasm 1.0 only where its whole reason is the proposal it names, and only that proposal is enabled for it: any other case reaching for a post-1.0 instruction fails to assemble here.
   case "$id" in
     eh_*) wat2wasm --enable-exceptions "$src" -o "cache/wat/$id.wasm" ;;
+    tail_call) wat2wasm --enable-tail-call "$src" -o "cache/wat/$id.wasm" ;;
     *) wat2wasm "$src" -o "cache/wat/$id.wasm" ;;
   esac
   echo "$id: $src -> cache/wat/$id.wasm"

--- a/benchmarks/wat/tail_call.wat
+++ b/benchmarks/wat/tail_call.wat
@@ -1,0 +1,126 @@
+;; tail_call: the same chain as call_direct, made of tail calls.
+;;
+;; One iteration walks the same four functions doing the same arithmetic, but each hop is a `return_call` instead of a `call`, so the chain replaces its frame rather than nesting four deep.
+;; call_direct prints the same number from the same work, so the difference between the two cases is the cost of a frame-replacing call against a nesting one; that pairing is why this case exists, and it is the shape eh_throw and eh_try already use for exception handling.
+;;
+;; The chain stays four hops rather than going a million deep on purpose.
+;; A depth no ordinary call could reach would measure the proposal's space guarantee, which is real, but it has no paired baseline to measure against and it would exclude every runner that lowers a tail call as an ordinary call.
+;;
+;; ---------------------------------------------------------------------------
+;; Shared preamble.
+;; Duplicated verbatim in every hand-written microbenchmark so each
+;; .wat stays a standalone module that wat2wasm and dewasm can consume directly.
+;;
+;; A microbenchmark is a WASI command module invoked as `<module> <iterations>`.
+;; It does
+;; <iterations> units of work, writes exactly one line (the decimal result followed by a newline) to stdout, and exits 0. <iterations> = 0 does no work but still prints, which is how the harness measures startup in isolation.
+;; Only args_sizes_get / args_get / fd_write / proc_exit are imported, and a body stays inside i32/i64/f64 except for the one axis its case exists to measure: f32 in f32_alu, exception handling in eh_throw and eh_try.
+;; That keeps every other case within reach of the pure-Ruby and pure-Python interpreters this suite compares, and a runner that cannot execute a case's axis is excluded for that case in the harness workload table, with the reason stated there.
+;;
+;; Memory map, shared by every microbenchmark.
+;; It starts at 0x1000 rather than at 0 because wasm3 traps with "out of bounds memory access" whenever a WASI out param is written to linear-memory address 0: address 0 is perfectly valid linear memory and every other runtime in the matrix accepts it, so the whole block is simply moved up out of wasm3's way:
+;;
+;; 0x1000   4  argc                     (args_sizes_get out param)
+;; 0x1004   4  argv buffer size         (args_sizes_get out param)
+;; 0x1010      argv pointer array       (args_get out param)
+;; 0x1100      argv string buffer       (args_get out param)
+;; 0x1400   8  iovec { base, len }
+;; 0x1408   4  fd_write nwritten
+;; 0x1410  24  decimal scratch, filled backwards from 0x1428
+;; 0x1800  29  usage message
+;; 0x10000+    working set, for the microbenchmarks that have one
+;; ---------------------------------------------------------------------------
+(module
+  (import "wasi_snapshot_preview1" "args_sizes_get"
+    (func $args_sizes_get (param i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "args_get"
+    (func $args_get (param i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "fd_write"
+    (func $fd_write (param i32 i32 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "proc_exit"
+    (func $proc_exit (param i32)))
+
+  (memory (export "memory") 2)
+
+  (data (i32.const 0x1800) "usage: <module> <iterations>\n")
+
+  ;; Every argv problem lands here.
+  ;; The harness always passes exactly one argument, so anything else is a caller bug, not an input to guess at.
+  (func $die
+    (i32.store (i32.const 0x1400) (i32.const 0x1800))
+    (i32.store (i32.const 0x1404) (i32.const 29))
+    (drop (call $fd_write
+      (i32.const 2) (i32.const 0x1400) (i32.const 1) (i32.const 0x1408)))
+    (call $proc_exit (i32.const 2))
+    (unreachable))
+
+  ;; argv[1] as an unsigned decimal.
+  ;; Hand-rolled atoi: ask for the sizes, ask for the strings, then walk the bytes of argv[1].
+  (func $iterations (result i32)
+    (local $p i32) (local $start i32) (local $c i32) (local $n i32)
+    (if (call $args_sizes_get (i32.const 0x1000) (i32.const 0x1004))
+      (then (call $die)))
+    (if (i32.ne (i32.load (i32.const 0x1000)) (i32.const 2))
+      (then (call $die)))
+    (if (call $args_get (i32.const 0x1010) (i32.const 0x1100))
+      (then (call $die)))
+    (local.set $p (i32.load (i32.const 0x1014)))
+    (local.set $start (local.get $p))
+    (block $end
+      (loop $byte
+        (local.set $c (i32.load8_u (local.get $p)))
+        (br_if $end (i32.eqz (local.get $c)))
+        ;; Unsigned wraparound turns every non-digit into a large value.
+        (if (i32.gt_u (i32.sub (local.get $c) (i32.const 48)) (i32.const 9))
+          (then (call $die)))
+        (local.set $n
+          (i32.add (i32.mul (local.get $n) (i32.const 10))
+                   (i32.sub (local.get $c) (i32.const 48))))
+        (local.set $p (i32.add (local.get $p) (i32.const 1)))
+        (br $byte)))
+    (if (i32.eq (local.get $p) (local.get $start)) (then (call $die)))
+    (local.get $n))
+
+  ;; Write `<v>\n` to stdout with v as an unsigned decimal.
+  ;; Digits come out least significant first, so the scratch area is filled backwards.
+  (func $print (param $v i64)
+    (local $p i32)
+    (local.set $p (i32.const 0x1427))
+    (i32.store8 (local.get $p) (i32.const 10))
+    (loop $digit
+      (local.set $p (i32.sub (local.get $p) (i32.const 1)))
+      (i32.store8 (local.get $p)
+        (i32.add (i32.const 48)
+                 (i32.wrap_i64 (i64.rem_u (local.get $v) (i64.const 10)))))
+      (local.set $v (i64.div_u (local.get $v) (i64.const 10)))
+      (br_if $digit (i64.ne (local.get $v) (i64.const 0))))
+    (i32.store (i32.const 0x1400) (local.get $p))
+    (i32.store (i32.const 0x1404) (i32.sub (i32.const 0x1428) (local.get $p)))
+    (drop (call $fd_write
+      (i32.const 1) (i32.const 0x1400) (i32.const 1) (i32.const 0x1408))))
+
+  (func $mix3 (param $x i32) (result i32)
+    (i32.xor (local.get $x) (i32.shr_u (local.get $x) (i32.const 16))))
+
+  (func $mix2 (param $x i32) (result i32)
+    (return_call $mix3
+      (i32.add (i32.mul (local.get $x) (i32.const 0x85ebca77)) (i32.const 1))))
+
+  (func $mix1 (param $x i32) (result i32)
+    (return_call $mix2
+      (i32.xor (local.get $x) (i32.shr_u (local.get $x) (i32.const 13)))))
+
+  (func $mix0 (param $x i32) (result i32)
+    (return_call $mix1 (i32.mul (local.get $x) (i32.const 1664525))))
+
+  (func (export "_start")
+    (local $n i32) (local $i i32) (local $a i32)
+    (local.set $n (call $iterations))
+    (block $done
+      (loop $next
+        (br_if $done (i32.ge_u (local.get $i) (local.get $n)))
+        (local.set $a (call $mix0 (i32.add (local.get $a) (local.get $i))))
+        (local.set $i (i32.add (local.get $i) (i32.const 1)))
+        (br $next)))
+    (call $print (i64.extend_i32_u (local.get $a))))
+)

--- a/crates/xtask/src/bench/workload.rs
+++ b/crates/xtask/src/bench/workload.rs
@@ -26,6 +26,7 @@ const MICRO_ITER_CAPS: &[(&str, u64)] = &[
     ("wat/mem_rw", 500_000_000),
     ("wat/mem_narrow", 600_000_000),
     ("wat/call_direct", 500_000_000),
+    ("wat/tail_call", 500_000_000),
     ("wat/call_indirect", 500_000_000),
     ("wat/eh_throw", 4_000_000),
     ("wat/eh_try", 330_000_000),
@@ -43,6 +44,7 @@ const MICRO_ITER_CAPS: &[(&str, u64)] = &[
 const MICRO_EXCLUDES: &[(&str, &[(&str, Exclusion)])] = &[
     ("wat/eh_throw", EH_EXCLUDES),
     ("wat/eh_try", EH_EXCLUDES),
+    ("wat/tail_call", TAIL_CALL_EXCLUDES),
     ("wat/f32_alu", F32_ALU_EXCLUDES),
     ("wat/i64_div", I64_DIV_EXCLUDES),
 ];
@@ -96,6 +98,46 @@ const EH_EXCLUDES: &[(&str, Exclusion)] = &[
     ("wardite", WARDITE_EH_EXCLUSION),
     ("wardite-yjit", WARDITE_EH_EXCLUSION),
 ];
+
+/// Runners excluded from the tail-call microbenchmark: none of these accepts `return_call`.
+/// The paired `call_direct` case has no exclusions, so a runner missing here is measured on both and a runner listed here is measured on the baseline alone.
+const TAIL_CALL_EXCLUDES: &[(&str, Exclusion)] = &[
+    (
+        "dewasm-bash",
+        Exclusion {
+            kind: ExclusionKind::Capability,
+            reason: "the bash backend has no tail-call lowering and rejects the module at conversion time with \"unsupported (tail-call): return_call/return_call_indirect instruction\" (see docs/support.md)",
+        },
+    ),
+    (
+        "wasmer",
+        Exclusion {
+            kind: ExclusionKind::Capability,
+            reason: "wasmer rejects the module: compile error Validate(\"tail calls support is not enabled\")",
+        },
+    ),
+    (
+        "wazero",
+        Exclusion {
+            kind: ExclusionKind::Capability,
+            reason: "wazero 1.12.0 rejects the module: \"return_call invalid as feature \\\"tail-call\\\" is disabled\"",
+        },
+    ),
+    ("pywasm-cpython", PYWASM_TAIL_CALL_EXCLUSION),
+    ("pywasm-pypy", PYWASM_TAIL_CALL_EXCLUSION),
+    ("wardite", WARDITE_TAIL_CALL_EXCLUSION),
+    ("wardite-yjit", WARDITE_TAIL_CALL_EXCLUSION),
+];
+
+const PYWASM_TAIL_CALL_EXCLUSION: Exclusion = Exclusion {
+    kind: ExclusionKind::Capability,
+    reason: "pywasm 2.2.3 has no tail-call opcodes; decoding dies with AssertionError on 0x12, the return_call opcode (pywasm/core.py)",
+};
+
+const WARDITE_TAIL_CALL_EXCLUSION: Exclusion = Exclusion {
+    kind: ExclusionKind::Capability,
+    reason: "wardite 0.9.0 decodes return_call but has no implementation: RuntimeError \"TODO! unsupported [:default, :return_call, [], nil, nil]\" (wardite.rb, eval_insn)",
+};
 
 const CONVERTED_WASM3_EH_EXCLUSION: Exclusion = Exclusion {
     kind: ExclusionKind::Capability,

--- a/crates/xtask/src/bench/workload.rs
+++ b/crates/xtask/src/bench/workload.rs
@@ -101,14 +101,8 @@ const EH_EXCLUDES: &[(&str, Exclusion)] = &[
 
 /// Runners excluded from the tail-call microbenchmark: none of these accepts `return_call`.
 /// The paired `call_direct` case has no exclusions, so a runner missing here is measured on both and a runner listed here is measured on the baseline alone.
+/// Every dewasm backend runs it, bash included: the proposal is lowered everywhere (see docs/support.md).
 const TAIL_CALL_EXCLUDES: &[(&str, Exclusion)] = &[
-    (
-        "dewasm-bash",
-        Exclusion {
-            kind: ExclusionKind::Capability,
-            reason: "the bash backend has no tail-call lowering and rejects the module at conversion time with \"unsupported (tail-call): return_call/return_call_indirect instruction\" (see docs/support.md)",
-        },
-    ),
     (
         "wasmer",
         Exclusion {


### PR DESCRIPTION
The suite measures the tail-call proposal on nothing today, so what the trampolines added in #288 cost is unmeasured.
Decision 88 left that as an open carry-over; this closes it.

## Design

The case is `call_direct` with its four hops turned into `return_call`.
That pairing is the whole design: `call_direct`'s chain is already four functions each in tail position, so replacing the calls changes the frame discipline and nothing else, and both cases print the same number from the same arithmetic (verified at 0, 1,000 and 1,000,000 iterations under wasmtime).
What separates them is a frame-replacing call against a nesting one, the same way `eh_throw` and `eh_try` separate a throw and a catch from a plain return.

The chain stays four hops.
A depth no ordinary call could reach would measure the space guarantee instead, which is real but has no paired baseline and would exclude every runner that lowers a tail call as an ordinary call.

## What it said, and what it drove

The first measurement is why #297 exists. Measured before it, ns per iteration:

| Runner | call_direct | tail_call | ratio |
| --- | ---: | ---: | ---: |
| wasmtime | 3.5 | 3.5 | 1.00x |
| wasmedge | 201.8 | 190.5 | 0.94x |
| wasm3 | 44.1 | 54.1 | 1.23x |
| dewasm-go | 4.1 | 40.6 | 9.93x |
| dewasm-java | 3.6 | 30.3 | 8.52x |
| dewasm-ruby-yjit | 107.2 | 688.3 | 6.42x |
| dewasm-perl | 1098.9 | 3694.9 | 3.36x |
| dewasm-python | 413.3 | 849.3 | 2.06x |
| dewasm-pypy | 87.5 | 144.9 | 1.66x |
| wasm3-ruby-yjit | 12501.9 | 11321.7 | 0.91x |

A native compiler makes a tail call free; a trampoline did not, and Go and Java paid the most because their ordinary call is nearly free and the thunk was an allocation per hop.
Parking the pending call (#297) took Go to 8.3 ns and Ruby with YJIT to 276 ns on this very case, so the row it added is now the one that watches for that cost coming back.

Nothing is claimed in the checked-in record: this is a filtered run for the design, not a full one, so the record and `docs/benchmarks/results.md` are untouched and want their own measured run.

## Exclusions

Seven runners, each with the error it actually produced:

| Runner | Observed |
| --- | --- |
| wasmer | `compile error Validate("tail calls support is not enabled")` |
| wazero | `return_call invalid as feature "tail-call" is disabled` |
| pywasm (both hosts) | `AssertionError: 0x12`, the `return_call` opcode |
| wardite (both hosts) | `RuntimeError "TODO! unsupported [:default, :return_call, ...]"` |

wasm3 runs it natively and through the conversion (v0.9.0 is a `tail-call` build), so the converted-interpreter rows stay.
Every dewasm backend runs it, bash included, since #296 lowered the proposal there too: measured at 78.6 us per iteration, the same order as its other rows.

`build.sh` enables the proposal for this case alone, the way it already does for the exception-handling pair.

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `shellcheck benchmarks/wat/build.sh`, and `cargo test` all pass.
