### PR TITLE
Park a pending tail call instead of allocating one

### DIFF
--- a/agents/decisions/18-ruby-tail-calls.md
+++ b/agents/decisions/18-ruby-tail-calls.md
@@ -2,8 +2,9 @@
 
 Status: **Accepted, 2026-08-31.**
 [Decision 88](88-tail-calls-accepted-input.md) put the design below back in force, and Python and Perl adopt it unchanged: all three lack dependable tail-call elimination, so the shape that keeps chains flat is the same in each.
-Go and Java follow the same body/entry split with the thunk typed instead of dynamic, and Bash parks it in the globals its results already travel through; both are described in decision 88.
-Perl differs only in the two places its language forces: the thunk escapes through the `try_table` outcome table rather than a bare `return` (perl's `return` inside an `eval` exits only the `eval`), and the trampoline is list-aware because perl flattens a multi-value return into its caller's argument list.
+Go, Java, and Bash follow the same body/entry split, described in decision 88.
+The thunk itself is gone everywhere: what a body leaves behind is parked in per-instance slots rather than allocated, the shape Bash had from the start and [decision 89](89-park-the-pending-tail-call.md) brought the rest to.
+Perl differs only in the two places its language forces: a parked call leaves through the `try_table` outcome table rather than a bare `return` (perl's `return` inside an `eval` exits only the `eval`), and the trampoline is list-aware because perl flattens a multi-value return into its caller's argument list.
 It had been superseded by [decision 24](24-01-scope-reset.md) between 2026-07-26 and 2026-08-31 and was kept as the design record that made the restoration cheap.
 The original acceptance note and implementation pointers below are retained as history; "ADR-18" in them is this decision, and the runtime units now live inside their backend crates ([decision 85](85-crates-io-publish-layout.md)).
 

--- a/agents/decisions/89-park-the-pending-tail-call.md
+++ b/agents/decisions/89-park-the-pending-tail-call.md
@@ -1,0 +1,55 @@
+# Decision 89: Park a Pending Tail Call, Never Allocate One
+
+Status: **Accepted, 2026-08-31.**
+A tail call writes its target and arguments into per-instance slots and returns; the entry's trampoline reads them back. No backend allocates anything per hop.
+
+## Context
+
+[Decision 18](18-ruby-tail-calls.md)'s trampoline was first implemented with a thunk: an object holding the target and an array of arguments, returned by the body and unwrapped by the entry.
+That is the obvious shape, and it costs an allocation, or several, on every hop.
+
+`wat/tail_call` measured what that costs against `call_direct`, the same chain of the same four functions made of ordinary calls: 9.93x on Go, 8.52x on Java, 6.42x on Ruby with YJIT.
+A tail call was an order of magnitude more expensive than the call it replaces, on the two backends where an ordinary call is nearly free.
+
+Counted on the converted official wasm3 asset, the app the proposal was accepted for, the shape that matters is the indirect one: 523 indirect tail calls, 5 direct, and no self tail calls at all.
+So the hop itself is the whole cost, and nothing about the surrounding code shape can be optimized instead.
+
+## Decision
+
+A tail call parks, and the entry's trampoline collects:
+
+- The **target** comes out of a per-instance table of tail entries built once at instantiation, so no callable is constructed per hop.
+  A slot in a function table carries the same entry, so an indirect tail call parks without allocating either.
+- The **arguments** go into per-position, per-type slots on the instance, so no argument array is built.
+  Ruby and Python dispatch the trampoline's call by parked arity, the way `table/call<n>` already avoids a splat ([decision 44](44-ruby-call-indirect-arity.md)); an arity past the fixed set parks an array, which no shipped app reaches.
+- The target is cleared before dispatching, so a callee that does not tail-call ends the chain, and the arguments are read as the dispatch call's own operands, before the callee can overwrite them.
+
+Bash was already this shape, because a global was the only place its pending call could live; what this decision does is bring the other five to it.
+
+A tail entry is bound to the instance that built it and reads *that* instance's slots, so the two statically-typed backends check ownership: `Rt.Funcref` carries the owner alongside the entry, and a slot is only parked by the instance that owns it.
+Anything else, a foreign instance's entry or a callee with no entry at all, is wrapped instead of parked: one allocation, on a path a chain does not take.
+Go needs no wrapper, because its tail call has already left every enclosing `try_table` closure by the time it is emitted; Java does, and getting that wrong is observable rather than merely slow (see below).
+
+The argument expressions are safe to write straight into the slots because the IR spills an effectful operand before the instruction, so nothing between the assignments can reach another trampoline.
+
+Code this governs: the `Stmt::ReturnCall`/`Stmt::ReturnCallIndirect` lowering and the entry in every backend, each backend's `rt/tail_call` unit and its table's tail-entry column.
+
+## Rejected alternatives
+
+- **Keep the thunk and make the allocation cheaper** (a reused instance, a struct rather than a class).
+  The argument array remains, and in Go the thunk is a closure whose whole cost *is* the capture.
+- **Defunctionalize the mutually tail-calling set into one dispatch loop**, so a hop is a state assignment.
+  Measured: 2.85x faster than parking at ten arms, even at two hundred, and nine times *slower* at five hundred, where the JIT's code size falls off a cliff; the app's group is 519.
+  Worth revisiting only as a pass gated on a small group.
+- **Extract the arms into methods and dispatch by `switch`**, keeping each arm JIT-compilable.
+  Measured: ties parking in Go, and needs a binary decision tree rather than a `case` in Ruby just to reach the same point.
+- **Rewrite a self tail call into a loop**, which needs no trampoline at all.
+  Still worth doing, and cheap, but it is not this: the motivating app has no self tail calls.
+
+## Consequences
+
+- Positive, measured on `wat/tail_call` against the same conversion before the change: Go 40.9 to 8.4 ns per hop (4.85x), Ruby with YJIT 653 to 269 ns (2.43x), Java 27.1 to 18.4 ns, Perl 3655 to 2480 ns, Python 854 to 684 ns.
+  Against an ordinary call, Go's tail call goes from 9.93x to 2.05x and Ruby's from 6.42x to 2.50x.
+- Positive: converted wasm3 on Ruby runs 8.36 to 6.75 us per guest iteration, starts 14% faster, and its artifact is 28% smaller, because a parked call spells out less than a constructed one.
+- Carry-over: Java's entry still boxes the chain's final result, since a tail entry returns `Object`; typing the entry table per result signature would remove that and is not done here.
+- Carry-over: the slots are per instance, so two instances sharing a table take the wrapped path between them. That is a correctness requirement, not a tuning choice, and the ownership check is what enforces it.

--- a/agents/decisions/README.md
+++ b/agents/decisions/README.md
@@ -108,6 +108,7 @@ An entry is numbered: `<N>-<slug>.md`, cited as "decision N".
 | 86 | [wasm3 as the Converted-Interpreter Benchmark Runner](86-converted-interpreter-benchmark-runner.md) | Accepted |
 | 87 | [Record Schema Evolution by In-Place Migration](87-record-schema-migration.md) | Accepted |
 | 88 | [Tail Calls Join the Accepted Input, Declared Per Backend](88-tail-calls-accepted-input.md) | Accepted |
+| 89 | [Park a Pending Tail Call, Never Allocate One](89-park-the-pending-tail-call.md) | Accepted |
 
 ## Adding a new decision
 

--- a/crates/dewasm-backend-go/src/lib.rs
+++ b/crates/dewasm-backend-go/src/lib.rs
@@ -191,7 +191,6 @@ pub fn generate_program_with_units(
         try_stack: RefCell::new(Vec::new()),
         tail_callers: tail_callers(module),
         cur_tail: RefCell::new(None),
-        tail_arg_seq: RefCell::new(0),
         spec: true,
         data_file: None,
         data_offsets: data_offsets(module),
@@ -223,7 +222,6 @@ fn generate_source(module: &Module, opts: &GenOptions) -> Result<String> {
         try_stack: RefCell::new(Vec::new()),
         tail_callers: tail_callers(module),
         cur_tail: RefCell::new(None),
-        tail_arg_seq: RefCell::new(0),
         spec: false,
         data_file: opts.data_file.as_ref().map(|c| c.data_file_name.clone()),
         data_offsets: data_offsets(module),
@@ -641,8 +639,6 @@ struct Gen<'a> {
     tail_callers: BTreeSet<u32>,
     /// The result signature of the tail-calling function currently being emitted, set by `function()`: every `return` in its body carries a trailing `nil` thunk.
     cur_tail: RefCell<Option<Vec<ValType>>>,
-    /// Names the per-argument bindings a tail call makes; only has to be unique within one function.
-    tail_arg_seq: RefCell<u32>,
     /// Spec-harness mode: emit the reflective `invoke`/`global_get` dispatch methods and the recursion guard.
     /// Off for the shipped standalone/library output, whose deep-but-valid recursions must not falsely trap.
     spec: bool,
@@ -665,64 +661,93 @@ impl<'a> Gen<'a> {
         seen.into_iter().collect()
     }
 
-    /// Evaluate each argument into a fresh local, so the thunk that runs later closes over the values the tail call had, not over variables the trampoline may reuse.
-    fn bind_args(&self, w: &mut CodeWriter, args: &[Expr]) -> Vec<String> {
-        let mut names = Vec::with_capacity(args.len());
-        for arg in args {
-            let n = self.next_tail_arg();
-            w.line(format!("{n} := {}", self.expr(arg)));
-            names.push(n);
-        }
-        names
+    /// The parked-target field for a result signature: a chain agrees on its results, so one field per signature is enough and nothing is boxed.
+    fn tail_field(&self, results: &[ValType]) -> String {
+        format!("tf{}", tail_suffix(results))
     }
 
-    fn next_tail_arg(&self) -> String {
-        let mut n = self.tail_arg_seq.borrow_mut();
-        *n += 1;
-        format!("__ta{n}")
+    /// The per-instance table of tail entries for a result signature, built once in the constructor.
+    fn tail_table(&self, results: &[ValType]) -> String {
+        format!("tb{}", tail_suffix(results))
     }
 
-    /// Return the thunk that continues the chain, alongside zero values for this frame's own results, which the trampoline discards.
-    /// `run` is the closure's whole body: it has the thunk signature, so it either forwards to another body or completes and ends the chain.
-    fn emit_thunk(&self, w: &mut CodeWriter, results: &[ValType], run: String) {
-        let mut parts: Vec<String> = results.iter().map(|t| zero_value(*t).to_string()).collect();
-        parts.push(format!(
-            "{}(func(){} {{ {run} }})",
-            self.tail_type(results),
-            self.body_results(results)
-        ));
-        w.line(format!("return {}", parts.join(", ")));
+    /// The Go type of a tail entry: a call that takes its arguments out of the parked slots and runs the callee's body.
+    /// Unnamed on purpose, so a slot written by another artifact still type-asserts here.
+    fn tail_entry_type(&self, results: &[ValType]) -> String {
+        format!("func(){}", go_results(results))
     }
 
-    /// A thunk body forwarding to another function's split body: its signature already matches.
-    fn forwarding_body(call: &str) -> String {
-        format!("return {call}")
+    /// The slot a tail call parks argument `i` of type `ty` in.
+    fn arg_slot(i: usize, ty: ValType) -> String {
+        format!("ta{i}{}", ty_suffix(ty))
     }
 
-    /// A thunk body calling a function that completes in one frame, so the chain ends with a `nil` thunk.
-    fn completing_body(results: &[ValType], call: &str) -> String {
-        match results.len() {
-            0 => format!("{call}; return nil"),
-            1 => format!("return {call}, nil"),
-            n => {
-                let rs: Vec<String> = (0..n).map(|i| format!("__r{i}")).collect();
-                format!("{} := {call}; return {}, nil", rs.join(", "), rs.join(", "))
+    /// Every argument slot the module's tail calls need: one per position and type a tail call passes.
+    /// A tail-calling function's own parameters, because its tail entry reads them back out; and every signature reachable through a table, because an indirect tail call parks against the *call site's* type, which need not be one of them.
+    fn arg_slots(&self) -> Vec<(String, ValType)> {
+        let mut seen: BTreeSet<(usize, ValType)> = BTreeSet::new();
+        let mut note = |params: &[ValType]| {
+            for (i, ty) in params.iter().enumerate() {
+                seen.insert((i, *ty));
             }
+        };
+        for idx in &self.tail_callers {
+            note(&self.module.func_type(*idx).params);
+        }
+        for f in &self.module.funcs {
+            Stmt::any(&f.body, &mut |st| {
+                if let Stmt::ReturnCallIndirect { type_idx, .. } = st {
+                    note(&self.module.types[*type_idx as usize].params);
+                }
+                false
+            });
+        }
+        seen.into_iter()
+            .map(|(i, ty)| (Self::arg_slot(i, ty), ty))
+            .collect()
+    }
+
+    /// A tail-calling function's dense position in its result signature's table.
+    fn tail_slot(&self, func_idx: u32) -> Option<usize> {
+        if !self.tail_callers.contains(&func_idx) {
+            return None;
+        }
+        let results = self.module.func_type(func_idx).results.clone();
+        self.tail_callers
+            .iter()
+            .filter(|f| self.module.func_type(**f).results == results)
+            .position(|f| *f == func_idx)
+    }
+
+    /// A tail call whose callee has no tail entry here: it completes in one frame, so the chain ends with its result.
+    fn return_call_completing(&self, w: &mut CodeWriter, call: &str) {
+        if self
+            .cur_tail
+            .borrow()
+            .as_ref()
+            .is_some_and(|r| r.is_empty())
+        {
+            w.line(call);
+            w.line("return");
+        } else {
+            w.line(format!("return {call}"));
         }
     }
 
-    /// The named type of a tail-call thunk for a given result signature: `func() (results, itself)`.
-    /// A type per signature rather than one dynamic wrapper, because a caller and the callee it tail-calls always agree on results (wasm requires it), so the thunk stays statically typed with nothing boxed.
-    /// Named after the module type, because the spec harness compiles several converted modules into one Go package.
-    fn tail_type(&self, results: &[ValType]) -> String {
-        format!("{}Tail{}", self.type_name, tail_suffix(results))
-    }
-
-    /// The Go signature of `f{idx}Body`: the function's own results followed by the thunk that continues the chain.
-    fn body_results(&self, results: &[ValType]) -> String {
-        let mut rets: Vec<String> = results.iter().map(|t| go_type(*t).to_string()).collect();
-        rets.push(self.tail_type(results));
-        format!(" ({})", rets.join(", "))
+    /// Park a tail call and leave: the arguments into their slots, then the target, then this frame's own zero results, which the trampoline discards.
+    /// The arguments are already free of calls (the IR spills an effectful operand before the instruction), so nothing between these assignments can reach another trampoline and overwrite a slot.
+    fn park_tail(&self, w: &mut CodeWriter, params: &[ValType], args: &[String], target: &str) {
+        for (i, (a, ty)) in args.iter().zip(params).enumerate() {
+            w.line(format!("p.{} = {a}", Self::arg_slot(i, *ty)));
+        }
+        let results = self.cur_tail.borrow().clone().unwrap_or_default();
+        w.line(format!("p.{} = {target}", self.tail_field(&results)));
+        let zeros: Vec<&str> = results.iter().map(|t| zero_value(*t)).collect();
+        if zeros.is_empty() {
+            w.line("return");
+        } else {
+            w.line(format!("return {}", zeros.join(", ")));
+        }
     }
 
     /// The Go expression yielding a data segment's bytes: a sub-slice of the embedded blob when `--data-file` is on (no runtime helper), else an `Rt.unhex(...)` inline hex literal.
@@ -763,13 +788,6 @@ impl<'a> Gen<'a> {
 
     fn emit_program(&self, w: &mut CodeWriter) {
         self.struct_def(w);
-        for sig in self.tail_signatures() {
-            let name = self.tail_type(&sig);
-            let mut rets: Vec<String> = sig.iter().map(|t| go_type(*t).to_string()).collect();
-            rets.push(name.clone());
-            w.line("");
-            w.line(format!("type {name} func() ({})", rets.join(", ")));
-        }
         w.line("");
         self.constructor(w);
         for (i, func) in self.module.funcs.iter().enumerate() {
@@ -906,6 +924,22 @@ impl<'a> Gen<'a> {
         for i in 0..m.datas.len() {
             w.line(format!("data{i} []byte"));
         }
+        // Parked tail calls: one argument slot per position and type a tail-calling function takes, and one target field plus one entry table per result signature.
+        for (name, ty) in self.arg_slots() {
+            w.line(format!("{name} {}", go_type(ty)));
+        }
+        for sig in self.tail_signatures() {
+            w.line(format!(
+                "{} {}",
+                self.tail_field(&sig),
+                self.tail_entry_type(&sig)
+            ));
+            w.line(format!(
+                "{} []{}",
+                self.tail_table(&sig),
+                self.tail_entry_type(&sig)
+            ));
+        }
         w.line("Exports map[string]any");
         w.dedent();
         w.line("}");
@@ -919,6 +953,35 @@ impl<'a> Gen<'a> {
         ));
         w.indent();
         w.line(format!("p := &{name}{{}}"));
+        // Built once, before anything that parks a target or stores one in a table: a tail call reads its target out of here rather than building a closure per hop.
+        // Each entry is bound to this instance and reads *its* parked slots, which is what makes the owner check at an indirect tail call necessary.
+        for sig in self.tail_signatures() {
+            let entries: Vec<String> = self
+                .tail_callers
+                .iter()
+                .filter(|f| self.module.func_type(**f).results == sig)
+                .map(|f| {
+                    let params = &self.module.func_type(*f).params;
+                    let args: Vec<String> = params
+                        .iter()
+                        .enumerate()
+                        .map(|(i, t)| format!("p.{}", Self::arg_slot(i, *t)))
+                        .collect();
+                    let call = format!("p.f{f}Body({})", args.join(", "));
+                    if sig.is_empty() {
+                        format!("func() {{ {call} }}")
+                    } else {
+                        format!("func(){} {{ return {call} }}", go_results(&sig))
+                    }
+                })
+                .collect();
+            w.line(format!(
+                "p.{} = []{}{{{}}}",
+                self.tail_table(&sig),
+                self.tail_entry_type(&sig),
+                entries.join(", ")
+            ));
+        }
 
         if let Some(import) = &m.imported_memory {
             self.emit_typed_import(w, "p.memory", "*Memory", &import.module, &import.name);
@@ -1267,10 +1330,12 @@ impl<'a> Gen<'a> {
     fn elem_item(&self, item: &ElemItem) -> String {
         match item {
             ElemItem::Func(func_idx) => {
-                let body = if self.tail_callers.contains(func_idx) {
-                    format!(", body: p.f{func_idx}Body")
-                } else {
-                    String::new()
+                let body = match self.tail_slot(*func_idx) {
+                    Some(k) => format!(
+                        ", body: p.{}[{k}], owner: p",
+                        self.tail_table(&self.module.func_type(*func_idx).results)
+                    ),
+                    None => String::new(),
                 };
                 format!(
                     "&funcref{{ty: {}, fn: {}{body}}}",
@@ -1322,26 +1387,35 @@ impl<'a> Gen<'a> {
             .map(|(i, t)| format!("l{i} {}", go_type(*t)))
             .collect::<Vec<_>>()
             .join(", ");
-        // A tail-calling function's real code lives in `f{idx}Body`, which returns a thunk alongside its results instead of growing the stack; the public `f{idx}` is the trampoline that runs the chain, so no call site changes.
+        // A tail-calling function's real code lives in `f{idx}Body`, which parks the next call in the instance's slots instead of growing the stack; the public `f{idx}` is the trampoline that runs the chain, so no call site changes.
         let is_tail_caller = self.tail_callers.contains(&idx);
         if is_tail_caller {
             let args = (0..nparams)
                 .map(|i| format!("l{i}"))
                 .collect::<Vec<_>>()
                 .join(", ");
-            let rs: Vec<String> = (0..ty.results.len()).map(|i| format!("r{i}")).collect();
-            let mut lhs = rs.clone();
-            lhs.push("next".to_string());
+            let field = self.tail_field(&ty.results);
             w.line(format!(
                 "func (p *{}) f{idx}({params_str}){} {{",
                 self.type_name,
                 go_results(&ty.results)
             ));
             w.indent();
-            w.line(format!("{} := p.f{idx}Body({args})", lhs.join(", ")));
-            w.line("for next != nil {");
+            let rs: Vec<String> = (0..ty.results.len()).map(|i| format!("r{i}")).collect();
+            if rs.is_empty() {
+                w.line(format!("p.f{idx}Body({args})"));
+            } else {
+                w.line(format!("{} := p.f{idx}Body({args})", rs.join(", ")));
+            }
+            w.line(format!("for p.{field} != nil {{"));
             w.indent();
-            w.line(format!("{} = next()", lhs.join(", ")));
+            w.line(format!("f := p.{field}"));
+            w.line(format!("p.{field} = nil"));
+            if rs.is_empty() {
+                w.line("f()");
+            } else {
+                w.line(format!("{} = f()", rs.join(", ")));
+            }
             w.dedent();
             w.line("}");
             if !rs.is_empty() {
@@ -1357,11 +1431,7 @@ impl<'a> Gen<'a> {
         } else {
             format!("f{idx}")
         };
-        let results_str = if is_tail_caller {
-            self.body_results(&ty.results)
-        } else {
-            go_results(&ty.results)
-        };
+        let results_str = go_results(&ty.results);
         w.line(format!(
             "func (p *{}) {name}({params_str}){results_str} {{",
             self.type_name
@@ -1406,12 +1476,9 @@ impl<'a> Gen<'a> {
 
         self.emit_seq(w, &body);
 
-        if (!ty.results.is_empty() || is_tail_caller) && !ends_unreachable(&body) {
+        if !ty.results.is_empty() && !ends_unreachable(&body) {
             // Go's missing-return rule is syntactic: a body whose last statement is a call that only panics inside the runtime (`Rt.trap`) still needs this.
-            let mut zeros: Vec<&str> = ty.results.iter().map(|t| zero_value(*t)).collect();
-            if is_tail_caller {
-                zeros.push("nil");
-            }
+            let zeros: Vec<&str> = ty.results.iter().map(|t| zero_value(*t)).collect();
             w.line(format!("return {}", zeros.join(", ")));
         }
         w.dedent();
@@ -1766,21 +1833,23 @@ impl<'a> Gen<'a> {
             Stmt::DataDrop { seg } => {
                 w.line(format!("p.data{seg} = nil"));
             }
-            // A thunk, never a plain call: the callee must run once this frame, including any `try_table` closure that installed a handler, is gone, and returning the thunk is what unwinds them.
-            // The thunk targets the callee's *body* where it has one, so a mutual chain runs in the one outermost trampoline with no frame per hop.
+            // Parked, never called: the callee must run once this frame, including any `try_table` closure that installed a handler, is gone, and returning is what unwinds them.
+            // The target is the callee's tail entry, built once at instantiation, so a hop allocates nothing.
             Stmt::ReturnCall { func, args } => {
                 if let Some(code) = self.escape_tail(stmt) {
                     w.line(format!("return {code}"));
                     return;
                 }
-                let callee = self.module.func_type(*func).results.clone();
-                let bound = self.bind_args(w, args);
-                let run = if self.tail_callers.contains(func) {
-                    Self::forwarding_body(&format!("p.f{func}Body({})", bound.join(", ")))
-                } else {
-                    Self::completing_body(&callee, &self.call_string(*func, &bound))
-                };
-                self.emit_thunk(w, &callee, run);
+                let fty = self.module.func_type(*func).clone();
+                let args: Vec<String> = args.iter().map(|a| self.expr(a)).collect();
+                match self.tail_slot(*func) {
+                    Some(k) => {
+                        let target = format!("p.{}[{k}]", self.tail_table(&fty.results));
+                        self.park_tail(w, &fty.params, &args, &target);
+                    }
+                    // A callee without a tail entry completes in a single frame, so calling it here ends the chain, which the criterion permits.
+                    None => self.return_call_completing(w, &self.call_string(*func, &args)),
+                }
             }
             Stmt::ReturnCallIndirect {
                 type_idx,
@@ -1793,39 +1862,30 @@ impl<'a> Gen<'a> {
                     return;
                 }
                 self.use_unit("table/tail_ref");
-                let callee = self.module.types[*type_idx as usize].results.clone();
-                let mut bound = self.bind_args(w, std::slice::from_ref(index));
-                bound.extend(self.bind_args(w, args));
-                let (i, rest) = bound.split_first().expect("the index binding");
-                // The slot is resolved, and its traps raised, here rather than inside the thunk: an indirect tail call's checks happen at the instruction, not after the frame is gone.
-                let params: Vec<String> = self.module.types[*type_idx as usize]
-                    .params
-                    .iter()
-                    .map(|t| go_type(*t).to_string())
-                    .collect();
-                let body_sig = format!("func({}){}", params.join(", "), self.body_results(&callee));
-                let plain_sig = format!("func({}){}", params.join(", "), go_results(&callee));
+                let ty = self.module.types[*type_idx as usize].clone();
+                let idx = self.expr(index);
+                let args: Vec<String> = args.iter().map(|a| self.expr(a)).collect();
+                // The slot is resolved, and its traps raised, here rather than after the frame is gone: an indirect tail call's checks happen at the instruction.
+                // A tail entry belongs to the instance that built it and reads *its* parked slots, so only this instance's own entries can be parked; anything else completes here instead.
                 w.line(format!(
-                    "__tf := p.t{table_index}.tailRef({i}, {})",
+                    "__tb, __tf := p.t{table_index}.tailRef({idx}, {}, p)",
                     go_string(&self.type_symbol(*type_idx))
                 ));
-                w.line(format!("if __tb, __ok := __tf.({body_sig}); __ok {{"));
+                w.line("if __tb != nil {");
                 w.indent();
-                self.emit_thunk(
-                    w,
-                    &callee,
-                    Self::forwarding_body(&format!("__tb({})", rest.join(", "))),
-                );
+                let target = format!("__tb.({})", self.tail_entry_type(&ty.results));
+                self.park_tail(w, &ty.params, &args, &target);
                 w.dedent();
                 w.line("}");
-                self.emit_thunk(
-                    w,
-                    &callee,
-                    Self::completing_body(
-                        &callee,
-                        &format!("__tf.({plain_sig})({})", rest.join(", ")),
-                    ),
+                let params: Vec<String> =
+                    ty.params.iter().map(|t| go_type(*t).to_string()).collect();
+                let plain = format!(
+                    "__tf.(func({}){})({})",
+                    params.join(", "),
+                    go_results(&ty.results),
+                    args.join(", ")
                 );
+                self.return_call_completing(w, &plain);
             }
             Stmt::Unreachable => {
                 w.line(format!("{}(\"unreachable\")", self.rt("trap")));
@@ -1926,12 +1986,7 @@ impl<'a> Gen<'a> {
             w.line(format!("return {code}"));
             return;
         }
-        // Inside a tail-calling function's body the thunk is part of the signature, and a plain return ends the chain.
-        let tail = self.cur_tail.borrow().is_some();
-        let mut vs: Vec<String> = values.iter().map(|v| self.expr(v)).collect();
-        if tail {
-            vs.push("nil".to_string());
-        }
+        let vs: Vec<String> = values.iter().map(|v| self.expr(v)).collect();
         match vs.as_slice() {
             [] => w.line("return"),
             vs => w.line(format!("return {}", vs.join(", "))),

--- a/crates/dewasm-backend-go/units/table/_class.go
+++ b/crates/dewasm-backend-go/units/table/_class.go
@@ -1,9 +1,10 @@
 // One table slot: a funcref (type key + the Go func value) or nil for a null slot. call_indirect compares type keys, so a table shared across modules stays consistent.
-// `body` is set only for a tail-calling function, whose split body `table/tail_ref` hands to the trampoline so a chain through the table stays flat.
+// `body` is set only for a tail-calling function: it is that function's tail entry, which reads the parked slots of the instance named by `owner`, so `table/tail_ref` hands it back only to that instance.
 type funcref struct {
-    ty   string
-    fn   any
-    body any
+    ty    string
+    fn    any
+    body  any
+    owner any
 }
 
 type Table struct {

--- a/crates/dewasm-backend-go/units/table/tail_ref.go
+++ b/crates/dewasm-backend-go/units/table/tail_ref.go
@@ -1,7 +1,7 @@
 // requires: rt/trap
-// `call`'s checks, raised at the same point in execution order, but returning the slot's func value for the trampoline instead of handing back the plain entry.
-// A slot's optional `body` is the split body of a tail-calling function; a slot without one completes in a single frame anyway, and the caller type-asserts whichever it got.
-func (t *Table) tailRef(i uint32, typeKey string) any {
+// `call`'s checks, raised at the same point in execution order, but resolving a tail call rather than an ordinary one.
+// A tail entry is bound to the instance that built it and reads *that* instance's parked slots, so it is only returned to its owner; every other caller gets the ordinary func value and completes the call itself, which costs one frame per instance switch.
+func (t *Table) tailRef(i uint32, typeKey string, owner any) (any, any) {
     if i >= uint32(len(t.slots)) {
         Rt.trap("undefined element")
     }
@@ -12,8 +12,8 @@ func (t *Table) tailRef(i uint32, typeKey string) any {
     if slot.ty != typeKey {
         Rt.trap("indirect call type mismatch")
     }
-    if slot.body != nil {
-        return slot.body
+    if slot.body != nil && slot.owner == owner {
+        return slot.body, nil
     }
-    return slot.fn
+    return nil, slot.fn
 }

--- a/crates/dewasm-backend-java/src/lib.rs
+++ b/crates/dewasm-backend-java/src/lib.rs
@@ -559,6 +559,18 @@ fn rel((r, cmp): (&str, Option<&str>), a: &str, b: &str) -> String {
     }
 }
 
+/// The field-name suffix distinguishing a parked argument slot's type.
+fn jtype_suffix(ty: ValType) -> &'static str {
+    match ty {
+        ValType::I32 => "i",
+        ValType::I64 => "l",
+        ValType::F32 => "f",
+        ValType::F64 => "d",
+        ValType::FuncRef => "r",
+        ValType::ExnRef => "e",
+    }
+}
+
 fn jtype(ty: ValType) -> &'static str {
     match ty {
         ValType::I32 => "int",
@@ -849,6 +861,28 @@ impl<'a> Gen<'a> {
             "{name}(java.util.Map<String, ?> imports, String[] args, String[] env, java.util.Map<String, String> preopens) {{"
         ));
         w.indent();
+
+        // Built once, before anything that parks a target or stores one in a table: a tail call reads its target out of here rather than building a lambda per hop.
+        // Each entry is bound to this instance and reads *its* parked slots, which is what makes the owner check at an indirect tail call necessary.
+        if !self.tail_callers.is_empty() {
+            let entries: Vec<String> = self
+                .tail_callers
+                .iter()
+                .map(|f| {
+                    let params = &self.module.func_type(*f).params;
+                    let args: Vec<String> = params
+                        .iter()
+                        .enumerate()
+                        .map(|(i, t)| Self::arg_slot(i, *t))
+                        .collect();
+                    format!("() -> f{f}Body({})", args.join(", "))
+                })
+                .collect();
+            w.line(format!(
+                "this.tb = new Rt.TailBody[]{{{}}};",
+                entries.join(", ")
+            ));
+        }
 
         // Memory: imported or locally defined (index space has at most one).
         if let Some(import) = &m.imported_memory {
@@ -1187,6 +1221,15 @@ impl<'a> Gen<'a> {
     }
 
     fn struct_fields(&self, w: &mut CodeWriter) {
+        // Parked tail calls: one argument slot per position and type a tail call passes, plus the pending target and the entry table built once in the constructor.
+        if !self.tail_callers.is_empty() {
+            self.use_unit("rt/tail_call");
+            for (name, ty) in self.arg_slots() {
+                w.line(format!("{} {name};", jtype(ty)));
+            }
+            w.line("Rt.TailBody tf;");
+            w.line("Rt.TailBody[] tb;");
+        }
         let m = self.module;
         if m.imported_memory.is_some() || m.memory.is_some() {
             w.line("Memory memory;");
@@ -1339,48 +1382,86 @@ impl<'a> Gen<'a> {
 
     /// The `Rt.Fn` value for a function export / table element.
     /// When emitting the nested `Elem` helper class, functions are reached through the passed module instance (`inst.`), so the lambdas can live in that class's own constant pool.
-    /// Evaluate each argument into a fresh final local, so the lambda that runs later closes over the values the tail call had; a Java lambda captures variables, and only effectively-final ones.
-    fn bind_tail_args(&self, w: &mut CodeWriter, params: &[ValType], args: &[Expr]) -> Vec<String> {
-        let mut names = Vec::with_capacity(args.len());
-        for (arg, ty) in args.iter().zip(params) {
-            let n = self.next_tail_name();
-            w.line(format!("final {} {n} = {};", jtype(*ty), self.expr(arg)));
-            names.push(n);
+    /// The instance a slot's tail entry is compared against: `inst` inside a partition class, `this` otherwise.
+    fn self_ref(&self) -> &'static str {
+        if self.partitioned.get() || self.via_inst() {
+            "inst"
+        } else {
+            "this"
         }
-        names
     }
 
     fn next_tail_name(&self) -> String {
         let n = self.mv_counter.get();
         self.mv_counter.set(n + 1);
-        format!("__ta{n}")
+        format!("__ts{n}")
     }
 
-    /// Return the thunk the way a `return` returns a value: the branch register unwinds this frame first, and the trampoline outside runs `call`.
-    fn emit_tail(&self, w: &mut CodeWriter, results: &[ValType], call: String) {
+    /// The slot a tail call parks argument `i` of type `ty` in.
+    fn arg_slot(i: usize, ty: ValType) -> String {
+        format!("ta{i}{}", jtype_suffix(ty))
+    }
+
+    /// Every argument slot the module's tail calls need: one per position and type a tail call passes.
+    /// A tail-calling function's own parameters, because its tail entry reads them back out; and every signature reachable through a table, because an indirect tail call parks against the call site's type.
+    fn arg_slots(&self) -> Vec<(String, ValType)> {
+        let mut seen: BTreeSet<(usize, ValType)> = BTreeSet::new();
+        let mut note = |params: &[ValType]| {
+            for (i, ty) in params.iter().enumerate() {
+                seen.insert((i, *ty));
+            }
+        };
+        for idx in &self.tail_callers {
+            note(&self.module.func_type(*idx).params);
+        }
+        for f in &self.module.funcs {
+            Stmt::any(&f.body, &mut |st| {
+                if let Stmt::ReturnCallIndirect { type_idx, .. } = st {
+                    note(&self.module.types[*type_idx as usize].params);
+                }
+                false
+            });
+        }
+        seen.into_iter()
+            .map(|(i, ty)| (Self::arg_slot(i, ty), ty))
+            .collect()
+    }
+
+    /// A tail-calling function's dense position in the instance's tail-entry table.
+    fn tail_slot(&self, func_idx: u32) -> Option<usize> {
+        self.tail_callers.iter().position(|f| *f == func_idx)
+    }
+
+    /// Bind each argument to a final local, so a lambda over them compiles: java captures variables, and only effectively-final ones.
+    fn bind_finals(&self, w: &mut CodeWriter, params: &[ValType], args: &[String]) -> Vec<String> {
+        let mut names = Vec::with_capacity(args.len());
+        for (a, ty) in args.iter().zip(params) {
+            let n = self.next_tail_name();
+            w.line(format!("final {} {n} = {a};", jtype(*ty)));
+            names.push(n);
+        }
+        names
+    }
+
+    /// Park a call that has no tail entry to reuse, as a lambda; it still runs after this frame is gone, which is what a tail call means.
+    fn park_lambda(&self, w: &mut CodeWriter, results: &[ValType], call: &str) {
         let run = if results.is_empty() {
             format!("{{ {call}; return null; }}")
         } else {
-            call
+            call.to_string()
         };
-        w.line(format!("{} = new Rt.TailCall(() -> {run});", self.ret()));
+        w.line(format!("{} = () -> {run};", self.iref("tf")));
         w.line(format!("{} = -1;", self.br()));
     }
 
-    /// The `Rt.Fn` view of a tail-calling function's split body: it returns `Object` (a result or a thunk), so no unboxing happens here.
-    fn body_value(&self, func_idx: u32) -> String {
-        let ty = self.module.func_type(func_idx);
-        let call_args = ty
-            .params
-            .iter()
-            .enumerate()
-            .map(|(k, t)| unbox(*t, &format!("__a[{k}]")))
-            .collect::<Vec<_>>()
-            .join(", ");
-        format!(
-            "(Rt.Fn)(__a -> {})",
-            self.defined_call_named(func_idx, &format!("f{func_idx}Body"), &call_args)
-        )
+    /// Park a tail call and end this frame: the arguments into their slots, then the target, then the branch register, which unwinds the frame the way a return does.
+    /// The arguments are already free of calls (the IR spills an effectful operand before the instruction), so nothing between these assignments can reach another trampoline and overwrite a slot.
+    fn park_tail(&self, w: &mut CodeWriter, params: &[ValType], args: &[String], target: &str) {
+        for (i, (a, ty)) in args.iter().zip(params).enumerate() {
+            w.line(format!("{} = {a};", self.iref(&Self::arg_slot(i, *ty))));
+        }
+        w.line(format!("{} = {target};", self.iref("tf")));
+        w.line(format!("{} = -1;", self.br()));
     }
 
     fn func_value(&self, func_idx: u32) -> String {
@@ -1406,10 +1487,9 @@ impl<'a> Gen<'a> {
     fn elem_item(&self, item: &ElemItem) -> String {
         match item {
             ElemItem::Func(func_idx) => {
-                let body = if self.tail_callers.contains(func_idx) {
-                    format!(", {}", self.body_value(*func_idx))
-                } else {
-                    String::new()
+                let body = match self.tail_slot(*func_idx) {
+                    Some(k) => format!(", {}[{k}], this", self.iref("tb")),
+                    None => String::new(),
                 };
                 format!(
                     "new Rt.Funcref({}, {}{body})",
@@ -1474,14 +1554,21 @@ impl<'a> Gen<'a> {
                 .join(", ");
             w.line(self.method_head(&ret_slot_ty(results), &format!("f{idx}"), &params_str));
             w.indent();
-            let unwrapped = format!(
-                "Rt.trampoline({})",
+            w.line(format!(
+                "Object __r = {};",
                 self.defined_call_named(idx, &format!("f{idx}Body"), &args)
-            );
+            ));
+            w.line(format!("while ({} != null) {{", self.iref("tf")));
+            w.indent();
+            w.line(format!("Rt.TailBody __t = {};", self.iref("tf")));
+            w.line(format!("{} = null;", self.iref("tf")));
+            w.line("__r = __t.run();");
+            w.dedent();
+            w.line("}");
             match results.as_slice() {
-                [] => w.line(format!("{unwrapped};")),
-                [t] => w.line(format!("return {};", unbox(*t, &unwrapped))),
-                _ => w.line(format!("return (Object[]) {unwrapped};")),
+                [] => {}
+                [t] => w.line(format!("return {};", unbox(*t, "__r"))),
+                _ => w.line("return (Object[]) __r;"),
             }
             w.dedent();
             w.line("}");
@@ -2154,18 +2241,25 @@ impl<'a> Gen<'a> {
                     self.iref(&format!("data{seg}"))
                 ));
             }
-            // A thunk returned like any other result: the enclosing frame's `_br = -1` unwinds it, including any `try_table` handler, before the trampoline runs the callee.
-            // The thunk targets the callee's *body* where it has one, so a mutual chain runs in the one outermost trampoline with no frame per hop.
+            // Parked, never called: the enclosing frame's `_br = -1` unwinds it, including any `try_table` handler, before the entry's trampoline runs the callee.
+            // The target is the callee's tail entry, built once at instantiation, so a hop allocates nothing.
             Stmt::ReturnCall { func, args } => {
                 self.use_unit("rt/tail_call");
                 let fty = self.module.func_type(*func).clone();
-                let bound = self.bind_tail_args(w, &fty.params, args);
-                let call = if self.tail_callers.contains(func) {
-                    self.defined_call_named(*func, &format!("f{func}Body"), &bound.join(", "))
-                } else {
-                    self.call_string(*func, &bound)
-                };
-                self.emit_tail(w, &fty.results, call);
+                let args: Vec<String> = args.iter().map(|a| self.expr(a)).collect();
+                match self.tail_slot(*func) {
+                    Some(k) => {
+                        let target = format!("{}[{k}]", self.iref("tb"));
+                        self.park_tail(w, &fty.params, &args, &target);
+                    }
+                    // A callee with no tail entry here still has to run once this frame is gone, or an exception it throws would be caught by a `try_table` this frame opened.
+                    // So it is parked too, as a lambda over the arguments; that costs one allocation, on a path a chain does not take.
+                    None => {
+                        let bound = self.bind_finals(w, &fty.params, &args);
+                        let call = self.call_string(*func, &bound);
+                        self.park_lambda(w, &fty.results, &call);
+                    }
+                }
             }
             Stmt::ReturnCallIndirect {
                 type_idx,
@@ -2176,18 +2270,32 @@ impl<'a> Gen<'a> {
                 self.use_unit("rt/tail_call");
                 self.use_unit("table/tail_ref");
                 let ty = self.module.types[*type_idx as usize].clone();
-                // The slot is resolved, and its traps raised, here rather than inside the thunk: an indirect tail call's checks happen at the instruction, not after the frame is gone.
+                // The slot is resolved, and its traps raised, here rather than after the frame is gone: an indirect tail call's checks happen at the instruction.
+                // A tail entry reads its owner's parked slots, so only this instance's own entries can be parked; anything else completes here instead.
                 let slot = self.next_tail_name();
                 w.line(format!(
-                    "Rt.Fn {slot} = {}.tailRef({}, {});",
+                    "Rt.Funcref {slot} = {}.tailSlot({}, {});",
                     self.iref(&format!("t{table_index}")),
                     self.expr(index),
                     java_string(&self.type_symbol(*type_idx))
                 ));
-                let bound = self.bind_tail_args(w, &ty.params, args);
-                // No unboxing: the slot may be a split body, whose `Object` is either the result or the next thunk.
-                let call = self.invoke_string(&slot, &bound.join(", "), None);
-                self.emit_tail(w, &ty.results, call);
+                let args: Vec<String> = args.iter().map(|a| self.expr(a)).collect();
+                w.line(format!("if ({slot}.owner == {}) {{", self.self_ref()));
+                w.indent();
+                self.park_tail(w, &ty.params, &args, &format!("(Rt.TailBody) {slot}.body"));
+                w.dedent();
+                w.line("} else {");
+                w.indent();
+                // Another instance's entry reads its own slots, so it cannot be parked; it is wrapped instead, which keeps it running after this frame is gone at the cost of one allocation.
+                let bound = self.bind_finals(w, &ty.params, &args);
+                let call = self.invoke_string(
+                    &format!("{slot}.fn"),
+                    &bound.join(", "),
+                    ty.results.first().copied(),
+                );
+                self.park_lambda(w, &ty.results, &call);
+                w.dedent();
+                w.line("}");
             }
             Stmt::Unreachable => {
                 // Void method that throws: emitting it as a statement (not a `throw`) avoids an "unreachable statement" error after it.

--- a/crates/dewasm-backend-java/units/rt/_prelude.java
+++ b/crates/dewasm-backend-java/units/rt/_prelude.java
@@ -23,16 +23,19 @@ interface ImportProvider {
 static final class Funcref {
     final String ty;
     final Fn fn;
-    // The split body of a tail-calling function, which `table/tail_ref` hands to the trampoline so a chain through the table stays flat; null for everything else, which completes in a single frame anyway.
-    final Fn body;
+    // The tail entry of a tail-calling function and the instance it belongs to; null for everything else, which completes in a single frame anyway.
+    // The entry reads its owner's parked slots, so `table/tail_slot` only lets that owner park it.
+    final Object body;
+    final Object owner;
 
     Funcref(String ty, Fn fn) {
-        this(ty, fn, null);
+        this(ty, fn, null, null);
     }
 
-    Funcref(String ty, Fn fn, Fn body) {
+    Funcref(String ty, Fn fn, Object body, Object owner) {
         this.ty = ty;
         this.fn = fn;
         this.body = body;
+        this.owner = owner;
     }
 }

--- a/crates/dewasm-backend-java/units/rt/tail_call.java
+++ b/crates/dewasm-backend-java/units/rt/tail_call.java
@@ -1,20 +1,6 @@
-// A pending tail call: a tail-calling function's body returns one of these instead of calling, and its entry wrapper unwraps them in a loop, so a chain of any length runs in constant stack space.
-// A wasm result is a boxed primitive, an `Object[]` (multi-value), or an `Fn` (funcref), never one of these, so nothing else can look like one.
-interface TailThunk {
+// The trampoline a tail-calling function's entry runs.
+// A tail call parks its target and arguments on the instance and returns; nothing is allocated per hop, which is what a chain of any length pays otherwise.
+// A tail entry is bound to the instance that built it and reads *that* instance's parked slots, which is why `table/tail_slot` hands one back only to its owner.
+interface TailBody {
 	Object run();
-}
-
-static final class TailCall {
-	final TailThunk thunk;
-
-	TailCall(TailThunk thunk) {
-		this.thunk = thunk;
-	}
-}
-
-static Object trampoline(Object r) {
-	while (r instanceof TailCall) {
-		r = ((TailCall) r).thunk.run();
-	}
-	return r;
 }

--- a/crates/dewasm-backend-java/units/table/tail_ref.java
+++ b/crates/dewasm-backend-java/units/table/tail_ref.java
@@ -1,7 +1,6 @@
 // requires: rt/trap
-// `call`'s checks, raised at the same point in execution order, but returning the slot's tail entry for the trampoline instead of the plain one.
-// A slot's optional `body` is the split body of a tail-calling function; a slot without one completes in a single frame anyway.
-Rt.Fn tailRef(int index, String ty) {
+// `call`'s checks, raised at the same point in execution order, but handing back the whole slot so the caller can see whether it owns the tail entry.
+Rt.Funcref tailSlot(int index, String ty) {
     if (index < 0 || index >= slots.length) {
         Rt.trap("undefined element");
     }
@@ -12,5 +11,5 @@ Rt.Fn tailRef(int index, String ty) {
     if (!f.ty.equals(ty)) {
         Rt.trap("indirect call type mismatch");
     }
-    return f.body != null ? f.body : f.fn;
+    return f;
 }

--- a/crates/dewasm-backend-perl/src/lib.rs
+++ b/crates/dewasm-backend-perl/src/lib.rs
@@ -586,6 +586,17 @@ impl<'a> Gen<'a> {
         }
         w.line("$imports = {} unless defined $imports;");
         w.line("my $self = bless({}, $class);");
+        // Built once, before anything that parks a target or stores one in a table: a tail call reads its target out of here rather than building a closure per hop, and reuses the one argument array.
+        if !self.tail_callers.is_empty() {
+            let bodies: Vec<String> = self
+                .tail_callers
+                .iter()
+                .map(|f| format!("sub {{ return $self->_f{f}_body(@_); }}"))
+                .collect();
+            w.line(format!("$self->{{__tm}} = [{}];", bodies.join(", ")));
+            w.line("$self->{__ta} = [];");
+            w.line("$self->{__tf} = undef;");
+        }
         if wasi_fallback {
             w.line("$self->{_wasi} = undef;");
             w.line("$self->{_wasi_args} = $opts{args} // [];");
@@ -890,10 +901,9 @@ impl<'a> Gen<'a> {
             self.func_type_symbol(func_idx),
             self.func_closure(func_idx)
         );
-        if self.tail_callers.contains(&func_idx) {
-            format!("[{base}, sub {{ return $self->_f{func_idx}_body(@_); }}]")
-        } else {
-            format!("[{base}]")
+        match self.tail_body_slot(func_idx) {
+            Some(k) => format!("[{base}, $self->{{__tm}}[{k}]]"),
+            None => format!("[{base}]"),
         }
     }
 
@@ -919,7 +929,7 @@ impl<'a> Gen<'a> {
             w.line(format!("sub _f{idx} {{"));
             w.indent();
             w.line(format!(
-                "return {}::trampoline($_[0]->_f{idx}_body(@_[1 .. $#_]));",
+                "return {}::trampoline($_[0], $_[0]->_f{idx}_body(@_[1 .. $#_]));",
                 self.rt_name
             ));
             w.dedent();
@@ -973,14 +983,10 @@ impl<'a> Gen<'a> {
             w.line("my $_bt = 0;");
         }
         // A `return` (or a branch to the function frame) that must cross a try_table's `eval` writes its values here first (`materialize_escape`), one set shared by every try_table in the function: at most one escape is ever in flight, and it only ever heads to this same final `return`, however many `eval`s it has to leave along the way.
-        // A tail call escapes as a one-value return carrying its thunk, so a nullary tail-calling function needs `$__tt_ret0` even though its own arity declares none.
-        let escape_slots = if self.tail_callers.contains(&idx) {
-            ty.results.len().max(1)
-        } else {
-            ty.results.len()
-        };
-        if escape_slots > 0 && seq_has_try_table(&func.body) {
-            let names: Vec<String> = (0..escape_slots).map(|i| format!("$__tt_ret{i}")).collect();
+        if !ty.results.is_empty() && seq_has_try_table(&func.body) {
+            let names: Vec<String> = (0..ty.results.len())
+                .map(|i| format!("$__tt_ret{i}"))
+                .collect();
             let decl = match names.as_slice() {
                 [one] => one.clone(),
                 many => format!("({})", many.join(", ")),
@@ -1198,15 +1204,13 @@ impl<'a> Gen<'a> {
             // A thunk, never a plain call: the callee must run once this frame, including every `eval` a try_table opened, is gone, and escaping the thunk as a return is what unwinds them.
             // The target is the callee's *body* where it has one, so a mutual chain bounces in the one outermost trampoline instead of entering a fresh one per hop.
             Stmt::ReturnCall { func, args } => {
-                let target = if self.tail_callers.contains(func) {
-                    format!("sub {{ return $self->_f{func}_body(@_); }}")
-                } else {
-                    self.func_closure(*func)
+                // A coderef for the callee's *body* where it has one, taken from the table built once at instantiation so no closure is allocated per hop.
+                let target = match self.tail_body_slot(*func) {
+                    Some(k) => format!("$self->{{__tm}}[{k}]"),
+                    None => self.func_closure(*func),
                 };
-                let mut parts = vec![target];
-                parts.extend(args.iter().map(|a| self.expr(a)));
-                let thunk = format!("{}({})", self.rt("tail_call"), parts.join(", "));
-                self.tail_escape(w, thunk);
+                let args: Vec<String> = args.iter().map(|a| self.expr(a)).collect();
+                self.park_tail(w, &target, &args);
             }
             Stmt::ReturnCallIndirect {
                 type_idx,
@@ -1215,14 +1219,14 @@ impl<'a> Gen<'a> {
                 args,
             } => {
                 self.use_unit("table/tail_ref");
-                let mut parts = vec![format!(
+                // The slot is resolved, and its traps raised, here rather than in the trampoline: an indirect tail call's checks happen at the instruction, not after the frame is gone.
+                let target = format!(
                     "$self->{{t{table_index}}}->tail_ref({}, {})",
                     self.expr(index),
                     self.type_symbol(*type_idx)
-                )];
-                parts.extend(args.iter().map(|a| self.expr(a)));
-                let thunk = format!("{}({})", self.rt("tail_call"), parts.join(", "));
-                self.tail_escape(w, thunk);
+                );
+                let args: Vec<String> = args.iter().map(|a| self.expr(a)).collect();
+                self.park_tail(w, &target, &args);
             }
             Stmt::Unreachable => {
                 w.line(format!("{}('unreachable');", self.rt("trap")));
@@ -1326,18 +1330,36 @@ impl<'a> Gen<'a> {
         }
     }
 
+    /// Park a tail call for the entry's trampoline, then leave the function.
+    /// The argument array is reused rather than rebuilt, and the arguments are already free of calls (the IR spills an effectful operand before the instruction), so nothing between these statements can reach another trampoline and overwrite a slot.
+    fn park_tail(&self, w: &mut CodeWriter, target: &str, args: &[String]) {
+        self.use_unit("rt/tail_call");
+        if args.is_empty() {
+            w.line("@{$self->{__ta}} = ();");
+        } else {
+            w.line(format!("@{{$self->{{__ta}}}} = ({});", args.join(", ")));
+        }
+        w.line(format!("$self->{{__tf}} = {target};"));
+        self.tail_escape(w);
+    }
+
+    /// A tail-calling function's dense position in `$self->{__tm}`.
+    fn tail_body_slot(&self, func_idx: u32) -> Option<usize> {
+        self.tail_callers.iter().position(|f| *f == func_idx)
+    }
+
     /// Leave the function carrying `thunk`, the way `branch` leaves it carrying return values: one value, so it crosses each open `try_table`'s `eval` through that barrier's outcome table rather than as a bare `return`, which would only exit the `eval`.
     /// The trampoline that unwraps it sits outside every barrier, which is what gives a tail call its frame-replacement semantics.
-    fn tail_escape(&self, w: &mut CodeWriter, thunk: String) {
-        let escape = Escape::Return { count: 1 };
+    fn tail_escape(&self, w: &mut CodeWriter) {
+        // A zero-value return: the parked call carries the target and the arguments, so nothing travels out with the escape.
+        let escape = Escape::Return { count: 0 };
         if let Some((barrier_id, code)) = self.cross_eval_barrier(&escape) {
-            w.line(format!("$__tt_ret0 = {thunk};"));
             w.line(format!(
                 "$__tt_out{barrier_id} = {code}; last TTBODY{barrier_id};"
             ));
             return;
         }
-        w.line(format!("return {thunk};"));
+        w.line("return;");
     }
 
     /// Write a deferred escape's operands before it crosses its first `eval` boundary: a `Label` target's `assigns` (already-materialized temps, so this is the same write `branch`'s direct case makes, only timed earlier), or a `Return` target's values into the function-scoped `$__tt_retN` lexicals (`function`'s declaration, `Escape::Return`).

--- a/crates/dewasm-backend-perl/units/rt/tail_call.pl
+++ b/crates/dewasm-backend-perl/units/rt/tail_call.pl
@@ -1,15 +1,12 @@
-# A pending tail call: a tail-calling function's body returns one of these instead of calling, and its entry wrapper unwraps them in a loop, so a chain of any length runs in constant stack space.
-# An arrayref rather than `goto &sub`, perl's real tail call, because the body runs inside an eval block and perl refuses to goto out of one.
-sub tail_call {
-    my ($target, @args) = @_;
-    return [$target, \@args];
-}
-
-# A body returns its results as a list, so a thunk is recognized by being the whole of a one-element list holding an arrayref: a wasm value is a number or a coderef, never an arrayref, so nothing else can look like one.
+# The trampoline a tail-calling function's entry runs.
+# A tail call parks its target and arguments on the instance and returns; nothing is allocated per hop, which is what a chain of any length pays otherwise.
+# The target is cleared before dispatching, so a callee that does not tail-call ends the chain, and the arguments are read as the call's own operands, before the callee can overwrite them.
+# The parked argument list is one array reused across hops, emptied and refilled rather than rebuilt, so the hop costs no allocation.
 sub trampoline {
-    my @r = @_;
-    while (@r == 1 && ref($r[0]) eq 'ARRAY') {
-        @r = $r[0][0]->(@{$r[0][1]});
+    my ($self, @r) = @_;
+    while (defined(my $f = $self->{__tf})) {
+        $self->{__tf} = undef;
+        @r = $f->(@{$self->{__ta}});
     }
     return wantarray ? @r : $r[0];
 }

--- a/crates/dewasm-backend-python/src/lib.rs
+++ b/crates/dewasm-backend-python/src/lib.rs
@@ -487,6 +487,10 @@ fn val_name(ty: ValType) -> &'static str {
     dewasm_backend::val_name(ty)
 }
 
+/// Arities a parked tail call spells out as `_ta<i>` slots; wider ones park a tuple.
+/// The `rt/tail_call` trampoline's fixed cases must cover the same range.
+const MAX_PARKED_ARITY: usize = 8;
+
 struct Gen<'a> {
     module: &'a Module,
     default_wasi: bool,
@@ -619,6 +623,11 @@ impl<'a> Gen<'a> {
         };
         w.line(header);
         w.indent();
+        // The parked-call slot has to exist before the first hop reads it; Python has no implicit nil for an unset attribute.
+        if !self.tail_callers.is_empty() {
+            w.line("self._tf = None");
+            w.line("self._tn = 0");
+        }
         w.line("if imports is None:");
         w.indent();
         w.line("imports = {}");
@@ -919,6 +928,23 @@ impl<'a> Gen<'a> {
         }
     }
 
+    /// Park a tail call for the entry's trampoline: the arguments, then the arity, then the target, and return.
+    /// The arguments are already free of calls (the IR spills an effectful operand before the instruction), so nothing between these assignments can reach another trampoline and overwrite a slot.
+    fn park_tail(&self, w: &mut CodeWriter, target: &str, args: &[String]) {
+        self.use_unit("rt/tail_call");
+        if args.len() <= MAX_PARKED_ARITY {
+            for (i, a) in args.iter().enumerate() {
+                w.line(format!("self._ta{i} = {a}"));
+            }
+            w.line(format!("self._tn = {}", args.len()));
+        } else {
+            w.line(format!("self._taw = ({},)", args.join(", ")));
+            w.line("self._tn = -1");
+        }
+        w.line(format!("self._tf = {target}"));
+        w.line("return None");
+    }
+
     /// A funcref value: the `[type_key, callable]` pair tables store.
     /// A tail-calling function carries its body method as a third element, which `table/tail_ref` hands to the trampoline so a chain through the table stays flat.
     fn func_pair(&self, func_idx: u32) -> String {
@@ -960,7 +986,7 @@ impl<'a> Gen<'a> {
             w.indent();
             self.use_unit("rt/tail_call");
             w.line(format!(
-                "return {}.trampoline(self._f{idx}_body({args}))",
+                "return {}.trampoline(self, self._f{idx}_body({args}))",
                 self.rt_name
             ));
             w.dedent();
@@ -1499,22 +1525,16 @@ impl<'a> Gen<'a> {
             Stmt::DataDrop { seg } => {
                 w.line(format!("self.data{seg} = b\"\""));
             }
-            // A thunk, never a plain call: the callee must run once this frame, including its `except` blocks, is gone, and returning the thunk is what unwinds them.
+            // Parked, never called: the callee must run once this frame, including its `except` blocks, is gone, and returning is what unwinds them.
             // The target is the callee's *body* where it has one, so a mutual chain bounces in the one outermost trampoline instead of entering a fresh one per hop.
             Stmt::ReturnCall { func, args } => {
-                self.use_unit("rt/tail_call");
                 let target = if self.tail_callers.contains(func) {
                     format!("self._f{func}_body")
                 } else {
                     self.func_ref(*func)
                 };
                 let args: Vec<String> = args.iter().map(|a| self.masked(a)).collect();
-                w.line(format!(
-                    "return {}.tail_call({target}, ({}{}))",
-                    self.rt_name,
-                    args.join(", "),
-                    if args.len() == 1 { "," } else { "" }
-                ));
+                self.park_tail(w, &target, &args);
             }
             Stmt::ReturnCallIndirect {
                 type_idx,
@@ -1522,17 +1542,15 @@ impl<'a> Gen<'a> {
                 index,
                 args,
             } => {
-                self.use_unit("rt/tail_call");
                 self.use_unit("table/tail_ref");
-                let args: Vec<String> = args.iter().map(|a| self.masked(a)).collect();
-                w.line(format!(
-                    "return {}.tail_call(self.t{table_index}.tail_ref({}, {}), ({}{}))",
-                    self.rt_name,
+                // The slot is resolved, and its traps raised, here rather than in the trampoline: an indirect tail call's checks happen at the instruction, not after the frame is gone.
+                let target = format!(
+                    "self.t{table_index}.tail_ref({}, {})",
                     self.masked(index),
-                    self.type_symbol(*type_idx),
-                    args.join(", "),
-                    if args.len() == 1 { "," } else { "" }
-                ));
+                    self.type_symbol(*type_idx)
+                );
+                let args: Vec<String> = args.iter().map(|a| self.masked(a)).collect();
+                self.park_tail(w, &target, &args);
             }
             Stmt::Unreachable => {
                 w.line(format!("{}(\"unreachable\")", self.rt("trap")));

--- a/crates/dewasm-backend-python/units/rt/tail_call.py
+++ b/crates/dewasm-backend-python/units/rt/tail_call.py
@@ -1,11 +1,32 @@
-# A pending tail call: a tail-calling function's body returns one of these instead of calling, and its entry wrapper unwraps them in a loop, so a chain of any length runs in constant stack space.
-# A plain list, recognized by its type: a wasm result is a number, a bound method (funcref), or a tuple (multi-value), never a list, so nothing else can look like one.
+# The trampoline a tail-calling function's entry runs.
+# A tail call parks its target, its arity and its arguments on the instance and returns; nothing is allocated per hop, which is what a chain of any length pays otherwise.
+# The target is cleared before dispatching, so a callee that does not tail-call ends the chain, and the arguments are read as the call's own operands, before the callee can overwrite them.
+# Fixed-arity dispatch for the same reason `table/call` avoids a splat: unpacking would build a tuple on both sides of every hop. Arities past the fixed set park a tuple instead (`_taw`).
 @staticmethod
-def tail_call(target, args):
-    return [target, args]
-
-@staticmethod
-def trampoline(r):
-    while type(r) is list:
-        r = r[0](*r[1])
-    return r
+def trampoline(inst, r):
+    while True:
+        f = inst._tf
+        if f is None:
+            return r
+        inst._tf = None
+        n = inst._tn
+        if n == 1:
+            r = f(inst._ta0)
+        elif n == 2:
+            r = f(inst._ta0, inst._ta1)
+        elif n == 3:
+            r = f(inst._ta0, inst._ta1, inst._ta2)
+        elif n == 0:
+            r = f()
+        elif n == 4:
+            r = f(inst._ta0, inst._ta1, inst._ta2, inst._ta3)
+        elif n == 5:
+            r = f(inst._ta0, inst._ta1, inst._ta2, inst._ta3, inst._ta4)
+        elif n == 6:
+            r = f(inst._ta0, inst._ta1, inst._ta2, inst._ta3, inst._ta4, inst._ta5)
+        elif n == 7:
+            r = f(inst._ta0, inst._ta1, inst._ta2, inst._ta3, inst._ta4, inst._ta5, inst._ta6)
+        elif n == 8:
+            r = f(inst._ta0, inst._ta1, inst._ta2, inst._ta3, inst._ta4, inst._ta5, inst._ta6, inst._ta7)
+        else:
+            r = f(*inst._taw)

--- a/crates/dewasm-backend-ruby/src/lib.rs
+++ b/crates/dewasm-backend-ruby/src/lib.rs
@@ -783,6 +783,15 @@ impl<'a> Gen<'a> {
             "def initialize(imports = {})"
         };
         w.block(header, "end", |w| {
+            // Built once, before anything that parks a target or stores one in a table: a tail call reads its target out of here rather than allocating a `Method` per hop.
+            if !self.tail_callers.is_empty() {
+                let methods: Vec<String> = self
+                    .tail_callers
+                    .iter()
+                    .map(|f| format!("method(:_f{f}_body)"))
+                    .collect();
+                w.line(format!("@__tm = [{}]", methods.join(", ")));
+            }
             if let Some(import) = &m.imported_memory {
                 w.line(format!(
                     "@m = {} || {}",
@@ -961,6 +970,36 @@ impl<'a> Gen<'a> {
         }
     }
 
+    /// Park a tail call for the entry's trampoline: the arguments, then the arity, then the target, and return.
+    /// The arguments are already free of calls (the IR spills an effectful operand before the instruction), so nothing between these assignments can reach another trampoline and overwrite a slot.
+    fn park_tail(&self, w: &mut CodeWriter, target: &str, args: &[String]) {
+        self.use_unit("rt/tail_call");
+        if args.len() <= MAX_FIXED_ARITY {
+            for (i, a) in args.iter().enumerate() {
+                w.line(format!("@__ta{i} = {a}"));
+            }
+            w.line(format!("@__tn = {}", args.len()));
+        } else {
+            w.line(format!("@__taw = [{}]", args.join(", ")));
+            w.line("@__tn = -1");
+        }
+        w.line(format!("@__tf = {target}"));
+        w.line("return nil");
+    }
+
+    /// The callable a direct tail call parks: a tail-calling callee's *body*, taken from the table built once at instantiation so no `Method` object is allocated per hop.
+    fn tail_target(&self, func_idx: u32) -> String {
+        match self.tail_body_slot(func_idx) {
+            Some(k) => format!("@__tm[{k}]"),
+            None => self.func_ref(func_idx),
+        }
+    }
+
+    /// A tail-calling function's dense position in `@__tm`.
+    fn tail_body_slot(&self, func_idx: u32) -> Option<usize> {
+        self.tail_callers.iter().position(|f| *f == func_idx)
+    }
+
     /// A funcref value: the `[type_symbol, callable]` pair tables store.
     /// Element items and `call_indirect` agree on this shape.
     /// A tail-calling function carries its body method as a third element, which `table/tail_ref` hands to the trampoline so a chain through the table stays flat.
@@ -970,10 +1009,9 @@ impl<'a> Gen<'a> {
             self.func_type_symbol(func_idx),
             self.func_ref(func_idx)
         );
-        if self.tail_callers.contains(&func_idx) {
-            format!("[{base}, method(:_f{func_idx}_body)]")
-        } else {
-            format!("[{base}]")
+        match self.tail_body_slot(func_idx) {
+            Some(k) => format!("[{base}, @__tm[{k}]]"),
+            None => format!("[{base}]"),
         }
     }
 
@@ -1450,20 +1488,12 @@ impl<'a> Gen<'a> {
             Stmt::ThrowRef { exn } => {
                 w.line(format!("{}({})", self.rt("throw_ref"), self.expr_text(exn)));
             }
-            // A thunk, never a plain call: the callee must run once this frame, including its `rescue` blocks, is gone, and returning the thunk is what unwinds them.
+            // Parked, never called: the callee must run once this frame, including its `rescue` blocks, is gone, and returning is what unwinds them.
             // The target is the callee's *body* where it has one, so a mutual chain bounces in the one outermost trampoline instead of entering a fresh one per hop.
             Stmt::ReturnCall { func, args } => {
-                self.use_unit("rt/tail_call");
-                let target = if self.tail_callers.contains(func) {
-                    format!("method(:_f{func}_body)")
-                } else {
-                    self.func_ref(*func)
-                };
+                let target = self.tail_target(*func);
                 let args: Vec<String> = args.iter().map(|a| self.expr_text(a)).collect();
-                w.line(format!(
-                    "return Rt::TailCall.new({target}, [{}])",
-                    args.join(", ")
-                ));
+                self.park_tail(w, &target, &args);
             }
             Stmt::ReturnCallIndirect {
                 type_idx,
@@ -1471,15 +1501,15 @@ impl<'a> Gen<'a> {
                 index,
                 args,
             } => {
-                self.use_unit("rt/tail_call");
                 self.use_unit("table/tail_ref");
-                let args: Vec<String> = args.iter().map(|a| self.expr_text(a)).collect();
-                w.line(format!(
-                    "return Rt::TailCall.new(@t{table_index}.tail_ref({}, {}), [{}])",
+                // The slot is resolved, and its traps raised, here rather than in the trampoline: an indirect tail call's checks happen at the instruction, not after the frame is gone.
+                let target = format!(
+                    "@t{table_index}.tail_ref({}, {})",
                     self.expr_text(index),
-                    self.type_symbol(*type_idx),
-                    args.join(", ")
-                ));
+                    self.type_symbol(*type_idx)
+                );
+                let args: Vec<String> = args.iter().map(|a| self.expr_text(a)).collect();
+                self.park_tail(w, &target, &args);
             }
             Stmt::Unreachable => {
                 w.line(format!("{}(\"unreachable\")", self.rt("trap")));

--- a/crates/dewasm-backend-ruby/units/rt/tail_call.rb
+++ b/crates/dewasm-backend-ruby/units/rt/tail_call.rb
@@ -1,7 +1,22 @@
-# A pending tail call: a tail-calling function's body returns one of these instead of calling, and its entry wrapper unwraps them in a loop, so a chain of any length runs in constant stack space.
-TailCall = Struct.new(:target, :args)
-
+# The trampoline a tail-calling function's entry runs.
+# A tail call parks its target, its arity and its arguments and returns; nothing is allocated per hop, which is what a chain of any length pays otherwise.
+# The target is cleared before dispatching, so a callee that does not tail-call ends the chain, and the arguments are read as the call's own operands, before the callee can overwrite them.
+# Fixed-arity dispatch for the same reason `table/call<n>` has it: a splat would build an array on both sides of every hop. Arities past the fixed set park an array instead (`@__taw`).
 def trampoline(r)
-  r = r.target.call(*r.args) while r.is_a?(TailCall)
+  while (f = @__tf)
+    @__tf = nil
+    r = case @__tn
+        when 0 then f.call
+        when 1 then f.call(@__ta0)
+        when 2 then f.call(@__ta0, @__ta1)
+        when 3 then f.call(@__ta0, @__ta1, @__ta2)
+        when 4 then f.call(@__ta0, @__ta1, @__ta2, @__ta3)
+        when 5 then f.call(@__ta0, @__ta1, @__ta2, @__ta3, @__ta4)
+        when 6 then f.call(@__ta0, @__ta1, @__ta2, @__ta3, @__ta4, @__ta5)
+        when 7 then f.call(@__ta0, @__ta1, @__ta2, @__ta3, @__ta4, @__ta5, @__ta6)
+        when 8 then f.call(@__ta0, @__ta1, @__ta2, @__ta3, @__ta4, @__ta5, @__ta6, @__ta7)
+        else f.call(*@__taw)
+        end
+  end
   r
 end


### PR DESCRIPTION
Closes the first item of #295.

## Why

#294 put a number on what the trampolines from #288 cost, against `call_direct`, the same chain of the same four functions made of ordinary calls:

| | Go | Java | Ruby+YJIT |
| --- | ---: | ---: | ---: |
| tail call vs ordinary call | 9.93x | 8.52x | 6.42x |

All of it was the thunk. A hop allocated an object holding the target, an array holding the arguments, and on Ruby a `Method` object for the target as well.

Counted on the converted official wasm3 asset, the app the proposal was accepted for, the hop is the whole cost: 523 indirect tail calls, 5 direct, and no self tail calls at all, so nothing about the surrounding code shape can be optimized instead.

## What this does

A tail call writes its target and arguments into per-instance slots and returns; the entry's trampoline reads them back.

- The **target** comes out of a table of tail entries built once at instantiation, so no callable is constructed per hop. A table slot carries the same entry, so an indirect hop allocates nothing either.
- The **arguments** go into per-position, per-type slots. Ruby and Python dispatch the trampoline's call by parked arity, the way `table/call<n>` already avoids a splat (decision 44); an arity past the fixed set parks an array, which no shipped app reaches.
- The target is cleared before dispatching, so a callee that does not tail-call ends the chain, and the arguments are read as the dispatch call's own operands, before the callee can overwrite them.

Bash was already this shape, because a global was the only place its pending call could live (#296); this brings the other five to it.

## The ownership check, and a bug it caught

A tail entry is bound to the instance that built it and reads *that* instance's slots, so Go and Java check ownership: `Funcref` carries the owner beside the entry, and only the owner parks it. Anything else is wrapped instead: one allocation, on a path a chain does not take.

Java needs that wrapper for correctness, not speed. Calling an unparkable callee in place let a `try_table` around the tail call catch what the callee threw, and `try_table.wast`'s `return-call-in-try-catch` requires it to escape. That is exactly the shortcut decision 18 records as passing every stack-depth test while being observably wrong; it reappeared here and the suite caught it. Go needs no wrapper, because its tail call has already left every enclosing `try_table` closure by the time it is emitted.

## Measured

Same conversion before and after, per hop on `wat/tail_call`, startup subtracted:

| backend | before | after | |
| --- | ---: | ---: | ---: |
| go | 40.87 ns | 8.42 ns | **4.85x** |
| ruby --yjit | 652.6 ns | 268.5 ns | **2.43x** |
| perl | 3655 ns | 2480 ns | 1.47x |
| java | 27.05 ns | 18.38 ns | 1.47x |
| python | 854 ns | 684 ns | 1.25x |

Against an ordinary call, Go's tail call goes from 9.93x to **2.05x** and Ruby's from 6.42x to **2.50x**.

On the app: converted wasm3 on Ruby runs 8.36 to 6.75 us per guest iteration, starts 14% faster, and its artifact is 28% smaller, because a parked call spells out less than a constructed one.

## Not in this change

Java's entry still boxes the chain's final result, since a tail entry returns `Object`; typing the entry table per result signature would remove that.
The self-call-to-loop pass and the thresholded fusion pass stay on #295, with the measurements that scoped them.

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` all pass. Recorded as decision 89.