### PR TITLE
Record the speed suite on the official wasm3 asset

### DIFF
--- a/docs/benchmarks/figs/app-cowsay-dark.svg
+++ b/docs/benchmarks/figs/app-cowsay-dark.svg
@@ -1,103 +1,103 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/cowsay: seconds per run for 22 runners on a log scale, fastest first. dewasm-go is fastest at 5.75 ms, then wasm3 at 8.16 ms; wasm3-python is slowest at 3.84 s, a span of 668x. The table below carries every number.">
-<title>app/cowsay: seconds per run for 22 runners on a log scale, fastest first. dewasm-go is fastest at 5.75 ms, then wasm3 at 8.16 ms; wasm3-python is slowest at 3.84 s, a span of 668x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/cowsay: seconds per run for 22 runners on a log scale, fastest first. dewasm-go is fastest at 3.94 ms, then wasm3 at 7.37 ms; wasm3-python is slowest at 2.33 s, a span of 590x. The table below carries every number.">
+<title>app/cowsay: seconds per run for 22 runners on a log scale, fastest first. dewasm-go is fastest at 3.94 ms, then wasm3 at 7.37 ms; wasm3-python is slowest at 2.33 s, a span of 590x. The table below carries every number.</title>
 <rect width="820" height="632" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ms</text>
-<line x1="321.4" y1="68.0" x2="321.4" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="321.4" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
-<line x1="474.9" y1="68.0" x2="474.9" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="474.9" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
-<line x1="628.3" y1="68.0" x2="628.3" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="628.3" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
+<line x1="331.4" y1="68.0" x2="331.4" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="331.4" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
+<line x1="494.7" y1="68.0" x2="494.7" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="494.7" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
+<line x1="658.1" y1="68.0" x2="658.1" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="658.1" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
 <line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="86.0" x2="284.6" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="284.6" cy="86.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.75 ms</text>
+<line x1="168.0" y1="86.0" x2="265.3" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="265.3" cy="86.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.94 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="110.0" x2="307.8" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="307.8" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.16 ms</text>
+<line x1="168.0" y1="110.0" x2="309.7" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="309.7" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.37 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="134.0" x2="323.3" y2="134.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="323.3" cy="134.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.3 ms</text>
+<line x1="168.0" y1="134.0" x2="325.6" y2="134.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="325.6" cy="134.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.22 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="158.0" x2="345.2" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="345.2" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.3 ms</text>
+<line x1="168.0" y1="158.0" x2="347.3" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="347.3" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.5 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="182.0" x2="387.0" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="387.0" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">26.7 ms</text>
+<line x1="168.0" y1="182.0" x2="392.6" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="392.6" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">23.7 ms</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="206.0" x2="479.5" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="479.5" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">107 ms</text>
+<line x1="168.0" y1="206.0" x2="495.3" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="495.3" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">101 ms</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="230.0" x2="482.3" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="482.3" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">112 ms</text>
+<line x1="168.0" y1="230.0" x2="496.4" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="496.4" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">102 ms</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="254.0" x2="494.3" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="494.3" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">134 ms</text>
+<line x1="168.0" y1="254.0" x2="508.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="508.6" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">122 ms</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="278.0" x2="500.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="500.1" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">146 ms</text>
+<line x1="168.0" y1="278.0" x2="515.0" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="515.0" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">133 ms</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="302.0" x2="520.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="520.8" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">199 ms</text>
+<line x1="168.0" y1="302.0" x2="536.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="536.8" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">181 ms</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="326.0" x2="533.5" y2="326.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="533.5" cy="326.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">241 ms</text>
+<line x1="168.0" y1="326.0" x2="550.5" y2="326.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="550.5" cy="326.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">219 ms</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="350.0" x2="538.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="538.1" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">258 ms</text>
+<line x1="168.0" y1="350.0" x2="555.8" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="555.8" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">236 ms</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="374.0" x2="542.6" y2="374.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="542.6" cy="374.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">276 ms</text>
+<line x1="168.0" y1="374.0" x2="558.3" y2="374.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="558.3" cy="374.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">245 ms</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="398.0" x2="571.8" y2="398.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="571.8" cy="398.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">428 ms</text>
+<line x1="168.0" y1="398.0" x2="592.1" y2="398.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="592.1" cy="398.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">394 ms</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="422.0" x2="582.7" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="582.7" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">504 ms</text>
+<line x1="168.0" y1="422.0" x2="605.1" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="605.1" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">474 ms</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="597.6" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="597.6" cy="446.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">631 ms</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="470.0" x2="620.7" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="620.7" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">892 ms</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="494.0" x2="643.3" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="643.3" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.25 s</text>
-<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="518.0" x2="647.7" y2="518.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="647.7" cy="518.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.34 s</text>
-<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
-<line x1="168.0" y1="542.0" x2="657.8" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="657.8" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.56 s</text>
+<line x1="168.0" y1="446.0" x2="621.6" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="621.6" cy="446.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">597 ms</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
+<line x1="168.0" y1="470.0" x2="643.9" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="643.9" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">819 ms</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="494.0" x2="644.8" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="644.8" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">829 ms</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="518.0" x2="665.6" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="665.6" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.11 s</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="542.0" x2="674.2" y2="542.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="674.2" cy="542.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.26 s</text>
 <text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
-<line x1="168.0" y1="566.0" x2="664.4" y2="566.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="664.4" cy="566.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.72 s</text>
+<line x1="168.0" y1="566.0" x2="697.8" y2="566.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="697.8" cy="566.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.75 s</text>
 <text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
 <line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="590.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.84 s</text>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.33 s</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">app/cowsay: seconds per run, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/app-cowsay.svg
+++ b/docs/benchmarks/figs/app-cowsay.svg
@@ -1,103 +1,103 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/cowsay: seconds per run for 22 runners on a log scale, fastest first. dewasm-go is fastest at 5.75 ms, then wasm3 at 8.16 ms; wasm3-python is slowest at 3.84 s, a span of 668x. The table below carries every number.">
-<title>app/cowsay: seconds per run for 22 runners on a log scale, fastest first. dewasm-go is fastest at 5.75 ms, then wasm3 at 8.16 ms; wasm3-python is slowest at 3.84 s, a span of 668x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/cowsay: seconds per run for 22 runners on a log scale, fastest first. dewasm-go is fastest at 3.94 ms, then wasm3 at 7.37 ms; wasm3-python is slowest at 2.33 s, a span of 590x. The table below carries every number.">
+<title>app/cowsay: seconds per run for 22 runners on a log scale, fastest first. dewasm-go is fastest at 3.94 ms, then wasm3 at 7.37 ms; wasm3-python is slowest at 2.33 s, a span of 590x. The table below carries every number.</title>
 <rect width="820" height="632" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 ms</text>
-<line x1="321.4" y1="68.0" x2="321.4" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="321.4" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
-<line x1="474.9" y1="68.0" x2="474.9" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="474.9" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
-<line x1="628.3" y1="68.0" x2="628.3" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="628.3" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
+<line x1="331.4" y1="68.0" x2="331.4" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="331.4" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
+<line x1="494.7" y1="68.0" x2="494.7" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="494.7" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
+<line x1="658.1" y1="68.0" x2="658.1" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="658.1" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
 <line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="86.0" x2="284.6" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="284.6" cy="86.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.75 ms</text>
+<line x1="168.0" y1="86.0" x2="265.3" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="265.3" cy="86.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.94 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="110.0" x2="307.8" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="307.8" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.16 ms</text>
+<line x1="168.0" y1="110.0" x2="309.7" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="309.7" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.37 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="134.0" x2="323.3" y2="134.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="323.3" cy="134.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.3 ms</text>
+<line x1="168.0" y1="134.0" x2="325.6" y2="134.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="325.6" cy="134.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.22 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="158.0" x2="345.2" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="345.2" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.3 ms</text>
+<line x1="168.0" y1="158.0" x2="347.3" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="347.3" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.5 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="182.0" x2="387.0" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="387.0" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">26.7 ms</text>
+<line x1="168.0" y1="182.0" x2="392.6" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="392.6" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">23.7 ms</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="206.0" x2="479.5" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="479.5" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">107 ms</text>
+<line x1="168.0" y1="206.0" x2="495.3" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="495.3" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">101 ms</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="230.0" x2="482.3" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="482.3" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">112 ms</text>
+<line x1="168.0" y1="230.0" x2="496.4" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="496.4" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">102 ms</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="254.0" x2="494.3" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="494.3" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">134 ms</text>
+<line x1="168.0" y1="254.0" x2="508.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="508.6" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">122 ms</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="278.0" x2="500.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="500.1" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">146 ms</text>
+<line x1="168.0" y1="278.0" x2="515.0" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="515.0" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">133 ms</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="302.0" x2="520.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="520.8" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">199 ms</text>
+<line x1="168.0" y1="302.0" x2="536.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="536.8" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">181 ms</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="326.0" x2="533.5" y2="326.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="533.5" cy="326.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">241 ms</text>
+<line x1="168.0" y1="326.0" x2="550.5" y2="326.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="550.5" cy="326.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">219 ms</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="350.0" x2="538.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="538.1" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">258 ms</text>
+<line x1="168.0" y1="350.0" x2="555.8" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="555.8" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">236 ms</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="374.0" x2="542.6" y2="374.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="542.6" cy="374.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">276 ms</text>
+<line x1="168.0" y1="374.0" x2="558.3" y2="374.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="558.3" cy="374.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">245 ms</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="398.0" x2="571.8" y2="398.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="571.8" cy="398.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">428 ms</text>
+<line x1="168.0" y1="398.0" x2="592.1" y2="398.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="592.1" cy="398.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">394 ms</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="422.0" x2="582.7" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="582.7" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">504 ms</text>
+<line x1="168.0" y1="422.0" x2="605.1" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="605.1" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">474 ms</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="597.6" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="597.6" cy="446.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">631 ms</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="470.0" x2="620.7" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="620.7" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">892 ms</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="494.0" x2="643.3" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="643.3" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.25 s</text>
-<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="518.0" x2="647.7" y2="518.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="647.7" cy="518.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.34 s</text>
-<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
-<line x1="168.0" y1="542.0" x2="657.8" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="657.8" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.56 s</text>
+<line x1="168.0" y1="446.0" x2="621.6" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="621.6" cy="446.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">597 ms</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
+<line x1="168.0" y1="470.0" x2="643.9" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="643.9" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">819 ms</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="494.0" x2="644.8" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="644.8" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">829 ms</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="518.0" x2="665.6" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="665.6" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.11 s</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="542.0" x2="674.2" y2="542.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="674.2" cy="542.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.26 s</text>
 <text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
-<line x1="168.0" y1="566.0" x2="664.4" y2="566.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="664.4" cy="566.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.72 s</text>
+<line x1="168.0" y1="566.0" x2="697.8" y2="566.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="697.8" cy="566.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.75 s</text>
 <text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
 <line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="590.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.84 s</text>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.33 s</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">app/cowsay: seconds per run, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/app-minigzip-dark.svg
+++ b/docs/benchmarks/figs/app-minigzip-dark.svg
@@ -1,75 +1,75 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="464" viewBox="0 0 820 464" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/minigzip: seconds per run for 15 runners on a log scale, fastest first. wasmtime is fastest at 45.0 ms, then wasmer at 53.0 ms; pywasm-pypy is slowest at 81.3 s, a span of 1810x. The table below carries every number.">
-<title>app/minigzip: seconds per run for 15 runners on a log scale, fastest first. wasmtime is fastest at 45.0 ms, then wasmer at 53.0 ms; pywasm-pypy is slowest at 81.3 s, a span of 1810x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="464" viewBox="0 0 820 464" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/minigzip: seconds per run for 15 runners on a log scale, fastest first. wasmtime is fastest at 42.7 ms, then wasmer at 49.0 ms; pywasm-pypy is slowest at 78.0 s, a span of 1830x. The table below carries every number.">
+<title>app/minigzip: seconds per run for 15 runners on a log scale, fastest first. wasmtime is fastest at 42.7 ms, then wasmer at 49.0 ms; pywasm-pypy is slowest at 78.0 s, a span of 1830x. The table below carries every number.</title>
 <rect width="820" height="464" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
-<line x1="308.7" y1="68.0" x2="308.7" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="308.7" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
-<line x1="449.3" y1="68.0" x2="449.3" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="449.3" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
-<line x1="590.0" y1="68.0" x2="590.0" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="590.0" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 s</text>
+<line x1="309.3" y1="68.0" x2="309.3" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="309.3" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
+<line x1="450.6" y1="68.0" x2="450.6" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="450.6" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
+<line x1="591.9" y1="68.0" x2="591.9" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="591.9" y="450.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 s</text>
 <line x1="168.0" y1="434.0" x2="726.0" y2="434.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="259.9" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="259.9" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">45.0 ms</text>
+<line x1="168.0" y1="86.0" x2="257.1" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="257.1" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">42.7 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="269.8" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="269.8" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">53.0 ms</text>
+<line x1="168.0" y1="110.0" x2="265.6" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="265.6" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">49.0 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="275.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="275.6" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">58.2 ms</text>
+<line x1="168.0" y1="134.0" x2="273.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="273.6" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">55.9 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="301.3" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="301.3" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">88.6 ms</text>
+<line x1="168.0" y1="158.0" x2="298.8" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="298.8" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">84.3 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="182.0" x2="366.2" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="366.2" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">257 ms</text>
+<line x1="168.0" y1="182.0" x2="365.2" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="365.2" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">249 ms</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="206.0" x2="409.9" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="409.9" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">524 ms</text>
+<line x1="168.0" y1="206.0" x2="411.1" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="411.1" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">526 ms</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="230.0" x2="479.3" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="479.3" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.63 s</text>
+<line x1="168.0" y1="230.0" x2="478.0" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="478.0" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.56 s</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="497.4" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="497.4" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.20 s</text>
+<line x1="168.0" y1="254.0" x2="497.6" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="497.6" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.15 s</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="278.0" x2="511.4" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="511.4" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.76 s</text>
+<line x1="168.0" y1="278.0" x2="508.7" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="508.7" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.58 s</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="522.4" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="522.4" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.31 s</text>
+<line x1="168.0" y1="302.0" x2="522.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="522.0" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.20 s</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="551.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="551.0" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.29 s</text>
+<line x1="168.0" y1="326.0" x2="551.3" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="551.3" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.16 s</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="616.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="616.1" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.3 s</text>
+<line x1="168.0" y1="350.0" x2="616.8" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="616.8" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.0 s</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="644.5" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="644.5" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">24.4 s</text>
+<line x1="168.0" y1="374.0" x2="644.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="644.8" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">23.7 s</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="398.0" x2="690.3" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="690.3" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">51.7 s</text>
+<line x1="168.0" y1="398.0" x2="694.3" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="694.3" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">53.0 s</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
 <line x1="168.0" y1="422.0" x2="718.0" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">81.3 s</text>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">78.0 s</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">app/minigzip: seconds per run, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/app-minigzip.svg
+++ b/docs/benchmarks/figs/app-minigzip.svg
@@ -1,75 +1,75 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="464" viewBox="0 0 820 464" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/minigzip: seconds per run for 15 runners on a log scale, fastest first. wasmtime is fastest at 45.0 ms, then wasmer at 53.0 ms; pywasm-pypy is slowest at 81.3 s, a span of 1810x. The table below carries every number.">
-<title>app/minigzip: seconds per run for 15 runners on a log scale, fastest first. wasmtime is fastest at 45.0 ms, then wasmer at 53.0 ms; pywasm-pypy is slowest at 81.3 s, a span of 1810x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="464" viewBox="0 0 820 464" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/minigzip: seconds per run for 15 runners on a log scale, fastest first. wasmtime is fastest at 42.7 ms, then wasmer at 49.0 ms; pywasm-pypy is slowest at 78.0 s, a span of 1830x. The table below carries every number.">
+<title>app/minigzip: seconds per run for 15 runners on a log scale, fastest first. wasmtime is fastest at 42.7 ms, then wasmer at 49.0 ms; pywasm-pypy is slowest at 78.0 s, a span of 1830x. The table below carries every number.</title>
 <rect width="820" height="464" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
-<line x1="308.7" y1="68.0" x2="308.7" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="308.7" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
-<line x1="449.3" y1="68.0" x2="449.3" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="449.3" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
-<line x1="590.0" y1="68.0" x2="590.0" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="590.0" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">10 s</text>
+<line x1="309.3" y1="68.0" x2="309.3" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="309.3" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
+<line x1="450.6" y1="68.0" x2="450.6" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="450.6" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
+<line x1="591.9" y1="68.0" x2="591.9" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="591.9" y="450.0" text-anchor="middle" font-size="11" fill="#52514e">10 s</text>
 <line x1="168.0" y1="434.0" x2="726.0" y2="434.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="259.9" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="259.9" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">45.0 ms</text>
+<line x1="168.0" y1="86.0" x2="257.1" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="257.1" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">42.7 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="269.8" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="269.8" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">53.0 ms</text>
+<line x1="168.0" y1="110.0" x2="265.6" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="265.6" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">49.0 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="275.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="275.6" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">58.2 ms</text>
+<line x1="168.0" y1="134.0" x2="273.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="273.6" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">55.9 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="301.3" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="301.3" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">88.6 ms</text>
+<line x1="168.0" y1="158.0" x2="298.8" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="298.8" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">84.3 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="182.0" x2="366.2" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="366.2" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">257 ms</text>
+<line x1="168.0" y1="182.0" x2="365.2" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="365.2" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">249 ms</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="206.0" x2="409.9" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="409.9" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">524 ms</text>
+<line x1="168.0" y1="206.0" x2="411.1" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="411.1" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">526 ms</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="230.0" x2="479.3" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="479.3" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.63 s</text>
+<line x1="168.0" y1="230.0" x2="478.0" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="478.0" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.56 s</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="497.4" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="497.4" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.20 s</text>
+<line x1="168.0" y1="254.0" x2="497.6" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="497.6" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.15 s</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="278.0" x2="511.4" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="511.4" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.76 s</text>
+<line x1="168.0" y1="278.0" x2="508.7" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="508.7" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.58 s</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="522.4" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="522.4" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.31 s</text>
+<line x1="168.0" y1="302.0" x2="522.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="522.0" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.20 s</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="551.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="551.0" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.29 s</text>
+<line x1="168.0" y1="326.0" x2="551.3" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="551.3" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.16 s</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="616.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="616.1" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.3 s</text>
+<line x1="168.0" y1="350.0" x2="616.8" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="616.8" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.0 s</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="644.5" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="644.5" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">24.4 s</text>
+<line x1="168.0" y1="374.0" x2="644.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="644.8" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">23.7 s</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="398.0" x2="690.3" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="690.3" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">51.7 s</text>
+<line x1="168.0" y1="398.0" x2="694.3" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="694.3" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">53.0 s</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
 <line x1="168.0" y1="422.0" x2="718.0" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">81.3 s</text>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">78.0 s</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">app/minigzip: seconds per run, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/app-sqlite3-mod-query-dark.svg
+++ b/docs/benchmarks/figs/app-sqlite3-mod-query-dark.svg
@@ -1,59 +1,59 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 85.8 ms, then wasmer at 90.0 ms; dewasm-ruby is slowest at 20.3 s, a span of 236x. The table below carries every number.">
-<title>app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 85.8 ms, then wasmer at 90.0 ms; dewasm-ruby is slowest at 20.3 s, a span of 236x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 82.6 ms, then wasmer at 85.9 ms; dewasm-ruby is slowest at 19.8 s, a span of 240x. The table below carries every number.">
+<title>app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 82.6 ms, then wasmer at 85.9 ms; dewasm-ruby is slowest at 19.8 s, a span of 240x. The table below carries every number.</title>
 <rect width="820" height="368" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
-<line x1="334.3" y1="68.0" x2="334.3" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="334.3" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
-<line x1="500.6" y1="68.0" x2="500.6" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="500.6" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
-<line x1="666.9" y1="68.0" x2="666.9" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="666.9" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 s</text>
+<line x1="334.8" y1="68.0" x2="334.8" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="334.8" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
+<line x1="501.6" y1="68.0" x2="501.6" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="501.6" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
+<line x1="668.5" y1="68.0" x2="668.5" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="668.5" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 s</text>
 <line x1="168.0" y1="338.0" x2="726.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="323.3" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="323.3" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">85.8 ms</text>
+<line x1="168.0" y1="86.0" x2="321.0" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="321.0" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">82.6 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="326.7" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="326.7" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">90.0 ms</text>
+<line x1="168.0" y1="110.0" x2="323.8" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="323.8" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">85.9 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="351.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="351.6" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">127 ms</text>
+<line x1="168.0" y1="134.0" x2="349.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="349.6" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">123 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="467.7" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="467.7" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">634 ms</text>
+<line x1="168.0" y1="158.0" x2="465.3" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="465.3" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">605 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="182.0" x2="513.5" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="513.5" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.20 s</text>
+<line x1="168.0" y1="182.0" x2="512.9" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="512.9" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.17 s</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="206.0" x2="624.4" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="624.4" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.55 s</text>
+<line x1="168.0" y1="206.0" x2="623.3" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="623.3" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.36 s</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="230.0" x2="653.6" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="653.6" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.31 s</text>
+<line x1="168.0" y1="230.0" x2="652.9" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="652.9" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.07 s</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="666.7" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="666.7" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.97 s</text>
+<line x1="168.0" y1="254.0" x2="667.0" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="667.0" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.80 s</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="278.0" x2="686.3" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="686.3" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.1 s</text>
+<line x1="168.0" y1="278.0" x2="683.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="683.1" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.2 s</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="694.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="694.0" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.5 s</text>
+<line x1="168.0" y1="302.0" x2="692.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="692.0" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.8 s</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
 <line x1="168.0" y1="326.0" x2="718.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.3 s</text>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">19.8 s</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">app/sqlite3_mod_query: seconds per run, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/app-sqlite3-mod-query.svg
+++ b/docs/benchmarks/figs/app-sqlite3-mod-query.svg
@@ -1,59 +1,59 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 85.8 ms, then wasmer at 90.0 ms; dewasm-ruby is slowest at 20.3 s, a span of 236x. The table below carries every number.">
-<title>app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 85.8 ms, then wasmer at 90.0 ms; dewasm-ruby is slowest at 20.3 s, a span of 236x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 82.6 ms, then wasmer at 85.9 ms; dewasm-ruby is slowest at 19.8 s, a span of 240x. The table below carries every number.">
+<title>app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 82.6 ms, then wasmer at 85.9 ms; dewasm-ruby is slowest at 19.8 s, a span of 240x. The table below carries every number.</title>
 <rect width="820" height="368" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
-<line x1="334.3" y1="68.0" x2="334.3" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="334.3" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
-<line x1="500.6" y1="68.0" x2="500.6" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="500.6" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
-<line x1="666.9" y1="68.0" x2="666.9" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="666.9" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 s</text>
+<line x1="334.8" y1="68.0" x2="334.8" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="334.8" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
+<line x1="501.6" y1="68.0" x2="501.6" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="501.6" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
+<line x1="668.5" y1="68.0" x2="668.5" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="668.5" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 s</text>
 <line x1="168.0" y1="338.0" x2="726.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="323.3" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="323.3" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">85.8 ms</text>
+<line x1="168.0" y1="86.0" x2="321.0" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="321.0" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">82.6 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="326.7" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="326.7" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">90.0 ms</text>
+<line x1="168.0" y1="110.0" x2="323.8" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="323.8" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">85.9 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="351.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="351.6" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">127 ms</text>
+<line x1="168.0" y1="134.0" x2="349.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="349.6" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">123 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="467.7" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="467.7" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">634 ms</text>
+<line x1="168.0" y1="158.0" x2="465.3" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="465.3" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">605 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="182.0" x2="513.5" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="513.5" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.20 s</text>
+<line x1="168.0" y1="182.0" x2="512.9" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="512.9" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.17 s</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="206.0" x2="624.4" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="624.4" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.55 s</text>
+<line x1="168.0" y1="206.0" x2="623.3" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="623.3" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.36 s</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="230.0" x2="653.6" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="653.6" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.31 s</text>
+<line x1="168.0" y1="230.0" x2="652.9" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="652.9" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.07 s</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="666.7" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="666.7" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.97 s</text>
+<line x1="168.0" y1="254.0" x2="667.0" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="667.0" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.80 s</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="278.0" x2="686.3" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="686.3" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.1 s</text>
+<line x1="168.0" y1="278.0" x2="683.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="683.1" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.2 s</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="694.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="694.0" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.5 s</text>
+<line x1="168.0" y1="302.0" x2="692.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="692.0" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.8 s</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
 <line x1="168.0" y1="326.0" x2="718.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.3 s</text>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">19.8 s</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">app/sqlite3_mod_query: seconds per run, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/app-sqlite3-query-dark.svg
+++ b/docs/benchmarks/figs/app-sqlite3-query-dark.svg
@@ -1,59 +1,59 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 79.4 ms, then wasmer at 87.5 ms; dewasm-ruby is slowest at 19.3 s, a span of 243x. The table below carries every number.">
-<title>app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 79.4 ms, then wasmer at 87.5 ms; dewasm-ruby is slowest at 19.3 s, a span of 243x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 75.2 ms, then wasmer at 83.1 ms; dewasm-ruby is slowest at 18.7 s, a span of 249x. The table below carries every number.">
+<title>app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 75.2 ms, then wasmer at 83.1 ms; dewasm-ruby is slowest at 18.7 s, a span of 249x. The table below carries every number.</title>
 <rect width="820" height="368" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
-<line x1="335.4" y1="68.0" x2="335.4" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="335.4" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
-<line x1="502.8" y1="68.0" x2="502.8" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="502.8" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
-<line x1="670.2" y1="68.0" x2="670.2" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="670.2" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 s</text>
+<line x1="336.0" y1="68.0" x2="336.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="336.0" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ms</text>
+<line x1="504.1" y1="68.0" x2="504.1" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="504.1" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 s</text>
+<line x1="672.1" y1="68.0" x2="672.1" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="672.1" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 s</text>
 <line x1="168.0" y1="338.0" x2="726.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="318.7" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="318.7" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">79.4 ms</text>
+<line x1="168.0" y1="86.0" x2="315.3" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="315.3" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">75.2 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="325.7" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="325.7" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">87.5 ms</text>
+<line x1="168.0" y1="110.0" x2="322.5" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="322.5" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">83.1 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
 <line x1="168.0" y1="134.0" x2="374.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="374.1" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">170 ms</text>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">168 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="471.3" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="471.3" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">649 ms</text>
+<line x1="168.0" y1="158.0" x2="468.3" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="468.3" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">612 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="182.0" x2="511.8" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="511.8" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.13 s</text>
+<line x1="168.0" y1="182.0" x2="510.9" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="510.9" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.10 s</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="206.0" x2="565.6" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="565.6" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.37 s</text>
+<line x1="168.0" y1="206.0" x2="565.0" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="565.0" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.30 s</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="230.0" x2="665.1" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="665.1" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.32 s</text>
+<line x1="168.0" y1="230.0" x2="663.2" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="663.2" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.84 s</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="667.3" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="667.3" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.61 s</text>
+<line x1="168.0" y1="254.0" x2="668.0" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="668.0" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.45 s</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="278.0" x2="683.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="683.5" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.0 s</text>
+<line x1="168.0" y1="278.0" x2="681.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="681.5" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">11.4 s</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="694.9" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="694.9" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.0 s</text>
+<line x1="168.0" y1="302.0" x2="693.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="693.6" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.4 s</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
 <line x1="168.0" y1="326.0" x2="718.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">19.3 s</text>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">18.7 s</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">app/sqlite3_query: seconds per run, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/app-sqlite3-query.svg
+++ b/docs/benchmarks/figs/app-sqlite3-query.svg
@@ -1,59 +1,59 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 79.4 ms, then wasmer at 87.5 ms; dewasm-ruby is slowest at 19.3 s, a span of 243x. The table below carries every number.">
-<title>app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 79.4 ms, then wasmer at 87.5 ms; dewasm-ruby is slowest at 19.3 s, a span of 243x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 75.2 ms, then wasmer at 83.1 ms; dewasm-ruby is slowest at 18.7 s, a span of 249x. The table below carries every number.">
+<title>app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 75.2 ms, then wasmer at 83.1 ms; dewasm-ruby is slowest at 18.7 s, a span of 249x. The table below carries every number.</title>
 <rect width="820" height="368" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
-<line x1="335.4" y1="68.0" x2="335.4" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="335.4" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
-<line x1="502.8" y1="68.0" x2="502.8" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="502.8" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
-<line x1="670.2" y1="68.0" x2="670.2" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="670.2" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 s</text>
+<line x1="336.0" y1="68.0" x2="336.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="336.0" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">100 ms</text>
+<line x1="504.1" y1="68.0" x2="504.1" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="504.1" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">1 s</text>
+<line x1="672.1" y1="68.0" x2="672.1" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="672.1" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 s</text>
 <line x1="168.0" y1="338.0" x2="726.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="318.7" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="318.7" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">79.4 ms</text>
+<line x1="168.0" y1="86.0" x2="315.3" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="315.3" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">75.2 ms</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="325.7" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="325.7" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">87.5 ms</text>
+<line x1="168.0" y1="110.0" x2="322.5" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="322.5" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">83.1 ms</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
 <line x1="168.0" y1="134.0" x2="374.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="374.1" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">170 ms</text>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">168 ms</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="471.3" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="471.3" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">649 ms</text>
+<line x1="168.0" y1="158.0" x2="468.3" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="468.3" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">612 ms</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="182.0" x2="511.8" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="511.8" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.13 s</text>
+<line x1="168.0" y1="182.0" x2="510.9" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="510.9" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.10 s</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="206.0" x2="565.6" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="565.6" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.37 s</text>
+<line x1="168.0" y1="206.0" x2="565.0" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="565.0" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.30 s</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="230.0" x2="665.1" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="665.1" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.32 s</text>
+<line x1="168.0" y1="230.0" x2="663.2" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="663.2" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.84 s</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="667.3" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="667.3" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.61 s</text>
+<line x1="168.0" y1="254.0" x2="668.0" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="668.0" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.45 s</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="278.0" x2="683.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="683.5" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.0 s</text>
+<line x1="168.0" y1="278.0" x2="681.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="681.5" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">11.4 s</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="694.9" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="694.9" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.0 s</text>
+<line x1="168.0" y1="302.0" x2="693.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="693.6" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.4 s</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
 <line x1="168.0" y1="326.0" x2="718.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">19.3 s</text>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">18.7 s</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">app/sqlite3_query: seconds per run, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/c-mandelbrot-dark.svg
+++ b/docs/benchmarks/figs/c-mandelbrot-dark.svg
@@ -1,109 +1,109 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/mandelbrot: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 96.4 ns, then wasmer at 96.4 ns; dewasm-bash is slowest at 20.3 ms, a span of 211000x. The table below carries every number.">
-<title>c/mandelbrot: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 96.4 ns, then wasmer at 96.4 ns; dewasm-bash is slowest at 20.3 ms, a span of 211000x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/mandelbrot: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 94.5 ns, then wasmtime at 94.6 ns; dewasm-bash is slowest at 19.4 ms, a span of 205000x. The table below carries every number.">
+<title>c/mandelbrot: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 94.5 ns, then wasmtime at 94.6 ns; dewasm-bash is slowest at 19.4 ms, a span of 205000x. The table below carries every number.</title>
 <rect width="820" height="632" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="255.2" y1="68.0" x2="255.2" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="255.2" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="342.4" y1="68.0" x2="342.4" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="342.4" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="429.6" y1="68.0" x2="429.6" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="429.6" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="516.8" y1="68.0" x2="516.8" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="516.8" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
-<line x1="604.0" y1="68.0" x2="604.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="604.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ms</text>
-<line x1="691.2" y1="68.0" x2="691.2" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="691.2" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
+<line x1="255.5" y1="68.0" x2="255.5" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="255.5" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="343.0" y1="68.0" x2="343.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="343.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="430.4" y1="68.0" x2="430.4" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="430.4" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="517.9" y1="68.0" x2="517.9" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="517.9" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="605.4" y1="68.0" x2="605.4" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="605.4" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ms</text>
+<line x1="692.9" y1="68.0" x2="692.9" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="692.9" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
 <line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="253.8" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="253.8" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">96.4 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="253.8" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="253.8" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">96.4 ns</text>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="86.0" x2="253.3" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="253.3" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">94.5 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="110.0" x2="253.4" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="253.4" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">94.6 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="253.9" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="253.9" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">96.6 ns</text>
+<line x1="168.0" y1="134.0" x2="253.7" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="253.7" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">95.4 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="258.0" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="258.0" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">108 ns</text>
+<line x1="168.0" y1="158.0" x2="257.8" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="257.8" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">106 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="182.0" x2="268.5" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="268.5" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">142 ns</text>
+<line x1="168.0" y1="182.0" x2="267.8" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="267.8" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">138 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
 <line x1="168.0" y1="206.0" x2="287.3" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="287.3" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">233 ns</text>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">231 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="230.0" x2="312.4" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="312.4" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">453 ns</text>
+<line x1="168.0" y1="230.0" x2="312.5" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="312.5" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">448 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="359.0" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="359.0" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.55 µs</text>
+<line x1="168.0" y1="254.0" x2="359.1" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="359.1" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.53 µs</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="278.0" x2="389.9" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="389.9" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="278.0" x2="390.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="390.6" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.50 µs</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="302.0" x2="390.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="390.7" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.58 µs</text>
+<line x1="168.0" y1="302.0" x2="391.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="391.1" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.55 µs</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="326.0" x2="391.9" y2="326.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="391.9" cy="326.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.70 µs</text>
+<line x1="168.0" y1="326.0" x2="392.9" y2="326.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="392.9" cy="326.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.73 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="350.0" x2="399.6" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="399.6" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.53 µs</text>
+<line x1="168.0" y1="350.0" x2="401.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="401.2" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.63 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="494.9" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="494.9" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">56.1 µs</text>
+<line x1="168.0" y1="374.0" x2="494.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="494.8" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">54.4 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="398.0" x2="515.4" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="515.4" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">96.5 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
-<line x1="168.0" y1="422.0" x2="539.4" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="539.4" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">182 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="446.0" x2="540.3" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="540.3" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">186 µs</text>
+<line x1="168.0" y1="398.0" x2="515.6" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="515.6" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">94.0 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
+<line x1="168.0" y1="422.0" x2="539.2" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="539.2" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">175 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
+<line x1="168.0" y1="446.0" x2="550.4" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="550.4" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">235 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
-<line x1="168.0" y1="470.0" x2="547.9" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="547.9" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">227 µs</text>
+<line x1="168.0" y1="470.0" x2="556.5" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="556.5" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">276 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="494.0" x2="568.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="568.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">386 µs</text>
+<line x1="168.0" y1="494.0" x2="567.8" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="567.8" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">372 µs</text>
 <text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
-<line x1="168.0" y1="518.0" x2="586.6" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="586.6" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">632 µs</text>
-<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="542.0" x2="619.0" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="619.0" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.49 ms</text>
-<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="566.0" x2="627.2" y2="566.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="627.2" cy="566.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.85 ms</text>
+<line x1="168.0" y1="518.0" x2="589.3" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="589.3" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">655 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="542.0" x2="609.7" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="609.7" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.12 ms</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
+<line x1="168.0" y1="566.0" x2="619.5" y2="566.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="619.5" cy="566.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.45 ms</text>
 <text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
 <line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="590.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.3 ms</text>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">19.4 ms</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">c/mandelbrot: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/c-mandelbrot.svg
+++ b/docs/benchmarks/figs/c-mandelbrot.svg
@@ -1,109 +1,109 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/mandelbrot: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 96.4 ns, then wasmer at 96.4 ns; dewasm-bash is slowest at 20.3 ms, a span of 211000x. The table below carries every number.">
-<title>c/mandelbrot: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 96.4 ns, then wasmer at 96.4 ns; dewasm-bash is slowest at 20.3 ms, a span of 211000x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/mandelbrot: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 94.5 ns, then wasmtime at 94.6 ns; dewasm-bash is slowest at 19.4 ms, a span of 205000x. The table below carries every number.">
+<title>c/mandelbrot: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 94.5 ns, then wasmtime at 94.6 ns; dewasm-bash is slowest at 19.4 ms, a span of 205000x. The table below carries every number.</title>
 <rect width="820" height="632" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="255.2" y1="68.0" x2="255.2" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="255.2" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="342.4" y1="68.0" x2="342.4" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="342.4" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="429.6" y1="68.0" x2="429.6" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="429.6" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="516.8" y1="68.0" x2="516.8" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="516.8" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
-<line x1="604.0" y1="68.0" x2="604.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="604.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 ms</text>
-<line x1="691.2" y1="68.0" x2="691.2" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="691.2" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
+<line x1="255.5" y1="68.0" x2="255.5" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="255.5" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="343.0" y1="68.0" x2="343.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="343.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="430.4" y1="68.0" x2="430.4" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="430.4" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="517.9" y1="68.0" x2="517.9" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="517.9" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="605.4" y1="68.0" x2="605.4" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="605.4" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 ms</text>
+<line x1="692.9" y1="68.0" x2="692.9" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="692.9" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
 <line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="253.8" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="253.8" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">96.4 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="253.8" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="253.8" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">96.4 ns</text>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="86.0" x2="253.3" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="253.3" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">94.5 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="110.0" x2="253.4" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="253.4" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">94.6 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="253.9" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="253.9" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">96.6 ns</text>
+<line x1="168.0" y1="134.0" x2="253.7" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="253.7" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">95.4 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="258.0" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="258.0" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">108 ns</text>
+<line x1="168.0" y1="158.0" x2="257.8" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="257.8" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">106 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="182.0" x2="268.5" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="268.5" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">142 ns</text>
+<line x1="168.0" y1="182.0" x2="267.8" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="267.8" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">138 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
 <line x1="168.0" y1="206.0" x2="287.3" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="287.3" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">233 ns</text>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">231 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="230.0" x2="312.4" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="312.4" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">453 ns</text>
+<line x1="168.0" y1="230.0" x2="312.5" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="312.5" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">448 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="359.0" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="359.0" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.55 µs</text>
+<line x1="168.0" y1="254.0" x2="359.1" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="359.1" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.53 µs</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="278.0" x2="389.9" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="389.9" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="278.0" x2="390.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="390.6" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.50 µs</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="302.0" x2="390.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="390.7" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.58 µs</text>
+<line x1="168.0" y1="302.0" x2="391.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="391.1" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.55 µs</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="326.0" x2="391.9" y2="326.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="391.9" cy="326.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.70 µs</text>
+<line x1="168.0" y1="326.0" x2="392.9" y2="326.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="392.9" cy="326.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.73 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="350.0" x2="399.6" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="399.6" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.53 µs</text>
+<line x1="168.0" y1="350.0" x2="401.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="401.2" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.63 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="494.9" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="494.9" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">56.1 µs</text>
+<line x1="168.0" y1="374.0" x2="494.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="494.8" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">54.4 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="398.0" x2="515.4" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="515.4" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">96.5 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
-<line x1="168.0" y1="422.0" x2="539.4" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="539.4" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">182 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="446.0" x2="540.3" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="540.3" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">186 µs</text>
+<line x1="168.0" y1="398.0" x2="515.6" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="515.6" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">94.0 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
+<line x1="168.0" y1="422.0" x2="539.2" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="539.2" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">175 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
+<line x1="168.0" y1="446.0" x2="550.4" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="550.4" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">235 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
-<line x1="168.0" y1="470.0" x2="547.9" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="547.9" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">227 µs</text>
+<line x1="168.0" y1="470.0" x2="556.5" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="556.5" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">276 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="494.0" x2="568.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="568.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">386 µs</text>
+<line x1="168.0" y1="494.0" x2="567.8" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="567.8" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">372 µs</text>
 <text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
-<line x1="168.0" y1="518.0" x2="586.6" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="586.6" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">632 µs</text>
-<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="542.0" x2="619.0" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="619.0" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.49 ms</text>
-<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="566.0" x2="627.2" y2="566.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="627.2" cy="566.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.85 ms</text>
+<line x1="168.0" y1="518.0" x2="589.3" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="589.3" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">655 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="542.0" x2="609.7" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="609.7" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.12 ms</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
+<line x1="168.0" y1="566.0" x2="619.5" y2="566.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="619.5" cy="566.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.45 ms</text>
 <text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
 <line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="590.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.3 ms</text>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">19.4 ms</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">c/mandelbrot: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/c-sha256-dark.svg
+++ b/docs/benchmarks/figs/c-sha256-dark.svg
@@ -1,107 +1,107 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/sha256: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 293 ns, then wasmtime at 294 ns; dewasm-bash is slowest at 15.9 ms, a span of 54300x. The table below carries every number.">
-<title>c/sha256: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 293 ns, then wasmtime at 294 ns; dewasm-bash is slowest at 15.9 ms, a span of 54300x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/sha256: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 288 ns, then wasmer at 289 ns; dewasm-bash is slowest at 15.3 ms, a span of 52900x. The table below carries every number.">
+<title>c/sha256: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 288 ns, then wasmer at 289 ns; dewasm-bash is slowest at 15.3 ms, a span of 52900x. The table below carries every number.</title>
 <rect width="820" height="632" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="273.7" y1="68.0" x2="273.7" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="273.7" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="379.5" y1="68.0" x2="379.5" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="379.5" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="485.2" y1="68.0" x2="485.2" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="485.2" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
-<line x1="590.9" y1="68.0" x2="590.9" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="590.9" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ms</text>
-<line x1="696.6" y1="68.0" x2="696.6" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="696.6" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
+<line x1="274.1" y1="68.0" x2="274.1" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="274.1" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="380.2" y1="68.0" x2="380.2" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="380.2" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="486.3" y1="68.0" x2="486.3" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="486.3" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="592.4" y1="68.0" x2="592.4" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="592.4" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ms</text>
+<line x1="698.5" y1="68.0" x2="698.5" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="698.5" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ms</text>
 <line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="86.0" x2="217.4" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="217.4" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">293 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="217.5" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="217.5" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">294 ns</text>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="216.8" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="216.8" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">288 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="110.0" x2="216.8" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="216.8" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">289 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="225.4" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="225.4" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">349 ns</text>
+<line x1="168.0" y1="134.0" x2="224.9" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="224.9" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">344 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="229.1" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="229.1" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">378 ns</text>
+<line x1="168.0" y1="158.0" x2="228.5" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="228.5" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">372 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="245.6" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="245.6" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">541 ns</text>
+<line x1="168.0" y1="182.0" x2="246.9" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="246.9" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">554 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="346.9" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="346.9" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.92 µs</text>
+<line x1="168.0" y1="206.0" x2="346.6" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="346.6" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.83 µs</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="394.9" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="394.9" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.0 µs</text>
+<line x1="168.0" y1="230.0" x2="396.5" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="396.5" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.2 µs</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="435.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="435.6" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">34.0 µs</text>
+<line x1="168.0" y1="254.0" x2="436.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="436.5" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">33.9 µs</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="278.0" x2="443.8" y2="278.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="443.8" cy="278.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">40.6 µs</text>
+<line x1="168.0" y1="278.0" x2="443.9" y2="278.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="443.9" cy="278.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">39.9 µs</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="457.3" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="457.3" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">54.5 µs</text>
+<line x1="168.0" y1="302.0" x2="457.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="457.1" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">53.0 µs</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="474.5" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="474.5" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">79.3 µs</text>
+<line x1="168.0" y1="326.0" x2="475.2" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="475.2" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">78.5 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="530.6" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="530.6" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">269 µs</text>
+<line x1="168.0" y1="350.0" x2="531.3" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="531.3" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">265 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="538.7" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="538.7" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">321 µs</text>
+<line x1="168.0" y1="374.0" x2="539.2" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="539.2" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">315 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="398.0" x2="600.9" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="600.9" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.24 ms</text>
+<line x1="168.0" y1="398.0" x2="604.0" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="604.0" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.29 ms</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="422.0" x2="621.6" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="621.6" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.95 ms</text>
+<line x1="168.0" y1="422.0" x2="621.2" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="621.2" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.87 ms</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
-<line x1="168.0" y1="446.0" x2="642.8" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="642.8" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.10 ms</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
-<line x1="168.0" y1="470.0" x2="652.3" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="652.3" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.81 ms</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="494.0" x2="656.2" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="656.2" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.15 ms</text>
+<line x1="168.0" y1="446.0" x2="651.4" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="651.4" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.60 ms</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
+<line x1="168.0" y1="470.0" x2="656.7" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="656.7" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.04 ms</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
+<line x1="168.0" y1="494.0" x2="676.2" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="676.2" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.17 ms</text>
 <text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="518.0" x2="682.1" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="682.1" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.28 ms</text>
+<line x1="168.0" y1="518.0" x2="676.6" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="676.6" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.22 ms</text>
 <text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
-<line x1="168.0" y1="542.0" x2="691.4" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="691.4" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.93 ms</text>
+<line x1="168.0" y1="542.0" x2="694.3" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="694.3" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.14 ms</text>
 <text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="566.0" x2="714.0" y2="566.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="714.0" cy="566.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.6 ms</text>
+<line x1="168.0" y1="566.0" x2="715.0" y2="566.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="715.0" cy="566.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.3 ms</text>
 <text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
 <line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="590.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.9 ms</text>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.3 ms</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">c/sha256: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/c-sha256.svg
+++ b/docs/benchmarks/figs/c-sha256.svg
@@ -1,107 +1,107 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/sha256: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 293 ns, then wasmtime at 294 ns; dewasm-bash is slowest at 15.9 ms, a span of 54300x. The table below carries every number.">
-<title>c/sha256: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 293 ns, then wasmtime at 294 ns; dewasm-bash is slowest at 15.9 ms, a span of 54300x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/sha256: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 288 ns, then wasmer at 289 ns; dewasm-bash is slowest at 15.3 ms, a span of 52900x. The table below carries every number.">
+<title>c/sha256: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 288 ns, then wasmer at 289 ns; dewasm-bash is slowest at 15.3 ms, a span of 52900x. The table below carries every number.</title>
 <rect width="820" height="632" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="273.7" y1="68.0" x2="273.7" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="273.7" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="379.5" y1="68.0" x2="379.5" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="379.5" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="485.2" y1="68.0" x2="485.2" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="485.2" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
-<line x1="590.9" y1="68.0" x2="590.9" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="590.9" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 ms</text>
-<line x1="696.6" y1="68.0" x2="696.6" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="696.6" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
+<line x1="274.1" y1="68.0" x2="274.1" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="274.1" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="380.2" y1="68.0" x2="380.2" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="380.2" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="486.3" y1="68.0" x2="486.3" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="486.3" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="592.4" y1="68.0" x2="592.4" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="592.4" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 ms</text>
+<line x1="698.5" y1="68.0" x2="698.5" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="698.5" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ms</text>
 <line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="86.0" x2="217.4" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="217.4" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">293 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="217.5" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="217.5" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">294 ns</text>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="216.8" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="216.8" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">288 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="110.0" x2="216.8" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="216.8" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">289 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="225.4" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="225.4" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">349 ns</text>
+<line x1="168.0" y1="134.0" x2="224.9" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="224.9" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">344 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="229.1" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="229.1" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">378 ns</text>
+<line x1="168.0" y1="158.0" x2="228.5" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="228.5" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">372 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="245.6" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="245.6" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">541 ns</text>
+<line x1="168.0" y1="182.0" x2="246.9" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="246.9" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">554 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="346.9" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="346.9" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.92 µs</text>
+<line x1="168.0" y1="206.0" x2="346.6" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="346.6" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.83 µs</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="394.9" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="394.9" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.0 µs</text>
+<line x1="168.0" y1="230.0" x2="396.5" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="396.5" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.2 µs</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="435.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="435.6" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">34.0 µs</text>
+<line x1="168.0" y1="254.0" x2="436.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="436.5" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">33.9 µs</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="278.0" x2="443.8" y2="278.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="443.8" cy="278.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">40.6 µs</text>
+<line x1="168.0" y1="278.0" x2="443.9" y2="278.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="443.9" cy="278.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">39.9 µs</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="457.3" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="457.3" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">54.5 µs</text>
+<line x1="168.0" y1="302.0" x2="457.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="457.1" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">53.0 µs</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="474.5" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="474.5" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">79.3 µs</text>
+<line x1="168.0" y1="326.0" x2="475.2" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="475.2" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">78.5 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="530.6" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="530.6" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">269 µs</text>
+<line x1="168.0" y1="350.0" x2="531.3" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="531.3" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">265 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="538.7" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="538.7" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">321 µs</text>
+<line x1="168.0" y1="374.0" x2="539.2" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="539.2" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">315 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="398.0" x2="600.9" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="600.9" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.24 ms</text>
+<line x1="168.0" y1="398.0" x2="604.0" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="604.0" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.29 ms</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="422.0" x2="621.6" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="621.6" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.95 ms</text>
+<line x1="168.0" y1="422.0" x2="621.2" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="621.2" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.87 ms</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
-<line x1="168.0" y1="446.0" x2="642.8" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="642.8" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.10 ms</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
-<line x1="168.0" y1="470.0" x2="652.3" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="652.3" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.81 ms</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="494.0" x2="656.2" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="656.2" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.15 ms</text>
+<line x1="168.0" y1="446.0" x2="651.4" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="651.4" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.60 ms</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
+<line x1="168.0" y1="470.0" x2="656.7" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="656.7" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.04 ms</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
+<line x1="168.0" y1="494.0" x2="676.2" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="676.2" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.17 ms</text>
 <text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="518.0" x2="682.1" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="682.1" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.28 ms</text>
+<line x1="168.0" y1="518.0" x2="676.6" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="676.6" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.22 ms</text>
 <text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
-<line x1="168.0" y1="542.0" x2="691.4" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="691.4" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.93 ms</text>
+<line x1="168.0" y1="542.0" x2="694.3" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="694.3" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.14 ms</text>
 <text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="566.0" x2="714.0" y2="566.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="714.0" cy="566.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.6 ms</text>
+<line x1="168.0" y1="566.0" x2="715.0" y2="566.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="715.0" cy="566.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.3 ms</text>
 <text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
 <line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="590.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.9 ms</text>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.3 ms</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">c/sha256: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/c-wordcount-dark.svg
+++ b/docs/benchmarks/figs/c-wordcount-dark.svg
@@ -1,105 +1,105 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/wordcount: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.62 ns; pywasm-cpython is slowest at 59.7 µs, a span of 39800x. The table below carries every number.">
-<title>c/wordcount: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.62 ns; pywasm-cpython is slowest at 59.7 µs, a span of 39800x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/wordcount: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 1.51 ns, then wasmer at 1.62 ns; pywasm-cpython is slowest at 59.4 µs, a span of 39400x. The table below carries every number.">
+<title>c/wordcount: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 1.51 ns, then wasmer at 1.62 ns; pywasm-cpython is slowest at 59.4 µs, a span of 39400x. The table below carries every number.</title>
 <rect width="820" height="632" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
 <line x1="283.2" y1="68.0" x2="283.2" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="283.2" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="398.3" y1="68.0" x2="398.3" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="398.3" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="513.5" y1="68.0" x2="513.5" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="513.5" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="628.6" y1="68.0" x2="628.6" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="628.6" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="398.4" y1="68.0" x2="398.4" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="398.4" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="513.7" y1="68.0" x2="513.7" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="513.7" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="628.9" y1="68.0" x2="628.9" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="628.9" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
 <line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="188.2" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="188.2" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.50 ns</text>
+<line x1="168.0" y1="86.0" x2="188.5" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="188.5" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.51 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
 <line x1="168.0" y1="110.0" x2="192.1" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="192.1" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.62 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="218.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="218.1" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.72 ns</text>
+<line x1="168.0" y1="134.0" x2="217.9" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="217.9" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.71 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="223.2" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="223.2" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.01 ns</text>
+<line x1="168.0" y1="158.0" x2="222.8" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="222.8" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.99 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="230.9" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="230.9" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.52 ns</text>
+<line x1="168.0" y1="182.0" x2="229.2" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="229.2" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.39 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="318.6" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="318.6" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.3 ns</text>
+<line x1="168.0" y1="206.0" x2="317.8" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="317.8" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">19.9 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="370.2" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="370.2" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">57.0 ns</text>
+<line x1="168.0" y1="230.0" x2="369.3" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="369.3" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">55.9 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="432.3" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="432.3" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">197 ns</text>
+<line x1="168.0" y1="254.0" x2="432.1" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="432.1" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">196 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="448.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="448.6" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">273 ns</text>
+<line x1="168.0" y1="278.0" x2="447.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="447.8" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">268 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="452.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="452.6" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">296 ns</text>
+<line x1="168.0" y1="302.0" x2="451.9" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="451.9" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">291 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="469.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="469.0" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">411 ns</text>
+<line x1="168.0" y1="326.0" x2="468.3" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="468.3" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">404 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="508.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="508.2" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">899 ns</text>
+<line x1="168.0" y1="350.0" x2="507.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="507.7" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">887 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="533.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="533.1" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.48 µs</text>
+<line x1="168.0" y1="374.0" x2="532.2" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="532.2" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.45 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="398.0" x2="587.3" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="587.3" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.37 µs</text>
+<line x1="168.0" y1="398.0" x2="590.3" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="590.3" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.63 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="422.0" x2="627.9" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="627.9" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.85 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
-<line x1="168.0" y1="446.0" x2="632.7" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="632.7" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.8 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
-<line x1="168.0" y1="470.0" x2="636.2" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="636.2" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">11.6 µs</text>
+<line x1="168.0" y1="422.0" x2="627.1" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="627.1" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.66 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
+<line x1="168.0" y1="446.0" x2="643.6" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="643.6" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.4 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
+<line x1="168.0" y1="470.0" x2="650.0" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="650.0" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.3 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="494.0" x2="652.2" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="652.2" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">16.0 µs</text>
+<line x1="168.0" y1="494.0" x2="650.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="650.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.3 µs</text>
 <text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="518.0" x2="665.3" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="665.3" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.8 µs</text>
+<line x1="168.0" y1="518.0" x2="664.5" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="664.5" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.4 µs</text>
 <text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
-<line x1="168.0" y1="542.0" x2="688.4" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="688.4" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">33.0 µs</text>
+<line x1="168.0" y1="542.0" x2="691.5" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="691.5" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">34.9 µs</text>
 <text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="566.0" x2="701.0" y2="566.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="701.0" cy="566.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">42.5 µs</text>
+<line x1="168.0" y1="566.0" x2="699.9" y2="566.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="699.9" cy="566.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">41.3 µs</text>
 <text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
 <line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="590.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">59.7 µs</text>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">59.4 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">c/wordcount: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/c-wordcount.svg
+++ b/docs/benchmarks/figs/c-wordcount.svg
@@ -1,105 +1,105 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/wordcount: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.62 ns; pywasm-cpython is slowest at 59.7 µs, a span of 39800x. The table below carries every number.">
-<title>c/wordcount: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.62 ns; pywasm-cpython is slowest at 59.7 µs, a span of 39800x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="c/wordcount: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 1.51 ns, then wasmer at 1.62 ns; pywasm-cpython is slowest at 59.4 µs, a span of 39400x. The table below carries every number.">
+<title>c/wordcount: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 1.51 ns, then wasmer at 1.62 ns; pywasm-cpython is slowest at 59.4 µs, a span of 39400x. The table below carries every number.</title>
 <rect width="820" height="632" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
 <line x1="283.2" y1="68.0" x2="283.2" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="283.2" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="398.3" y1="68.0" x2="398.3" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="398.3" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="513.5" y1="68.0" x2="513.5" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="513.5" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="628.6" y1="68.0" x2="628.6" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="628.6" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="398.4" y1="68.0" x2="398.4" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="398.4" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="513.7" y1="68.0" x2="513.7" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="513.7" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="628.9" y1="68.0" x2="628.9" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="628.9" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
 <line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="188.2" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="188.2" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.50 ns</text>
+<line x1="168.0" y1="86.0" x2="188.5" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="188.5" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.51 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
 <line x1="168.0" y1="110.0" x2="192.1" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="192.1" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.62 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="218.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="218.1" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.72 ns</text>
+<line x1="168.0" y1="134.0" x2="217.9" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="217.9" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.71 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="223.2" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="223.2" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.01 ns</text>
+<line x1="168.0" y1="158.0" x2="222.8" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="222.8" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.99 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="230.9" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="230.9" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.52 ns</text>
+<line x1="168.0" y1="182.0" x2="229.2" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="229.2" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.39 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="318.6" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="318.6" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.3 ns</text>
+<line x1="168.0" y1="206.0" x2="317.8" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="317.8" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">19.9 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="370.2" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="370.2" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">57.0 ns</text>
+<line x1="168.0" y1="230.0" x2="369.3" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="369.3" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">55.9 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="432.3" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="432.3" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">197 ns</text>
+<line x1="168.0" y1="254.0" x2="432.1" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="432.1" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">196 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="448.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="448.6" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">273 ns</text>
+<line x1="168.0" y1="278.0" x2="447.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="447.8" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">268 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="452.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="452.6" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">296 ns</text>
+<line x1="168.0" y1="302.0" x2="451.9" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="451.9" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">291 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="469.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="469.0" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">411 ns</text>
+<line x1="168.0" y1="326.0" x2="468.3" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="468.3" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">404 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="508.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="508.2" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">899 ns</text>
+<line x1="168.0" y1="350.0" x2="507.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="507.7" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">887 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="533.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="533.1" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.48 µs</text>
+<line x1="168.0" y1="374.0" x2="532.2" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="532.2" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.45 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="398.0" x2="587.3" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="587.3" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.37 µs</text>
+<line x1="168.0" y1="398.0" x2="590.3" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="590.3" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.63 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="422.0" x2="627.9" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="627.9" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.85 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
-<line x1="168.0" y1="446.0" x2="632.7" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="632.7" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.8 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
-<line x1="168.0" y1="470.0" x2="636.2" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="636.2" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">11.6 µs</text>
+<line x1="168.0" y1="422.0" x2="627.1" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="627.1" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.66 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
+<line x1="168.0" y1="446.0" x2="643.6" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="643.6" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.4 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
+<line x1="168.0" y1="470.0" x2="650.0" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="650.0" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.3 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="494.0" x2="652.2" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="652.2" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">16.0 µs</text>
+<line x1="168.0" y1="494.0" x2="650.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="650.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.3 µs</text>
 <text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="518.0" x2="665.3" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="665.3" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.8 µs</text>
+<line x1="168.0" y1="518.0" x2="664.5" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="664.5" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.4 µs</text>
 <text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
-<line x1="168.0" y1="542.0" x2="688.4" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="688.4" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">33.0 µs</text>
+<line x1="168.0" y1="542.0" x2="691.5" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="691.5" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">34.9 µs</text>
 <text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="566.0" x2="701.0" y2="566.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="701.0" cy="566.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">42.5 µs</text>
+<line x1="168.0" y1="566.0" x2="699.9" y2="566.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="699.9" cy="566.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">41.3 µs</text>
 <text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
 <line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="590.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">59.7 µs</text>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">59.4 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">c/wordcount: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-br-table-dark.svg
+++ b/docs/benchmarks/figs/wat-br-table-dark.svg
@@ -1,105 +1,105 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/br_table: seconds per iteration for 22 runners on a log scale, fastest first. dewasm-go is fastest at 7.65 ns, then wasmer at 8.48 ns; pywasm-pypy is slowest at 54.2 µs, a span of 7080x. The table below carries every number.">
-<title>wat/br_table: seconds per iteration for 22 runners on a log scale, fastest first. dewasm-go is fastest at 7.65 ns, then wasmer at 8.48 ns; pywasm-pypy is slowest at 54.2 µs, a span of 7080x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/br_table: seconds per iteration for 22 runners on a log scale, fastest first. dewasm-go is fastest at 7.65 ns, then wasmer at 8.41 ns; pywasm-cpython is slowest at 49.4 µs, a span of 6460x. The table below carries every number.">
+<title>wat/br_table: seconds per iteration for 22 runners on a log scale, fastest first. dewasm-go is fastest at 7.65 ns, then wasmer at 8.41 ns; pywasm-cpython is slowest at 49.4 µs, a span of 6460x. The table below carries every number.</title>
 <rect width="820" height="632" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="284.2" y1="68.0" x2="284.2" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="284.2" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="400.4" y1="68.0" x2="400.4" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="400.4" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="516.6" y1="68.0" x2="516.6" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="516.6" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="632.8" y1="68.0" x2="632.8" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="632.8" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="285.2" y1="68.0" x2="285.2" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="285.2" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="402.3" y1="68.0" x2="402.3" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="402.3" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="519.5" y1="68.0" x2="519.5" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="519.5" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="636.7" y1="68.0" x2="636.7" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="636.7" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
 <line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="86.0" x2="270.6" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="270.6" cy="86.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="86.0" x2="271.6" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="271.6" cy="86.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.65 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="275.8" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="275.8" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.48 ns</text>
+<line x1="168.0" y1="110.0" x2="276.4" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="276.4" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.41 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="134.0" x2="276.0" y2="134.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="276.0" cy="134.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.50 ns</text>
+<line x1="168.0" y1="134.0" x2="276.4" y2="134.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="276.4" cy="134.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.42 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="278.1" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="278.1" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.85 ns</text>
+<line x1="168.0" y1="158.0" x2="278.2" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="278.2" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.72 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="282.9" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="282.9" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.75 ns</text>
+<line x1="168.0" y1="182.0" x2="283.2" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="283.2" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.61 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="333.5" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="333.5" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">26.6 ns</text>
+<line x1="168.0" y1="206.0" x2="334.6" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="334.6" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">26.4 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="377.1" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="377.1" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">63.0 ns</text>
+<line x1="168.0" y1="230.0" x2="377.3" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="377.3" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">61.2 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="254.0" x2="439.4" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="439.4" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">217 ns</text>
-<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="278.0" x2="439.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="439.5" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">217 ns</text>
-<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="302.0" x2="440.3" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="440.3" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">221 ns</text>
+<line x1="168.0" y1="254.0" x2="440.7" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="440.7" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">213 ns</text>
+<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
+<line x1="168.0" y1="278.0" x2="440.7" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="440.7" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">213 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
+<line x1="168.0" y1="302.0" x2="441.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="441.0" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">214 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="326.0" x2="440.3" y2="326.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="440.3" cy="326.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">221 ns</text>
+<line x1="168.0" y1="326.0" x2="441.9" y2="326.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="441.9" cy="326.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">218 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="470.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="470.2" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">399 ns</text>
+<line x1="168.0" y1="350.0" x2="471.9" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="471.9" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">393 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="510.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="510.0" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">878 ns</text>
+<line x1="168.0" y1="374.0" x2="512.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="512.1" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">864 ns</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="398.0" x2="574.1" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="574.1" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.13 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
-<line x1="168.0" y1="422.0" x2="622.3" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="622.3" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.13 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
-<line x1="168.0" y1="446.0" x2="626.0" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="626.0" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.75 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="470.0" x2="626.6" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="626.6" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.85 µs</text>
+<line x1="168.0" y1="398.0" x2="581.0" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="581.0" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.35 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
+<line x1="168.0" y1="422.0" x2="612.8" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="612.8" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.25 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
+<line x1="168.0" y1="446.0" x2="627.8" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="627.8" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.39 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
+<line x1="168.0" y1="470.0" x2="634.7" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="634.7" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.62 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="494.0" x2="671.2" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="671.2" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">21.4 µs</text>
+<line x1="168.0" y1="494.0" x2="672.4" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="672.4" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.2 µs</text>
 <text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
-<line x1="168.0" y1="518.0" x2="674.8" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="674.8" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="518.0" x2="679.1" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="679.1" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">23.0 µs</text>
-<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="542.0" x2="698.2" y2="542.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="698.2" cy="542.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">36.6 µs</text>
-<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="566.0" x2="715.3" y2="566.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="715.3" cy="566.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">51.4 µs</text>
-<text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="542.0" x2="679.9" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="679.9" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">23.4 µs</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="566.0" x2="701.6" y2="566.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="701.6" cy="566.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">35.8 µs</text>
+<text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
 <line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="590.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">54.2 µs</text>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">49.4 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/br_table: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-br-table.svg
+++ b/docs/benchmarks/figs/wat-br-table.svg
@@ -1,105 +1,105 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/br_table: seconds per iteration for 22 runners on a log scale, fastest first. dewasm-go is fastest at 7.65 ns, then wasmer at 8.48 ns; pywasm-pypy is slowest at 54.2 µs, a span of 7080x. The table below carries every number.">
-<title>wat/br_table: seconds per iteration for 22 runners on a log scale, fastest first. dewasm-go is fastest at 7.65 ns, then wasmer at 8.48 ns; pywasm-pypy is slowest at 54.2 µs, a span of 7080x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/br_table: seconds per iteration for 22 runners on a log scale, fastest first. dewasm-go is fastest at 7.65 ns, then wasmer at 8.41 ns; pywasm-cpython is slowest at 49.4 µs, a span of 6460x. The table below carries every number.">
+<title>wat/br_table: seconds per iteration for 22 runners on a log scale, fastest first. dewasm-go is fastest at 7.65 ns, then wasmer at 8.41 ns; pywasm-cpython is slowest at 49.4 µs, a span of 6460x. The table below carries every number.</title>
 <rect width="820" height="632" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="284.2" y1="68.0" x2="284.2" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="284.2" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="400.4" y1="68.0" x2="400.4" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="400.4" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="516.6" y1="68.0" x2="516.6" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="516.6" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="632.8" y1="68.0" x2="632.8" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="632.8" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="285.2" y1="68.0" x2="285.2" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="285.2" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="402.3" y1="68.0" x2="402.3" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="402.3" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="519.5" y1="68.0" x2="519.5" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="519.5" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="636.7" y1="68.0" x2="636.7" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="636.7" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
 <line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="86.0" x2="270.6" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="270.6" cy="86.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="86.0" x2="271.6" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="271.6" cy="86.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.65 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="275.8" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="275.8" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.48 ns</text>
+<line x1="168.0" y1="110.0" x2="276.4" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="276.4" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.41 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="134.0" x2="276.0" y2="134.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="276.0" cy="134.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.50 ns</text>
+<line x1="168.0" y1="134.0" x2="276.4" y2="134.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="276.4" cy="134.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.42 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="278.1" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="278.1" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.85 ns</text>
+<line x1="168.0" y1="158.0" x2="278.2" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="278.2" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.72 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="282.9" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="282.9" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.75 ns</text>
+<line x1="168.0" y1="182.0" x2="283.2" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="283.2" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.61 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="333.5" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="333.5" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">26.6 ns</text>
+<line x1="168.0" y1="206.0" x2="334.6" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="334.6" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">26.4 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="377.1" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="377.1" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">63.0 ns</text>
+<line x1="168.0" y1="230.0" x2="377.3" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="377.3" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">61.2 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="254.0" x2="439.4" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="439.4" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">217 ns</text>
-<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="278.0" x2="439.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="439.5" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">217 ns</text>
-<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="302.0" x2="440.3" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="440.3" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">221 ns</text>
+<line x1="168.0" y1="254.0" x2="440.7" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="440.7" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">213 ns</text>
+<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
+<line x1="168.0" y1="278.0" x2="440.7" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="440.7" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">213 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
+<line x1="168.0" y1="302.0" x2="441.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="441.0" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">214 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="326.0" x2="440.3" y2="326.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="440.3" cy="326.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">221 ns</text>
+<line x1="168.0" y1="326.0" x2="441.9" y2="326.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="441.9" cy="326.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">218 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="470.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="470.2" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">399 ns</text>
+<line x1="168.0" y1="350.0" x2="471.9" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="471.9" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">393 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="510.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="510.0" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">878 ns</text>
+<line x1="168.0" y1="374.0" x2="512.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="512.1" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">864 ns</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="398.0" x2="574.1" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="574.1" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.13 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
-<line x1="168.0" y1="422.0" x2="622.3" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="622.3" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.13 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
-<line x1="168.0" y1="446.0" x2="626.0" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="626.0" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.75 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="470.0" x2="626.6" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="626.6" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.85 µs</text>
+<line x1="168.0" y1="398.0" x2="581.0" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="581.0" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.35 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
+<line x1="168.0" y1="422.0" x2="612.8" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="612.8" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.25 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
+<line x1="168.0" y1="446.0" x2="627.8" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="627.8" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.39 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
+<line x1="168.0" y1="470.0" x2="634.7" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="634.7" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.62 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="494.0" x2="671.2" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="671.2" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">21.4 µs</text>
+<line x1="168.0" y1="494.0" x2="672.4" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="672.4" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.2 µs</text>
 <text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
-<line x1="168.0" y1="518.0" x2="674.8" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="674.8" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="518.0" x2="679.1" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="679.1" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">23.0 µs</text>
-<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="542.0" x2="698.2" y2="542.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="698.2" cy="542.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">36.6 µs</text>
-<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="566.0" x2="715.3" y2="566.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="715.3" cy="566.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">51.4 µs</text>
-<text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="542.0" x2="679.9" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="679.9" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">23.4 µs</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="566.0" x2="701.6" y2="566.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="701.6" cy="566.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">35.8 µs</text>
+<text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
 <line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="590.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">54.2 µs</text>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">49.4 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/br_table: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-call-direct-dark.svg
+++ b/docs/benchmarks/figs/wat-call-direct-dark.svg
@@ -1,105 +1,105 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_direct: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 3.50 ns, then wasmtime at 3.51 ns; wasm3-python is slowest at 73.3 µs, a span of 21000x. The table below carries every number.">
-<title>wat/call_direct: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 3.50 ns, then wasmtime at 3.51 ns; wasm3-python is slowest at 73.3 µs, a span of 21000x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_direct: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 3.43 ns, then wasmer at 3.44 ns; wasm3-python is slowest at 56.2 µs, a span of 16400x. The table below carries every number.">
+<title>wat/call_direct: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 3.43 ns, then wasmer at 3.44 ns; wasm3-python is slowest at 56.2 µs, a span of 16400x. The table below carries every number.</title>
 <rect width="820" height="632" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="281.0" y1="68.0" x2="281.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="281.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="394.1" y1="68.0" x2="394.1" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="394.1" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="507.1" y1="68.0" x2="507.1" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="507.1" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="620.2" y1="68.0" x2="620.2" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="620.2" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="283.8" y1="68.0" x2="283.8" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="283.8" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="399.6" y1="68.0" x2="399.6" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="399.6" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="515.4" y1="68.0" x2="515.4" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="515.4" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="631.2" y1="68.0" x2="631.2" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="631.2" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
 <line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="86.0" x2="229.5" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="229.5" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.50 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="229.7" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="229.7" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.51 ns</text>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="230.0" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="230.0" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.43 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="110.0" x2="230.2" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="230.2" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.44 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="231.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="231.1" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.61 ns</text>
+<line x1="168.0" y1="134.0" x2="231.3" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="231.3" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.52 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="158.0" x2="237.2" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="237.2" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.10 ns</text>
+<line x1="168.0" y1="158.0" x2="238.4" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="238.4" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.05 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="182.0" x2="256.3" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="256.3" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.03 ns</text>
+<line x1="168.0" y1="182.0" x2="257.3" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="257.3" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.91 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="354.7" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="354.7" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">44.9 ns</text>
+<line x1="168.0" y1="206.0" x2="358.0" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="358.0" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">43.7 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="389.0" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="389.0" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">90.1 ns</text>
+<line x1="168.0" y1="230.0" x2="393.2" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="393.2" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">88.0 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="398.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="398.6" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">110 ns</text>
+<line x1="168.0" y1="254.0" x2="402.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="402.5" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">106 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="278.0" x2="405.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="405.6" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">127 ns</text>
-<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="302.0" x2="429.1" y2="302.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="429.1" cy="302.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">204 ns</text>
-<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="430.3" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="430.3" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">209 ns</text>
+<line x1="168.0" y1="278.0" x2="409.7" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="409.7" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">122 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
+<line x1="168.0" y1="302.0" x2="434.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="434.7" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">201 ns</text>
+<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
+<line x1="168.0" y1="326.0" x2="434.7" y2="326.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="434.7" cy="326.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">201 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="465.0" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="465.0" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">424 ns</text>
+<line x1="168.0" y1="350.0" x2="470.5" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="470.5" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">410 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="512.4" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="512.4" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.11 µs</text>
+<line x1="168.0" y1="374.0" x2="519.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="519.1" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.08 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="611.1" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="611.1" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.32 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="422.0" x2="617.8" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="617.8" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.52 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="620.2" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="620.2" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.0 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
-<line x1="168.0" y1="470.0" x2="647.3" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="647.3" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">17.4 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="494.0" x2="649.2" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="649.2" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">18.1 µs</text>
+<line x1="168.0" y1="398.0" x2="619.8" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="619.8" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.98 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="422.0" x2="622.1" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="622.1" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.34 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="446.0" x2="624.5" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="624.5" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.75 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
+<line x1="168.0" y1="470.0" x2="658.7" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="658.7" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">17.3 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
+<line x1="168.0" y1="494.0" x2="662.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="662.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">18.4 µs</text>
 <text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
-<line x1="168.0" y1="518.0" x2="659.8" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="659.8" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">22.4 µs</text>
+<line x1="168.0" y1="518.0" x2="669.8" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="669.8" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">21.6 µs</text>
 <text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="542.0" x2="698.7" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="698.7" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">49.5 µs</text>
+<line x1="168.0" y1="542.0" x2="710.2" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="710.2" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">48.1 µs</text>
 <text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="566.0" x2="704.9" y2="566.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="704.9" cy="566.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">56.2 µs</text>
+<line x1="168.0" y1="566.0" x2="716.1" y2="566.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="716.1" cy="566.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">54.1 µs</text>
 <text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
 <line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="590.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">73.3 µs</text>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">56.2 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/call_direct: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-call-direct.svg
+++ b/docs/benchmarks/figs/wat-call-direct.svg
@@ -1,105 +1,105 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_direct: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 3.50 ns, then wasmtime at 3.51 ns; wasm3-python is slowest at 73.3 µs, a span of 21000x. The table below carries every number.">
-<title>wat/call_direct: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 3.50 ns, then wasmtime at 3.51 ns; wasm3-python is slowest at 73.3 µs, a span of 21000x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_direct: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 3.43 ns, then wasmer at 3.44 ns; wasm3-python is slowest at 56.2 µs, a span of 16400x. The table below carries every number.">
+<title>wat/call_direct: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 3.43 ns, then wasmer at 3.44 ns; wasm3-python is slowest at 56.2 µs, a span of 16400x. The table below carries every number.</title>
 <rect width="820" height="632" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="281.0" y1="68.0" x2="281.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="281.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="394.1" y1="68.0" x2="394.1" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="394.1" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="507.1" y1="68.0" x2="507.1" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="507.1" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="620.2" y1="68.0" x2="620.2" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="620.2" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="283.8" y1="68.0" x2="283.8" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="283.8" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="399.6" y1="68.0" x2="399.6" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="399.6" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="515.4" y1="68.0" x2="515.4" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="515.4" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="631.2" y1="68.0" x2="631.2" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="631.2" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
 <line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="86.0" x2="229.5" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="229.5" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.50 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="229.7" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="229.7" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.51 ns</text>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="230.0" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="230.0" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.43 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="110.0" x2="230.2" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="230.2" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.44 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="231.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="231.1" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.61 ns</text>
+<line x1="168.0" y1="134.0" x2="231.3" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="231.3" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.52 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="158.0" x2="237.2" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="237.2" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.10 ns</text>
+<line x1="168.0" y1="158.0" x2="238.4" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="238.4" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.05 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="182.0" x2="256.3" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="256.3" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.03 ns</text>
+<line x1="168.0" y1="182.0" x2="257.3" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="257.3" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.91 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="354.7" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="354.7" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">44.9 ns</text>
+<line x1="168.0" y1="206.0" x2="358.0" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="358.0" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">43.7 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="389.0" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="389.0" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">90.1 ns</text>
+<line x1="168.0" y1="230.0" x2="393.2" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="393.2" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">88.0 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="398.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="398.6" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">110 ns</text>
+<line x1="168.0" y1="254.0" x2="402.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="402.5" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">106 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="278.0" x2="405.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="405.6" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">127 ns</text>
-<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="302.0" x2="429.1" y2="302.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="429.1" cy="302.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">204 ns</text>
-<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="430.3" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="430.3" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">209 ns</text>
+<line x1="168.0" y1="278.0" x2="409.7" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="409.7" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">122 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
+<line x1="168.0" y1="302.0" x2="434.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="434.7" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">201 ns</text>
+<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
+<line x1="168.0" y1="326.0" x2="434.7" y2="326.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="434.7" cy="326.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">201 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="465.0" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="465.0" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">424 ns</text>
+<line x1="168.0" y1="350.0" x2="470.5" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="470.5" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">410 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="512.4" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="512.4" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.11 µs</text>
+<line x1="168.0" y1="374.0" x2="519.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="519.1" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.08 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="398.0" x2="611.1" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="611.1" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.32 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="422.0" x2="617.8" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="617.8" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.52 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="446.0" x2="620.2" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="620.2" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.0 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
-<line x1="168.0" y1="470.0" x2="647.3" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="647.3" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">17.4 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="494.0" x2="649.2" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="649.2" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">18.1 µs</text>
+<line x1="168.0" y1="398.0" x2="619.8" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="619.8" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.98 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="422.0" x2="622.1" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="622.1" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.34 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="446.0" x2="624.5" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="624.5" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.75 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
+<line x1="168.0" y1="470.0" x2="658.7" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="658.7" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">17.3 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
+<line x1="168.0" y1="494.0" x2="662.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="662.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">18.4 µs</text>
 <text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
-<line x1="168.0" y1="518.0" x2="659.8" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="659.8" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">22.4 µs</text>
+<line x1="168.0" y1="518.0" x2="669.8" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="669.8" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">21.6 µs</text>
 <text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="542.0" x2="698.7" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="698.7" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">49.5 µs</text>
+<line x1="168.0" y1="542.0" x2="710.2" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="710.2" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">48.1 µs</text>
 <text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="566.0" x2="704.9" y2="566.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="704.9" cy="566.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">56.2 µs</text>
+<line x1="168.0" y1="566.0" x2="716.1" y2="566.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="716.1" cy="566.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">54.1 µs</text>
 <text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
 <line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="590.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">73.3 µs</text>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">56.2 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/call_direct: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-call-indirect-dark.svg
+++ b/docs/benchmarks/figs/wat-call-indirect-dark.svg
@@ -1,105 +1,103 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_indirect: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 10.5 ns, then wasmer at 10.5 ns; wasm3-python is slowest at 107 µs, a span of 10200x. The table below carries every number.">
-<title>wat/call_indirect: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 10.5 ns, then wasmer at 10.5 ns; wasm3-python is slowest at 107 µs, a span of 10200x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_indirect: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 10.3 ns, then wasmer at 10.3 ns; wasm3-python is slowest at 86.9 µs, a span of 8430x. The table below carries every number.">
+<title>wat/call_indirect: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 10.3 ns, then wasmer at 10.3 ns; wasm3-python is slowest at 86.9 µs, a span of 8430x. The table below carries every number.</title>
 <rect width="820" height="632" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="304.5" y1="68.0" x2="304.5" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="304.5" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="441.0" y1="68.0" x2="441.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="441.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="577.6" y1="68.0" x2="577.6" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="577.6" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="714.1" y1="68.0" x2="714.1" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="714.1" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="307.6" y1="68.0" x2="307.6" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="307.6" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="447.3" y1="68.0" x2="447.3" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="447.3" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="586.9" y1="68.0" x2="586.9" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="586.9" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
 <line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="170.7" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="170.7" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.5 ns</text>
+<line x1="168.0" y1="86.0" x2="169.9" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="169.9" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.3 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="170.8" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="170.8" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.5 ns</text>
+<line x1="168.0" y1="110.0" x2="169.9" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="169.9" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.3 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="172.5" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="172.5" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.8 ns</text>
+<line x1="168.0" y1="134.0" x2="171.5" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="171.5" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.6 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="178.2" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="178.2" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">11.9 ns</text>
+<line x1="168.0" y1="158.0" x2="176.9" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="176.9" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">11.6 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="272.4" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="272.4" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">58.2 ns</text>
+<line x1="168.0" y1="182.0" x2="269.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="269.7" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">53.5 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="280.5" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="280.5" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">66.7 ns</text>
+<line x1="168.0" y1="206.0" x2="281.2" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="281.2" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">64.7 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="324.3" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="324.3" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">140 ns</text>
+<line x1="168.0" y1="230.0" x2="327.5" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="327.5" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">139 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="388.4" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="388.4" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">412 ns</text>
+<line x1="168.0" y1="254.0" x2="391.4" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="391.4" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">398 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="388.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="388.5" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">412 ns</text>
+<line x1="168.0" y1="278.0" x2="391.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="391.6" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">400 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="397.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="397.5" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">480 ns</text>
+<line x1="168.0" y1="302.0" x2="400.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="400.7" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">464 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="417.1" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="417.1" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">668 ns</text>
+<line x1="168.0" y1="326.0" x2="421.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="421.7" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">656 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="427.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="427.2" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">791 ns</text>
+<line x1="168.0" y1="350.0" x2="431.4" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="431.4" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">770 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="494.5" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="494.5" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.47 µs</text>
+<line x1="168.0" y1="374.0" x2="500.2" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="500.2" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.39 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="398.0" x2="588.7" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="588.7" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.1 µs</text>
+<line x1="168.0" y1="398.0" x2="596.8" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="596.8" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">11.8 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="422.0" x2="597.5" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="597.5" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.0 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="446.0" x2="639.0" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="639.0" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">28.2 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
-<line x1="168.0" y1="470.0" x2="645.8" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="645.8" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">31.6 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
-<line x1="168.0" y1="494.0" x2="647.3" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="647.3" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">32.4 µs</text>
-<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="518.0" x2="654.9" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="654.9" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">36.9 µs</text>
+<line x1="168.0" y1="422.0" x2="604.9" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="604.9" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.5 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="446.0" x2="646.1" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="646.1" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">26.5 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
+<line x1="168.0" y1="470.0" x2="647.9" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="647.9" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">27.4 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
+<line x1="168.0" y1="494.0" x2="656.2" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="656.2" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">31.4 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
+<line x1="168.0" y1="518.0" x2="672.4" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="672.4" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">41.0 µs</text>
 <text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="542.0" x2="697.2" y2="542.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="697.2" cy="542.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">75.3 µs</text>
+<line x1="168.0" y1="542.0" x2="707.5" y2="542.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="707.5" cy="542.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">73.0 µs</text>
 <text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="566.0" x2="702.7" y2="566.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="702.7" cy="566.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">82.6 µs</text>
+<line x1="168.0" y1="566.0" x2="712.6" y2="566.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="712.6" cy="566.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">79.5 µs</text>
 <text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
 <line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="590.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">107 µs</text>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">86.9 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/call_indirect: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-call-indirect.svg
+++ b/docs/benchmarks/figs/wat-call-indirect.svg
@@ -1,105 +1,103 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_indirect: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 10.5 ns, then wasmer at 10.5 ns; wasm3-python is slowest at 107 µs, a span of 10200x. The table below carries every number.">
-<title>wat/call_indirect: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 10.5 ns, then wasmer at 10.5 ns; wasm3-python is slowest at 107 µs, a span of 10200x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/call_indirect: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 10.3 ns, then wasmer at 10.3 ns; wasm3-python is slowest at 86.9 µs, a span of 8430x. The table below carries every number.">
+<title>wat/call_indirect: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 10.3 ns, then wasmer at 10.3 ns; wasm3-python is slowest at 86.9 µs, a span of 8430x. The table below carries every number.</title>
 <rect width="820" height="632" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="304.5" y1="68.0" x2="304.5" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="304.5" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="441.0" y1="68.0" x2="441.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="441.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="577.6" y1="68.0" x2="577.6" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="577.6" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="714.1" y1="68.0" x2="714.1" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="714.1" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="307.6" y1="68.0" x2="307.6" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="307.6" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="447.3" y1="68.0" x2="447.3" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="447.3" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="586.9" y1="68.0" x2="586.9" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="586.9" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
 <line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="170.7" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="170.7" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.5 ns</text>
+<line x1="168.0" y1="86.0" x2="169.9" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="169.9" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.3 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="170.8" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="170.8" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.5 ns</text>
+<line x1="168.0" y1="110.0" x2="169.9" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="169.9" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.3 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="172.5" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="172.5" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.8 ns</text>
+<line x1="168.0" y1="134.0" x2="171.5" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="171.5" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.6 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="178.2" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="178.2" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">11.9 ns</text>
+<line x1="168.0" y1="158.0" x2="176.9" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="176.9" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">11.6 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="272.4" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="272.4" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">58.2 ns</text>
+<line x1="168.0" y1="182.0" x2="269.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="269.7" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">53.5 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="280.5" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="280.5" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">66.7 ns</text>
+<line x1="168.0" y1="206.0" x2="281.2" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="281.2" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">64.7 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="324.3" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="324.3" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">140 ns</text>
+<line x1="168.0" y1="230.0" x2="327.5" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="327.5" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">139 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="388.4" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="388.4" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">412 ns</text>
+<line x1="168.0" y1="254.0" x2="391.4" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="391.4" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">398 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="388.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="388.5" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">412 ns</text>
+<line x1="168.0" y1="278.0" x2="391.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="391.6" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">400 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="397.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="397.5" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">480 ns</text>
+<line x1="168.0" y1="302.0" x2="400.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="400.7" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">464 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="417.1" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="417.1" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">668 ns</text>
+<line x1="168.0" y1="326.0" x2="421.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="421.7" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">656 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="427.2" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="427.2" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">791 ns</text>
+<line x1="168.0" y1="350.0" x2="431.4" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="431.4" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">770 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="494.5" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="494.5" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.47 µs</text>
+<line x1="168.0" y1="374.0" x2="500.2" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="500.2" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.39 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="398.0" x2="588.7" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="588.7" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.1 µs</text>
+<line x1="168.0" y1="398.0" x2="596.8" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="596.8" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">11.8 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="422.0" x2="597.5" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="597.5" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.0 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="446.0" x2="639.0" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="639.0" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">28.2 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
-<line x1="168.0" y1="470.0" x2="645.8" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="645.8" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">31.6 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
-<line x1="168.0" y1="494.0" x2="647.3" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="647.3" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">32.4 µs</text>
-<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="518.0" x2="654.9" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="654.9" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">36.9 µs</text>
+<line x1="168.0" y1="422.0" x2="604.9" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="604.9" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.5 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="446.0" x2="646.1" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="646.1" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">26.5 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
+<line x1="168.0" y1="470.0" x2="647.9" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="647.9" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">27.4 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
+<line x1="168.0" y1="494.0" x2="656.2" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="656.2" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">31.4 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
+<line x1="168.0" y1="518.0" x2="672.4" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="672.4" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">41.0 µs</text>
 <text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="542.0" x2="697.2" y2="542.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="697.2" cy="542.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">75.3 µs</text>
+<line x1="168.0" y1="542.0" x2="707.5" y2="542.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="707.5" cy="542.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">73.0 µs</text>
 <text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="566.0" x2="702.7" y2="566.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="702.7" cy="566.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">82.6 µs</text>
+<line x1="168.0" y1="566.0" x2="712.6" y2="566.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="712.6" cy="566.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">79.5 µs</text>
 <text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
 <line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="590.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">107 µs</text>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">86.9 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/call_indirect: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-conv-dark.svg
+++ b/docs/benchmarks/figs/wat-conv-dark.svg
@@ -1,107 +1,107 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/conv: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 7.64 ns, then wasmtime at 7.67 ns; pywasm-pypy is slowest at 795 µs, a span of 104000x. The table below carries every number.">
-<title>wat/conv: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 7.64 ns, then wasmtime at 7.67 ns; pywasm-pypy is slowest at 795 µs, a span of 104000x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/conv: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 7.51 ns, then wasmer at 7.54 ns; pywasm-pypy is slowest at 726 µs, a span of 96700x. The table below carries every number.">
+<title>wat/conv: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 7.51 ns, then wasmer at 7.54 ns; pywasm-pypy is slowest at 726 µs, a span of 96700x. The table below carries every number.</title>
 <rect width="820" height="632" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="261.2" y1="68.0" x2="261.2" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="261.2" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="354.4" y1="68.0" x2="354.4" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="354.4" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="447.6" y1="68.0" x2="447.6" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="447.6" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="540.9" y1="68.0" x2="540.9" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="540.9" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="634.1" y1="68.0" x2="634.1" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="634.1" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="261.8" y1="68.0" x2="261.8" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="261.8" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="355.7" y1="68.0" x2="355.7" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="355.7" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="449.5" y1="68.0" x2="449.5" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="449.5" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="543.4" y1="68.0" x2="543.4" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="543.4" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="637.2" y1="68.0" x2="637.2" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="637.2" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
 <line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="86.0" x2="250.3" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="250.3" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.64 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="250.5" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="250.5" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.67 ns</text>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="250.2" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="250.2" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.51 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="110.0" x2="250.3" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="250.3" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.54 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="263.3" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="263.3" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.5 ns</text>
+<line x1="168.0" y1="134.0" x2="263.2" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="263.2" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.3 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="158.0" x2="286.1" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="286.1" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">18.5 ns</text>
+<line x1="168.0" y1="158.0" x2="286.0" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="286.0" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">18.1 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="182.0" x2="292.6" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="292.6" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">21.7 ns</text>
+<line x1="168.0" y1="182.0" x2="292.5" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="292.5" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">21.2 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="206.0" x2="331.7" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="331.7" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">57.1 ns</text>
+<line x1="168.0" y1="206.0" x2="332.2" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="332.2" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">56.3 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="230.0" x2="387.8" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="387.8" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">228 ns</text>
+<line x1="168.0" y1="230.0" x2="388.1" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="388.1" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">221 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="254.0" x2="392.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="392.6" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">257 ns</text>
+<line x1="168.0" y1="254.0" x2="393.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="393.5" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">253 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="441.9" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="441.9" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">868 ns</text>
+<line x1="168.0" y1="278.0" x2="442.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="442.1" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">834 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="447.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="447.5" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">996 ns</text>
+<line x1="168.0" y1="302.0" x2="447.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="447.6" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">953 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="460.2" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="460.2" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.36 µs</text>
+<line x1="168.0" y1="326.0" x2="460.6" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="460.6" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.31 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="462.6" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="462.6" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.45 µs</text>
+<line x1="168.0" y1="350.0" x2="462.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="462.7" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.38 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="480.3" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="480.3" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.24 µs</text>
+<line x1="168.0" y1="374.0" x2="481.9" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="481.9" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.21 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="398.0" x2="536.7" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="536.7" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.03 µs</text>
+<line x1="168.0" y1="398.0" x2="533.8" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="533.8" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.91 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="422.0" x2="558.1" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="558.1" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.3 µs</text>
+<line x1="168.0" y1="422.0" x2="559.1" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="559.1" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.7 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
-<line x1="168.0" y1="446.0" x2="563.4" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="563.4" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">17.4 µs</text>
+<line x1="168.0" y1="446.0" x2="568.2" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="568.2" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">18.4 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="470.0" x2="579.7" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="579.7" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">26.1 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
-<line x1="168.0" y1="494.0" x2="598.3" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="598.3" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">41.3 µs</text>
-<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
-<line x1="168.0" y1="518.0" x2="605.3" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="605.3" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">49.1 µs</text>
+<line x1="168.0" y1="470.0" x2="581.1" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="581.1" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">25.3 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
+<line x1="168.0" y1="494.0" x2="594.3" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="594.3" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">34.9 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
+<line x1="168.0" y1="518.0" x2="600.5" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="600.5" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">40.6 µs</text>
 <text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="542.0" x2="634.7" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="634.7" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">102 µs</text>
+<line x1="168.0" y1="542.0" x2="636.7" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="636.7" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">98.7 µs</text>
 <text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="566.0" x2="700.9" y2="566.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="700.9" cy="566.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">521 µs</text>
+<line x1="168.0" y1="566.0" x2="703.1" y2="566.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="703.1" cy="566.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">504 µs</text>
 <text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
 <line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="590.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">795 µs</text>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">726 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/conv: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-conv.svg
+++ b/docs/benchmarks/figs/wat-conv.svg
@@ -1,107 +1,107 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/conv: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 7.64 ns, then wasmtime at 7.67 ns; pywasm-pypy is slowest at 795 µs, a span of 104000x. The table below carries every number.">
-<title>wat/conv: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 7.64 ns, then wasmtime at 7.67 ns; pywasm-pypy is slowest at 795 µs, a span of 104000x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/conv: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 7.51 ns, then wasmer at 7.54 ns; pywasm-pypy is slowest at 726 µs, a span of 96700x. The table below carries every number.">
+<title>wat/conv: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 7.51 ns, then wasmer at 7.54 ns; pywasm-pypy is slowest at 726 µs, a span of 96700x. The table below carries every number.</title>
 <rect width="820" height="632" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="261.2" y1="68.0" x2="261.2" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="261.2" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="354.4" y1="68.0" x2="354.4" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="354.4" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="447.6" y1="68.0" x2="447.6" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="447.6" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="540.9" y1="68.0" x2="540.9" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="540.9" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="634.1" y1="68.0" x2="634.1" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="634.1" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="261.8" y1="68.0" x2="261.8" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="261.8" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="355.7" y1="68.0" x2="355.7" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="355.7" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="449.5" y1="68.0" x2="449.5" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="449.5" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="543.4" y1="68.0" x2="543.4" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="543.4" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="637.2" y1="68.0" x2="637.2" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="637.2" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
 <line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="86.0" x2="250.3" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="250.3" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.64 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="250.5" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="250.5" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.67 ns</text>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="250.2" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="250.2" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.51 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="110.0" x2="250.3" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="250.3" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.54 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="263.3" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="263.3" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.5 ns</text>
+<line x1="168.0" y1="134.0" x2="263.2" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="263.2" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.3 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="158.0" x2="286.1" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="286.1" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">18.5 ns</text>
+<line x1="168.0" y1="158.0" x2="286.0" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="286.0" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">18.1 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="182.0" x2="292.6" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="292.6" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">21.7 ns</text>
+<line x1="168.0" y1="182.0" x2="292.5" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="292.5" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">21.2 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="206.0" x2="331.7" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="331.7" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">57.1 ns</text>
+<line x1="168.0" y1="206.0" x2="332.2" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="332.2" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">56.3 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="230.0" x2="387.8" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="387.8" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">228 ns</text>
+<line x1="168.0" y1="230.0" x2="388.1" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="388.1" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">221 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="254.0" x2="392.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="392.6" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">257 ns</text>
+<line x1="168.0" y1="254.0" x2="393.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="393.5" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">253 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="441.9" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="441.9" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">868 ns</text>
+<line x1="168.0" y1="278.0" x2="442.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="442.1" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">834 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="447.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="447.5" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">996 ns</text>
+<line x1="168.0" y1="302.0" x2="447.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="447.6" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">953 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="460.2" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="460.2" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.36 µs</text>
+<line x1="168.0" y1="326.0" x2="460.6" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="460.6" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.31 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="462.6" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="462.6" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.45 µs</text>
+<line x1="168.0" y1="350.0" x2="462.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="462.7" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.38 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="480.3" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="480.3" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.24 µs</text>
+<line x1="168.0" y1="374.0" x2="481.9" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="481.9" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.21 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="398.0" x2="536.7" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="536.7" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.03 µs</text>
+<line x1="168.0" y1="398.0" x2="533.8" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="533.8" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.91 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="422.0" x2="558.1" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="558.1" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.3 µs</text>
+<line x1="168.0" y1="422.0" x2="559.1" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="559.1" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.7 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
-<line x1="168.0" y1="446.0" x2="563.4" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="563.4" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">17.4 µs</text>
+<line x1="168.0" y1="446.0" x2="568.2" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="568.2" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">18.4 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="470.0" x2="579.7" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="579.7" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">26.1 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
-<line x1="168.0" y1="494.0" x2="598.3" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="598.3" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">41.3 µs</text>
-<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
-<line x1="168.0" y1="518.0" x2="605.3" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="605.3" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">49.1 µs</text>
+<line x1="168.0" y1="470.0" x2="581.1" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="581.1" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">25.3 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
+<line x1="168.0" y1="494.0" x2="594.3" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="594.3" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">34.9 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
+<line x1="168.0" y1="518.0" x2="600.5" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="600.5" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">40.6 µs</text>
 <text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="542.0" x2="634.7" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="634.7" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">102 µs</text>
+<line x1="168.0" y1="542.0" x2="636.7" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="636.7" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">98.7 µs</text>
 <text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="566.0" x2="700.9" y2="566.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="700.9" cy="566.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">521 µs</text>
+<line x1="168.0" y1="566.0" x2="703.1" y2="566.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="703.1" cy="566.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">504 µs</text>
 <text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
 <line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="590.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">795 µs</text>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">726 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/conv: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-eh-throw-dark.svg
+++ b/docs/benchmarks/figs/wat-eh-throw-dark.svg
@@ -1,61 +1,59 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.61 ns, then wasmedge at 114 ns; wasmer is slowest at 10.2 µs, a span of 2220x. The table below carries every number.">
-<title>wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.61 ns, then wasmedge at 114 ns; wasmer is slowest at 10.2 µs, a span of 2220x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.26 ns, then wasmedge at 112 ns; wasmer is slowest at 9.96 µs, a span of 2340x. The table below carries every number.">
+<title>wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.26 ns, then wasmedge at 112 ns; wasmer is slowest at 9.96 µs, a span of 2340x. The table below carries every number.</title>
 <rect width="820" height="368" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="305.2" y1="68.0" x2="305.2" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="305.2" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="442.4" y1="68.0" x2="442.4" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="442.4" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="579.5" y1="68.0" x2="579.5" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="579.5" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="716.7" y1="68.0" x2="716.7" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="716.7" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="305.6" y1="68.0" x2="305.6" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="305.6" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="443.1" y1="68.0" x2="443.1" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="443.1" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="580.7" y1="68.0" x2="580.7" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="580.7" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
 <line x1="168.0" y1="338.0" x2="726.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="86.0" x2="259.0" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="259.0" cy="86.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.61 ns</text>
+<line x1="168.0" y1="86.0" x2="254.6" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="254.6" cy="86.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.26 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="110.0" x2="450.0" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="450.0" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">114 ns</text>
+<line x1="168.0" y1="110.0" x2="449.9" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="449.9" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">112 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="483.3" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="483.3" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">199 ns</text>
+<line x1="168.0" y1="134.0" x2="482.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="482.6" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">194 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="158.0" x2="489.6" y2="158.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="489.6" cy="158.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">221 ns</text>
+<line x1="168.0" y1="158.0" x2="489.4" y2="158.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="489.4" cy="158.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">217 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="182.0" x2="534.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="534.7" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">471 ns</text>
+<line x1="168.0" y1="182.0" x2="534.5" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="534.5" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">461 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="206.0" x2="544.0" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="544.0" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">551 ns</text>
+<line x1="168.0" y1="206.0" x2="540.3" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="540.3" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">509 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="230.0" x2="550.2" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="550.2" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">611 ns</text>
+<line x1="168.0" y1="230.0" x2="549.6" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="549.6" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">594 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="254.0" x2="552.4" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="552.4" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">634 ns</text>
+<line x1="168.0" y1="254.0" x2="552.0" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="552.0" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">619 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
 <line x1="168.0" y1="278.0" x2="555.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="555.6" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">669 ns</text>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">657 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="302.0" x2="589.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="589.7" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.19 µs</text>
+<line x1="168.0" y1="302.0" x2="589.9" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="589.9" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.17 µs</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
 <line x1="168.0" y1="326.0" x2="718.0" y2="326.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="326.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.2 µs</text>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.96 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/eh_throw: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-eh-throw.svg
+++ b/docs/benchmarks/figs/wat-eh-throw.svg
@@ -1,61 +1,59 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.61 ns, then wasmedge at 114 ns; wasmer is slowest at 10.2 µs, a span of 2220x. The table below carries every number.">
-<title>wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.61 ns, then wasmedge at 114 ns; wasmer is slowest at 10.2 µs, a span of 2220x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.26 ns, then wasmedge at 112 ns; wasmer is slowest at 9.96 µs, a span of 2340x. The table below carries every number.">
+<title>wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.26 ns, then wasmedge at 112 ns; wasmer is slowest at 9.96 µs, a span of 2340x. The table below carries every number.</title>
 <rect width="820" height="368" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="305.2" y1="68.0" x2="305.2" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="305.2" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="442.4" y1="68.0" x2="442.4" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="442.4" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="579.5" y1="68.0" x2="579.5" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="579.5" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="716.7" y1="68.0" x2="716.7" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="716.7" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="305.6" y1="68.0" x2="305.6" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="305.6" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="443.1" y1="68.0" x2="443.1" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="443.1" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="580.7" y1="68.0" x2="580.7" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="580.7" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
 <line x1="168.0" y1="338.0" x2="726.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="86.0" x2="259.0" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="259.0" cy="86.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.61 ns</text>
+<line x1="168.0" y1="86.0" x2="254.6" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="254.6" cy="86.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.26 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="110.0" x2="450.0" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="450.0" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">114 ns</text>
+<line x1="168.0" y1="110.0" x2="449.9" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="449.9" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">112 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="483.3" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="483.3" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">199 ns</text>
+<line x1="168.0" y1="134.0" x2="482.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="482.6" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">194 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="158.0" x2="489.6" y2="158.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="489.6" cy="158.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">221 ns</text>
+<line x1="168.0" y1="158.0" x2="489.4" y2="158.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="489.4" cy="158.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">217 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="182.0" x2="534.7" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="534.7" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">471 ns</text>
+<line x1="168.0" y1="182.0" x2="534.5" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="534.5" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">461 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="206.0" x2="544.0" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="544.0" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">551 ns</text>
+<line x1="168.0" y1="206.0" x2="540.3" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="540.3" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">509 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="230.0" x2="550.2" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="550.2" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">611 ns</text>
+<line x1="168.0" y1="230.0" x2="549.6" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="549.6" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">594 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="254.0" x2="552.4" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="552.4" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">634 ns</text>
+<line x1="168.0" y1="254.0" x2="552.0" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="552.0" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">619 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
 <line x1="168.0" y1="278.0" x2="555.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="555.6" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">669 ns</text>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">657 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="302.0" x2="589.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="589.7" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.19 µs</text>
+<line x1="168.0" y1="302.0" x2="589.9" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="589.9" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.17 µs</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
 <line x1="168.0" y1="326.0" x2="718.0" y2="326.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="326.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.2 µs</text>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.96 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/eh_throw: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-eh-try-dark.svg
+++ b/docs/benchmarks/figs/wat-eh-try-dark.svg
@@ -1,57 +1,57 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.27 ns, then dewasm-java at 1.43 ns; dewasm-perl is slowest at 515 ns, a span of 406x. The table below carries every number.">
-<title>wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.27 ns, then dewasm-java at 1.43 ns; dewasm-perl is slowest at 515 ns, a span of 406x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.25 ns, then dewasm-java at 1.41 ns; dewasm-perl is slowest at 506 ns, a span of 406x. The table below carries every number.">
+<title>wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.25 ns, then dewasm-java at 1.41 ns; dewasm-perl is slowest at 506 ns, a span of 406x. The table below carries every number.</title>
 <rect width="820" height="368" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="370.8" y1="68.0" x2="370.8" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="370.8" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="573.6" y1="68.0" x2="573.6" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="573.6" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="371.4" y1="68.0" x2="371.4" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="371.4" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="574.8" y1="68.0" x2="574.8" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="574.8" y="354.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
 <line x1="168.0" y1="338.0" x2="726.0" y2="338.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="86.0" x2="189.0" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="189.0" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.27 ns</text>
+<line x1="168.0" y1="86.0" x2="187.4" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="187.4" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.25 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="110.0" x2="199.8" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="199.8" cy="110.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.43 ns</text>
+<line x1="168.0" y1="110.0" x2="198.4" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="198.4" cy="110.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.41 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="134.0" x2="252.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="252.6" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.61 ns</text>
+<line x1="168.0" y1="134.0" x2="250.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="250.6" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.55 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="158.0" x2="258.1" y2="158.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="258.1" cy="158.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.78 ns</text>
+<line x1="168.0" y1="158.0" x2="256.5" y2="158.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="256.5" cy="158.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.72 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="182.0" x2="295.5" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="295.5" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.25 ns</text>
+<line x1="168.0" y1="182.0" x2="295.2" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="295.2" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.22 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="206.0" x2="586.0" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="586.0" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">115 ns</text>
+<line x1="168.0" y1="206.0" x2="585.2" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="585.2" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">112 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="230.0" x2="590.8" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="590.8" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">122 ns</text>
+<line x1="168.0" y1="230.0" x2="590.4" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="590.4" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">119 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="254.0" x2="590.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="590.8" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">122 ns</text>
+<line x1="168.0" y1="254.0" x2="590.7" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="590.7" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">120 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="591.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="591.5" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">123 ns</text>
+<line x1="168.0" y1="278.0" x2="591.4" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="591.4" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">121 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="302.0" x2="633.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="633.7" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="302.0" x2="635.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="635.2" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">198 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
 <line x1="168.0" y1="326.0" x2="718.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">515 ns</text>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">506 ns</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/eh_try: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-eh-try.svg
+++ b/docs/benchmarks/figs/wat-eh-try.svg
@@ -1,57 +1,57 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.27 ns, then dewasm-java at 1.43 ns; dewasm-perl is slowest at 515 ns, a span of 406x. The table below carries every number.">
-<title>wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.27 ns, then dewasm-java at 1.43 ns; dewasm-perl is slowest at 515 ns, a span of 406x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="368" viewBox="0 0 820 368" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.25 ns, then dewasm-java at 1.41 ns; dewasm-perl is slowest at 506 ns, a span of 406x. The table below carries every number.">
+<title>wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.25 ns, then dewasm-java at 1.41 ns; dewasm-perl is slowest at 506 ns, a span of 406x. The table below carries every number.</title>
 <rect width="820" height="368" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="370.8" y1="68.0" x2="370.8" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="370.8" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="573.6" y1="68.0" x2="573.6" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="573.6" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="371.4" y1="68.0" x2="371.4" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="371.4" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="574.8" y1="68.0" x2="574.8" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="574.8" y="354.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
 <line x1="168.0" y1="338.0" x2="726.0" y2="338.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="86.0" x2="189.0" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="189.0" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.27 ns</text>
+<line x1="168.0" y1="86.0" x2="187.4" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="187.4" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.25 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="110.0" x2="199.8" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="199.8" cy="110.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.43 ns</text>
+<line x1="168.0" y1="110.0" x2="198.4" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="198.4" cy="110.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.41 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="134.0" x2="252.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="252.6" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.61 ns</text>
+<line x1="168.0" y1="134.0" x2="250.6" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="250.6" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.55 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="158.0" x2="258.1" y2="158.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="258.1" cy="158.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.78 ns</text>
+<line x1="168.0" y1="158.0" x2="256.5" y2="158.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="256.5" cy="158.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.72 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="182.0" x2="295.5" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="295.5" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.25 ns</text>
+<line x1="168.0" y1="182.0" x2="295.2" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="295.2" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.22 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="206.0" x2="586.0" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="586.0" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">115 ns</text>
+<line x1="168.0" y1="206.0" x2="585.2" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="585.2" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">112 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="230.0" x2="590.8" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="590.8" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">122 ns</text>
+<line x1="168.0" y1="230.0" x2="590.4" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="590.4" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">119 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="254.0" x2="590.8" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="590.8" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">122 ns</text>
+<line x1="168.0" y1="254.0" x2="590.7" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="590.7" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">120 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="591.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="591.5" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">123 ns</text>
+<line x1="168.0" y1="278.0" x2="591.4" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="591.4" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">121 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="302.0" x2="633.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="633.7" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="302.0" x2="635.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="635.2" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">198 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
 <line x1="168.0" y1="326.0" x2="718.0" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">515 ns</text>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">506 ns</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/eh_try: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-f32-alu-dark.svg
+++ b/docs/benchmarks/figs/wat-f32-alu-dark.svg
@@ -1,103 +1,103 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="584" viewBox="0 0 820 584" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f32_alu: seconds per iteration for 20 runners on a log scale, fastest first. wazero is fastest at 0.96 ns, then wasmtime at 1.00 ns; dewasm-bash is slowest at 1.21 ms, a span of 1260000x. The table below carries every number.">
-<title>wat/f32_alu: seconds per iteration for 20 runners on a log scale, fastest first. wazero is fastest at 0.96 ns, then wasmtime at 1.00 ns; dewasm-bash is slowest at 1.21 ms, a span of 1260000x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="584" viewBox="0 0 820 584" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f32_alu: seconds per iteration for 20 runners on a log scale, fastest first. wazero is fastest at 0.94 ns, then wasmtime at 0.98 ns; dewasm-bash is slowest at 1.16 ms, a span of 1240000x. The table below carries every number.">
+<title>wat/f32_alu: seconds per iteration for 20 runners on a log scale, fastest first. wazero is fastest at 0.94 ns, then wasmtime at 0.98 ns; dewasm-bash is slowest at 1.16 ms, a span of 1240000x. The table below carries every number.</title>
 <rect width="820" height="584" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">0 ns</text>
-<line x1="245.7" y1="68.0" x2="245.7" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="245.7" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="323.3" y1="68.0" x2="323.3" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="323.3" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="401.0" y1="68.0" x2="401.0" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="401.0" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="478.7" y1="68.0" x2="478.7" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="478.7" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="556.3" y1="68.0" x2="556.3" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="556.3" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="634.0" y1="68.0" x2="634.0" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="634.0" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
-<line x1="711.7" y1="68.0" x2="711.7" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="711.7" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ms</text>
+<line x1="245.8" y1="68.0" x2="245.8" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="245.8" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
+<line x1="323.7" y1="68.0" x2="323.7" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="323.7" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="401.5" y1="68.0" x2="401.5" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="401.5" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="479.4" y1="68.0" x2="479.4" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="479.4" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="557.2" y1="68.0" x2="557.2" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="557.2" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="635.1" y1="68.0" x2="635.1" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="635.1" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="712.9" y1="68.0" x2="712.9" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="712.9" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ms</text>
 <line x1="168.0" y1="554.0" x2="726.0" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="86.0" x2="244.3" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="244.3" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.96 ns</text>
+<line x1="168.0" y1="86.0" x2="243.8" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="243.8" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.94 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="245.7" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="245.7" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.00 ns</text>
+<line x1="168.0" y1="110.0" x2="245.3" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="245.3" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.98 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="134.0" x2="245.7" y2="134.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="245.7" cy="134.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.00 ns</text>
+<line x1="168.0" y1="134.0" x2="245.4" y2="134.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="245.4" cy="134.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.99 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="158.0" x2="262.3" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="262.3" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.64 ns</text>
+<line x1="168.0" y1="158.0" x2="262.2" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="262.2" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.62 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="182.0" x2="287.8" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="287.8" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.48 ns</text>
+<line x1="168.0" y1="182.0" x2="287.4" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="287.4" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.42 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="206.0" x2="303.5" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="303.5" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.55 ns</text>
+<line x1="168.0" y1="206.0" x2="303.0" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="303.0" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.42 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="230.0" x2="311.3" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="311.3" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.00 ns</text>
+<line x1="168.0" y1="230.0" x2="311.0" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="311.0" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.87 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="393.0" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="393.0" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">79.0 ns</text>
+<line x1="168.0" y1="254.0" x2="393.2" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="393.2" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">78.1 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
 <line x1="168.0" y1="278.0" x2="428.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="428.6" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">227 ns</text>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">223 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="435.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="435.8" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">281 ns</text>
+<line x1="168.0" y1="302.0" x2="435.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="435.7" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">275 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="444.5" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="444.5" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">363 ns</text>
+<line x1="168.0" y1="326.0" x2="444.6" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="444.6" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">358 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="457.9" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="457.9" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">541 ns</text>
+<line x1="168.0" y1="350.0" x2="458.4" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="458.4" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">538 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="493.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="493.1" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="374.0" x2="493.7" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="493.7" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.53 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="398.0" x2="499.5" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="499.5" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.86 µs</text>
+<line x1="168.0" y1="398.0" x2="503.8" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="503.8" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.06 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
-<line x1="168.0" y1="422.0" x2="518.1" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="518.1" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.22 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
-<line x1="168.0" y1="446.0" x2="535.3" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="535.3" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.36 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="470.0" x2="540.0" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="540.0" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.17 µs</text>
+<line x1="168.0" y1="422.0" x2="509.8" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="509.8" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.46 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="446.0" x2="540.8" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="540.8" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.15 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
+<line x1="168.0" y1="470.0" x2="541.3" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="541.3" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.24 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
-<line x1="168.0" y1="494.0" x2="567.7" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="567.7" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.0 µs</text>
+<line x1="168.0" y1="494.0" x2="569.7" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="569.7" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.5 µs</text>
 <text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="518.0" x2="592.5" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="592.5" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">29.2 µs</text>
+<line x1="168.0" y1="518.0" x2="592.4" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="592.4" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">28.3 µs</text>
 <text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
 <line x1="168.0" y1="542.0" x2="718.0" y2="542.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="542.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.21 ms</text>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.16 ms</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/f32_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-f32-alu.svg
+++ b/docs/benchmarks/figs/wat-f32-alu.svg
@@ -1,103 +1,103 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="584" viewBox="0 0 820 584" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f32_alu: seconds per iteration for 20 runners on a log scale, fastest first. wazero is fastest at 0.96 ns, then wasmtime at 1.00 ns; dewasm-bash is slowest at 1.21 ms, a span of 1260000x. The table below carries every number.">
-<title>wat/f32_alu: seconds per iteration for 20 runners on a log scale, fastest first. wazero is fastest at 0.96 ns, then wasmtime at 1.00 ns; dewasm-bash is slowest at 1.21 ms, a span of 1260000x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="584" viewBox="0 0 820 584" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f32_alu: seconds per iteration for 20 runners on a log scale, fastest first. wazero is fastest at 0.94 ns, then wasmtime at 0.98 ns; dewasm-bash is slowest at 1.16 ms, a span of 1240000x. The table below carries every number.">
+<title>wat/f32_alu: seconds per iteration for 20 runners on a log scale, fastest first. wazero is fastest at 0.94 ns, then wasmtime at 0.98 ns; dewasm-bash is slowest at 1.16 ms, a span of 1240000x. The table below carries every number.</title>
 <rect width="820" height="584" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">0 ns</text>
-<line x1="245.7" y1="68.0" x2="245.7" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="245.7" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="323.3" y1="68.0" x2="323.3" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="323.3" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="401.0" y1="68.0" x2="401.0" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="401.0" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="478.7" y1="68.0" x2="478.7" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="478.7" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="556.3" y1="68.0" x2="556.3" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="556.3" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="634.0" y1="68.0" x2="634.0" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="634.0" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
-<line x1="711.7" y1="68.0" x2="711.7" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="711.7" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">1 ms</text>
+<line x1="245.8" y1="68.0" x2="245.8" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="245.8" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
+<line x1="323.7" y1="68.0" x2="323.7" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="323.7" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="401.5" y1="68.0" x2="401.5" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="401.5" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="479.4" y1="68.0" x2="479.4" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="479.4" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="557.2" y1="68.0" x2="557.2" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="557.2" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="635.1" y1="68.0" x2="635.1" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="635.1" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="712.9" y1="68.0" x2="712.9" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="712.9" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">1 ms</text>
 <line x1="168.0" y1="554.0" x2="726.0" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="86.0" x2="244.3" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="244.3" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.96 ns</text>
+<line x1="168.0" y1="86.0" x2="243.8" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="243.8" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.94 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="110.0" x2="245.7" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="245.7" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.00 ns</text>
+<line x1="168.0" y1="110.0" x2="245.3" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="245.3" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.98 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="134.0" x2="245.7" y2="134.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="245.7" cy="134.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.00 ns</text>
+<line x1="168.0" y1="134.0" x2="245.4" y2="134.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="245.4" cy="134.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.99 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="158.0" x2="262.3" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="262.3" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.64 ns</text>
+<line x1="168.0" y1="158.0" x2="262.2" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="262.2" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.62 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="182.0" x2="287.8" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="287.8" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.48 ns</text>
+<line x1="168.0" y1="182.0" x2="287.4" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="287.4" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.42 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="206.0" x2="303.5" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="303.5" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.55 ns</text>
+<line x1="168.0" y1="206.0" x2="303.0" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="303.0" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.42 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="230.0" x2="311.3" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="311.3" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.00 ns</text>
+<line x1="168.0" y1="230.0" x2="311.0" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="311.0" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.87 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="393.0" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="393.0" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">79.0 ns</text>
+<line x1="168.0" y1="254.0" x2="393.2" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="393.2" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">78.1 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
 <line x1="168.0" y1="278.0" x2="428.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="428.6" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">227 ns</text>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">223 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="435.8" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="435.8" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">281 ns</text>
+<line x1="168.0" y1="302.0" x2="435.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="435.7" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">275 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="444.5" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="444.5" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">363 ns</text>
+<line x1="168.0" y1="326.0" x2="444.6" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="444.6" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">358 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="457.9" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="457.9" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">541 ns</text>
+<line x1="168.0" y1="350.0" x2="458.4" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="458.4" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">538 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="493.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="493.1" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="374.0" x2="493.7" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="493.7" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.53 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="398.0" x2="499.5" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="499.5" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.86 µs</text>
+<line x1="168.0" y1="398.0" x2="503.8" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="503.8" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.06 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
-<line x1="168.0" y1="422.0" x2="518.1" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="518.1" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.22 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
-<line x1="168.0" y1="446.0" x2="535.3" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="535.3" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.36 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="470.0" x2="540.0" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="540.0" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.17 µs</text>
+<line x1="168.0" y1="422.0" x2="509.8" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="509.8" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.46 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="446.0" x2="540.8" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="540.8" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.15 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
+<line x1="168.0" y1="470.0" x2="541.3" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="541.3" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.24 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
-<line x1="168.0" y1="494.0" x2="567.7" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="567.7" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.0 µs</text>
+<line x1="168.0" y1="494.0" x2="569.7" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="569.7" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.5 µs</text>
 <text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="518.0" x2="592.5" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="592.5" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">29.2 µs</text>
+<line x1="168.0" y1="518.0" x2="592.4" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="592.4" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">28.3 µs</text>
 <text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
 <line x1="168.0" y1="542.0" x2="718.0" y2="542.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="542.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.21 ms</text>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.16 ms</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/f32_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-f64-alu-dark.svg
+++ b/docs/benchmarks/figs/wat-f64-alu-dark.svg
@@ -1,109 +1,109 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f64_alu: seconds per iteration for 22 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmer at 0.98 ns; dewasm-bash is slowest at 578 µs, a span of 599000x. The table below carries every number.">
-<title>wat/f64_alu: seconds per iteration for 22 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmer at 0.98 ns; dewasm-bash is slowest at 578 µs, a span of 599000x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f64_alu: seconds per iteration for 22 runners on a log scale, fastest first. wazero is fastest at 0.95 ns, then wasmtime at 0.96 ns; dewasm-bash is slowest at 561 µs, a span of 588000x. The table below carries every number.">
+<title>wat/f64_alu: seconds per iteration for 22 runners on a log scale, fastest first. wazero is fastest at 0.95 ns, then wasmtime at 0.96 ns; dewasm-bash is slowest at 561 µs, a span of 588000x. The table below carries every number.</title>
 <rect width="820" height="632" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">0 ns</text>
-<line x1="249.3" y1="68.0" x2="249.3" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="249.3" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="330.7" y1="68.0" x2="330.7" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="330.7" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="412.0" y1="68.0" x2="412.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="412.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="493.3" y1="68.0" x2="493.3" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="493.3" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="574.7" y1="68.0" x2="574.7" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="574.7" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="656.0" y1="68.0" x2="656.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="656.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="249.5" y1="68.0" x2="249.5" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="249.5" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
+<line x1="331.0" y1="68.0" x2="331.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="331.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="412.5" y1="68.0" x2="412.5" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="412.5" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="494.0" y1="68.0" x2="494.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="494.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="575.5" y1="68.0" x2="575.5" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="575.5" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="656.9" y1="68.0" x2="656.9" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="656.9" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
 <line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="86.0" x2="248.1" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="248.1" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.97 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="248.5" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="248.5" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.98 ns</text>
-<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="134.0" x2="248.6" y2="134.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="248.6" cy="134.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.98 ns</text>
+<line x1="168.0" y1="86.0" x2="247.8" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="247.8" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.95 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="110.0" x2="248.1" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="248.1" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.96 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="134.0" x2="248.3" y2="134.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="248.3" cy="134.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.97 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="158.0" x2="268.3" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="268.3" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.71 ns</text>
+<line x1="168.0" y1="158.0" x2="266.3" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="266.3" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.61 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="182.0" x2="276.3" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="276.3" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.15 ns</text>
+<line x1="168.0" y1="182.0" x2="276.1" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="276.1" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.12 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="206.0" x2="293.8" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="293.8" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.52 ns</text>
+<line x1="168.0" y1="206.0" x2="293.3" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="293.3" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.45 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="230.0" x2="308.9" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="308.9" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.40 ns</text>
+<line x1="168.0" y1="230.0" x2="308.6" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="308.6" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.32 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="402.2" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="402.2" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">75.8 ns</text>
+<line x1="168.0" y1="254.0" x2="401.9" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="401.9" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">74.1 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="278.0" x2="403.7" y2="278.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="403.7" cy="278.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">79.0 ns</text>
+<line x1="168.0" y1="278.0" x2="403.2" y2="278.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="403.2" cy="278.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">76.9 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="405.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="405.2" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">82.5 ns</text>
+<line x1="168.0" y1="302.0" x2="405.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="405.5" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">82.0 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="412.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="412.7" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">102 ns</text>
+<line x1="168.0" y1="326.0" x2="412.8" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="412.8" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">101 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="426.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="426.7" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">152 ns</text>
+<line x1="168.0" y1="350.0" x2="426.8" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="426.8" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">150 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="486.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="486.8" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">831 ns</text>
+<line x1="168.0" y1="374.0" x2="487.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="487.0" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">821 ns</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="398.0" x2="509.8" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="509.8" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.59 µs</text>
+<line x1="168.0" y1="398.0" x2="512.6" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="512.6" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.69 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
-<line x1="168.0" y1="422.0" x2="528.2" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="528.2" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.68 µs</text>
+<line x1="168.0" y1="422.0" x2="518.8" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="518.8" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.02 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="446.0" x2="538.1" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="538.1" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.55 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
-<line x1="168.0" y1="470.0" x2="547.0" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="547.0" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.57 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="494.0" x2="565.2" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="565.2" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.64 µs</text>
-<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="518.0" x2="565.5" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="565.5" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.72 µs</text>
+<line x1="168.0" y1="446.0" x2="537.6" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="537.6" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.43 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="470.0" x2="552.4" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="552.4" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.21 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
+<line x1="168.0" y1="494.0" x2="554.5" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="554.5" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.53 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
+<line x1="168.0" y1="518.0" x2="564.7" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="564.7" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.37 µs</text>
 <text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
-<line x1="168.0" y1="542.0" x2="582.7" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="582.7" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.6 µs</text>
+<line x1="168.0" y1="542.0" x2="585.3" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="585.3" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.2 µs</text>
 <text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="566.0" x2="613.1" y2="566.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="613.1" cy="566.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">29.6 µs</text>
+<line x1="168.0" y1="566.0" x2="612.6" y2="566.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="612.6" cy="566.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">28.5 µs</text>
 <text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
 <line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="590.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">578 µs</text>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">561 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/f64_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-f64-alu.svg
+++ b/docs/benchmarks/figs/wat-f64-alu.svg
@@ -1,109 +1,109 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f64_alu: seconds per iteration for 22 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmer at 0.98 ns; dewasm-bash is slowest at 578 µs, a span of 599000x. The table below carries every number.">
-<title>wat/f64_alu: seconds per iteration for 22 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmer at 0.98 ns; dewasm-bash is slowest at 578 µs, a span of 599000x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/f64_alu: seconds per iteration for 22 runners on a log scale, fastest first. wazero is fastest at 0.95 ns, then wasmtime at 0.96 ns; dewasm-bash is slowest at 561 µs, a span of 588000x. The table below carries every number.">
+<title>wat/f64_alu: seconds per iteration for 22 runners on a log scale, fastest first. wazero is fastest at 0.95 ns, then wasmtime at 0.96 ns; dewasm-bash is slowest at 561 µs, a span of 588000x. The table below carries every number.</title>
 <rect width="820" height="632" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">0 ns</text>
-<line x1="249.3" y1="68.0" x2="249.3" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="249.3" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="330.7" y1="68.0" x2="330.7" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="330.7" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="412.0" y1="68.0" x2="412.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="412.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="493.3" y1="68.0" x2="493.3" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="493.3" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="574.7" y1="68.0" x2="574.7" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="574.7" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="656.0" y1="68.0" x2="656.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="656.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="249.5" y1="68.0" x2="249.5" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="249.5" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
+<line x1="331.0" y1="68.0" x2="331.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="331.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="412.5" y1="68.0" x2="412.5" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="412.5" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="494.0" y1="68.0" x2="494.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="494.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="575.5" y1="68.0" x2="575.5" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="575.5" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="656.9" y1="68.0" x2="656.9" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="656.9" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
 <line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="86.0" x2="248.1" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="248.1" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.97 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="248.5" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="248.5" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.98 ns</text>
-<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="134.0" x2="248.6" y2="134.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="248.6" cy="134.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.98 ns</text>
+<line x1="168.0" y1="86.0" x2="247.8" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="247.8" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.95 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="110.0" x2="248.1" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="248.1" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.96 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="134.0" x2="248.3" y2="134.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="248.3" cy="134.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.97 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="158.0" x2="268.3" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="268.3" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.71 ns</text>
+<line x1="168.0" y1="158.0" x2="266.3" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="266.3" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.61 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="182.0" x2="276.3" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="276.3" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.15 ns</text>
+<line x1="168.0" y1="182.0" x2="276.1" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="276.1" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.12 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="206.0" x2="293.8" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="293.8" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.52 ns</text>
+<line x1="168.0" y1="206.0" x2="293.3" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="293.3" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.45 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="230.0" x2="308.9" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="308.9" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.40 ns</text>
+<line x1="168.0" y1="230.0" x2="308.6" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="308.6" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.32 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="402.2" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="402.2" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">75.8 ns</text>
+<line x1="168.0" y1="254.0" x2="401.9" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="401.9" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">74.1 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="278.0" x2="403.7" y2="278.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="403.7" cy="278.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">79.0 ns</text>
+<line x1="168.0" y1="278.0" x2="403.2" y2="278.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="403.2" cy="278.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">76.9 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="405.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="405.2" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">82.5 ns</text>
+<line x1="168.0" y1="302.0" x2="405.5" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="405.5" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">82.0 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="412.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="412.7" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">102 ns</text>
+<line x1="168.0" y1="326.0" x2="412.8" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="412.8" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">101 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="426.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="426.7" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">152 ns</text>
+<line x1="168.0" y1="350.0" x2="426.8" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="426.8" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">150 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="486.8" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="486.8" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">831 ns</text>
+<line x1="168.0" y1="374.0" x2="487.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="487.0" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">821 ns</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="398.0" x2="509.8" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="509.8" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.59 µs</text>
+<line x1="168.0" y1="398.0" x2="512.6" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="512.6" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.69 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
-<line x1="168.0" y1="422.0" x2="528.2" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="528.2" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.68 µs</text>
+<line x1="168.0" y1="422.0" x2="518.8" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="518.8" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.02 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="446.0" x2="538.1" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="538.1" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.55 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
-<line x1="168.0" y1="470.0" x2="547.0" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="547.0" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.57 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="494.0" x2="565.2" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="565.2" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.64 µs</text>
-<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="518.0" x2="565.5" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="565.5" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.72 µs</text>
+<line x1="168.0" y1="446.0" x2="537.6" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="537.6" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.43 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="470.0" x2="552.4" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="552.4" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.21 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
+<line x1="168.0" y1="494.0" x2="554.5" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="554.5" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.53 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
+<line x1="168.0" y1="518.0" x2="564.7" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="564.7" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.37 µs</text>
 <text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
-<line x1="168.0" y1="542.0" x2="582.7" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="582.7" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.6 µs</text>
+<line x1="168.0" y1="542.0" x2="585.3" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="585.3" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.2 µs</text>
 <text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="566.0" x2="613.1" y2="566.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="613.1" cy="566.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">29.6 µs</text>
+<line x1="168.0" y1="566.0" x2="612.6" y2="566.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="612.6" cy="566.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">28.5 µs</text>
 <text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
 <line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="590.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">578 µs</text>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">561 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/f64_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i32-alu-dark.svg
+++ b/docs/benchmarks/figs/wat-i32-alu-dark.svg
@@ -1,105 +1,105 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_alu: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 2.32 ns, then wasmer at 2.32 ns; pywasm-cpython is slowest at 54.2 µs, a span of 23400x. The table below carries every number.">
-<title>wat/i32_alu: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 2.32 ns, then wasmer at 2.32 ns; pywasm-cpython is slowest at 54.2 µs, a span of 23400x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_alu: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 2.28 ns, then wasmer at 2.29 ns; pywasm-cpython is slowest at 52.7 µs, a span of 23100x. The table below carries every number.">
+<title>wat/i32_alu: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 2.28 ns, then wasmer at 2.29 ns; pywasm-cpython is slowest at 52.7 µs, a span of 23100x. The table below carries every number.</title>
 <rect width="820" height="632" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="284.2" y1="68.0" x2="284.2" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="284.2" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="400.4" y1="68.0" x2="400.4" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="400.4" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="516.5" y1="68.0" x2="516.5" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="516.5" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="632.7" y1="68.0" x2="632.7" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="632.7" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="284.5" y1="68.0" x2="284.5" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="284.5" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="401.0" y1="68.0" x2="401.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="401.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="517.5" y1="68.0" x2="517.5" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="517.5" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="633.9" y1="68.0" x2="633.9" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="633.9" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
 <line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="210.5" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="210.5" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.32 ns</text>
+<line x1="168.0" y1="86.0" x2="209.8" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="209.8" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.28 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="210.5" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="210.5" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.32 ns</text>
+<line x1="168.0" y1="110.0" x2="209.8" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="209.8" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.29 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="210.9" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="210.9" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.34 ns</text>
+<line x1="168.0" y1="134.0" x2="209.9" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="209.9" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.29 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="217.6" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="217.6" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.67 ns</text>
+<line x1="168.0" y1="158.0" x2="216.7" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="216.7" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.62 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="182.0" x2="224.3" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="224.3" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.06 ns</text>
+<line x1="168.0" y1="182.0" x2="223.8" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="223.8" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.01 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="206.0" x2="282.2" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="282.2" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.62 ns</text>
+<line x1="168.0" y1="206.0" x2="281.5" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="281.5" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.42 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="230.0" x2="297.6" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="297.6" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.1 ns</text>
+<line x1="168.0" y1="230.0" x2="296.8" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="296.8" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.8 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="416.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="416.5" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">138 ns</text>
+<line x1="168.0" y1="254.0" x2="416.9" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="416.9" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">137 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="278.0" x2="421.4" y2="278.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="421.4" cy="278.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">152 ns</text>
+<line x1="168.0" y1="278.0" x2="420.7" y2="278.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="420.7" cy="278.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">148 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="421.4" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="421.4" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">152 ns</text>
+<line x1="168.0" y1="302.0" x2="421.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="421.1" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">149 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="431.3" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="431.3" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">185 ns</text>
+<line x1="168.0" y1="326.0" x2="431.2" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="431.2" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">182 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="487.5" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="487.5" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">563 ns</text>
+<line x1="168.0" y1="350.0" x2="487.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="487.7" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">555 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="497.9" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="497.9" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">691 ns</text>
+<line x1="168.0" y1="374.0" x2="498.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="498.1" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">682 ns</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="398.0" x2="581.5" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="581.5" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.62 µs</text>
+<line x1="168.0" y1="398.0" x2="584.8" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="584.8" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.78 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="422.0" x2="614.1" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="614.1" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.92 µs</text>
+<line x1="168.0" y1="422.0" x2="614.7" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="614.7" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.83 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
-<line x1="168.0" y1="446.0" x2="622.1" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="622.1" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.11 µs</text>
+<line x1="168.0" y1="446.0" x2="617.0" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="617.0" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.15 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
-<line x1="168.0" y1="470.0" x2="629.2" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="629.2" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.32 µs</text>
+<line x1="168.0" y1="470.0" x2="638.4" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="638.4" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.9 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="494.0" x2="654.3" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="654.3" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.4 µs</text>
-<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="518.0" x2="679.1" y2="518.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="679.1" cy="518.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">25.1 µs</text>
-<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
-<line x1="168.0" y1="542.0" x2="680.3" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="680.3" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">25.7 µs</text>
-<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="566.0" x2="687.2" y2="566.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="687.2" cy="566.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">29.5 µs</text>
+<line x1="168.0" y1="494.0" x2="654.4" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="654.4" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.0 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="518.0" x2="657.3" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="657.3" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.9 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="542.0" x2="679.5" y2="542.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="679.5" cy="542.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">24.6 µs</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
+<line x1="168.0" y1="566.0" x2="683.4" y2="566.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="683.4" cy="566.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">26.6 µs</text>
 <text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
 <line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="590.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">54.2 µs</text>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">52.7 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/i32_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i32-alu.svg
+++ b/docs/benchmarks/figs/wat-i32-alu.svg
@@ -1,105 +1,105 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_alu: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 2.32 ns, then wasmer at 2.32 ns; pywasm-cpython is slowest at 54.2 µs, a span of 23400x. The table below carries every number.">
-<title>wat/i32_alu: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 2.32 ns, then wasmer at 2.32 ns; pywasm-cpython is slowest at 54.2 µs, a span of 23400x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_alu: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 2.28 ns, then wasmer at 2.29 ns; pywasm-cpython is slowest at 52.7 µs, a span of 23100x. The table below carries every number.">
+<title>wat/i32_alu: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 2.28 ns, then wasmer at 2.29 ns; pywasm-cpython is slowest at 52.7 µs, a span of 23100x. The table below carries every number.</title>
 <rect width="820" height="632" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="284.2" y1="68.0" x2="284.2" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="284.2" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="400.4" y1="68.0" x2="400.4" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="400.4" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="516.5" y1="68.0" x2="516.5" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="516.5" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="632.7" y1="68.0" x2="632.7" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="632.7" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="284.5" y1="68.0" x2="284.5" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="284.5" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="401.0" y1="68.0" x2="401.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="401.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="517.5" y1="68.0" x2="517.5" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="517.5" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="633.9" y1="68.0" x2="633.9" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="633.9" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
 <line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="210.5" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="210.5" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.32 ns</text>
+<line x1="168.0" y1="86.0" x2="209.8" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="209.8" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.28 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="210.5" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="210.5" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.32 ns</text>
+<line x1="168.0" y1="110.0" x2="209.8" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="209.8" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.29 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="210.9" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="210.9" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.34 ns</text>
+<line x1="168.0" y1="134.0" x2="209.9" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="209.9" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.29 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="217.6" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="217.6" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.67 ns</text>
+<line x1="168.0" y1="158.0" x2="216.7" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="216.7" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.62 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="182.0" x2="224.3" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="224.3" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.06 ns</text>
+<line x1="168.0" y1="182.0" x2="223.8" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="223.8" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.01 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="206.0" x2="282.2" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="282.2" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.62 ns</text>
+<line x1="168.0" y1="206.0" x2="281.5" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="281.5" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.42 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="230.0" x2="297.6" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="297.6" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.1 ns</text>
+<line x1="168.0" y1="230.0" x2="296.8" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="296.8" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.8 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="254.0" x2="416.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="416.5" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">138 ns</text>
+<line x1="168.0" y1="254.0" x2="416.9" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="416.9" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">137 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="278.0" x2="421.4" y2="278.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="421.4" cy="278.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">152 ns</text>
+<line x1="168.0" y1="278.0" x2="420.7" y2="278.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="420.7" cy="278.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">148 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="421.4" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="421.4" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">152 ns</text>
+<line x1="168.0" y1="302.0" x2="421.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="421.1" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">149 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="431.3" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="431.3" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">185 ns</text>
+<line x1="168.0" y1="326.0" x2="431.2" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="431.2" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">182 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="487.5" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="487.5" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">563 ns</text>
+<line x1="168.0" y1="350.0" x2="487.7" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="487.7" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">555 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="497.9" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="497.9" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">691 ns</text>
+<line x1="168.0" y1="374.0" x2="498.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="498.1" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">682 ns</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="398.0" x2="581.5" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="581.5" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.62 µs</text>
+<line x1="168.0" y1="398.0" x2="584.8" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="584.8" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.78 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="422.0" x2="614.1" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="614.1" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.92 µs</text>
+<line x1="168.0" y1="422.0" x2="614.7" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="614.7" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.83 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
-<line x1="168.0" y1="446.0" x2="622.1" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="622.1" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.11 µs</text>
+<line x1="168.0" y1="446.0" x2="617.0" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="617.0" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.15 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
-<line x1="168.0" y1="470.0" x2="629.2" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="629.2" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.32 µs</text>
+<line x1="168.0" y1="470.0" x2="638.4" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="638.4" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.9 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="494.0" x2="654.3" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="654.3" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.4 µs</text>
-<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="518.0" x2="679.1" y2="518.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="679.1" cy="518.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">25.1 µs</text>
-<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
-<line x1="168.0" y1="542.0" x2="680.3" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="680.3" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">25.7 µs</text>
-<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="566.0" x2="687.2" y2="566.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="687.2" cy="566.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">29.5 µs</text>
+<line x1="168.0" y1="494.0" x2="654.4" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="654.4" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.0 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="518.0" x2="657.3" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="657.3" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.9 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="542.0" x2="679.5" y2="542.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="679.5" cy="542.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">24.6 µs</text>
+<text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
+<line x1="168.0" y1="566.0" x2="683.4" y2="566.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="683.4" cy="566.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">26.6 µs</text>
 <text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
 <line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="590.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">54.2 µs</text>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">52.7 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/i32_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i32-div-dark.svg
+++ b/docs/benchmarks/figs/wat-i32-div-dark.svg
@@ -1,105 +1,105 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_div: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 7.66 ns, then wasmer at 7.67 ns; dewasm-bash is slowest at 68.2 µs, a span of 8910x. The table below carries every number.">
-<title>wat/i32_div: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 7.66 ns, then wasmer at 7.67 ns; dewasm-bash is slowest at 68.2 µs, a span of 8910x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_div: seconds per iteration for 22 runners on a log scale, fastest first. wazero is fastest at 7.53 ns, then wasmtime at 7.55 ns; dewasm-bash is slowest at 67.1 µs, a span of 8910x. The table below carries every number.">
+<title>wat/i32_div: seconds per iteration for 22 runners on a log scale, fastest first. wazero is fastest at 7.53 ns, then wasmtime at 7.55 ns; dewasm-bash is slowest at 67.1 µs, a span of 8910x. The table below carries every number.</title>
 <rect width="820" height="632" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="281.8" y1="68.0" x2="281.8" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="281.8" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="395.6" y1="68.0" x2="395.6" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="395.6" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="509.3" y1="68.0" x2="509.3" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="509.3" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="623.1" y1="68.0" x2="623.1" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="623.1" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="281.9" y1="68.0" x2="281.9" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="281.9" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="395.9" y1="68.0" x2="395.9" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="395.9" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="509.8" y1="68.0" x2="509.8" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="509.8" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="623.8" y1="68.0" x2="623.8" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="623.8" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
 <line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="268.6" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="268.6" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.66 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="268.7" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="268.7" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.67 ns</text>
-<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="268.7" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="268.7" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.68 ns</text>
-<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="268.7" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="268.7" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.68 ns</text>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
+<line x1="168.0" y1="86.0" x2="267.9" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="267.9" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.53 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="110.0" x2="268.1" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="268.1" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.55 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="134.0" x2="268.2" y2="134.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="268.2" cy="134.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.57 ns</text>
+<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
+<line x1="168.0" y1="158.0" x2="268.3" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="268.3" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.59 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="270.2" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="270.2" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.90 ns</text>
+<line x1="168.0" y1="182.0" x2="270.5" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="270.5" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.93 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="206.0" x2="299.0" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="299.0" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.2 ns</text>
+<line x1="168.0" y1="206.0" x2="298.4" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="298.4" cy="206.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.9 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="230.0" x2="304.3" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="304.3" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.8 ns</text>
+<line x1="168.0" y1="230.0" x2="303.9" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="303.9" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.6 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="425.0" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="425.0" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">181 ns</text>
+<line x1="168.0" y1="254.0" x2="424.7" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="424.7" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">179 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="426.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="426.5" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">187 ns</text>
+<line x1="168.0" y1="278.0" x2="428.7" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="428.7" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">194 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="439.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="439.2" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">242 ns</text>
+<line x1="168.0" y1="302.0" x2="439.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="439.0" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">239 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="459.8" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="459.8" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">367 ns</text>
+<line x1="168.0" y1="326.0" x2="460.5" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="460.5" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">369 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="508.0" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="508.0" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<line x1="168.0" y1="350.0" x2="508.5" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="508.5" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
 <text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">974 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="519.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="519.1" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.22 µs</text>
+<line x1="168.0" y1="374.0" x2="519.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="519.0" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.20 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="398.0" x2="585.4" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="585.4" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.66 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="422.0" x2="615.2" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="615.2" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.51 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
-<line x1="168.0" y1="446.0" x2="631.0" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="631.0" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">11.7 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
-<line x1="168.0" y1="470.0" x2="634.4" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="634.4" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.6 µs</text>
+<line x1="168.0" y1="398.0" x2="591.3" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="591.3" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.19 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
+<line x1="168.0" y1="422.0" x2="612.0" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="612.0" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.88 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
+<line x1="168.0" y1="446.0" x2="615.6" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="615.6" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.48 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
+<line x1="168.0" y1="470.0" x2="638.6" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="638.6" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.5 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="494.0" x2="652.9" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="652.9" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">18.3 µs</text>
-<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
-<line x1="168.0" y1="518.0" x2="679.9" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="679.9" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">31.6 µs</text>
-<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="542.0" x2="700.1" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="700.1" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">47.5 µs</text>
+<line x1="168.0" y1="494.0" x2="652.4" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="652.4" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">17.8 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="518.0" x2="661.5" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="661.5" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">21.4 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
+<line x1="168.0" y1="542.0" x2="682.1" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="682.1" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">32.5 µs</text>
 <text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="566.0" x2="712.7" y2="566.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="712.7" cy="566.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">61.2 µs</text>
+<line x1="168.0" y1="566.0" x2="712.9" y2="566.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="712.9" cy="566.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">60.6 µs</text>
 <text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
 <line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="590.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">68.2 µs</text>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">67.1 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/i32_div: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i32-div.svg
+++ b/docs/benchmarks/figs/wat-i32-div.svg
@@ -1,105 +1,105 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_div: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 7.66 ns, then wasmer at 7.67 ns; dewasm-bash is slowest at 68.2 µs, a span of 8910x. The table below carries every number.">
-<title>wat/i32_div: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 7.66 ns, then wasmer at 7.67 ns; dewasm-bash is slowest at 68.2 µs, a span of 8910x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i32_div: seconds per iteration for 22 runners on a log scale, fastest first. wazero is fastest at 7.53 ns, then wasmtime at 7.55 ns; dewasm-bash is slowest at 67.1 µs, a span of 8910x. The table below carries every number.">
+<title>wat/i32_div: seconds per iteration for 22 runners on a log scale, fastest first. wazero is fastest at 7.53 ns, then wasmtime at 7.55 ns; dewasm-bash is slowest at 67.1 µs, a span of 8910x. The table below carries every number.</title>
 <rect width="820" height="632" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="281.8" y1="68.0" x2="281.8" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="281.8" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="395.6" y1="68.0" x2="395.6" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="395.6" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="509.3" y1="68.0" x2="509.3" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="509.3" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="623.1" y1="68.0" x2="623.1" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="623.1" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="281.9" y1="68.0" x2="281.9" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="281.9" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="395.9" y1="68.0" x2="395.9" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="395.9" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="509.8" y1="68.0" x2="509.8" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="509.8" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="623.8" y1="68.0" x2="623.8" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="623.8" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
 <line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="268.6" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="268.6" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.66 ns</text>
-<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="268.7" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="268.7" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.67 ns</text>
-<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="268.7" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="268.7" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.68 ns</text>
-<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="268.7" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="268.7" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.68 ns</text>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
+<line x1="168.0" y1="86.0" x2="267.9" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="267.9" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.53 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="110.0" x2="268.1" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="268.1" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.55 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="134.0" x2="268.2" y2="134.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="268.2" cy="134.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.57 ns</text>
+<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
+<line x1="168.0" y1="158.0" x2="268.3" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="268.3" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.59 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="270.2" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="270.2" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.90 ns</text>
+<line x1="168.0" y1="182.0" x2="270.5" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="270.5" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.93 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="206.0" x2="299.0" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="299.0" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.2 ns</text>
+<line x1="168.0" y1="206.0" x2="298.4" y2="206.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="298.4" cy="206.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.9 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="230.0" x2="304.3" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="304.3" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.8 ns</text>
+<line x1="168.0" y1="230.0" x2="303.9" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="303.9" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.6 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="425.0" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="425.0" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">181 ns</text>
+<line x1="168.0" y1="254.0" x2="424.7" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="424.7" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">179 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="426.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="426.5" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">187 ns</text>
+<line x1="168.0" y1="278.0" x2="428.7" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="428.7" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">194 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="439.2" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="439.2" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">242 ns</text>
+<line x1="168.0" y1="302.0" x2="439.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="439.0" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">239 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="459.8" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="459.8" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">367 ns</text>
+<line x1="168.0" y1="326.0" x2="460.5" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="460.5" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">369 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="508.0" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="508.0" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<line x1="168.0" y1="350.0" x2="508.5" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="508.5" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
 <text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">974 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="519.1" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="519.1" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.22 µs</text>
+<line x1="168.0" y1="374.0" x2="519.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="519.0" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.20 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="398.0" x2="585.4" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="585.4" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.66 µs</text>
-<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="422.0" x2="615.2" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="615.2" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.51 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
-<line x1="168.0" y1="446.0" x2="631.0" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="631.0" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">11.7 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
-<line x1="168.0" y1="470.0" x2="634.4" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="634.4" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.6 µs</text>
+<line x1="168.0" y1="398.0" x2="591.3" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="591.3" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.19 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
+<line x1="168.0" y1="422.0" x2="612.0" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="612.0" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.88 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
+<line x1="168.0" y1="446.0" x2="615.6" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="615.6" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.48 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
+<line x1="168.0" y1="470.0" x2="638.6" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="638.6" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.5 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="494.0" x2="652.9" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="652.9" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">18.3 µs</text>
-<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
-<line x1="168.0" y1="518.0" x2="679.9" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="679.9" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">31.6 µs</text>
-<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="542.0" x2="700.1" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="700.1" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">47.5 µs</text>
+<line x1="168.0" y1="494.0" x2="652.4" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="652.4" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">17.8 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="518.0" x2="661.5" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="661.5" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">21.4 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
+<line x1="168.0" y1="542.0" x2="682.1" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="682.1" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">32.5 µs</text>
 <text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="566.0" x2="712.7" y2="566.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="712.7" cy="566.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">61.2 µs</text>
+<line x1="168.0" y1="566.0" x2="712.9" y2="566.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="712.9" cy="566.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">60.6 µs</text>
 <text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
 <line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="590.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">68.2 µs</text>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">67.1 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/i32_div: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i64-alu-dark.svg
+++ b/docs/benchmarks/figs/wat-i64-alu-dark.svg
@@ -1,107 +1,107 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_alu: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 2.33 ns, then wasmer at 2.33 ns; pywasm-pypy is slowest at 408 µs, a span of 175000x. The table below carries every number.">
-<title>wat/i64_alu: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 2.33 ns, then wasmer at 2.33 ns; pywasm-pypy is slowest at 408 µs, a span of 175000x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_alu: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 2.29 ns, then wasmer at 2.30 ns; pywasm-pypy is slowest at 286 µs, a span of 125000x. The table below carries every number.">
+<title>wat/i64_alu: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 2.29 ns, then wasmer at 2.30 ns; pywasm-pypy is slowest at 286 µs, a span of 125000x. The table below carries every number.</title>
 <rect width="820" height="632" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="266.0" y1="68.0" x2="266.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="266.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="364.0" y1="68.0" x2="364.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="364.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="462.1" y1="68.0" x2="462.1" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="462.1" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="560.1" y1="68.0" x2="560.1" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="560.1" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="658.1" y1="68.0" x2="658.1" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="658.1" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="268.8" y1="68.0" x2="268.8" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="268.8" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="369.6" y1="68.0" x2="369.6" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="369.6" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="470.4" y1="68.0" x2="470.4" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="470.4" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="571.2" y1="68.0" x2="571.2" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="571.2" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="672.0" y1="68.0" x2="672.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="672.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
 <line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="204.0" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="204.0" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.33 ns</text>
+<line x1="168.0" y1="86.0" x2="204.3" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="204.3" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.29 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="204.0" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="204.0" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.33 ns</text>
+<line x1="168.0" y1="110.0" x2="204.5" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="204.5" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.30 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="204.4" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="204.4" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.35 ns</text>
+<line x1="168.0" y1="134.0" x2="205.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="205.1" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.33 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="158.0" x2="209.0" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="209.0" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.62 ns</text>
+<line x1="168.0" y1="158.0" x2="209.7" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="209.7" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.59 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="182.0" x2="209.8" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="209.8" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.67 ns</text>
+<line x1="168.0" y1="182.0" x2="210.0" y2="182.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="210.0" cy="182.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.61 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="274.0" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="274.0" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.1 ns</text>
+<line x1="168.0" y1="206.0" x2="276.1" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="276.1" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">11.8 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="230.0" x2="381.8" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="381.8" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">152 ns</text>
+<line x1="168.0" y1="230.0" x2="387.3" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="387.3" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">150 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="254.0" x2="398.1" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="398.1" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">223 ns</text>
+<line x1="168.0" y1="254.0" x2="404.2" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="404.2" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">220 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="278.0" x2="441.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="441.5" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">616 ns</text>
+<line x1="168.0" y1="278.0" x2="450.0" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="450.0" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">627 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="302.0" x2="460.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="460.1" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">954 ns</text>
+<line x1="168.0" y1="302.0" x2="467.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="467.7" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">940 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="326.0" x2="462.1" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="462.1" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.00 µs</text>
+<line x1="168.0" y1="326.0" x2="469.5" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="469.5" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">980 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="350.0" x2="463.3" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="463.3" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.03 µs</text>
+<line x1="168.0" y1="350.0" x2="470.6" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="470.6" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.00 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="374.0" x2="472.3" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="472.3" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.27 µs</text>
+<line x1="168.0" y1="374.0" x2="479.2" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="479.2" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.22 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="398.0" x2="529.9" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="529.9" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.92 µs</text>
+<line x1="168.0" y1="398.0" x2="541.4" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="541.4" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.06 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="422.0" x2="556.7" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="556.7" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.24 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
-<line x1="168.0" y1="446.0" x2="562.3" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="562.3" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">10.5 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
-<line x1="168.0" y1="470.0" x2="567.5" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="567.5" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">11.9 µs</text>
+<line x1="168.0" y1="422.0" x2="566.1" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="566.1" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.89 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
+<line x1="168.0" y1="446.0" x2="569.5" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="569.5" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.62 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
+<line x1="168.0" y1="470.0" x2="579.1" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="579.1" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.0 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="494.0" x2="581.9" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="581.9" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">16.7 µs</text>
+<line x1="168.0" y1="494.0" x2="592.5" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="592.5" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">16.2 µs</text>
 <text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
-<line x1="168.0" y1="518.0" x2="599.3" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="599.3" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">25.1 µs</text>
+<line x1="168.0" y1="518.0" x2="612.8" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="612.8" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">25.9 µs</text>
 <text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="542.0" x2="603.2" y2="542.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="603.2" cy="542.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">27.6 µs</text>
+<line x1="168.0" y1="542.0" x2="614.8" y2="542.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="614.8" cy="542.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">27.1 µs</text>
 <text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="566.0" x2="635.0" y2="566.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="635.0" cy="566.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">58.2 µs</text>
+<line x1="168.0" y1="566.0" x2="646.8" y2="566.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="646.8" cy="566.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">56.3 µs</text>
 <text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
 <line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="590.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">408 µs</text>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">286 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/i64_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i64-alu.svg
+++ b/docs/benchmarks/figs/wat-i64-alu.svg
@@ -1,107 +1,107 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_alu: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 2.33 ns, then wasmer at 2.33 ns; pywasm-pypy is slowest at 408 µs, a span of 175000x. The table below carries every number.">
-<title>wat/i64_alu: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 2.33 ns, then wasmer at 2.33 ns; pywasm-pypy is slowest at 408 µs, a span of 175000x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_alu: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 2.29 ns, then wasmer at 2.30 ns; pywasm-pypy is slowest at 286 µs, a span of 125000x. The table below carries every number.">
+<title>wat/i64_alu: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 2.29 ns, then wasmer at 2.30 ns; pywasm-pypy is slowest at 286 µs, a span of 125000x. The table below carries every number.</title>
 <rect width="820" height="632" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="266.0" y1="68.0" x2="266.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="266.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="364.0" y1="68.0" x2="364.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="364.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="462.1" y1="68.0" x2="462.1" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="462.1" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="560.1" y1="68.0" x2="560.1" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="560.1" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="658.1" y1="68.0" x2="658.1" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="658.1" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="268.8" y1="68.0" x2="268.8" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="268.8" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="369.6" y1="68.0" x2="369.6" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="369.6" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="470.4" y1="68.0" x2="470.4" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="470.4" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="571.2" y1="68.0" x2="571.2" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="571.2" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="672.0" y1="68.0" x2="672.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="672.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
 <line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="204.0" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="204.0" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.33 ns</text>
+<line x1="168.0" y1="86.0" x2="204.3" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="204.3" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.29 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="204.0" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="204.0" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.33 ns</text>
+<line x1="168.0" y1="110.0" x2="204.5" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="204.5" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.30 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="134.0" x2="204.4" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="204.4" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.35 ns</text>
+<line x1="168.0" y1="134.0" x2="205.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="205.1" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.33 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="158.0" x2="209.0" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="209.0" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.62 ns</text>
+<line x1="168.0" y1="158.0" x2="209.7" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="209.7" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.59 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="182.0" x2="209.8" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="209.8" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.67 ns</text>
+<line x1="168.0" y1="182.0" x2="210.0" y2="182.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="210.0" cy="182.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.61 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="274.0" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="274.0" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.1 ns</text>
+<line x1="168.0" y1="206.0" x2="276.1" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="276.1" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">11.8 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="230.0" x2="381.8" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="381.8" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">152 ns</text>
+<line x1="168.0" y1="230.0" x2="387.3" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="387.3" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">150 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="254.0" x2="398.1" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="398.1" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">223 ns</text>
+<line x1="168.0" y1="254.0" x2="404.2" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="404.2" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">220 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="278.0" x2="441.5" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="441.5" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">616 ns</text>
+<line x1="168.0" y1="278.0" x2="450.0" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="450.0" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">627 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="302.0" x2="460.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="460.1" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">954 ns</text>
+<line x1="168.0" y1="302.0" x2="467.7" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="467.7" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">940 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="326.0" x2="462.1" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="462.1" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.00 µs</text>
+<line x1="168.0" y1="326.0" x2="469.5" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="469.5" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">980 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="350.0" x2="463.3" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="463.3" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.03 µs</text>
+<line x1="168.0" y1="350.0" x2="470.6" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="470.6" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.00 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="374.0" x2="472.3" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="472.3" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.27 µs</text>
+<line x1="168.0" y1="374.0" x2="479.2" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="479.2" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.22 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="398.0" x2="529.9" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="529.9" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.92 µs</text>
+<line x1="168.0" y1="398.0" x2="541.4" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="541.4" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.06 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="422.0" x2="556.7" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="556.7" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.24 µs</text>
-<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
-<line x1="168.0" y1="446.0" x2="562.3" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="562.3" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">10.5 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
-<line x1="168.0" y1="470.0" x2="567.5" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="567.5" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">11.9 µs</text>
+<line x1="168.0" y1="422.0" x2="566.1" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="566.1" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.89 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
+<line x1="168.0" y1="446.0" x2="569.5" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="569.5" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.62 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
+<line x1="168.0" y1="470.0" x2="579.1" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="579.1" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.0 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="494.0" x2="581.9" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="581.9" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">16.7 µs</text>
+<line x1="168.0" y1="494.0" x2="592.5" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="592.5" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">16.2 µs</text>
 <text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
-<line x1="168.0" y1="518.0" x2="599.3" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="599.3" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">25.1 µs</text>
+<line x1="168.0" y1="518.0" x2="612.8" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="612.8" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">25.9 µs</text>
 <text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="542.0" x2="603.2" y2="542.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="603.2" cy="542.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">27.6 µs</text>
+<line x1="168.0" y1="542.0" x2="614.8" y2="542.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="614.8" cy="542.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">27.1 µs</text>
 <text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="566.0" x2="635.0" y2="566.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="635.0" cy="566.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">58.2 µs</text>
+<line x1="168.0" y1="566.0" x2="646.8" y2="566.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="646.8" cy="566.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">56.3 µs</text>
 <text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
 <line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="590.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">408 µs</text>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">286 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/i64_alu: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i64-div-dark.svg
+++ b/docs/benchmarks/figs/wat-i64-div-dark.svg
@@ -1,99 +1,99 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="584" viewBox="0 0 820 584" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_div: seconds per iteration for 20 runners on a log scale, fastest first. dewasm-go is fastest at 8.24 ns, then wasmtime at 8.27 ns; pywasm-pypy is slowest at 419 µs, a span of 50800x. The table below carries every number.">
-<title>wat/i64_div: seconds per iteration for 20 runners on a log scale, fastest first. dewasm-go is fastest at 8.24 ns, then wasmtime at 8.27 ns; pywasm-pypy is slowest at 419 µs, a span of 50800x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="584" viewBox="0 0 820 584" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_div: seconds per iteration for 20 runners on a log scale, fastest first. wasmer is fastest at 8.13 ns, then wasmtime at 8.15 ns; pywasm-pypy is slowest at 389 µs, a span of 47900x. The table below carries every number.">
+<title>wat/i64_div: seconds per iteration for 20 runners on a log scale, fastest first. wasmer is fastest at 8.13 ns, then wasmtime at 8.15 ns; pywasm-pypy is slowest at 389 µs, a span of 47900x. The table below carries every number.</title>
 <rect width="820" height="584" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="265.8" y1="68.0" x2="265.8" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="265.8" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="363.7" y1="68.0" x2="363.7" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="363.7" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="461.5" y1="68.0" x2="461.5" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="461.5" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="559.3" y1="68.0" x2="559.3" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="559.3" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
-<line x1="657.1" y1="68.0" x2="657.1" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="657.1" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
+<line x1="266.4" y1="68.0" x2="266.4" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="266.4" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="364.8" y1="68.0" x2="364.8" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="364.8" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="463.1" y1="68.0" x2="463.1" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="463.1" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="561.5" y1="68.0" x2="561.5" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="561.5" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="659.9" y1="68.0" x2="659.9" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="659.9" y="570.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 µs</text>
 <line x1="168.0" y1="554.0" x2="726.0" y2="554.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="86.0" x2="257.6" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="257.6" cy="86.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.24 ns</text>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
+<line x1="168.0" y1="86.0" x2="257.6" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="257.6" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.13 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
 <line x1="168.0" y1="110.0" x2="257.7" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="257.7" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.27 ns</text>
-<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="134.0" x2="257.8" y2="134.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="257.8" cy="134.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.28 ns</text>
-<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="258.0" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="258.0" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.32 ns</text>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.15 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
+<line x1="168.0" y1="134.0" x2="257.7" y2="134.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="257.7" cy="134.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.16 ns</text>
+<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
+<line x1="168.0" y1="158.0" x2="257.7" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="257.7" cy="158.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.16 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="260.1" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="260.1" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.74 ns</text>
+<line x1="168.0" y1="182.0" x2="259.3" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="259.3" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.46 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="286.2" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="286.2" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">16.2 ns</text>
+<line x1="168.0" y1="206.0" x2="286.1" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="286.1" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">15.9 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="230.0" x2="388.8" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="388.8" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">181 ns</text>
+<line x1="168.0" y1="230.0" x2="389.8" y2="230.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="389.8" cy="230.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">179 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="254.0" x2="405.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="405.5" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">268 ns</text>
+<line x1="168.0" y1="254.0" x2="406.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="406.6" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">266 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="278.0" x2="462.9" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="462.9" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.03 µs</text>
+<line x1="168.0" y1="278.0" x2="464.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="464.8" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.04 µs</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="302.0" x2="467.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="467.0" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.14 µs</text>
+<line x1="168.0" y1="302.0" x2="467.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="467.6" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.11 µs</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="326.0" x2="475.9" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="475.9" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.40 µs</text>
+<line x1="168.0" y1="326.0" x2="476.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="476.7" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.37 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="350.0" x2="479.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="479.1" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.52 µs</text>
+<line x1="168.0" y1="350.0" x2="480.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="480.1" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.49 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="374.0" x2="484.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="484.0" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.70 µs</text>
+<line x1="168.0" y1="374.0" x2="484.2" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="484.2" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.64 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="398.0" x2="540.0" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="540.0" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.35 µs</text>
+<line x1="168.0" y1="398.0" x2="542.6" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="542.6" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.42 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
-<line x1="168.0" y1="422.0" x2="571.4" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="571.4" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.3 µs</text>
+<line x1="168.0" y1="422.0" x2="577.7" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="577.7" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.6 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
-<line x1="168.0" y1="446.0" x2="588.9" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="588.9" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.1 µs</text>
+<line x1="168.0" y1="446.0" x2="591.2" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="591.2" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.0 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
-<line x1="168.0" y1="470.0" x2="606.9" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="606.9" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">30.6 µs</text>
+<line x1="168.0" y1="470.0" x2="610.4" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="610.4" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">31.4 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
-<line x1="168.0" y1="494.0" x2="640.0" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="640.0" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">66.8 µs</text>
+<line x1="168.0" y1="494.0" x2="641.5" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="641.5" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">65.0 µs</text>
 <text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="518.0" x2="646.1" y2="518.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="646.1" cy="518.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">77.1 µs</text>
+<line x1="168.0" y1="518.0" x2="647.6" y2="518.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="647.6" cy="518.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">74.9 µs</text>
 <text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
 <line x1="168.0" y1="542.0" x2="718.0" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">419 µs</text>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">389 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/i64_div: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-i64-div.svg
+++ b/docs/benchmarks/figs/wat-i64-div.svg
@@ -1,99 +1,99 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="584" viewBox="0 0 820 584" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_div: seconds per iteration for 20 runners on a log scale, fastest first. dewasm-go is fastest at 8.24 ns, then wasmtime at 8.27 ns; pywasm-pypy is slowest at 419 µs, a span of 50800x. The table below carries every number.">
-<title>wat/i64_div: seconds per iteration for 20 runners on a log scale, fastest first. dewasm-go is fastest at 8.24 ns, then wasmtime at 8.27 ns; pywasm-pypy is slowest at 419 µs, a span of 50800x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="584" viewBox="0 0 820 584" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/i64_div: seconds per iteration for 20 runners on a log scale, fastest first. wasmer is fastest at 8.13 ns, then wasmtime at 8.15 ns; pywasm-pypy is slowest at 389 µs, a span of 47900x. The table below carries every number.">
+<title>wat/i64_div: seconds per iteration for 20 runners on a log scale, fastest first. wasmer is fastest at 8.13 ns, then wasmtime at 8.15 ns; pywasm-pypy is slowest at 389 µs, a span of 47900x. The table below carries every number.</title>
 <rect width="820" height="584" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="265.8" y1="68.0" x2="265.8" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="265.8" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="363.7" y1="68.0" x2="363.7" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="363.7" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="461.5" y1="68.0" x2="461.5" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="461.5" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="559.3" y1="68.0" x2="559.3" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="559.3" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
-<line x1="657.1" y1="68.0" x2="657.1" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="657.1" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
+<line x1="266.4" y1="68.0" x2="266.4" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="266.4" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="364.8" y1="68.0" x2="364.8" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="364.8" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="463.1" y1="68.0" x2="463.1" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="463.1" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="561.5" y1="68.0" x2="561.5" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="561.5" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="659.9" y1="68.0" x2="659.9" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="659.9" y="570.0" text-anchor="middle" font-size="11" fill="#52514e">100 µs</text>
 <line x1="168.0" y1="554.0" x2="726.0" y2="554.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
-<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="86.0" x2="257.6" y2="86.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="257.6" cy="86.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.24 ns</text>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
+<line x1="168.0" y1="86.0" x2="257.6" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="257.6" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.13 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
 <line x1="168.0" y1="110.0" x2="257.7" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="257.7" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.27 ns</text>
-<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="134.0" x2="257.8" y2="134.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="257.8" cy="134.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.28 ns</text>
-<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="258.0" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="258.0" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.32 ns</text>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.15 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
+<line x1="168.0" y1="134.0" x2="257.7" y2="134.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="257.7" cy="134.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.16 ns</text>
+<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
+<line x1="168.0" y1="158.0" x2="257.7" y2="158.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="257.7" cy="158.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.16 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="260.1" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="260.1" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.74 ns</text>
+<line x1="168.0" y1="182.0" x2="259.3" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="259.3" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.46 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="286.2" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="286.2" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">16.2 ns</text>
+<line x1="168.0" y1="206.0" x2="286.1" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="286.1" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">15.9 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="230.0" x2="388.8" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="388.8" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">181 ns</text>
+<line x1="168.0" y1="230.0" x2="389.8" y2="230.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="389.8" cy="230.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">179 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="254.0" x2="405.5" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="405.5" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">268 ns</text>
+<line x1="168.0" y1="254.0" x2="406.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="406.6" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">266 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="278.0" x2="462.9" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="462.9" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.03 µs</text>
+<line x1="168.0" y1="278.0" x2="464.8" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="464.8" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.04 µs</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="302.0" x2="467.0" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="467.0" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.14 µs</text>
+<line x1="168.0" y1="302.0" x2="467.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="467.6" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.11 µs</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="326.0" x2="475.9" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="475.9" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.40 µs</text>
+<line x1="168.0" y1="326.0" x2="476.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="476.7" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.37 µs</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="350.0" x2="479.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="479.1" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.52 µs</text>
+<line x1="168.0" y1="350.0" x2="480.1" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="480.1" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.49 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="374.0" x2="484.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="484.0" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.70 µs</text>
+<line x1="168.0" y1="374.0" x2="484.2" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="484.2" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.64 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="398.0" x2="540.0" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="540.0" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.35 µs</text>
+<line x1="168.0" y1="398.0" x2="542.6" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="542.6" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.42 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
-<line x1="168.0" y1="422.0" x2="571.4" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="571.4" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.3 µs</text>
+<line x1="168.0" y1="422.0" x2="577.7" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="577.7" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.6 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
-<line x1="168.0" y1="446.0" x2="588.9" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="588.9" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.1 µs</text>
+<line x1="168.0" y1="446.0" x2="591.2" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="591.2" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.0 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
-<line x1="168.0" y1="470.0" x2="606.9" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="606.9" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">30.6 µs</text>
+<line x1="168.0" y1="470.0" x2="610.4" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="610.4" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">31.4 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
-<line x1="168.0" y1="494.0" x2="640.0" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="640.0" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">66.8 µs</text>
+<line x1="168.0" y1="494.0" x2="641.5" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="641.5" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">65.0 µs</text>
 <text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="518.0" x2="646.1" y2="518.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="646.1" cy="518.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">77.1 µs</text>
+<line x1="168.0" y1="518.0" x2="647.6" y2="518.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="647.6" cy="518.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">74.9 µs</text>
 <text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
 <line x1="168.0" y1="542.0" x2="718.0" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">419 µs</text>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">389 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/i64_div: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-mem-narrow-dark.svg
+++ b/docs/benchmarks/figs/wat-mem-narrow-dark.svg
@@ -1,105 +1,105 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_narrow: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.58 ns; pywasm-cpython is slowest at 87.8 µs, a span of 58500x. The table below carries every number.">
-<title>wat/mem_narrow: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.58 ns; pywasm-cpython is slowest at 87.8 µs, a span of 58500x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_narrow: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 1.47 ns, then wasmer at 1.56 ns; pywasm-cpython is slowest at 84.8 µs, a span of 57700x. The table below carries every number.">
+<title>wat/mem_narrow: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 1.47 ns, then wasmer at 1.56 ns; pywasm-cpython is slowest at 84.8 µs, a span of 57700x. The table below carries every number.</title>
 <rect width="820" height="632" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="279.3" y1="68.0" x2="279.3" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="279.3" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="390.5" y1="68.0" x2="390.5" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="390.5" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="501.8" y1="68.0" x2="501.8" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="501.8" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="613.0" y1="68.0" x2="613.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="613.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="279.6" y1="68.0" x2="279.6" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="279.6" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="391.2" y1="68.0" x2="391.2" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="391.2" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="502.8" y1="68.0" x2="502.8" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="502.8" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="614.4" y1="68.0" x2="614.4" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="614.4" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
 <line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="187.6" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="187.6" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.50 ns</text>
+<line x1="168.0" y1="86.0" x2="186.6" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="186.6" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.47 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<line x1="168.0" y1="110.0" x2="190.0" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="190.0" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.58 ns</text>
+<line x1="168.0" y1="110.0" x2="189.5" y2="110.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="189.5" cy="110.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.56 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="212.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="212.1" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.49 ns</text>
+<line x1="168.0" y1="134.0" x2="211.5" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="211.5" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.45 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="212.7" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="212.7" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.52 ns</text>
+<line x1="168.0" y1="158.0" x2="212.3" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="212.3" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.49 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="240.0" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="240.0" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.44 ns</text>
+<line x1="168.0" y1="182.0" x2="238.4" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="238.4" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.27 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="313.1" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="313.1" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.1 ns</text>
+<line x1="168.0" y1="206.0" x2="312.8" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="312.8" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">19.8 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="375.2" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="375.2" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">72.8 ns</text>
+<line x1="168.0" y1="230.0" x2="374.3" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="374.3" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">70.6 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="437.0" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="437.0" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">261 ns</text>
+<line x1="168.0" y1="254.0" x2="435.4" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="435.4" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">249 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="444.9" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="444.9" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">308 ns</text>
+<line x1="168.0" y1="278.0" x2="444.7" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="444.7" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">302 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="449.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="449.1" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">336 ns</text>
+<line x1="168.0" y1="302.0" x2="448.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="448.6" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">327 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="461.4" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="461.4" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">434 ns</text>
+<line x1="168.0" y1="326.0" x2="461.5" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="461.5" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">426 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="533.5" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="533.5" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.93 µs</text>
+<line x1="168.0" y1="350.0" x2="532.4" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="532.4" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.84 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="558.4" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="558.4" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.23 µs</text>
+<line x1="168.0" y1="374.0" x2="556.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="556.0" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.99 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="398.0" x2="597.3" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="597.3" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.22 µs</text>
+<line x1="168.0" y1="398.0" x2="597.8" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="597.8" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.11 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="422.0" x2="631.7" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="631.7" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">14.7 µs</text>
+<line x1="168.0" y1="422.0" x2="629.6" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="629.6" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.7 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
-<line x1="168.0" y1="446.0" x2="638.2" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="638.2" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">16.8 µs</text>
+<line x1="168.0" y1="446.0" x2="644.2" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="644.2" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">18.5 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
-<line x1="168.0" y1="470.0" x2="647.4" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="647.4" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">20.4 µs</text>
+<line x1="168.0" y1="470.0" x2="645.7" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="645.7" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">19.1 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="494.0" x2="663.5" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="663.5" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">28.4 µs</text>
-<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
-<line x1="168.0" y1="518.0" x2="687.5" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="687.5" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">46.7 µs</text>
-<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="542.0" x2="688.0" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="688.0" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">47.1 µs</text>
+<line x1="168.0" y1="494.0" x2="662.3" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="662.3" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">26.8 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="518.0" x2="682.4" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="682.4" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">40.7 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
+<line x1="168.0" y1="542.0" x2="690.0" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="690.0" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">47.6 µs</text>
 <text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="566.0" x2="692.5" y2="566.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="692.5" cy="566.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">51.8 µs</text>
+<line x1="168.0" y1="566.0" x2="690.9" y2="566.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="690.9" cy="566.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">48.5 µs</text>
 <text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
 <line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="590.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">87.8 µs</text>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">84.8 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/mem_narrow: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-mem-narrow.svg
+++ b/docs/benchmarks/figs/wat-mem-narrow.svg
@@ -1,105 +1,105 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_narrow: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.58 ns; pywasm-cpython is slowest at 87.8 µs, a span of 58500x. The table below carries every number.">
-<title>wat/mem_narrow: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.58 ns; pywasm-cpython is slowest at 87.8 µs, a span of 58500x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_narrow: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 1.47 ns, then wasmer at 1.56 ns; pywasm-cpython is slowest at 84.8 µs, a span of 57700x. The table below carries every number.">
+<title>wat/mem_narrow: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 1.47 ns, then wasmer at 1.56 ns; pywasm-cpython is slowest at 84.8 µs, a span of 57700x. The table below carries every number.</title>
 <rect width="820" height="632" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
 <text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="279.3" y1="68.0" x2="279.3" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="279.3" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="390.5" y1="68.0" x2="390.5" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="390.5" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="501.8" y1="68.0" x2="501.8" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="501.8" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="613.0" y1="68.0" x2="613.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="613.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="279.6" y1="68.0" x2="279.6" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="279.6" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="391.2" y1="68.0" x2="391.2" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="391.2" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="502.8" y1="68.0" x2="502.8" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="502.8" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="614.4" y1="68.0" x2="614.4" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="614.4" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
 <line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<line x1="168.0" y1="86.0" x2="187.6" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="187.6" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.50 ns</text>
+<line x1="168.0" y1="86.0" x2="186.6" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="186.6" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.47 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<line x1="168.0" y1="110.0" x2="190.0" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="190.0" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.58 ns</text>
+<line x1="168.0" y1="110.0" x2="189.5" y2="110.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="189.5" cy="110.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.56 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="212.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="212.1" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.49 ns</text>
+<line x1="168.0" y1="134.0" x2="211.5" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="211.5" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.45 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="212.7" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="212.7" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.52 ns</text>
+<line x1="168.0" y1="158.0" x2="212.3" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="212.3" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.49 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="240.0" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="240.0" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.44 ns</text>
+<line x1="168.0" y1="182.0" x2="238.4" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="238.4" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.27 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="313.1" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="313.1" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.1 ns</text>
+<line x1="168.0" y1="206.0" x2="312.8" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="312.8" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">19.8 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="375.2" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="375.2" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">72.8 ns</text>
+<line x1="168.0" y1="230.0" x2="374.3" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="374.3" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">70.6 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="437.0" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="437.0" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">261 ns</text>
+<line x1="168.0" y1="254.0" x2="435.4" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="435.4" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">249 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="444.9" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="444.9" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">308 ns</text>
+<line x1="168.0" y1="278.0" x2="444.7" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="444.7" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">302 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="449.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="449.1" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">336 ns</text>
+<line x1="168.0" y1="302.0" x2="448.6" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="448.6" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">327 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="461.4" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="461.4" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">434 ns</text>
+<line x1="168.0" y1="326.0" x2="461.5" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="461.5" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">426 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="533.5" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="533.5" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.93 µs</text>
+<line x1="168.0" y1="350.0" x2="532.4" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="532.4" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.84 µs</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="558.4" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="558.4" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.23 µs</text>
+<line x1="168.0" y1="374.0" x2="556.0" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="556.0" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.99 µs</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="398.0" x2="597.3" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="597.3" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.22 µs</text>
+<line x1="168.0" y1="398.0" x2="597.8" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="597.8" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.11 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="422.0" x2="631.7" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="631.7" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">14.7 µs</text>
+<line x1="168.0" y1="422.0" x2="629.6" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="629.6" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.7 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
-<line x1="168.0" y1="446.0" x2="638.2" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="638.2" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">16.8 µs</text>
+<line x1="168.0" y1="446.0" x2="644.2" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="644.2" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">18.5 µs</text>
 <text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
-<line x1="168.0" y1="470.0" x2="647.4" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="647.4" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">20.4 µs</text>
+<line x1="168.0" y1="470.0" x2="645.7" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="645.7" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">19.1 µs</text>
 <text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="494.0" x2="663.5" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="663.5" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">28.4 µs</text>
-<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
-<line x1="168.0" y1="518.0" x2="687.5" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="687.5" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">46.7 µs</text>
-<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="542.0" x2="688.0" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="688.0" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">47.1 µs</text>
+<line x1="168.0" y1="494.0" x2="662.3" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="662.3" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">26.8 µs</text>
+<text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="518.0" x2="682.4" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="682.4" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">40.7 µs</text>
+<text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
+<line x1="168.0" y1="542.0" x2="690.0" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="690.0" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">47.6 µs</text>
 <text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="566.0" x2="692.5" y2="566.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="692.5" cy="566.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">51.8 µs</text>
+<line x1="168.0" y1="566.0" x2="690.9" y2="566.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="690.9" cy="566.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">48.5 µs</text>
 <text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
 <line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="590.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">87.8 µs</text>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">84.8 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/mem_narrow: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-mem-rw-dark.svg
+++ b/docs/benchmarks/figs/wat-mem-rw-dark.svg
@@ -1,103 +1,107 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_rw: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 1.01 ns, then wasmtime at 1.01 ns; pywasm-cpython is slowest at 39.9 µs, a span of 39700x. The table below carries every number.">
-<title>wat/mem_rw: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 1.01 ns, then wasmtime at 1.01 ns; pywasm-cpython is slowest at 39.9 µs, a span of 39700x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_rw: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 0.98 ns, then wasmtime at 0.98 ns; pywasm-cpython is slowest at 38.6 µs, a span of 39300x. The table below carries every number.">
+<title>wat/mem_rw: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 0.98 ns, then wasmtime at 0.98 ns; pywasm-cpython is slowest at 38.6 µs, a span of 39300x. The table below carries every number.</title>
 <rect width="820" height="632" fill="#1a1a19"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
-<line x1="287.5" y1="68.0" x2="287.5" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="287.5" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
-<line x1="407.1" y1="68.0" x2="407.1" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="407.1" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
-<line x1="526.6" y1="68.0" x2="526.6" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="526.6" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
-<line x1="646.2" y1="68.0" x2="646.2" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
-<text x="646.2" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">0 ns</text>
+<line x1="266.4" y1="68.0" x2="266.4" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="266.4" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
+<line x1="364.9" y1="68.0" x2="364.9" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="364.9" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="463.3" y1="68.0" x2="463.3" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="463.3" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="561.8" y1="68.0" x2="561.8" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="561.8" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="660.2" y1="68.0" x2="660.2" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="660.2" y="618.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
 <line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmer</text>
-<circle cx="168.3" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.01 ns</text>
+<line x1="168.0" y1="86.0" x2="265.8" y2="86.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="265.8" cy="86.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.98 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
-<circle cx="168.5" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.01 ns</text>
+<line x1="168.0" y1="110.0" x2="265.8" y2="110.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="265.8" cy="110.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">0.98 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="189.3" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="189.3" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.51 ns</text>
+<line x1="168.0" y1="134.0" x2="283.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="283.1" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.48 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wazero</text>
-<line x1="168.0" y1="158.0" x2="190.8" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="190.8" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.55 ns</text>
+<line x1="168.0" y1="158.0" x2="284.3" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="284.3" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.52 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="198.2" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="198.2" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.79 ns</text>
+<line x1="168.0" y1="182.0" x2="289.5" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="289.5" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.72 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
-<line x1="168.0" y1="206.0" x2="287.1" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="287.1" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.91 ns</text>
+<line x1="168.0" y1="206.0" x2="364.0" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="364.0" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.79 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="375.5" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="375.5" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">54.4 ns</text>
+<line x1="168.0" y1="230.0" x2="435.7" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="435.7" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">52.4 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="419.7" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="419.7" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">127 ns</text>
+<line x1="168.0" y1="254.0" x2="471.5" y2="254.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="471.5" cy="254.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">121 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="422.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="422.6" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">135 ns</text>
+<line x1="168.0" y1="278.0" x2="475.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="475.1" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">132 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="425.3" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="425.3" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">142 ns</text>
+<line x1="168.0" y1="302.0" x2="477.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="477.1" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">138 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="437.5" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="437.5" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">180 ns</text>
+<line x1="168.0" y1="326.0" x2="487.6" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="487.6" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">176 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="513.3" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="513.3" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">773 ns</text>
+<line x1="168.0" y1="350.0" x2="548.5" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="548.5" cy="350.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">734 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="526.7" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="526.7" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">1.00 µs</text>
+<line x1="168.0" y1="374.0" x2="559.9" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="559.9" cy="374.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">957 ns</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="398.0" x2="586.4" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="586.4" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.16 µs</text>
+<line x1="168.0" y1="398.0" x2="608.8" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="608.8" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.00 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
-<line x1="168.0" y1="422.0" x2="618.9" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="618.9" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.92 µs</text>
+<line x1="168.0" y1="422.0" x2="625.7" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="625.7" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">4.46 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">wardite-yjit</text>
-<line x1="168.0" y1="446.0" x2="622.0" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="622.0" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">6.27 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
-<line x1="168.0" y1="470.0" x2="634.4" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="634.4" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.97 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
-<line x1="168.0" y1="494.0" x2="635.2" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="635.2" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.09 µs</text>
+<line x1="168.0" y1="446.0" x2="638.1" y2="446.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="638.1" cy="446.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">5.96 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-pypy</text>
+<line x1="168.0" y1="470.0" x2="646.2" y2="470.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="646.2" cy="470.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.21 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
+<line x1="168.0" y1="494.0" x2="655.1" y2="494.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="655.1" cy="494.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">8.88 µs</text>
 <text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#ffffff">wardite</text>
-<line x1="168.0" y1="518.0" x2="660.6" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="660.6" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">13.2 µs</text>
+<line x1="168.0" y1="518.0" x2="670.5" y2="518.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="670.5" cy="518.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">12.7 µs</text>
 <text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
-<line x1="168.0" y1="542.0" x2="688.2" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="688.2" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">22.5 µs</text>
+<line x1="168.0" y1="542.0" x2="695.6" y2="542.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="695.6" cy="542.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">22.9 µs</text>
 <text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
-<line x1="168.0" y1="566.0" x2="706.3" y2="566.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="706.3" cy="566.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">31.9 µs</text>
+<line x1="168.0" y1="566.0" x2="707.2" y2="566.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="707.2" cy="566.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">30.0 µs</text>
 <text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#ffffff">pywasm-cpython</text>
 <line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="590.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
-<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">39.9 µs</text>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">38.6 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/mem_rw: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-mem-rw.svg
+++ b/docs/benchmarks/figs/wat-mem-rw.svg
@@ -1,103 +1,107 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_rw: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 1.01 ns, then wasmtime at 1.01 ns; pywasm-cpython is slowest at 39.9 µs, a span of 39700x. The table below carries every number.">
-<title>wat/mem_rw: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 1.01 ns, then wasmtime at 1.01 ns; pywasm-cpython is slowest at 39.9 µs, a span of 39700x. The table below carries every number.</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="632" viewBox="0 0 820 632" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/mem_rw: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 0.98 ns, then wasmtime at 0.98 ns; pywasm-cpython is slowest at 38.6 µs, a span of 39300x. The table below carries every number.">
+<title>wat/mem_rw: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 0.98 ns, then wasmtime at 0.98 ns; pywasm-cpython is slowest at 38.6 µs, a span of 39300x. The table below carries every number.</title>
 <rect width="820" height="632" fill="#fcfcfb"/>
 <line x1="168.0" y1="68.0" x2="168.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
-<line x1="287.5" y1="68.0" x2="287.5" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="287.5" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
-<line x1="407.1" y1="68.0" x2="407.1" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="407.1" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
-<line x1="526.6" y1="68.0" x2="526.6" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="526.6" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
-<line x1="646.2" y1="68.0" x2="646.2" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
-<text x="646.2" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<text x="168.0" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">0 ns</text>
+<line x1="266.4" y1="68.0" x2="266.4" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="266.4" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
+<line x1="364.9" y1="68.0" x2="364.9" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="364.9" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="463.3" y1="68.0" x2="463.3" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="463.3" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="561.8" y1="68.0" x2="561.8" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="561.8" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="660.2" y1="68.0" x2="660.2" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="660.2" y="618.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
 <line x1="168.0" y1="602.0" x2="726.0" y2="602.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
 <text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmer</text>
-<circle cx="168.3" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.01 ns</text>
+<line x1="168.0" y1="86.0" x2="265.8" y2="86.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="265.8" cy="86.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.98 ns</text>
 <text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
-<circle cx="168.5" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.01 ns</text>
+<line x1="168.0" y1="110.0" x2="265.8" y2="110.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="265.8" cy="110.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">0.98 ns</text>
 <text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
-<line x1="168.0" y1="134.0" x2="189.3" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="189.3" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.51 ns</text>
+<line x1="168.0" y1="134.0" x2="283.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="283.1" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.48 ns</text>
 <text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wazero</text>
-<line x1="168.0" y1="158.0" x2="190.8" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="190.8" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.55 ns</text>
+<line x1="168.0" y1="158.0" x2="284.3" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="284.3" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.52 ns</text>
 <text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
-<line x1="168.0" y1="182.0" x2="198.2" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="198.2" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.79 ns</text>
+<line x1="168.0" y1="182.0" x2="289.5" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="289.5" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.72 ns</text>
 <text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
-<line x1="168.0" y1="206.0" x2="287.1" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="287.1" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.91 ns</text>
+<line x1="168.0" y1="206.0" x2="364.0" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="364.0" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.79 ns</text>
 <text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
-<line x1="168.0" y1="230.0" x2="375.5" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="375.5" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">54.4 ns</text>
+<line x1="168.0" y1="230.0" x2="435.7" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="435.7" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">52.4 ns</text>
 <text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
-<line x1="168.0" y1="254.0" x2="419.7" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="419.7" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">127 ns</text>
+<line x1="168.0" y1="254.0" x2="471.5" y2="254.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="471.5" cy="254.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">121 ns</text>
 <text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
-<line x1="168.0" y1="278.0" x2="422.6" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="422.6" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">135 ns</text>
+<line x1="168.0" y1="278.0" x2="475.1" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="475.1" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">132 ns</text>
 <text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
-<line x1="168.0" y1="302.0" x2="425.3" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="425.3" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">142 ns</text>
+<line x1="168.0" y1="302.0" x2="477.1" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="477.1" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">138 ns</text>
 <text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
-<line x1="168.0" y1="326.0" x2="437.5" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="437.5" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">180 ns</text>
+<line x1="168.0" y1="326.0" x2="487.6" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="487.6" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">176 ns</text>
 <text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
-<line x1="168.0" y1="350.0" x2="513.3" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="513.3" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">773 ns</text>
+<line x1="168.0" y1="350.0" x2="548.5" y2="350.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="548.5" cy="350.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">734 ns</text>
 <text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
-<line x1="168.0" y1="374.0" x2="526.7" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="526.7" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">1.00 µs</text>
+<line x1="168.0" y1="374.0" x2="559.9" y2="374.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="559.9" cy="374.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">957 ns</text>
 <text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
-<line x1="168.0" y1="398.0" x2="586.4" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="586.4" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.16 µs</text>
+<line x1="168.0" y1="398.0" x2="608.8" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="608.8" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.00 µs</text>
 <text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
-<line x1="168.0" y1="422.0" x2="618.9" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="618.9" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.92 µs</text>
+<line x1="168.0" y1="422.0" x2="625.7" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="625.7" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">4.46 µs</text>
 <text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite-yjit</text>
-<line x1="168.0" y1="446.0" x2="622.0" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="622.0" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">6.27 µs</text>
-<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
-<line x1="168.0" y1="470.0" x2="634.4" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="634.4" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.97 µs</text>
-<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
-<line x1="168.0" y1="494.0" x2="635.2" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="635.2" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.09 µs</text>
+<line x1="168.0" y1="446.0" x2="638.1" y2="446.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="638.1" cy="446.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">5.96 µs</text>
+<text x="152.0" y="474.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-pypy</text>
+<line x1="168.0" y1="470.0" x2="646.2" y2="470.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="646.2" cy="470.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="474.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.21 µs</text>
+<text x="152.0" y="498.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
+<line x1="168.0" y1="494.0" x2="655.1" y2="494.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="655.1" cy="494.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="498.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">8.88 µs</text>
 <text x="152.0" y="522.0" text-anchor="end" font-size="12" fill="#0b0b0b">wardite</text>
-<line x1="168.0" y1="518.0" x2="660.6" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="660.6" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">13.2 µs</text>
+<line x1="168.0" y1="518.0" x2="670.5" y2="518.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="670.5" cy="518.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="522.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">12.7 µs</text>
 <text x="152.0" y="546.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
-<line x1="168.0" y1="542.0" x2="688.2" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="688.2" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">22.5 µs</text>
+<line x1="168.0" y1="542.0" x2="695.6" y2="542.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="695.6" cy="542.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="546.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">22.9 µs</text>
 <text x="152.0" y="570.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
-<line x1="168.0" y1="566.0" x2="706.3" y2="566.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
-<circle cx="706.3" cy="566.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">31.9 µs</text>
+<line x1="168.0" y1="566.0" x2="707.2" y2="566.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="707.2" cy="566.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="570.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">30.0 µs</text>
 <text x="152.0" y="594.0" text-anchor="end" font-size="12" fill="#0b0b0b">pywasm-cpython</text>
 <line x1="168.0" y1="590.0" x2="718.0" y2="590.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
 <circle cx="718.0" cy="590.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
-<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">39.9 µs</text>
+<text x="806.0" y="594.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">38.6 µs</text>
 <text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/mem_rw: seconds per iteration, median of the timed runs (log scale)</text>
 <circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
 <text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>

--- a/docs/benchmarks/figs/wat-tail-call-dark.svg
+++ b/docs/benchmarks/figs/wat-tail-call-dark.svg
@@ -1,0 +1,88 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="488" viewBox="0 0 820 488" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/tail_call: seconds per iteration for 16 runners on a log scale, fastest first. wasmtime is fastest at 3.43 ns, then dewasm-go at 9.08 ns; dewasm-bash is slowest at 77.1 µs, a span of 22500x. The table below carries every number.">
+<title>wat/tail_call: seconds per iteration for 16 runners on a log scale, fastest first. wasmtime is fastest at 3.43 ns, then dewasm-go at 9.08 ns; dewasm-bash is slowest at 77.1 µs, a span of 22500x. The table below carries every number.</title>
+<rect width="820" height="488" fill="#1a1a19"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 ns</text>
+<line x1="280.5" y1="68.0" x2="280.5" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="280.5" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 ns</text>
+<line x1="393.1" y1="68.0" x2="393.1" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="393.1" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">100 ns</text>
+<line x1="505.6" y1="68.0" x2="505.6" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="505.6" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">1 µs</text>
+<line x1="618.2" y1="68.0" x2="618.2" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.25"/>
+<text x="618.2" y="474.0" text-anchor="middle" font-size="11" fill="#c3c2b7">10 µs</text>
+<line x1="168.0" y1="458.0" x2="726.0" y2="458.0" stroke="#c3c2b7" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#ffffff">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="228.3" y2="86.0" stroke="#3987e5" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="228.3" cy="86.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">3.43 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-go</text>
+<line x1="168.0" y1="110.0" x2="275.8" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="275.8" cy="110.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">9.08 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-java</text>
+<line x1="168.0" y1="134.0" x2="308.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="308.1" cy="134.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">17.6 ns</text>
+<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3</text>
+<line x1="168.0" y1="158.0" x2="361.4" y2="158.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="361.4" cy="158.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">52.3 ns</text>
+<text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-pypy</text>
+<line x1="168.0" y1="182.0" x2="409.1" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="409.1" cy="182.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">139 ns</text>
+<text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#ffffff">wasmedge</text>
+<line x1="168.0" y1="206.0" x2="423.9" y2="206.0" stroke="#c98500" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="423.9" cy="206.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">188 ns</text>
+<text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-yjit</text>
+<line x1="168.0" y1="230.0" x2="441.7" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="441.7" cy="230.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">270 ns</text>
+<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby-zjit</text>
+<line x1="168.0" y1="254.0" x2="457.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="457.6" cy="254.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">374 ns</text>
+<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-ruby</text>
+<line x1="168.0" y1="278.0" x2="482.3" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="482.3" cy="278.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">620 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-python</text>
+<line x1="168.0" y1="302.0" x2="486.9" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="486.9" cy="302.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">682 ns</text>
+<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-perl</text>
+<line x1="168.0" y1="326.0" x2="549.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="549.7" cy="326.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">2.47 µs</text>
+<text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="350.0" x2="604.1" y2="350.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="604.1" cy="350.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">7.50 µs</text>
+<text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-ruby</text>
+<line x1="168.0" y1="374.0" x2="648.6" y2="374.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="648.6" cy="374.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">18.6 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-pypy</text>
+<line x1="168.0" y1="398.0" x2="649.1" y2="398.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="649.1" cy="398.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">18.8 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#ffffff">wasm3-python</text>
+<line x1="168.0" y1="422.0" x2="695.7" y2="422.0" stroke="#d55181" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="695.7" cy="422.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">48.8 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#ffffff">dewasm-bash</text>
+<line x1="168.0" y1="446.0" x2="718.0" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="446.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#ffffff">77.1 µs</text>
+<text x="14.0" y="24" font-size="15" font-weight="600" fill="#ffffff">wat/tail_call: seconds per iteration, median of the timed runs (log scale)</text>
+<circle cx="19.5" cy="48.0" r="5.5" fill="#3987e5" stroke="#1a1a19" stroke-width="2"/>
+<text x="31.0" y="52.0" font-size="12" fill="#c3c2b7">wasmtime (baseline)</text>
+<circle cx="179.9" cy="48.0" r="5.5" fill="#008300" stroke="#1a1a19" stroke-width="2"/>
+<text x="191.4" y="52.0" font-size="12" fill="#c3c2b7">dewasm backends</text>
+<circle cx="313.9" cy="48.0" r="5.5" fill="#c98500" stroke="#1a1a19" stroke-width="2"/>
+<text x="325.4" y="52.0" font-size="12" fill="#c3c2b7">native runtimes</text>
+<circle cx="447.9" cy="48.0" r="5.5" fill="#d55181" stroke="#1a1a19" stroke-width="2"/>
+<text x="459.4" y="52.0" font-size="12" fill="#c3c2b7">wasm interpreters in a host language</text>
+</svg>

--- a/docs/benchmarks/figs/wat-tail-call.svg
+++ b/docs/benchmarks/figs/wat-tail-call.svg
@@ -1,0 +1,88 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="488" viewBox="0 0 820 488" font-family="system-ui, -apple-system, Segoe UI, sans-serif" role="img" aria-label="wat/tail_call: seconds per iteration for 16 runners on a log scale, fastest first. wasmtime is fastest at 3.43 ns, then dewasm-go at 9.08 ns; dewasm-bash is slowest at 77.1 µs, a span of 22500x. The table below carries every number.">
+<title>wat/tail_call: seconds per iteration for 16 runners on a log scale, fastest first. wasmtime is fastest at 3.43 ns, then dewasm-go at 9.08 ns; dewasm-bash is slowest at 77.1 µs, a span of 22500x. The table below carries every number.</title>
+<rect width="820" height="488" fill="#fcfcfb"/>
+<line x1="168.0" y1="68.0" x2="168.0" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="168.0" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">1 ns</text>
+<line x1="280.5" y1="68.0" x2="280.5" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="280.5" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">10 ns</text>
+<line x1="393.1" y1="68.0" x2="393.1" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="393.1" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">100 ns</text>
+<line x1="505.6" y1="68.0" x2="505.6" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="505.6" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">1 µs</text>
+<line x1="618.2" y1="68.0" x2="618.2" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.25"/>
+<text x="618.2" y="474.0" text-anchor="middle" font-size="11" fill="#52514e">10 µs</text>
+<line x1="168.0" y1="458.0" x2="726.0" y2="458.0" stroke="#52514e" stroke-width="1" stroke-opacity="0.4"/>
+<text x="152.0" y="90.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmtime</text>
+<line x1="168.0" y1="86.0" x2="228.3" y2="86.0" stroke="#2a78d6" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="228.3" cy="86.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="90.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">3.43 ns</text>
+<text x="152.0" y="114.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-go</text>
+<line x1="168.0" y1="110.0" x2="275.8" y2="110.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="275.8" cy="110.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="114.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">9.08 ns</text>
+<text x="152.0" y="138.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-java</text>
+<line x1="168.0" y1="134.0" x2="308.1" y2="134.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="308.1" cy="134.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="138.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">17.6 ns</text>
+<text x="152.0" y="162.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3</text>
+<line x1="168.0" y1="158.0" x2="361.4" y2="158.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="361.4" cy="158.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="162.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">52.3 ns</text>
+<text x="152.0" y="186.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-pypy</text>
+<line x1="168.0" y1="182.0" x2="409.1" y2="182.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="409.1" cy="182.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="186.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">139 ns</text>
+<text x="152.0" y="210.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasmedge</text>
+<line x1="168.0" y1="206.0" x2="423.9" y2="206.0" stroke="#eda100" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="423.9" cy="206.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="210.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">188 ns</text>
+<text x="152.0" y="234.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-yjit</text>
+<line x1="168.0" y1="230.0" x2="441.7" y2="230.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="441.7" cy="230.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="234.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">270 ns</text>
+<text x="152.0" y="258.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby-zjit</text>
+<line x1="168.0" y1="254.0" x2="457.6" y2="254.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="457.6" cy="254.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="258.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">374 ns</text>
+<text x="152.0" y="282.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-ruby</text>
+<line x1="168.0" y1="278.0" x2="482.3" y2="278.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="482.3" cy="278.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="282.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">620 ns</text>
+<text x="152.0" y="306.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-python</text>
+<line x1="168.0" y1="302.0" x2="486.9" y2="302.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="486.9" cy="302.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="306.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">682 ns</text>
+<text x="152.0" y="330.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-perl</text>
+<line x1="168.0" y1="326.0" x2="549.7" y2="326.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="549.7" cy="326.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="330.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">2.47 µs</text>
+<text x="152.0" y="354.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby-yjit</text>
+<line x1="168.0" y1="350.0" x2="604.1" y2="350.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="604.1" cy="350.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="354.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">7.50 µs</text>
+<text x="152.0" y="378.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-ruby</text>
+<line x1="168.0" y1="374.0" x2="648.6" y2="374.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="648.6" cy="374.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="378.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">18.6 µs</text>
+<text x="152.0" y="402.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-pypy</text>
+<line x1="168.0" y1="398.0" x2="649.1" y2="398.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="649.1" cy="398.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="402.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">18.8 µs</text>
+<text x="152.0" y="426.0" text-anchor="end" font-size="12" fill="#0b0b0b">wasm3-python</text>
+<line x1="168.0" y1="422.0" x2="695.7" y2="422.0" stroke="#e87ba4" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="695.7" cy="422.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="426.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">48.8 µs</text>
+<text x="152.0" y="450.0" text-anchor="end" font-size="12" fill="#0b0b0b">dewasm-bash</text>
+<line x1="168.0" y1="446.0" x2="718.0" y2="446.0" stroke="#008300" stroke-width="2" stroke-opacity="0.45"/>
+<circle cx="718.0" cy="446.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="806.0" y="450.0" text-anchor="end" font-size="12" font-weight="600" fill="#0b0b0b">77.1 µs</text>
+<text x="14.0" y="24" font-size="15" font-weight="600" fill="#0b0b0b">wat/tail_call: seconds per iteration, median of the timed runs (log scale)</text>
+<circle cx="19.5" cy="48.0" r="5.5" fill="#2a78d6" stroke="#fcfcfb" stroke-width="2"/>
+<text x="31.0" y="52.0" font-size="12" fill="#52514e">wasmtime (baseline)</text>
+<circle cx="179.9" cy="48.0" r="5.5" fill="#008300" stroke="#fcfcfb" stroke-width="2"/>
+<text x="191.4" y="52.0" font-size="12" fill="#52514e">dewasm backends</text>
+<circle cx="313.9" cy="48.0" r="5.5" fill="#eda100" stroke="#fcfcfb" stroke-width="2"/>
+<text x="325.4" y="52.0" font-size="12" fill="#52514e">native runtimes</text>
+<circle cx="447.9" cy="48.0" r="5.5" fill="#e87ba4" stroke="#fcfcfb" stroke-width="2"/>
+<text x="459.4" y="52.0" font-size="12" fill="#52514e">wasm interpreters in a host language</text>
+</svg>

--- a/docs/benchmarks/results.md
+++ b/docs/benchmarks/results.md
@@ -7,7 +7,7 @@ How to run and read these measurements is [README.md](README.md).
 
 ## Environment
 
-Measured 2026-08-30T05:11:20Z.
+Measured 2026-08-31T09:49:13Z.
 
 | | |
 | --- | --- |
@@ -58,7 +58,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-br-table-dark.svg">
-  <img alt="wat/br_table: seconds per iteration for 22 runners on a log scale, fastest first. dewasm-go is fastest at 7.65 ns, then wasmer at 8.48 ns; pywasm-pypy is slowest at 54.2 µs, a span of 7080x. The table below carries every number." src="figs/wat-br-table.svg">
+  <img alt="wat/br_table: seconds per iteration for 22 runners on a log scale, fastest first. dewasm-go is fastest at 7.65 ns, then wasmer at 8.41 ns; pywasm-cpython is slowest at 49.4 µs, a span of 6460x. The table below carries every number." src="figs/wat-br-table.svg">
 </picture>
 
 <details>
@@ -66,28 +66,28 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 35 239 116 | 8.44 | 8.50 | 5.8 ms | 303.1 ms | 1.00x | — |
-| `wasmer` | 35 419 097 | 8.46 | 8.48 | 9.0 ms | 308.6 ms | 1.00x | — |
-| `wasmedge` | 1 333 994 | 220.9 | 220.8 | 15.5 ms | 310.1 ms | 26x | — |
-| `wazero` | 34 105 260 | 8.83 | 8.85 | 5.2 ms | 306.5 ms | 1.05x | — |
-| `wasm3` | 11 214 447 | 26.5 | 26.6 | 4.4 ms | 302.1 ms | 3.15x | — |
-| `dewasm-ruby` | 1 166 279 | 217.7 | 216.9 | 38.6 ms | 292.6 ms | 26x | — |
-| `dewasm-ruby-yjit` | 1 121 504 | 218.6 | 220.7 | 38.7 ms | 283.8 ms | 26x | — |
-| `dewasm-ruby-zjit` | 1 295 469 | 216.8 | 216.8 | 40.6 ms | 321.4 ms | 26x | — |
-| `dewasm-python` | 712 829 | 397.0 | 398.9 | 29.2 ms | 312.1 ms | 47x | — |
-| `dewasm-pypy` | 4 049 969 | 62.8 | 63.0 | 40.1 ms | 294.5 ms | 7.44x | — |
-| `dewasm-perl` | 335 558 | 878.3 | 878.3 | 10.2 ms | 305.0 ms | 104x | — |
-| `dewasm-go` | 37 618 165 | 7.62 | 7.65 | 4.8 ms | 291.5 ms | 0.90x | — |
-| `dewasm-java` | 25 986 047 | 9.73 | 9.75 | 66.2 ms | 319.1 ms | 1.15x | — |
-| `dewasm-bash` | 7 275 | 36520 | 36574 | 12.7 ms | 278.4 ms | 4329x | — |
-| `wasm3-ruby` | 37 411 | 8086 | 8134 | 160.3 ms | 462.8 ms | 958x | — |
-| `wasm3-ruby-yjit` | 99 364 | 3123 | 3127 | 271.6 ms | 581.9 ms | 370x | — |
-| `wasm3-python` | 11 875 | 22743 | 23012 | 351.0 ms | 621.1 ms | 2696x | — |
-| `wasm3-pypy` | 22 397 | 8718 | 8754 | 399.6 ms | 594.8 ms | 1033x | — |
-| `pywasm-cpython` | 5 421 | 51427 | 51377 | 44.9 ms | 323.7 ms | 6096x | 0.9 ms |
-| `pywasm-pypy` | 3 527 | 53795 | 54155 | 81.6 ms | 271.4 ms | 6377x | 5.3 ms |
-| `wardite` | 9 046 | 21372 | 21403 | 52.2 ms | 245.5 ms | 2533x | 4.3 ms |
-| `wardite-yjit` | 24 427 | 8854 | 8847 | 102.3 ms | 318.6 ms | 1049x | 10.3 ms |
+| `wasmtime` | 35 580 703 | 8.39 | 8.42 | 5.1 ms | 303.8 ms | 1.00x | — |
+| `wasmer` | 35 566 665 | 8.41 | 8.41 | 8.1 ms | 307.3 ms | 1.00x | — |
+| `wasmedge` | 1 427 536 | 216.0 | 217.5 | 14.4 ms | 322.8 ms | 26x | — |
+| `wazero` | 34 445 047 | 8.71 | 8.72 | 4.6 ms | 304.8 ms | 1.04x | — |
+| `wasm3` | 8 285 355 | 26.3 | 26.4 | 3.9 ms | 222.1 ms | 3.14x | — |
+| `dewasm-ruby` | 1 185 366 | 213.1 | 213.9 | 35.1 ms | 287.7 ms | 25x | — |
+| `dewasm-ruby-yjit` | 1 231 670 | 212.7 | 212.7 | 36.0 ms | 297.9 ms | 25x | — |
+| `dewasm-ruby-zjit` | 1 286 196 | 212.6 | 212.7 | 35.3 ms | 308.8 ms | 25x | — |
+| `dewasm-python` | 769 013 | 390.7 | 392.6 | 26.3 ms | 326.8 ms | 47x | — |
+| `dewasm-pypy` | 4 270 974 | 61.4 | 61.2 | 36.0 ms | 298.0 ms | 7.31x | — |
+| `dewasm-perl` | 352 630 | 858.2 | 864.2 | 10.0 ms | 312.6 ms | 102x | — |
+| `dewasm-go` | 39 624 796 | 7.59 | 7.65 | 2.6 ms | 303.5 ms | 0.90x | — |
+| `dewasm-java` | 27 398 136 | 9.68 | 9.61 | 60.4 ms | 325.5 ms | 1.15x | — |
+| `dewasm-bash` | 8 019 | 35833 | 35831 | 11.5 ms | 298.9 ms | 4269x | — |
+| `wasm3-ruby` | 38 466 | 9616 | 9619 | 116.8 ms | 486.7 ms | 1146x | — |
+| `wasm3-ruby-yjit` | 58 577 | 3318 | 3347 | 286.8 ms | 481.1 ms | 395x | — |
+| `wasm3-python` | 10 201 | 23324 | 23032 | 313.5 ms | 551.5 ms | 2779x | — |
+| `wasm3-pypy` | 33 152 | 6288 | 6251 | 483.1 ms | 691.5 ms | 749x | — |
+| `pywasm-cpython` | 5 949 | 49399 | 49422 | 38.9 ms | 332.8 ms | 5885x | 0.9 ms |
+| `pywasm-pypy` | 8 600 | 23239 | 23384 | 70.6 ms | 270.5 ms | 2769x | 5.1 ms |
+| `wardite` | 15 366 | 20165 | 20187 | 46.4 ms | 356.3 ms | 2402x | 3.6 ms |
+| `wardite-yjit` | 30 532 | 8388 | 8394 | 91.4 ms | 347.5 ms | 999x | 8.7 ms |
 
 </details>
 
@@ -95,7 +95,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-call-direct-dark.svg">
-  <img alt="wat/call_direct: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 3.50 ns, then wasmtime at 3.51 ns; wasm3-python is slowest at 73.3 µs, a span of 21000x. The table below carries every number." src="figs/wat-call-direct.svg">
+  <img alt="wat/call_direct: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 3.43 ns, then wasmer at 3.44 ns; wasm3-python is slowest at 56.2 µs, a span of 16400x. The table below carries every number." src="figs/wat-call-direct.svg">
 </picture>
 
 <details>
@@ -103,28 +103,28 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 85 655 520 | 3.52 | 3.51 | 5.6 ms | 307.1 ms | 1.00x | — |
-| `wasmer` | 84 775 575 | 3.49 | 3.50 | 9.1 ms | 304.6 ms | 0.99x | — |
-| `wasmedge` | 1 447 425 | 204.2 | 204.0 | 16.0 ms | 311.5 ms | 58x | — |
-| `wazero` | 49 851 598 | 6.03 | 6.03 | 5.2 ms | 305.6 ms | 1.71x | — |
-| `wasm3` | 6 364 347 | 44.9 | 44.9 | 4.2 ms | 289.8 ms | 13x | — |
-| `dewasm-ruby` | 1 373 608 | 208.3 | 209.1 | 40.7 ms | 326.8 ms | 59x | — |
-| `dewasm-ruby-yjit` | 3 084 746 | 109.7 | 109.5 | 39.5 ms | 378.0 ms | 31x | — |
-| `dewasm-ruby-zjit` | 1 850 551 | 126.5 | 126.5 | 41.0 ms | 275.0 ms | 36x | — |
-| `dewasm-python` | 707 203 | 423.2 | 424.2 | 29.6 ms | 328.8 ms | 120x | — |
-| `dewasm-pypy` | 2 043 202 | 90.0 | 90.1 | 40.3 ms | 224.1 ms | 26x | — |
-| `dewasm-perl` | 270 353 | 1113 | 1113 | 10.9 ms | 311.7 ms | 316x | — |
-| `dewasm-go` | 67 239 232 | 4.10 | 4.10 | 4.8 ms | 280.7 ms | 1.17x | — |
-| `dewasm-java` | 74 403 853 | 3.59 | 3.61 | 66.4 ms | 333.8 ms | 1.02x | — |
-| `dewasm-bash` | 5 007 | 55811 | 56182 | 12.4 ms | 291.9 ms | 15859x | — |
-| `wasm3-ruby` | 10 010 | 22350 | 22418 | 152.3 ms | 376.0 ms | 6351x | — |
-| `wasm3-ruby-yjit` | 19 045 | 9560 | 9525 | 192.3 ms | 374.3 ms | 2716x | — |
-| `wasm3-python` | 3 614 | 73519 | 73306 | 341.2 ms | 606.9 ms | 20890x | — |
-| `wasm3-pypy` | 11 824 | 17260 | 17352 | 391.1 ms | 595.2 ms | 4904x | — |
-| `pywasm-cpython` | 6 000 | 49558 | 49464 | 43.5 ms | 340.9 ms | 14082x | 0.6 ms |
-| `pywasm-pypy` | 23 314 | 9998 | 10001 | 79.8 ms | 312.9 ms | 2841x | 3.6 ms |
-| `wardite` | 11 302 | 18043 | 18057 | 52.5 ms | 256.4 ms | 5127x | 3.7 ms |
-| `wardite-yjit` | 36 951 | 8328 | 8316 | 102.8 ms | 410.5 ms | 2366x | 9.3 ms |
+| `wasmtime` | 84 753 866 | 3.42 | 3.43 | 5.0 ms | 294.8 ms | 1.00x | — |
+| `wasmer` | 87 391 953 | 3.44 | 3.44 | 7.9 ms | 308.2 ms | 1.01x | — |
+| `wasmedge` | 1 486 788 | 198.0 | 201.0 | 14.1 ms | 308.5 ms | 58x | — |
+| `wazero` | 50 901 297 | 5.90 | 5.91 | 4.4 ms | 304.7 ms | 1.73x | — |
+| `wasm3` | 6 978 720 | 43.6 | 43.7 | 4.0 ms | 308.4 ms | 13x | — |
+| `dewasm-ruby` | 1 364 086 | 200.7 | 200.9 | 34.4 ms | 308.2 ms | 59x | — |
+| `dewasm-ruby-yjit` | 2 304 123 | 105.4 | 105.9 | 34.9 ms | 277.7 ms | 31x | — |
+| `dewasm-ruby-zjit` | 1 925 696 | 122.2 | 122.2 | 35.0 ms | 270.2 ms | 36x | — |
+| `dewasm-python` | 738 481 | 408.4 | 409.7 | 25.6 ms | 327.2 ms | 119x | — |
+| `dewasm-pypy` | 2 663 117 | 86.8 | 88.0 | 36.1 ms | 267.2 ms | 25x | — |
+| `dewasm-perl` | 273 922 | 1075 | 1077 | 9.9 ms | 304.5 ms | 315x | — |
+| `dewasm-go` | 74 343 248 | 4.04 | 4.05 | 2.4 ms | 303.0 ms | 1.18x | — |
+| `dewasm-java` | 71 772 145 | 3.52 | 3.52 | 60.1 ms | 312.8 ms | 1.03x | — |
+| `dewasm-bash` | 5 383 | 54106 | 54105 | 11.4 ms | 302.7 ms | 15827x | — |
+| `wasm3-ruby` | 9 852 | 21707 | 21557 | 113.4 ms | 327.2 ms | 6350x | — |
+| `wasm3-ruby-yjit` | 23 446 | 8650 | 8746 | 198.2 ms | 401.0 ms | 2530x | — |
+| `wasm3-python` | 4 546 | 55867 | 56171 | 308.7 ms | 562.7 ms | 16342x | — |
+| `wasm3-pypy` | 12 500 | 18407 | 18442 | 472.0 ms | 702.0 ms | 5385x | — |
+| `pywasm-cpython` | 6 188 | 47871 | 48132 | 38.4 ms | 334.7 ms | 14003x | 0.6 ms |
+| `pywasm-pypy` | 30 422 | 8336 | 8343 | 68.9 ms | 322.5 ms | 2438x | 3.5 ms |
+| `wardite` | 14 381 | 17198 | 17284 | 46.2 ms | 293.5 ms | 5031x | 3.4 ms |
+| `wardite-yjit` | 37 699 | 7991 | 7977 | 90.8 ms | 392.1 ms | 2337x | 8.4 ms |
 
 </details>
 
@@ -132,7 +132,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-call-indirect-dark.svg">
-  <img alt="wat/call_indirect: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 10.5 ns, then wasmer at 10.5 ns; wasm3-python is slowest at 107 µs, a span of 10200x. The table below carries every number." src="figs/wat-call-indirect.svg">
+  <img alt="wat/call_indirect: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 10.3 ns, then wasmer at 10.3 ns; wasm3-python is slowest at 86.9 µs, a span of 8430x. The table below carries every number." src="figs/wat-call-indirect.svg">
 </picture>
 
 <details>
@@ -140,28 +140,28 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 33 554 432 | 10.5 | 10.5 | 5.6 ms | 356.9 ms | 1.00x | — |
-| `wasmer` | 33 554 432 | 10.5 | 10.5 | 9.2 ms | 360.5 ms | 1.00x | — |
-| `wasmedge` | 723 435 | 411.9 | 411.7 | 15.7 ms | 313.7 ms | 39x | — |
-| `wazero` | 16 777 216 | 11.8 | 11.9 | 5.2 ms | 203.8 ms | 1.13x | — |
-| `wasm3` | 4 216 115 | 65.9 | 66.7 | 4.1 ms | 281.9 ms | 6.29x | — |
-| `dewasm-ruby` | 435 056 | 665.8 | 668.2 | 40.0 ms | 329.7 ms | 64x | — |
-| `dewasm-ruby-yjit` | 688 799 | 411.5 | 412.1 | 41.1 ms | 324.6 ms | 39x | — |
-| `dewasm-ruby-zjit` | 475 540 | 478.5 | 480.2 | 40.3 ms | 267.8 ms | 46x | — |
-| `dewasm-python` | 374 416 | 787.2 | 791.2 | 29.1 ms | 323.9 ms | 75x | — |
-| `dewasm-pypy` | 1 915 712 | 139.5 | 139.5 | 40.3 ms | 307.5 ms | 13x | — |
-| `dewasm-perl` | 131 072 | 2459 | 2465 | 11.2 ms | 333.5 ms | 235x | — |
-| `dewasm-go` | 25 722 013 | 10.8 | 10.8 | 3.3 ms | 280.2 ms | 1.03x | — |
-| `dewasm-java` | 3 620 267 | 55.5 | 58.2 | 66.2 ms | 267.2 ms | 5.30x | — |
-| `dewasm-bash` | 3 803 | 75121 | 75261 | 12.9 ms | 298.6 ms | 7175x | — |
-| `wasm3-ruby` | 8 331 | 31483 | 31621 | 158.9 ms | 421.1 ms | 3007x | — |
-| `wasm3-ruby-yjit` | 18 069 | 12027 | 12059 | 220.8 ms | 438.1 ms | 1149x | — |
-| `wasm3-python` | 2 638 | 107024 | 106835 | 350.9 ms | 633.2 ms | 10222x | — |
-| `wasm3-pypy` | 6 087 | 32432 | 32404 | 389.7 ms | 587.1 ms | 3097x | — |
-| `pywasm-cpython` | 3 474 | 82644 | 82560 | 43.9 ms | 331.0 ms | 7893x | 0.8 ms |
-| `pywasm-pypy` | 5 128 | 36982 | 36885 | 79.2 ms | 268.8 ms | 3532x | 4.4 ms |
-| `wardite` | 8 924 | 28101 | 28186 | 52.2 ms | 303.0 ms | 2684x | 4.1 ms |
-| `wardite-yjit` | 17 114 | 13997 | 13995 | 102.9 ms | 342.5 ms | 1337x | 9.9 ms |
+| `wasmtime` | 33 554 432 | 10.2 | 10.3 | 5.2 ms | 348.8 ms | 1.00x | — |
+| `wasmer` | 33 554 432 | 10.3 | 10.3 | 8.1 ms | 354.0 ms | 1.01x | — |
+| `wasmedge` | 761 262 | 398.1 | 398.3 | 14.1 ms | 317.2 ms | 39x | — |
+| `wazero` | 16 777 216 | 11.6 | 11.6 | 4.5 ms | 198.4 ms | 1.13x | — |
+| `wasm3` | 4 680 818 | 64.4 | 64.7 | 4.0 ms | 305.2 ms | 6.29x | — |
+| `dewasm-ruby` | 420 916 | 652.1 | 655.7 | 34.7 ms | 309.2 ms | 64x | — |
+| `dewasm-ruby-yjit` | 708 117 | 399.2 | 399.6 | 35.1 ms | 317.7 ms | 39x | — |
+| `dewasm-ruby-zjit` | 614 939 | 460.0 | 463.8 | 35.2 ms | 318.1 ms | 45x | — |
+| `dewasm-python` | 392 868 | 764.2 | 769.9 | 25.8 ms | 326.0 ms | 75x | — |
+| `dewasm-pypy` | 1 978 238 | 138.4 | 138.7 | 35.9 ms | 309.8 ms | 14x | — |
+| `dewasm-perl` | 131 072 | 2378 | 2394 | 10.7 ms | 322.4 ms | 232x | — |
+| `dewasm-go` | 33 554 432 | 10.6 | 10.6 | 2.6 ms | 357.9 ms | 1.03x | — |
+| `dewasm-java` | 3 944 469 | 53.6 | 53.5 | 58.9 ms | 270.2 ms | 5.23x | — |
+| `dewasm-bash` | 4 038 | 72936 | 73036 | 11.6 ms | 306.1 ms | 7123x | — |
+| `wasm3-ruby` | 8 645 | 31223 | 31356 | 114.4 ms | 384.3 ms | 3049x | — |
+| `wasm3-ruby-yjit` | 20 390 | 11772 | 11765 | 235.0 ms | 475.0 ms | 1150x | — |
+| `wasm3-python` | 3 429 | 86298 | 86883 | 307.9 ms | 603.8 ms | 8428x | — |
+| `wasm3-pypy` | 4 760 | 40376 | 40979 | 474.3 ms | 666.4 ms | 3943x | — |
+| `pywasm-cpython` | 3 695 | 79416 | 79488 | 38.4 ms | 331.8 ms | 7756x | 0.7 ms |
+| `pywasm-pypy` | 7 448 | 26572 | 26534 | 69.6 ms | 267.5 ms | 2595x | 4.1 ms |
+| `wardite` | 10 110 | 27025 | 27368 | 46.4 ms | 319.6 ms | 2639x | 3.5 ms |
+| `wardite-yjit` | 21 391 | 13477 | 13455 | 91.6 ms | 379.9 ms | 1316x | 8.3 ms |
 
 </details>
 
@@ -169,7 +169,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-conv-dark.svg">
-  <img alt="wat/conv: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 7.64 ns, then wasmtime at 7.67 ns; pywasm-pypy is slowest at 795 µs, a span of 104000x. The table below carries every number." src="figs/wat-conv.svg">
+  <img alt="wat/conv: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 7.51 ns, then wasmer at 7.54 ns; pywasm-pypy is slowest at 726 µs, a span of 96700x. The table below carries every number." src="figs/wat-conv.svg">
 </picture>
 
 <details>
@@ -177,28 +177,28 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 39 141 196 | 7.66 | 7.67 | 5.0 ms | 304.9 ms | 1.00x | — |
-| `wasmer` | 39 093 364 | 7.64 | 7.64 | 8.9 ms | 307.6 ms | 1.00x | — |
-| `wasmedge` | 1 317 133 | 228.0 | 228.0 | 15.5 ms | 315.8 ms | 30x | — |
-| `wazero` | 4 458 568 | 57.1 | 57.1 | 4.5 ms | 259.2 ms | 7.46x | — |
-| `wasm3` | 12 272 980 | 21.7 | 21.7 | 4.2 ms | 271.0 ms | 2.84x | — |
-| `dewasm-ruby` | 215 378 | 1367 | 1364 | 39.2 ms | 333.6 ms | 178x | — |
-| `dewasm-ruby-yjit` | 308 833 | 864.4 | 867.5 | 40.9 ms | 307.9 ms | 113x | — |
-| `dewasm-ruby-zjit` | 185 097 | 999.7 | 996.3 | 39.0 ms | 224.0 ms | 130x | — |
-| `dewasm-python` | 203 391 | 1446 | 1447 | 29.5 ms | 323.6 ms | 189x | — |
-| `dewasm-pypy` | 1 123 714 | 257.5 | 256.5 | 40.6 ms | 330.0 ms | 34x | — |
-| `dewasm-perl` | 133 640 | 2242 | 2241 | 14.8 ms | 314.4 ms | 293x | — |
-| `dewasm-go` | 33 554 432 | 10.5 | 10.5 | 2.7 ms | 356.1 ms | 1.37x | — |
-| `dewasm-java` | 10 291 101 | 18.5 | 18.5 | 67.3 ms | 257.6 ms | 2.41x | — |
-| `dewasm-bash` | 567 | 520245 | 521016 | 12.7 ms | 307.7 ms | 67910x | — |
-| `wasm3-ruby` | 22 153 | 17229 | 17444 | 154.6 ms | 536.3 ms | 2249x | — |
-| `wasm3-ruby-yjit` | 22 463 | 9076 | 9027 | 220.8 ms | 424.6 ms | 1185x | — |
-| `wasm3-python` | 5 933 | 41626 | 41317 | 338.0 ms | 585.0 ms | 5434x | — |
-| `wasm3-pypy` | 4 268 | 49354 | 49125 | 389.6 ms | 600.2 ms | 6442x | — |
-| `pywasm-cpython` | 3 083 | 101403 | 101642 | 44.6 ms | 357.2 ms | 13237x | 0.7 ms |
-| `pywasm-pypy` | 321 | 794746 | 795048 | 79.9 ms | 335.0 ms | 103743x | 3.7 ms |
-| `wardite` | 10 468 | 25919 | 26111 | 52.8 ms | 324.2 ms | 3383x | 4.1 ms |
-| `wardite-yjit` | 14 628 | 15296 | 15310 | 102.9 ms | 326.7 ms | 1997x | 9.9 ms |
+| `wasmtime` | 40 042 826 | 7.51 | 7.51 | 5.1 ms | 305.8 ms | 1.00x | — |
+| `wasmer` | 39 934 989 | 7.53 | 7.54 | 8.0 ms | 308.8 ms | 1.00x | — |
+| `wasmedge` | 1 359 832 | 221.3 | 221.4 | 14.2 ms | 315.0 ms | 29x | — |
+| `wazero` | 5 217 891 | 56.0 | 56.3 | 4.5 ms | 296.7 ms | 7.46x | — |
+| `wasm3` | 13 394 056 | 21.2 | 21.2 | 3.9 ms | 288.2 ms | 2.83x | — |
+| `dewasm-ruby` | 225 461 | 1311 | 1313 | 34.8 ms | 330.5 ms | 175x | — |
+| `dewasm-ruby-yjit` | 327 852 | 833.4 | 834.3 | 34.9 ms | 308.2 ms | 111x | — |
+| `dewasm-ruby-zjit` | 287 444 | 952.5 | 952.9 | 35.1 ms | 308.9 ms | 127x | — |
+| `dewasm-python` | 217 112 | 1379 | 1381 | 25.8 ms | 325.2 ms | 184x | — |
+| `dewasm-pypy` | 723 178 | 252.6 | 252.8 | 35.9 ms | 218.6 ms | 34x | — |
+| `dewasm-perl` | 138 082 | 2193 | 2214 | 13.6 ms | 316.3 ms | 292x | — |
+| `dewasm-go` | 33 554 432 | 10.3 | 10.3 | 2.5 ms | 349.5 ms | 1.38x | — |
+| `dewasm-java` | 11 105 278 | 18.1 | 18.1 | 60.2 ms | 261.1 ms | 2.41x | — |
+| `dewasm-bash` | 603 | 499694 | 503765 | 12.8 ms | 314.1 ms | 66541x | — |
+| `wasm3-ruby` | 21 330 | 18214 | 18415 | 114.2 ms | 502.7 ms | 2425x | — |
+| `wasm3-ruby-yjit` | 32 416 | 7812 | 7912 | 238.5 ms | 491.8 ms | 1040x | — |
+| `wasm3-python` | 7 562 | 40479 | 40642 | 311.0 ms | 617.1 ms | 5390x | — |
+| `wasm3-pypy` | 5 536 | 35268 | 34898 | 471.6 ms | 666.8 ms | 4696x | — |
+| `pywasm-cpython` | 2 976 | 98522 | 98728 | 38.5 ms | 331.7 ms | 13120x | 0.6 ms |
+| `pywasm-pypy` | 351 | 710404 | 726053 | 69.0 ms | 318.4 ms | 94601x | 3.6 ms |
+| `wardite` | 10 969 | 25273 | 25265 | 46.7 ms | 323.9 ms | 3365x | 3.5 ms |
+| `wardite-yjit` | 15 601 | 14700 | 14722 | 90.0 ms | 319.4 ms | 1957x | 8.6 ms |
 
 </details>
 
@@ -206,7 +206,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-eh-throw-dark.svg">
-  <img alt="wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.61 ns, then wasmedge at 114 ns; wasmer is slowest at 10.2 µs, a span of 2220x. The table below carries every number." src="figs/wat-eh-throw.svg">
+  <img alt="wat/eh_throw: seconds per iteration for 11 runners on a log scale, fastest first. dewasm-pypy is fastest at 4.26 ns, then wasmedge at 112 ns; wasmer is slowest at 9.96 µs, a span of 2340x. The table below carries every number." src="figs/wat-eh-throw.svg">
 </picture>
 
 <details>
@@ -214,17 +214,17 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 1 321 919 | 221.2 | 221.1 | 5.5 ms | 297.9 ms | 1.00x | — |
-| `wasmer` | 21 505 | 10214 | 10217 | 9.0 ms | 228.7 ms | 46x | — |
-| `wasmedge` | 2 249 852 | 113.9 | 113.8 | 15.6 ms | 271.9 ms | 0.51x | — |
-| `dewasm-ruby` | 400 463 | 630.4 | 634.3 | 39.4 ms | 291.9 ms | 2.85x | — |
-| `dewasm-ruby-yjit` | 430 841 | 462.4 | 471.4 | 40.9 ms | 240.1 ms | 2.09x | — |
-| `dewasm-ruby-zjit` | 455 002 | 608.9 | 610.8 | 39.5 ms | 316.5 ms | 2.75x | — |
-| `dewasm-python` | 442 140 | 668.1 | 668.7 | 28.8 ms | 324.2 ms | 3.02x | — |
-| `dewasm-pypy` | 4 000 000 | 4.75 | 4.61 | 39.3 ms | 58.2 ms | 0.02x | — |
-| `dewasm-perl` | 255 611 | 1177 | 1187 | 11.3 ms | 312.2 ms | 5.32x | — |
-| `dewasm-go` | 1 041 645 | 200.4 | 198.9 | 3.2 ms | 212.0 ms | 0.91x | — |
-| `dewasm-java` | 321 098 | 560.5 | 551.1 | 64.2 ms | 244.2 ms | 2.53x | — |
+| `wasmtime` | 1 376 525 | 214.2 | 217.0 | 5.1 ms | 299.9 ms | 1.00x | — |
+| `wasmer` | 28 628 | 9951 | 9956 | 8.0 ms | 292.8 ms | 46x | — |
+| `wasmedge` | 2 710 245 | 111.1 | 112.0 | 14.1 ms | 315.2 ms | 0.52x | — |
+| `dewasm-ruby` | 474 641 | 609.5 | 618.6 | 34.6 ms | 323.9 ms | 2.85x | — |
+| `dewasm-ruby-yjit` | 490 564 | 449.5 | 461.1 | 35.0 ms | 255.6 ms | 2.10x | — |
+| `dewasm-ruby-zjit` | 496 372 | 587.7 | 594.2 | 35.1 ms | 326.8 ms | 2.74x | — |
+| `dewasm-python` | 460 195 | 655.6 | 656.9 | 25.8 ms | 327.5 ms | 3.06x | — |
+| `dewasm-pypy` | 4 000 000 | 4.30 | 4.26 | 35.5 ms | 52.7 ms | 0.02x | — |
+| `dewasm-perl` | 261 333 | 1154 | 1166 | 10.7 ms | 312.3 ms | 5.39x | — |
+| `dewasm-go` | 1 504 226 | 193.3 | 193.6 | 2.4 ms | 293.2 ms | 0.90x | — |
+| `dewasm-java` | 423 986 | 507.5 | 508.9 | 59.9 ms | 275.1 ms | 2.37x | — |
 
 </details>
 
@@ -232,7 +232,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-eh-try-dark.svg">
-  <img alt="wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.27 ns, then dewasm-java at 1.43 ns; dewasm-perl is slowest at 515 ns, a span of 406x. The table below carries every number." src="figs/wat-eh-try.svg">
+  <img alt="wat/eh_try: seconds per iteration for 11 runners on a log scale, fastest first. wasmer is fastest at 1.25 ns, then dewasm-java at 1.41 ns; dewasm-perl is slowest at 506 ns, a span of 406x. The table below carries every number." src="figs/wat-eh-try.svg">
 </picture>
 
 <details>
@@ -240,17 +240,17 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 106 710 677 | 2.78 | 2.78 | 5.6 ms | 301.8 ms | 1.00x | — |
-| `wasmer` | 235 152 025 | 1.27 | 1.27 | 9.4 ms | 307.5 ms | 0.46x | — |
-| `wasmedge` | 2 635 760 | 114.8 | 115.1 | 16.0 ms | 318.6 ms | 41x | — |
-| `dewasm-ruby` | 2 284 539 | 121.4 | 121.5 | 39.7 ms | 317.0 ms | 44x | — |
-| `dewasm-ruby-yjit` | 2 223 097 | 121.9 | 122.5 | 39.9 ms | 310.9 ms | 44x | — |
-| `dewasm-ruby-zjit` | 2 771 590 | 121.5 | 121.5 | 40.6 ms | 377.4 ms | 44x | — |
-| `dewasm-python` | 1 439 446 | 197.7 | 197.8 | 29.3 ms | 313.9 ms | 71x | — |
-| `dewasm-pypy` | 103 860 134 | 2.60 | 2.61 | 40.7 ms | 311.1 ms | 0.94x | — |
-| `dewasm-perl` | 577 933 | 515.4 | 515.0 | 10.6 ms | 308.5 ms | 186x | — |
-| `dewasm-go` | 62 254 918 | 4.26 | 4.25 | 3.2 ms | 268.3 ms | 1.53x | — |
-| `dewasm-java` | 232 371 486 | 1.43 | 1.43 | 67.3 ms | 400.0 ms | 0.52x | — |
+| `wasmtime` | 110 122 947 | 2.73 | 2.72 | 5.1 ms | 305.2 ms | 1.00x | — |
+| `wasmer` | 236 489 418 | 1.25 | 1.25 | 7.8 ms | 302.6 ms | 0.46x | — |
+| `wasmedge` | 2 622 853 | 112.3 | 112.4 | 14.0 ms | 308.6 ms | 41x | — |
+| `dewasm-ruby` | 2 451 420 | 119.1 | 119.3 | 34.6 ms | 326.5 ms | 44x | — |
+| `dewasm-ruby-yjit` | 2 515 871 | 120.4 | 120.6 | 34.9 ms | 337.7 ms | 44x | — |
+| `dewasm-ruby-zjit` | 2 547 973 | 119.9 | 119.6 | 35.2 ms | 340.6 ms | 44x | — |
+| `dewasm-python` | 1 527 977 | 194.9 | 198.0 | 25.7 ms | 323.5 ms | 72x | — |
+| `dewasm-pypy` | 114 891 453 | 2.55 | 2.55 | 35.6 ms | 328.3 ms | 0.93x | — |
+| `dewasm-perl` | 595 735 | 502.5 | 505.5 | 9.9 ms | 309.2 ms | 184x | — |
+| `dewasm-go` | 73 850 197 | 4.13 | 4.22 | 2.6 ms | 307.4 ms | 1.51x | — |
+| `dewasm-java` | 208 221 136 | 1.41 | 1.41 | 59.3 ms | 352.8 ms | 0.52x | — |
 
 </details>
 
@@ -258,7 +258,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-f32-alu-dark.svg">
-  <img alt="wat/f32_alu: seconds per iteration for 20 runners on a log scale, fastest first. wazero is fastest at 0.96 ns, then wasmtime at 1.00 ns; dewasm-bash is slowest at 1.21 ms, a span of 1260000x. The table below carries every number." src="figs/wat-f32-alu.svg">
+  <img alt="wat/f32_alu: seconds per iteration for 20 runners on a log scale, fastest first. wazero is fastest at 0.94 ns, then wasmtime at 0.98 ns; dewasm-bash is slowest at 1.16 ms, a span of 1240000x. The table below carries every number." src="figs/wat-f32-alu.svg">
 </picture>
 
 <details>
@@ -266,26 +266,26 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 280 698 883 | 1.00 | 1.00 | 5.2 ms | 286.6 ms | 1.00x | — |
-| `wasmer` | 290 391 634 | 1.00 | 1.00 | 9.0 ms | 299.1 ms | 1.00x | — |
-| `wasmedge` | 3 175 480 | 79.0 | 79.0 | 15.7 ms | 266.6 ms | 79x | — |
-| `wazero` | 303 213 828 | 0.96 | 0.96 | 4.7 ms | 295.4 ms | 0.96x | — |
-| `wasm3` | 42 223 961 | 7.01 | 7.00 | 3.9 ms | 299.9 ms | 6.99x | — |
-| `dewasm-ruby` | 832 283 | 362.2 | 362.9 | 41.0 ms | 342.4 ms | 361x | — |
-| `dewasm-ruby-yjit` | 1 186 483 | 227.1 | 226.9 | 40.1 ms | 309.5 ms | 227x | — |
-| `dewasm-ruby-zjit` | 805 841 | 280.9 | 280.9 | 39.5 ms | 265.9 ms | 280x | — |
-| `dewasm-python` | 530 383 | 541.8 | 541.0 | 29.3 ms | 316.7 ms | 540x | — |
-| `dewasm-pypy` | 49 140 324 | 5.54 | 5.55 | 40.6 ms | 312.8 ms | 5.53x | — |
-| `dewasm-perl` | 191 797 | 1538 | 1532 | 10.4 ms | 305.4 ms | 1534x | — |
-| `dewasm-go` | 76 869 252 | 3.48 | 3.48 | 3.8 ms | 271.6 ms | 3.48x | — |
-| `dewasm-java` | 200 010 216 | 1.64 | 1.64 | 66.4 ms | 394.4 ms | 1.64x | — |
-| `dewasm-bash` | 191 | 1204096 | 1206844 | 12.8 ms | 242.8 ms | 1201098x | — |
-| `wasm3-ruby` | 65 536 | 5356 | 5362 | 153.7 ms | 504.7 ms | 5342x | — |
-| `wasm3-ruby-yjit` | 179 080 | 1856 | 1855 | 209.3 ms | 541.7 ms | 1852x | — |
-| `wasm3-python` | 21 740 | 14043 | 14020 | 336.3 ms | 641.6 ms | 14008x | — |
-| `wasm3-pypy` | 64 624 | 3217 | 3220 | 384.2 ms | 592.1 ms | 3209x | — |
-| `pywasm-cpython` | 9 553 | 29180 | 29245 | 43.2 ms | 322.0 ms | 29108x | 0.7 ms |
-| `pywasm-pypy` | 38 048 | 6158 | 6168 | 78.2 ms | 312.5 ms | 6143x | 3.2 ms |
+| `wasmtime` | 303 074 129 | 0.98 | 0.99 | 4.9 ms | 303.0 ms | 1.00x | — |
+| `wasmer` | 303 555 463 | 0.98 | 0.99 | 8.0 ms | 306.6 ms | 1.00x | — |
+| `wasmedge` | 3 458 870 | 78.1 | 78.1 | 14.1 ms | 284.1 ms | 79x | — |
+| `wazero` | 319 029 219 | 0.94 | 0.94 | 4.6 ms | 304.1 ms | 0.95x | — |
+| `wasm3` | 43 912 660 | 6.87 | 6.87 | 4.0 ms | 305.8 ms | 6.99x | — |
+| `dewasm-ruby` | 839 681 | 357.8 | 357.7 | 34.8 ms | 335.2 ms | 364x | — |
+| `dewasm-ruby-yjit` | 1 279 059 | 222.9 | 222.6 | 35.2 ms | 320.3 ms | 227x | — |
+| `dewasm-ruby-zjit` | 1 017 492 | 274.5 | 274.9 | 35.1 ms | 314.3 ms | 279x | — |
+| `dewasm-python` | 560 975 | 537.7 | 538.1 | 26.0 ms | 327.6 ms | 547x | — |
+| `dewasm-pypy` | 51 030 231 | 5.42 | 5.42 | 35.8 ms | 312.4 ms | 5.51x | — |
+| `dewasm-perl` | 199 606 | 1508 | 1527 | 9.9 ms | 310.9 ms | 1533x | — |
+| `dewasm-go` | 87 970 797 | 3.42 | 3.42 | 2.7 ms | 303.8 ms | 3.48x | — |
+| `dewasm-java` | 178 975 442 | 1.62 | 1.62 | 60.0 ms | 349.2 ms | 1.64x | — |
+| `dewasm-bash` | 162 | 1163938 | 1162900 | 11.7 ms | 200.2 ms | 1183411x | — |
+| `wasm3-ruby` | 47 000 | 6253 | 6240 | 112.5 ms | 406.4 ms | 6358x | — |
+| `wasm3-ruby-yjit` | 125 035 | 2069 | 2060 | 217.7 ms | 476.4 ms | 2104x | — |
+| `wasm3-python` | 19 886 | 14430 | 14480 | 307.1 ms | 594.1 ms | 14671x | — |
+| `wasm3-pypy` | 121 778 | 2458 | 2462 | 468.8 ms | 768.1 ms | 2499x | — |
+| `pywasm-cpython` | 10 049 | 28268 | 28282 | 38.3 ms | 322.3 ms | 28741x | 0.6 ms |
+| `pywasm-pypy` | 33 756 | 6144 | 6153 | 69.0 ms | 276.4 ms | 6247x | 3.1 ms |
 
 </details>
 
@@ -293,7 +293,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-f64-alu-dark.svg">
-  <img alt="wat/f64_alu: seconds per iteration for 22 runners on a log scale, fastest first. wazero is fastest at 0.97 ns, then wasmer at 0.98 ns; dewasm-bash is slowest at 578 µs, a span of 599000x. The table below carries every number." src="figs/wat-f64-alu.svg">
+  <img alt="wat/f64_alu: seconds per iteration for 22 runners on a log scale, fastest first. wazero is fastest at 0.95 ns, then wasmtime at 0.96 ns; dewasm-bash is slowest at 561 µs, a span of 588000x. The table below carries every number." src="figs/wat-f64-alu.svg">
 </picture>
 
 <details>
@@ -301,28 +301,28 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 312 833 484 | 0.98 | 0.98 | 5.4 ms | 311.2 ms | 1.00x | — |
-| `wasmer` | 305 968 246 | 0.98 | 0.98 | 9.0 ms | 308.3 ms | 1.00x | — |
-| `wasmedge` | 3 419 021 | 79.2 | 79.0 | 15.6 ms | 286.3 ms | 81x | — |
-| `wazero` | 302 242 260 | 0.96 | 0.97 | 5.0 ms | 296.4 ms | 0.99x | — |
-| `wasm3` | 55 393 303 | 5.41 | 5.40 | 4.2 ms | 304.1 ms | 5.54x | — |
-| `dewasm-ruby` | 2 939 163 | 102.2 | 102.0 | 39.1 ms | 339.5 ms | 105x | — |
-| `dewasm-ruby-yjit` | 3 893 067 | 75.2 | 75.8 | 40.0 ms | 332.7 ms | 77x | — |
-| `dewasm-ruby-zjit` | 3 808 571 | 81.7 | 82.5 | 40.3 ms | 351.3 ms | 84x | — |
-| `dewasm-python` | 2 355 738 | 151.3 | 151.6 | 30.0 ms | 386.4 ms | 155x | — |
-| `dewasm-pypy` | 127 247 474 | 2.15 | 2.15 | 40.8 ms | 314.9 ms | 2.20x | — |
-| `dewasm-perl` | 357 962 | 831.3 | 830.9 | 14.8 ms | 312.4 ms | 851x | — |
-| `dewasm-go` | 71 050 685 | 3.52 | 3.52 | 2.7 ms | 252.9 ms | 3.60x | — |
-| `dewasm-java` | 104 920 190 | 1.71 | 1.71 | 62.3 ms | 241.7 ms | 1.75x | — |
-| `dewasm-bash` | 516 | 577997 | 578211 | 12.9 ms | 311.2 ms | 591389x | — |
-| `wasm3-ruby` | 65 442 | 4529 | 4570 | 153.1 ms | 449.5 ms | 4634x | — |
-| `wasm3-ruby-yjit` | 114 552 | 1583 | 1593 | 208.7 ms | 390.1 ms | 1620x | — |
-| `wasm3-python` | 23 080 | 12568 | 12557 | 337.6 ms | 627.7 ms | 12860x | — |
-| `wasm3-pypy` | 84 158 | 2694 | 2682 | 386.6 ms | 613.4 ms | 2757x | — |
-| `pywasm-cpython` | 10 149 | 29695 | 29637 | 42.2 ms | 343.6 ms | 30383x | 0.6 ms |
-| `pywasm-pypy` | 24 726 | 7759 | 7719 | 78.2 ms | 270.1 ms | 7939x | 3.6 ms |
-| `wardite` | 42 335 | 7625 | 7640 | 53.0 ms | 375.8 ms | 7802x | 3.9 ms |
-| `wardite-yjit` | 56 468 | 3588 | 3548 | 104.4 ms | 307.0 ms | 3671x | 9.5 ms |
+| `wasmtime` | 309 722 106 | 0.96 | 0.96 | 4.8 ms | 302.2 ms | 1.00x | — |
+| `wasmer` | 310 531 849 | 0.96 | 0.97 | 7.9 ms | 307.1 ms | 1.00x | — |
+| `wasmedge` | 3 762 387 | 77.1 | 76.9 | 14.1 ms | 304.2 ms | 80x | — |
+| `wazero` | 312 611 669 | 0.95 | 0.95 | 4.3 ms | 301.8 ms | 0.99x | — |
+| `wasm3` | 57 022 852 | 5.30 | 5.32 | 4.0 ms | 306.0 ms | 5.52x | — |
+| `dewasm-ruby` | 3 083 361 | 100.6 | 100.9 | 34.6 ms | 344.7 ms | 105x | — |
+| `dewasm-ruby-yjit` | 4 179 925 | 74.0 | 74.1 | 35.4 ms | 344.7 ms | 77x | — |
+| `dewasm-ruby-zjit` | 3 621 106 | 81.2 | 82.0 | 35.2 ms | 329.3 ms | 85x | — |
+| `dewasm-python` | 1 602 770 | 150.1 | 150.0 | 25.8 ms | 266.3 ms | 156x | — |
+| `dewasm-pypy` | 138 501 581 | 2.11 | 2.12 | 35.9 ms | 328.3 ms | 2.20x | — |
+| `dewasm-perl` | 369 755 | 810.6 | 821.0 | 13.6 ms | 313.3 ms | 844x | — |
+| `dewasm-go` | 87 154 116 | 3.45 | 3.45 | 2.5 ms | 302.8 ms | 3.59x | — |
+| `dewasm-java` | 182 196 682 | 1.61 | 1.61 | 60.2 ms | 352.9 ms | 1.67x | — |
+| `dewasm-bash` | 535 | 561158 | 561266 | 11.8 ms | 312.0 ms | 584494x | — |
+| `wasm3-ruby` | 58 497 | 5458 | 5530 | 113.8 ms | 433.1 ms | 5685x | — |
+| `wasm3-ruby-yjit` | 165 520 | 1691 | 1691 | 218.4 ms | 498.4 ms | 1762x | — |
+| `wasm3-python` | 54 626 | 13189 | 13194 | 310.0 ms | 1.03 s | 13737x | — |
+| `wasm3-pypy` | 111 750 | 2027 | 2018 | 469.5 ms | 696.1 ms | 2112x | — |
+| `pywasm-cpython` | 10 362 | 28512 | 28542 | 38.5 ms | 333.9 ms | 29698x | 0.6 ms |
+| `pywasm-pypy` | 44 700 | 5176 | 5206 | 69.0 ms | 300.4 ms | 5391x | 3.2 ms |
+| `wardite` | 37 254 | 7368 | 7369 | 46.6 ms | 321.1 ms | 7674x | 3.5 ms |
+| `wardite-yjit` | 83 370 | 3431 | 3427 | 94.5 ms | 380.5 ms | 3574x | 8.2 ms |
 
 </details>
 
@@ -330,7 +330,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-i32-alu-dark.svg">
-  <img alt="wat/i32_alu: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 2.32 ns, then wasmer at 2.32 ns; pywasm-cpython is slowest at 54.2 µs, a span of 23400x. The table below carries every number." src="figs/wat-i32-alu.svg">
+  <img alt="wat/i32_alu: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 2.28 ns, then wasmer at 2.29 ns; pywasm-cpython is slowest at 52.7 µs, a span of 23100x. The table below carries every number." src="figs/wat-i32-alu.svg">
 </picture>
 
 <details>
@@ -338,28 +338,28 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 125 909 648 | 2.32 | 2.32 | 5.1 ms | 297.7 ms | 1.00x | — |
-| `wasmer` | 128 404 565 | 2.32 | 2.32 | 9.2 ms | 307.3 ms | 1.00x | — |
-| `wasmedge` | 1 751 609 | 151.9 | 151.6 | 15.5 ms | 281.6 ms | 65x | — |
-| `wazero` | 112 657 465 | 2.67 | 2.67 | 5.1 ms | 306.1 ms | 1.15x | — |
-| `wasm3` | 15 248 317 | 13.0 | 13.1 | 4.5 ms | 202.5 ms | 5.58x | — |
-| `dewasm-ruby` | 1 602 740 | 184.4 | 184.8 | 39.1 ms | 334.7 ms | 79x | — |
-| `dewasm-ruby-yjit` | 2 365 102 | 137.7 | 137.8 | 41.2 ms | 366.8 ms | 59x | — |
-| `dewasm-ruby-zjit` | 1 702 710 | 151.6 | 151.7 | 39.0 ms | 297.1 ms | 65x | — |
-| `dewasm-python` | 516 029 | 563.3 | 562.5 | 29.5 ms | 320.2 ms | 242x | — |
-| `dewasm-pypy` | 28 507 321 | 9.59 | 9.62 | 40.1 ms | 313.5 ms | 4.13x | — |
-| `dewasm-perl` | 422 668 | 692.0 | 690.8 | 10.6 ms | 303.0 ms | 298x | — |
-| `dewasm-go` | 85 678 303 | 3.05 | 3.06 | 3.7 ms | 265.3 ms | 1.31x | — |
-| `dewasm-java` | 123 953 808 | 2.36 | 2.34 | 65.4 ms | 357.8 ms | 1.01x | — |
-| `dewasm-bash` | 11 609 | 25075 | 25065 | 13.3 ms | 304.4 ms | 10788x | — |
-| `wasm3-ruby` | 31 074 | 9296 | 9322 | 153.2 ms | 442.1 ms | 3999x | — |
-| `wasm3-ruby-yjit` | 75 528 | 3629 | 3625 | 217.7 ms | 491.8 ms | 1561x | — |
-| `wasm3-python` | 9 432 | 25499 | 25663 | 341.0 ms | 581.5 ms | 10970x | — |
-| `wasm3-pypy` | 28 118 | 8073 | 8106 | 386.4 ms | 613.4 ms | 3473x | — |
-| `pywasm-cpython` | 5 206 | 54256 | 54228 | 43.2 ms | 325.6 ms | 23343x | 0.7 ms |
-| `pywasm-pypy` | 6 026 | 29619 | 29477 | 81.9 ms | 260.4 ms | 12743x | 3.9 ms |
-| `wardite` | 15 728 | 15278 | 15355 | 53.1 ms | 293.4 ms | 6573x | 4.6 ms |
-| `wardite-yjit` | 29 146 | 6898 | 6922 | 101.2 ms | 302.2 ms | 2968x | 9.5 ms |
+| `wasmtime` | 131 671 637 | 2.28 | 2.28 | 4.9 ms | 305.5 ms | 1.00x | — |
+| `wasmer` | 131 513 515 | 2.28 | 2.29 | 8.0 ms | 308.3 ms | 1.00x | — |
+| `wasmedge` | 2 056 604 | 147.4 | 147.8 | 14.1 ms | 317.3 ms | 65x | — |
+| `wazero` | 115 104 499 | 2.62 | 2.62 | 4.4 ms | 305.8 ms | 1.15x | — |
+| `wasm3` | 16 777 216 | 12.8 | 12.8 | 3.9 ms | 217.9 ms | 5.59x | — |
+| `dewasm-ruby` | 1 675 249 | 180.2 | 181.7 | 34.7 ms | 336.6 ms | 79x | — |
+| `dewasm-ruby-yjit` | 2 190 852 | 136.3 | 137.0 | 35.2 ms | 333.9 ms | 60x | — |
+| `dewasm-ruby-zjit` | 1 912 475 | 148.2 | 148.8 | 34.9 ms | 318.3 ms | 65x | — |
+| `dewasm-python` | 548 200 | 550.5 | 554.8 | 25.7 ms | 327.5 ms | 241x | — |
+| `dewasm-pypy` | 30 309 930 | 9.41 | 9.42 | 35.7 ms | 320.9 ms | 4.12x | — |
+| `dewasm-perl` | 444 661 | 675.0 | 682.0 | 9.9 ms | 310.1 ms | 296x | — |
+| `dewasm-go` | 99 371 466 | 3.01 | 3.01 | 2.5 ms | 302.0 ms | 1.32x | — |
+| `dewasm-java` | 133 502 140 | 2.29 | 2.29 | 60.1 ms | 365.7 ms | 1.00x | — |
+| `dewasm-bash` | 12 121 | 24552 | 24598 | 11.9 ms | 309.5 ms | 10754x | — |
+| `wasm3-ruby` | 26 526 | 10923 | 10916 | 112.8 ms | 402.5 ms | 4784x | — |
+| `wasm3-ruby-yjit` | 73 092 | 3799 | 3785 | 233.6 ms | 511.3 ms | 1664x | — |
+| `wasm3-python` | 20 313 | 26265 | 26582 | 309.2 ms | 842.7 ms | 11504x | — |
+| `wasm3-pypy` | 26 535 | 6994 | 7148 | 471.8 ms | 657.4 ms | 3064x | — |
+| `pywasm-cpython` | 5 519 | 52638 | 52669 | 38.5 ms | 329.0 ms | 23055x | 0.6 ms |
+| `pywasm-pypy` | 14 028 | 15861 | 15861 | 71.2 ms | 293.7 ms | 6947x | 3.4 ms |
+| `wardite` | 17 510 | 14878 | 14982 | 47.0 ms | 307.5 ms | 6516x | 3.5 ms |
+| `wardite-yjit` | 31 422 | 6817 | 6834 | 90.8 ms | 305.0 ms | 2986x | 8.0 ms |
 
 </details>
 
@@ -367,7 +367,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-i32-div-dark.svg">
-  <img alt="wat/i32_div: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 7.66 ns, then wasmer at 7.67 ns; dewasm-bash is slowest at 68.2 µs, a span of 8910x. The table below carries every number." src="figs/wat-i32-div.svg">
+  <img alt="wat/i32_div: seconds per iteration for 22 runners on a log scale, fastest first. wazero is fastest at 7.53 ns, then wasmtime at 7.55 ns; dewasm-bash is slowest at 67.1 µs, a span of 8910x. The table below carries every number." src="figs/wat-i32-div.svg">
 </picture>
 
 <details>
@@ -375,28 +375,28 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 39 310 654 | 7.65 | 7.66 | 5.5 ms | 306.4 ms | 1.00x | — |
-| `wasmer` | 38 898 318 | 7.64 | 7.67 | 8.8 ms | 306.1 ms | 1.00x | — |
-| `wasmedge` | 1 624 300 | 181.2 | 181.3 | 15.8 ms | 310.2 ms | 24x | — |
-| `wazero` | 39 140 777 | 7.67 | 7.68 | 5.4 ms | 305.7 ms | 1.00x | — |
-| `wasm3` | 13 119 225 | 15.8 | 15.8 | 4.1 ms | 211.4 ms | 2.06x | — |
-| `dewasm-ruby` | 745 314 | 367.2 | 367.1 | 39.7 ms | 313.3 ms | 48x | — |
-| `dewasm-ruby-yjit` | 1 622 501 | 185.7 | 187.2 | 40.7 ms | 342.1 ms | 24x | — |
-| `dewasm-ruby-zjit` | 933 732 | 240.5 | 241.8 | 40.2 ms | 264.7 ms | 31x | — |
-| `dewasm-python` | 304 998 | 973.5 | 974.1 | 30.2 ms | 327.1 ms | 127x | — |
-| `dewasm-pypy` | 12 959 713 | 14.2 | 14.2 | 39.7 ms | 224.1 ms | 1.86x | — |
-| `dewasm-perl` | 246 418 | 1214 | 1218 | 11.6 ms | 310.8 ms | 159x | — |
-| `dewasm-go` | 36 409 793 | 7.68 | 7.68 | 3.4 ms | 283.1 ms | 1.00x | — |
-| `dewasm-java` | 29 107 804 | 7.91 | 7.90 | 67.4 ms | 297.5 ms | 1.03x | — |
-| `dewasm-bash` | 4 203 | 68435 | 68217 | 12.7 ms | 300.4 ms | 8941x | — |
-| `wasm3-ruby` | 17 417 | 11749 | 11727 | 153.5 ms | 358.1 ms | 1535x | — |
-| `wasm3-ruby-yjit` | 56 016 | 4657 | 4663 | 214.3 ms | 475.2 ms | 608x | — |
-| `wasm3-python` | 10 078 | 31240 | 31572 | 340.1 ms | 654.9 ms | 4082x | — |
-| `wasm3-pypy` | 16 576 | 12645 | 12559 | 389.3 ms | 598.9 ms | 1652x | — |
-| `pywasm-cpython` | 4 011 | 61492 | 61234 | 43.6 ms | 290.2 ms | 8034x | 0.7 ms |
-| `pywasm-pypy` | 4 032 | 47605 | 47464 | 78.8 ms | 270.8 ms | 6220x | 3.6 ms |
-| `wardite` | 15 238 | 18102 | 18266 | 52.9 ms | 328.8 ms | 2365x | 3.7 ms |
-| `wardite-yjit` | 32 894 | 8493 | 8514 | 101.3 ms | 380.7 ms | 1110x | 10.0 ms |
+| `wasmtime` | 40 050 301 | 7.53 | 7.55 | 4.9 ms | 306.4 ms | 1.00x | — |
+| `wasmer` | 40 159 084 | 7.53 | 7.57 | 8.2 ms | 310.6 ms | 1.00x | — |
+| `wasmedge` | 1 714 168 | 178.0 | 179.1 | 14.3 ms | 319.4 ms | 24x | — |
+| `wazero` | 39 514 012 | 7.53 | 7.53 | 4.4 ms | 302.0 ms | 1.00x | — |
+| `wasm3` | 16 777 216 | 15.5 | 15.6 | 3.9 ms | 264.3 ms | 2.06x | — |
+| `dewasm-ruby` | 806 591 | 362.8 | 368.8 | 35.0 ms | 327.6 ms | 48x | — |
+| `dewasm-ruby-yjit` | 1 304 573 | 193.0 | 194.2 | 35.6 ms | 287.5 ms | 26x | — |
+| `dewasm-ruby-zjit` | 822 294 | 238.6 | 239.2 | 35.4 ms | 231.7 ms | 32x | — |
+| `dewasm-python` | 286 040 | 962.6 | 973.6 | 26.1 ms | 301.4 ms | 128x | — |
+| `dewasm-pypy` | 13 730 730 | 13.9 | 13.9 | 35.9 ms | 226.9 ms | 1.85x | — |
+| `dewasm-perl` | 248 573 | 1196 | 1204 | 10.1 ms | 307.4 ms | 159x | — |
+| `dewasm-go` | 39 698 098 | 7.58 | 7.59 | 2.5 ms | 303.5 ms | 1.01x | — |
+| `dewasm-java` | 23 905 571 | 7.91 | 7.93 | 60.5 ms | 249.7 ms | 1.05x | — |
+| `dewasm-bash` | 4 357 | 67025 | 67131 | 11.5 ms | 303.5 ms | 8903x | — |
+| `wasm3-ruby` | 16 332 | 13591 | 13503 | 113.2 ms | 335.2 ms | 1805x | — |
+| `wasm3-ruby-yjit` | 44 309 | 5149 | 5188 | 227.4 ms | 455.5 ms | 684x | — |
+| `wasm3-python` | 9 220 | 32267 | 32508 | 308.4 ms | 605.9 ms | 4286x | — |
+| `wasm3-pypy` | 27 298 | 7881 | 7882 | 470.5 ms | 685.6 ms | 1047x | — |
+| `pywasm-cpython` | 4 855 | 60300 | 60580 | 38.3 ms | 331.1 ms | 8010x | 0.6 ms |
+| `pywasm-pypy` | 9 760 | 21399 | 21432 | 69.7 ms | 278.5 ms | 2842x | 3.4 ms |
+| `wardite` | 14 812 | 17798 | 17841 | 46.6 ms | 310.2 ms | 2364x | 3.4 ms |
+| `wardite-yjit` | 27 205 | 8384 | 8482 | 91.0 ms | 319.0 ms | 1114x | 8.0 ms |
 
 </details>
 
@@ -404,7 +404,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-i64-alu-dark.svg">
-  <img alt="wat/i64_alu: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 2.33 ns, then wasmer at 2.33 ns; pywasm-pypy is slowest at 408 µs, a span of 175000x. The table below carries every number." src="figs/wat-i64-alu.svg">
+  <img alt="wat/i64_alu: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 2.29 ns, then wasmer at 2.30 ns; pywasm-pypy is slowest at 286 µs, a span of 125000x. The table below carries every number." src="figs/wat-i64-alu.svg">
 </picture>
 
 <details>
@@ -412,28 +412,28 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 128 742 317 | 2.33 | 2.33 | 5.7 ms | 305.6 ms | 1.00x | — |
-| `wasmer` | 129 557 406 | 2.33 | 2.33 | 9.4 ms | 311.2 ms | 1.00x | — |
-| `wasmedge` | 1 967 678 | 151.8 | 151.8 | 15.6 ms | 314.3 ms | 65x | — |
-| `wazero` | 112 940 596 | 2.67 | 2.67 | 5.1 ms | 306.2 ms | 1.14x | — |
-| `wasm3` | 16 777 216 | 12.1 | 12.1 | 4.5 ms | 207.0 ms | 5.18x | — |
-| `dewasm-ruby` | 235 760 | 1260 | 1273 | 39.8 ms | 336.8 ms | 541x | — |
-| `dewasm-ruby-yjit` | 258 973 | 953.4 | 954.2 | 39.3 ms | 286.2 ms | 409x | — |
-| `dewasm-ruby-zjit` | 266 250 | 1024 | 1029 | 40.8 ms | 313.6 ms | 440x | — |
-| `dewasm-python` | 459 986 | 614.5 | 616.1 | 29.1 ms | 311.8 ms | 264x | — |
-| `dewasm-pypy` | 1 028 338 | 220.3 | 222.7 | 40.2 ms | 266.7 ms | 95x | — |
-| `dewasm-perl` | 299 368 | 1001 | 1001 | 10.9 ms | 310.5 ms | 429x | — |
-| `dewasm-go` | 96 940 225 | 2.63 | 2.62 | 3.7 ms | 258.8 ms | 1.13x | — |
-| `dewasm-java` | 87 673 825 | 2.35 | 2.35 | 67.4 ms | 273.1 ms | 1.01x | — |
-| `dewasm-bash` | 9 690 | 27581 | 27553 | 13.7 ms | 280.9 ms | 11839x | — |
-| `wasm3-ruby` | 28 128 | 10602 | 10531 | 153.3 ms | 451.5 ms | 4551x | — |
-| `wasm3-ruby-yjit` | 48 196 | 4914 | 4924 | 217.3 ms | 454.1 ms | 2109x | — |
-| `wasm3-python` | 9 691 | 25191 | 25094 | 339.8 ms | 583.9 ms | 10813x | — |
-| `wasm3-pypy` | 15 988 | 11941 | 11903 | 390.4 ms | 581.3 ms | 5125x | — |
-| `pywasm-cpython` | 5 260 | 58273 | 58157 | 44.9 ms | 351.4 ms | 25013x | 0.7 ms |
-| `pywasm-pypy` | 455 | 408852 | 408203 | 82.4 ms | 268.5 ms | 175493x | 3.7 ms |
-| `wardite` | 12 205 | 16651 | 16708 | 53.5 ms | 256.7 ms | 7147x | 4.3 ms |
-| `wardite-yjit` | 30 900 | 9208 | 9239 | 101.4 ms | 386.0 ms | 3952x | 9.5 ms |
+| `wasmtime` | 131 932 944 | 2.29 | 2.29 | 5.1 ms | 307.3 ms | 1.00x | — |
+| `wasmer` | 131 695 323 | 2.29 | 2.30 | 8.3 ms | 309.6 ms | 1.00x | — |
+| `wasmedge` | 2 037 678 | 149.1 | 149.7 | 14.1 ms | 317.8 ms | 65x | — |
+| `wazero` | 112 301 993 | 2.60 | 2.61 | 4.9 ms | 297.3 ms | 1.14x | — |
+| `wasm3` | 16 777 216 | 11.8 | 11.8 | 3.9 ms | 202.1 ms | 5.16x | — |
+| `dewasm-ruby` | 242 355 | 1228 | 1222 | 35.1 ms | 332.6 ms | 536x | — |
+| `dewasm-ruby-yjit` | 309 953 | 939.1 | 940.2 | 35.0 ms | 326.0 ms | 410x | — |
+| `dewasm-ruby-zjit` | 251 132 | 998.0 | 1004 | 35.1 ms | 285.7 ms | 436x | — |
+| `dewasm-python` | 479 435 | 615.9 | 626.8 | 25.6 ms | 320.9 ms | 269x | — |
+| `dewasm-pypy` | 1 107 302 | 216.9 | 220.5 | 35.6 ms | 275.8 ms | 95x | — |
+| `dewasm-perl` | 302 703 | 975.2 | 980.3 | 9.9 ms | 305.1 ms | 426x | — |
+| `dewasm-go` | 115 816 204 | 2.59 | 2.59 | 2.5 ms | 302.0 ms | 1.13x | — |
+| `dewasm-java` | 79 902 297 | 2.34 | 2.33 | 60.1 ms | 246.9 ms | 1.02x | — |
+| `dewasm-bash` | 8 274 | 26986 | 27067 | 12.2 ms | 235.5 ms | 11779x | — |
+| `wasm3-ruby` | 27 258 | 11865 | 11978 | 114.3 ms | 437.7 ms | 5179x | — |
+| `wasm3-ruby-yjit` | 53 063 | 5024 | 5056 | 233.8 ms | 500.5 ms | 2193x | — |
+| `wasm3-python` | 9 648 | 25589 | 25873 | 309.9 ms | 556.8 ms | 11169x | — |
+| `wasm3-pypy` | 22 842 | 9399 | 9623 | 470.6 ms | 685.3 ms | 4103x | — |
+| `pywasm-cpython` | 5 374 | 56187 | 56265 | 38.8 ms | 340.8 ms | 24524x | 0.6 ms |
+| `pywasm-pypy` | 649 | 282904 | 285800 | 72.6 ms | 256.2 ms | 123481x | 3.4 ms |
+| `wardite` | 11 634 | 16041 | 16244 | 46.3 ms | 232.9 ms | 7002x | 3.6 ms |
+| `wardite-yjit` | 36 512 | 8836 | 8892 | 89.2 ms | 411.8 ms | 3857x | 8.6 ms |
 
 </details>
 
@@ -441,7 +441,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-i64-div-dark.svg">
-  <img alt="wat/i64_div: seconds per iteration for 20 runners on a log scale, fastest first. dewasm-go is fastest at 8.24 ns, then wasmtime at 8.27 ns; pywasm-pypy is slowest at 419 µs, a span of 50800x. The table below carries every number." src="figs/wat-i64-div.svg">
+  <img alt="wat/i64_div: seconds per iteration for 20 runners on a log scale, fastest first. wasmer is fastest at 8.13 ns, then wasmtime at 8.15 ns; pywasm-pypy is slowest at 389 µs, a span of 47900x. The table below carries every number." src="figs/wat-i64-div.svg">
 </picture>
 
 <details>
@@ -449,26 +449,26 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 36 187 407 | 8.29 | 8.27 | 5.2 ms | 305.0 ms | 1.00x | — |
-| `wasmer` | 35 952 591 | 8.28 | 8.28 | 9.2 ms | 307.0 ms | 1.00x | — |
-| `wasmedge` | 1 662 336 | 180.2 | 180.6 | 15.8 ms | 315.3 ms | 22x | — |
-| `wazero` | 36 083 066 | 8.32 | 8.32 | 4.9 ms | 305.2 ms | 1.00x | — |
-| `wasm3` | 14 261 590 | 16.1 | 16.2 | 4.3 ms | 234.2 ms | 1.95x | — |
-| `dewasm-ruby` | 165 828 | 1683 | 1697 | 39.9 ms | 319.0 ms | 203x | — |
-| `dewasm-ruby-yjit` | 183 238 | 1106 | 1139 | 39.6 ms | 242.4 ms | 134x | — |
-| `dewasm-ruby-zjit` | 186 417 | 1401 | 1404 | 40.1 ms | 301.3 ms | 169x | — |
-| `dewasm-python` | 290 159 | 1030 | 1033 | 29.7 ms | 328.6 ms | 124x | — |
-| `dewasm-pypy` | 715 479 | 268.3 | 267.9 | 41.1 ms | 233.1 ms | 32x | — |
-| `dewasm-perl` | 200 301 | 1512 | 1515 | 11.0 ms | 313.9 ms | 183x | — |
-| `dewasm-go` | 33 385 589 | 8.29 | 8.24 | 3.1 ms | 279.8 ms | 1.00x | — |
-| `dewasm-java` | 21 095 517 | 8.78 | 8.74 | 65.5 ms | 250.7 ms | 1.06x | — |
-| `dewasm-bash` | 3 721 | 77143 | 77138 | 12.8 ms | 299.9 ms | 9311x | — |
-| `wasm3-ruby` | 21 976 | 13171 | 13306 | 151.8 ms | 441.2 ms | 1590x | — |
-| `wasm3-ruby-yjit` | 32 021 | 6346 | 6351 | 212.4 ms | 415.6 ms | 766x | — |
-| `wasm3-python` | 11 369 | 30701 | 30627 | 339.4 ms | 688.4 ms | 3705x | — |
-| `wasm3-pypy` | 10 754 | 20119 | 20083 | 387.8 ms | 604.1 ms | 2428x | — |
-| `pywasm-cpython` | 4 194 | 66862 | 66832 | 43.0 ms | 323.5 ms | 8070x | 0.7 ms |
-| `pywasm-pypy` | 463 | 414074 | 418985 | 79.2 ms | 270.9 ms | 49977x | 3.9 ms |
+| `wasmtime` | 36 833 376 | 8.15 | 8.15 | 5.0 ms | 305.1 ms | 1.00x | — |
+| `wasmer` | 36 430 157 | 8.13 | 8.13 | 8.1 ms | 304.2 ms | 1.00x | — |
+| `wasmedge` | 1 748 598 | 179.6 | 179.5 | 14.3 ms | 328.3 ms | 22x | — |
+| `wazero` | 36 531 881 | 8.14 | 8.16 | 4.4 ms | 301.7 ms | 1.00x | — |
+| `wasm3` | 16 739 719 | 15.9 | 15.9 | 3.9 ms | 269.2 ms | 1.95x | — |
+| `dewasm-ruby` | 170 863 | 1632 | 1635 | 34.7 ms | 313.6 ms | 200x | — |
+| `dewasm-ruby-yjit` | 232 551 | 1085 | 1110 | 35.0 ms | 287.3 ms | 133x | — |
+| `dewasm-ruby-zjit` | 200 310 | 1371 | 1372 | 35.2 ms | 309.8 ms | 168x | — |
+| `dewasm-python` | 292 937 | 1037 | 1038 | 25.6 ms | 329.3 ms | 127x | — |
+| `dewasm-pypy` | 766 931 | 265.7 | 266.1 | 35.7 ms | 239.4 ms | 33x | — |
+| `dewasm-perl` | 202 182 | 1484 | 1486 | 9.8 ms | 309.9 ms | 182x | — |
+| `dewasm-go` | 36 463 918 | 8.15 | 8.16 | 2.5 ms | 299.5 ms | 1.00x | — |
+| `dewasm-java` | 26 114 761 | 8.43 | 8.46 | 60.6 ms | 280.8 ms | 1.03x | — |
+| `dewasm-bash` | 3 923 | 74640 | 74918 | 11.5 ms | 304.4 ms | 9161x | — |
+| `wasm3-ruby` | 21 603 | 14597 | 14607 | 113.8 ms | 429.2 ms | 1792x | — |
+| `wasm3-ruby-yjit` | 35 811 | 6559 | 6424 | 227.4 ms | 462.3 ms | 805x | — |
+| `wasm3-python` | 10 756 | 31161 | 31395 | 308.5 ms | 643.7 ms | 3825x | — |
+| `wasm3-pypy` | 10 036 | 19757 | 20012 | 471.3 ms | 669.5 ms | 2425x | — |
+| `pywasm-cpython` | 4 638 | 64861 | 64998 | 38.6 ms | 339.5 ms | 7961x | 0.6 ms |
+| `pywasm-pypy` | 460 | 388403 | 389395 | 69.2 ms | 247.9 ms | 47672x | 3.4 ms |
 
 </details>
 
@@ -476,7 +476,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-mem-narrow-dark.svg">
-  <img alt="wat/mem_narrow: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.58 ns; pywasm-cpython is slowest at 87.8 µs, a span of 58500x. The table below carries every number." src="figs/wat-mem-narrow.svg">
+  <img alt="wat/mem_narrow: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 1.47 ns, then wasmer at 1.56 ns; pywasm-cpython is slowest at 84.8 µs, a span of 57700x. The table below carries every number." src="figs/wat-mem-narrow.svg">
 </picture>
 
 <details>
@@ -484,28 +484,28 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 197 866 562 | 1.50 | 1.50 | 5.3 ms | 301.5 ms | 1.00x | — |
-| `wasmer` | 182 896 153 | 1.58 | 1.58 | 9.0 ms | 297.9 ms | 1.06x | — |
-| `wasmedge` | 1 097 745 | 261.5 | 261.4 | 15.6 ms | 302.6 ms | 175x | — |
-| `wazero` | 120 287 021 | 2.50 | 2.52 | 5.2 ms | 306.4 ms | 1.67x | — |
-| `wasm3` | 14 577 052 | 20.1 | 20.1 | 4.4 ms | 298.1 ms | 13x | — |
-| `dewasm-ruby` | 715 050 | 434.3 | 433.6 | 39.5 ms | 350.1 ms | 290x | — |
-| `dewasm-ruby-yjit` | 839 357 | 308.3 | 308.3 | 39.8 ms | 298.6 ms | 206x | — |
-| `dewasm-ruby-zjit` | 808 241 | 335.2 | 336.2 | 40.3 ms | 311.2 ms | 224x | — |
-| `dewasm-python` | 156 625 | 1908 | 1927 | 29.2 ms | 328.1 ms | 1275x | — |
-| `dewasm-pypy` | 3 203 405 | 73.0 | 72.8 | 40.6 ms | 274.5 ms | 49x | — |
-| `dewasm-perl` | 94 648 | 3224 | 3226 | 10.5 ms | 315.6 ms | 2153x | — |
-| `dewasm-go` | 99 145 868 | 2.49 | 2.49 | 3.4 ms | 250.5 ms | 1.66x | — |
-| `dewasm-java` | 43 951 401 | 4.45 | 4.44 | 65.7 ms | 261.3 ms | 2.97x | — |
-| `dewasm-bash` | 5 861 | 51685 | 51782 | 12.4 ms | 315.4 ms | 34521x | — |
-| `wasm3-ruby` | 12 076 | 16668 | 16831 | 178.9 ms | 380.2 ms | 11133x | — |
-| `wasm3-ruby-yjit` | 33 510 | 7248 | 7224 | 232.4 ms | 475.3 ms | 4841x | — |
-| `wasm3-python` | 5 183 | 46395 | 46694 | 389.1 ms | 629.6 ms | 30988x | — |
-| `wasm3-pypy` | 10 416 | 20379 | 20372 | 386.7 ms | 599.0 ms | 13611x | — |
-| `pywasm-cpython` | 3 599 | 87469 | 87770 | 45.1 ms | 359.9 ms | 58421x | 0.8 ms |
-| `pywasm-pypy` | 4 086 | 47592 | 47138 | 78.9 ms | 273.3 ms | 31788x | 4.8 ms |
-| `wardite` | 9 442 | 28239 | 28399 | 53.5 ms | 320.2 ms | 18861x | 4.4 ms |
-| `wardite-yjit` | 21 940 | 14667 | 14715 | 103.1 ms | 424.9 ms | 9796x | 9.4 ms |
+| `wasmtime` | 204 340 275 | 1.47 | 1.47 | 5.0 ms | 304.6 ms | 1.00x | — |
+| `wasmer` | 192 003 237 | 1.55 | 1.56 | 7.9 ms | 305.8 ms | 1.06x | — |
+| `wasmedge` | 1 215 436 | 248.7 | 248.9 | 14.0 ms | 316.2 ms | 170x | — |
+| `wazero` | 122 401 742 | 2.47 | 2.49 | 4.5 ms | 307.3 ms | 1.69x | — |
+| `wasm3` | 15 076 340 | 19.6 | 19.8 | 4.0 ms | 298.8 ms | 13x | — |
+| `dewasm-ruby` | 712 448 | 425.1 | 426.5 | 34.6 ms | 337.4 ms | 290x | — |
+| `dewasm-ruby-yjit` | 904 085 | 301.6 | 301.8 | 34.7 ms | 307.4 ms | 206x | — |
+| `dewasm-ruby-zjit` | 842 104 | 323.1 | 326.9 | 35.2 ms | 307.3 ms | 220x | — |
+| `dewasm-python` | 164 381 | 1834 | 1840 | 25.8 ms | 327.3 ms | 1251x | — |
+| `dewasm-pypy` | 4 012 239 | 69.3 | 70.6 | 36.6 ms | 314.7 ms | 47x | — |
+| `dewasm-perl` | 65 536 | 2938 | 2994 | 9.8 ms | 202.4 ms | 2003x | — |
+| `dewasm-go` | 122 957 926 | 2.45 | 2.45 | 2.4 ms | 303.3 ms | 1.67x | — |
+| `dewasm-java` | 52 135 954 | 4.22 | 4.27 | 59.8 ms | 280.1 ms | 2.88x | — |
+| `dewasm-bash` | 6 337 | 48425 | 48480 | 11.5 ms | 318.4 ms | 33023x | — |
+| `wasm3-ruby` | 14 546 | 18499 | 18496 | 114.5 ms | 383.6 ms | 12615x | — |
+| `wasm3-ruby-yjit` | 38 711 | 6819 | 7105 | 240.4 ms | 504.4 ms | 4650x | — |
+| `wasm3-python` | 5 584 | 47951 | 47555 | 308.4 ms | 576.1 ms | 32699x | — |
+| `wasm3-pypy` | 10 604 | 19123 | 19067 | 472.0 ms | 674.8 ms | 13041x | — |
+| `pywasm-cpython` | 3 506 | 84605 | 84760 | 38.6 ms | 335.3 ms | 57694x | 0.7 ms |
+| `pywasm-pypy` | 4 528 | 40485 | 40703 | 70.8 ms | 254.1 ms | 27608x | 4.8 ms |
+| `wardite` | 11 204 | 26717 | 26835 | 46.7 ms | 346.1 ms | 18219x | 3.6 ms |
+| `wardite-yjit` | 25 328 | 13613 | 13683 | 91.2 ms | 436.0 ms | 9283x | 8.1 ms |
 
 </details>
 
@@ -513,7 +513,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/wat-mem-rw-dark.svg">
-  <img alt="wat/mem_rw: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 1.01 ns, then wasmtime at 1.01 ns; pywasm-cpython is slowest at 39.9 µs, a span of 39700x. The table below carries every number." src="figs/wat-mem-rw.svg">
+  <img alt="wat/mem_rw: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 0.98 ns, then wasmtime at 0.98 ns; pywasm-cpython is slowest at 38.6 µs, a span of 39300x. The table below carries every number." src="figs/wat-mem-rw.svg">
 </picture>
 
 <details>
@@ -521,28 +521,59 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 284 180 286 | 1.01 | 1.01 | 5.7 ms | 292.3 ms | 1.00x | — |
-| `wasmer` | 286 572 989 | 1.01 | 1.01 | 9.2 ms | 297.4 ms | 1.00x | — |
-| `wasmedge` | 2 246 338 | 127.3 | 127.5 | 15.5 ms | 301.6 ms | 126x | — |
-| `wazero` | 193 108 533 | 1.55 | 1.55 | 4.9 ms | 303.9 ms | 1.54x | — |
-| `wasm3` | 33 554 432 | 9.90 | 9.91 | 4.6 ms | 336.8 ms | 9.82x | — |
-| `dewasm-ruby` | 1 737 235 | 179.6 | 179.6 | 40.1 ms | 352.2 ms | 178x | — |
-| `dewasm-ruby-yjit` | 2 475 521 | 134.6 | 134.9 | 40.3 ms | 373.5 ms | 133x | — |
-| `dewasm-ruby-zjit` | 2 105 621 | 142.2 | 141.9 | 40.3 ms | 339.7 ms | 141x | — |
-| `dewasm-python` | 389 292 | 760.0 | 773.0 | 29.4 ms | 325.3 ms | 754x | — |
-| `dewasm-pypy` | 5 417 848 | 54.6 | 54.4 | 41.0 ms | 336.7 ms | 54x | — |
-| `dewasm-perl` | 295 649 | 1002 | 1002 | 10.3 ms | 306.4 ms | 993x | — |
-| `dewasm-go` | 157 221 506 | 1.50 | 1.51 | 4.1 ms | 240.4 ms | 1.49x | — |
-| `dewasm-java` | 145 104 918 | 1.77 | 1.79 | 66.4 ms | 323.7 ms | 1.76x | — |
-| `dewasm-bash` | 9 223 | 31865 | 31855 | 12.4 ms | 306.3 ms | 31602x | — |
-| `wasm3-ruby` | 44 000 | 7939 | 7974 | 177.3 ms | 526.6 ms | 7873x | — |
-| `wasm3-ruby-yjit` | 89 670 | 3105 | 3161 | 221.1 ms | 499.5 ms | 3079x | — |
-| `wasm3-python` | 12 941 | 22143 | 22456 | 392.4 ms | 679.0 ms | 21960x | — |
-| `wasm3-pypy` | 33 816 | 5857 | 5916 | 389.3 ms | 587.4 ms | 5808x | — |
-| `pywasm-cpython` | 6 069 | 39704 | 39895 | 42.8 ms | 283.7 ms | 39376x | 0.7 ms |
-| `pywasm-pypy` | 30 798 | 8048 | 8090 | 81.2 ms | 329.0 ms | 7981x | 4.8 ms |
-| `wardite` | 26 680 | 13222 | 13201 | 52.3 ms | 405.0 ms | 13113x | 3.9 ms |
-| `wardite-yjit` | 42 768 | 6263 | 6274 | 102.8 ms | 370.7 ms | 6212x | 9.4 ms |
+| `wasmtime` | 300 255 922 | 0.98 | 0.98 | 5.0 ms | 300.6 ms | 1.00x | — |
+| `wasmer` | 307 213 294 | 0.98 | 0.98 | 7.9 ms | 309.8 ms | 1.00x | — |
+| `wasmedge` | 2 694 983 | 121.2 | 121.0 | 14.7 ms | 341.2 ms | 123x | — |
+| `wazero` | 197 883 085 | 1.51 | 1.52 | 4.4 ms | 303.4 ms | 1.53x | — |
+| `wasm3` | 33 554 432 | 9.77 | 9.79 | 4.0 ms | 331.8 ms | 9.92x | — |
+| `dewasm-ruby` | 1 722 736 | 175.1 | 176.4 | 34.5 ms | 336.2 ms | 178x | — |
+| `dewasm-ruby-yjit` | 2 126 756 | 129.9 | 131.8 | 34.7 ms | 311.1 ms | 132x | — |
+| `dewasm-ruby-zjit` | 1 923 394 | 137.6 | 138.0 | 35.2 ms | 299.9 ms | 140x | — |
+| `dewasm-python` | 391 714 | 727.2 | 733.8 | 25.4 ms | 310.3 ms | 738x | — |
+| `dewasm-pypy` | 5 812 182 | 52.2 | 52.4 | 36.6 ms | 339.8 ms | 53x | — |
+| `dewasm-perl` | 308 837 | 943.0 | 957.2 | 9.7 ms | 301.0 ms | 958x | — |
+| `dewasm-go` | 202 985 666 | 1.48 | 1.48 | 2.5 ms | 302.2 ms | 1.50x | — |
+| `dewasm-java` | 166 020 287 | 1.72 | 1.72 | 60.3 ms | 345.1 ms | 1.74x | — |
+| `dewasm-bash` | 10 077 | 29885 | 30047 | 11.5 ms | 312.7 ms | 30347x | — |
+| `wasm3-ruby` | 39 498 | 8885 | 8885 | 112.4 ms | 463.3 ms | 9022x | — |
+| `wasm3-ruby-yjit` | 94 331 | 3006 | 3004 | 223.9 ms | 507.5 ms | 3053x | — |
+| `wasm3-python` | 8 753 | 22717 | 22869 | 308.6 ms | 507.5 ms | 23068x | — |
+| `wasm3-pypy` | 55 812 | 4479 | 4461 | 471.1 ms | 721.1 ms | 4548x | — |
+| `pywasm-cpython` | 7 025 | 38394 | 38650 | 38.3 ms | 308.0 ms | 38987x | 0.7 ms |
+| `pywasm-pypy` | 35 016 | 7187 | 7210 | 70.4 ms | 322.0 ms | 7298x | 4.5 ms |
+| `wardite` | 14 722 | 12686 | 12737 | 46.4 ms | 233.1 ms | 12883x | 3.6 ms |
+| `wardite-yjit` | 39 520 | 5908 | 5958 | 89.7 ms | 323.2 ms | 6000x | 8.2 ms |
+
+</details>
+
+#### `wat/tail_call`
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="figs/wat-tail-call-dark.svg">
+  <img alt="wat/tail_call: seconds per iteration for 16 runners on a log scale, fastest first. wasmtime is fastest at 3.43 ns, then dewasm-go at 9.08 ns; dewasm-bash is slowest at 77.1 µs, a span of 22500x. The table below carries every number." src="figs/wat-tail-call.svg">
+</picture>
+
+<details>
+<summary>Full numbers for <code>wat/tail_call</code></summary>
+
+| Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `wasmtime` | 87 823 627 | 3.43 | 3.43 | 5.0 ms | 306.2 ms | 1.00x | — |
+| `wasmedge` | 1 622 373 | 185.2 | 188.0 | 14.0 ms | 314.5 ms | 54x | — |
+| `wasm3` | 5 743 174 | 51.3 | 52.3 | 3.9 ms | 298.3 ms | 15x | — |
+| `dewasm-ruby` | 483 388 | 615.6 | 620.2 | 34.6 ms | 332.2 ms | 179x | — |
+| `dewasm-ruby-yjit` | 978 383 | 267.5 | 270.1 | 34.8 ms | 296.5 ms | 78x | — |
+| `dewasm-ruby-zjit` | 630 900 | 373.0 | 374.1 | 35.1 ms | 270.4 ms | 109x | — |
+| `dewasm-python` | 444 673 | 669.1 | 682.4 | 25.8 ms | 323.3 ms | 195x | — |
+| `dewasm-pypy` | 1 491 521 | 138.9 | 138.9 | 35.5 ms | 242.7 ms | 41x | — |
+| `dewasm-perl` | 118 652 | 2456 | 2466 | 10.0 ms | 301.4 ms | 716x | — |
+| `dewasm-go` | 34 414 360 | 8.89 | 9.08 | 2.5 ms | 308.5 ms | 2.59x | — |
+| `dewasm-java` | 13 927 883 | 17.6 | 17.6 | 58.8 ms | 303.9 ms | 5.13x | — |
+| `dewasm-bash` | 3 871 | 77043 | 77113 | 11.9 ms | 310.1 ms | 22461x | — |
+| `wasm3-ruby` | 15 860 | 18552 | 18633 | 112.0 ms | 406.2 ms | 5409x | — |
+| `wasm3-ruby-yjit` | 30 103 | 7509 | 7501 | 198.3 ms | 424.4 ms | 2189x | — |
+| `wasm3-python` | 7 028 | 48131 | 48833 | 309.4 ms | 647.7 ms | 14032x | — |
+| `wasm3-pypy` | 12 320 | 18864 | 18840 | 470.5 ms | 702.9 ms | 5500x | — |
 
 </details>
 
@@ -550,7 +581,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/c-mandelbrot-dark.svg">
-  <img alt="c/mandelbrot: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 96.4 ns, then wasmer at 96.4 ns; dewasm-bash is slowest at 20.3 ms, a span of 211000x. The table below carries every number." src="figs/c-mandelbrot.svg">
+  <img alt="c/mandelbrot: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 94.5 ns, then wasmtime at 94.6 ns; dewasm-bash is slowest at 19.4 ms, a span of 205000x. The table below carries every number." src="figs/c-mandelbrot.svg">
 </picture>
 
 <details>
@@ -558,28 +589,28 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 3 075 042 | 96.4 | 96.4 | 5.6 ms | 301.9 ms | 1.00x | — |
-| `wasmer` | 3 070 839 | 96.3 | 96.4 | 9.5 ms | 305.1 ms | 1.00x | — |
-| `wasmedge` | 87 134 | 3700 | 3698 | 15.4 ms | 337.8 ms | 38x | — |
-| `wazero` | 2 465 523 | 107.4 | 107.7 | 4.8 ms | 269.7 ms | 1.12x | — |
-| `wasm3` | 653 731 | 452.6 | 453.0 | 4.4 ms | 300.2 ms | 4.70x | — |
-| `dewasm-ruby` | 65 536 | 4534 | 4533 | 40.9 ms | 338.1 ms | 47x | — |
-| `dewasm-ruby-yjit` | 167 113 | 1555 | 1551 | 39.3 ms | 299.1 ms | 16x | — |
-| `dewasm-ruby-zjit` | 78 988 | 3484 | 3502 | 40.4 ms | 315.6 ms | 36x | — |
-| `dewasm-python` | 95 700 | 3574 | 3577 | 30.3 ms | 372.4 ms | 37x | — |
-| `dewasm-pypy` | 2 027 383 | 142.0 | 142.1 | 40.5 ms | 328.3 ms | 1.47x | — |
-| `dewasm-perl` | 5 352 | 55811 | 56073 | 11.2 ms | 309.9 ms | 579x | — |
-| `dewasm-go` | 923 094 | 235.0 | 233.2 | 3.5 ms | 220.4 ms | 2.44x | — |
-| `dewasm-java` | 2 838 348 | 96.3 | 96.6 | 67.3 ms | 340.7 ms | 1.00x | — |
-| `dewasm-bash` | 111 | 20274933 | 20302567 | 13.4 ms | 2.26 s | 210422x | — |
-| `wasm3-ruby` | 1 211 | 227479 | 227424 | 148.7 ms | 424.2 ms | 2361x | — |
-| `wasm3-ruby-yjit` | 2 059 | 96240 | 96482 | 236.9 ms | 435.0 ms | 999x | — |
-| `wasm3-python` | 512 | 629755 | 631857 | 334.2 ms | 656.6 ms | 6536x | — |
-| `wasm3-pypy` | 1 512 | 180778 | 181513 | 393.2 ms | 666.5 ms | 1876x | — |
-| `pywasm-cpython` | 256 | 1481182 | 1486747 | 44.3 ms | 423.5 ms | 15372x | 0.8 ms |
-| `pywasm-pypy` | 112 | 1835368 | 1847883 | 81.3 ms | 286.9 ms | 19048x | 4.9 ms |
-| `wardite` | 701 | 389068 | 386166 | 51.8 ms | 324.5 ms | 4038x | 4.3 ms |
-| `wardite-yjit` | 1 378 | 184893 | 186030 | 104.3 ms | 359.1 ms | 1919x | 10.4 ms |
+| `wasmtime` | 3 073 840 | 94.3 | 94.6 | 4.9 ms | 294.9 ms | 1.00x | — |
+| `wasmer` | 2 911 399 | 94.4 | 94.5 | 8.3 ms | 283.1 ms | 1.00x | — |
+| `wasmedge` | 65 536 | 3688 | 3727 | 14.1 ms | 255.8 ms | 39x | — |
+| `wazero` | 2 833 631 | 105.9 | 106.3 | 4.8 ms | 305.0 ms | 1.12x | — |
+| `wasm3` | 673 524 | 443.6 | 448.2 | 4.0 ms | 302.7 ms | 4.70x | — |
+| `dewasm-ruby` | 42 173 | 4568 | 4635 | 35.2 ms | 227.8 ms | 48x | — |
+| `dewasm-ruby-yjit` | 135 395 | 1545 | 1530 | 35.3 ms | 244.5 ms | 16x | — |
+| `dewasm-ruby-zjit` | 81 804 | 3492 | 3503 | 35.4 ms | 321.0 ms | 37x | — |
+| `dewasm-python` | 65 536 | 3543 | 3555 | 26.4 ms | 258.5 ms | 38x | — |
+| `dewasm-pypy` | 2 288 272 | 138.2 | 138.2 | 36.2 ms | 352.5 ms | 1.47x | — |
+| `dewasm-perl` | 5 403 | 54312 | 54392 | 10.0 ms | 303.4 ms | 576x | — |
+| `dewasm-go` | 1 299 150 | 231.0 | 231.1 | 2.5 ms | 302.5 ms | 2.45x | — |
+| `dewasm-java` | 2 611 945 | 95.7 | 95.4 | 59.9 ms | 309.8 ms | 1.01x | — |
+| `dewasm-bash` | 180 | 19314657 | 19369017 | 12.2 ms | 3.49 s | 204751x | — |
+| `wasm3-ruby` | 1 086 | 273259 | 275968 | 115.3 ms | 412.0 ms | 2897x | — |
+| `wasm3-ruby-yjit` | 2 964 | 94166 | 93970 | 260.0 ms | 539.1 ms | 998x | — |
+| `wasm3-python` | 512 | 656694 | 655244 | 312.5 ms | 648.7 ms | 6961x | — |
+| `wasm3-pypy` | 932 | 235064 | 235012 | 478.9 ms | 698.0 ms | 2492x | — |
+| `pywasm-cpython` | 256 | 1447154 | 1450451 | 38.4 ms | 408.9 ms | 15341x | 0.8 ms |
+| `pywasm-pypy` | 196 | 1120033 | 1119270 | 70.9 ms | 290.4 ms | 11873x | 5.1 ms |
+| `wardite` | 792 | 371401 | 372049 | 46.4 ms | 340.5 ms | 3937x | 3.5 ms |
+| `wardite-yjit` | 1 448 | 175391 | 175064 | 92.2 ms | 346.1 ms | 1859x | 8.9 ms |
 
 </details>
 
@@ -587,7 +618,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/c-sha256-dark.svg">
-  <img alt="c/sha256: seconds per iteration for 22 runners on a log scale, fastest first. wasmer is fastest at 293 ns, then wasmtime at 294 ns; dewasm-bash is slowest at 15.9 ms, a span of 54300x. The table below carries every number." src="figs/c-sha256.svg">
+  <img alt="c/sha256: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 288 ns, then wasmer at 289 ns; dewasm-bash is slowest at 15.3 ms, a span of 52900x. The table below carries every number." src="figs/c-sha256.svg">
 </picture>
 
 <details>
@@ -595,28 +626,28 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 997 415 | 294.1 | 294.1 | 5.3 ms | 298.7 ms | 1.00x | — |
-| `wasmer` | 962 488 | 293.3 | 293.3 | 8.9 ms | 291.3 ms | 1.00x | — |
-| `wasmedge` | 6 953 | 40643 | 40648 | 15.5 ms | 298.1 ms | 138x | — |
-| `wazero` | 767 517 | 378.7 | 378.5 | 5.0 ms | 295.6 ms | 1.29x | — |
-| `wasm3` | 65 536 | 4916 | 4917 | 4.7 ms | 326.9 ms | 17x | — |
-| `dewasm-ruby` | 3 601 | 79581 | 79260 | 39.2 ms | 325.7 ms | 271x | — |
-| `dewasm-ruby-yjit` | 8 594 | 34055 | 33985 | 40.8 ms | 333.4 ms | 116x | — |
-| `dewasm-ruby-zjit` | 3 285 | 54569 | 54506 | 40.5 ms | 219.8 ms | 186x | — |
-| `dewasm-python` | 1 112 | 267274 | 269116 | 30.1 ms | 327.4 ms | 909x | — |
-| `dewasm-pypy` | 18 529 | 13983 | 14012 | 41.0 ms | 300.1 ms | 48x | — |
-| `dewasm-perl` | 917 | 320255 | 320630 | 10.8 ms | 304.5 ms | 1089x | — |
-| `dewasm-go` | 779 032 | 348.4 | 348.7 | 3.6 ms | 275.0 ms | 1.18x | — |
-| `dewasm-java` | 334 711 | 534.5 | 541.4 | 66.7 ms | 245.5 ms | 1.82x | — |
-| `dewasm-bash` | 18 | 15913394 | 15923049 | 15.0 ms | 301.5 ms | 54101x | — |
-| `wasm3-ruby` | 79 | 3092359 | 3096225 | 150.1 ms | 394.4 ms | 10513x | — |
-| `wasm3-ruby-yjit` | 208 | 1252763 | 1244240 | 249.6 ms | 510.2 ms | 4259x | — |
-| `wasm3-python` | 25 | 8947055 | 8930102 | 339.4 ms | 563.1 ms | 30417x | — |
-| `wasm3-pypy` | 60 | 3822547 | 3807396 | 406.2 ms | 635.6 ms | 12996x | — |
-| `pywasm-cpython` | 19 | 14479471 | 14597695 | 45.0 ms | 320.1 ms | 49226x | 1.2 ms |
-| `pywasm-pypy` | 28 | 7281929 | 7282771 | 88.8 ms | 292.7 ms | 24756x | 8.0 ms |
-| `wardite` | 53 | 4169347 | 4147897 | 53.0 ms | 273.9 ms | 14175x | 4.4 ms |
-| `wardite-yjit` | 135 | 1929772 | 1949294 | 104.7 ms | 365.2 ms | 6561x | 10.3 ms |
+| `wasmtime` | 1 041 374 | 287.8 | 288.4 | 4.9 ms | 304.7 ms | 1.00x | — |
+| `wasmer` | 999 866 | 287.8 | 288.5 | 8.3 ms | 296.0 ms | 1.00x | — |
+| `wasmedge` | 7 623 | 39554 | 39894 | 14.3 ms | 315.8 ms | 137x | — |
+| `wazero` | 802 548 | 370.9 | 371.7 | 4.6 ms | 302.3 ms | 1.29x | — |
+| `wasm3` | 53 700 | 4828 | 4828 | 4.0 ms | 263.2 ms | 17x | — |
+| `dewasm-ruby` | 3 383 | 78457 | 78533 | 34.8 ms | 300.2 ms | 273x | — |
+| `dewasm-ruby-yjit` | 5 624 | 33956 | 33921 | 36.1 ms | 227.1 ms | 118x | — |
+| `dewasm-ruby-zjit` | 5 740 | 52926 | 53045 | 35.6 ms | 339.4 ms | 184x | — |
+| `dewasm-python` | 1 083 | 264689 | 265307 | 26.7 ms | 313.4 ms | 920x | — |
+| `dewasm-pypy` | 13 308 | 14074 | 14244 | 37.1 ms | 224.4 ms | 49x | — |
+| `dewasm-perl` | 954 | 311542 | 315047 | 10.1 ms | 307.3 ms | 1082x | — |
+| `dewasm-go` | 871 481 | 343.6 | 343.9 | 2.5 ms | 302.0 ms | 1.19x | — |
+| `dewasm-java` | 512 038 | 549.0 | 554.2 | 59.8 ms | 340.9 ms | 1.91x | — |
+| `dewasm-bash` | 19 | 15261283 | 15272239 | 13.8 ms | 303.8 ms | 53023x | — |
+| `wasm3-ruby` | 75 | 3553375 | 3598362 | 117.2 ms | 383.7 ms | 12346x | — |
+| `wasm3-ruby-yjit` | 192 | 1282779 | 1287357 | 276.7 ms | 523.0 ms | 4457x | — |
+| `wasm3-python` | 27 | 9130228 | 9136816 | 320.1 ms | 566.6 ms | 31722x | — |
+| `wasm3-pypy` | 36 | 6078487 | 6166523 | 506.4 ms | 725.2 ms | 21119x | — |
+| `pywasm-cpython` | 20 | 14282075 | 14300394 | 39.7 ms | 325.3 ms | 49621x | 1.2 ms |
+| `pywasm-pypy` | 32 | 6265911 | 6224393 | 80.2 ms | 280.7 ms | 21770x | 7.6 ms |
+| `wardite` | 74 | 4033930 | 4039560 | 47.6 ms | 346.1 ms | 14015x | 3.7 ms |
+| `wardite-yjit` | 133 | 1867489 | 1868561 | 92.7 ms | 341.1 ms | 6488x | 9.0 ms |
 
 </details>
 
@@ -624,7 +655,7 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/c-wordcount-dark.svg">
-  <img alt="c/wordcount: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 1.50 ns, then wasmer at 1.62 ns; pywasm-cpython is slowest at 59.7 µs, a span of 39800x. The table below carries every number." src="figs/c-wordcount.svg">
+  <img alt="c/wordcount: seconds per iteration for 22 runners on a log scale, fastest first. wasmtime is fastest at 1.51 ns, then wasmer at 1.62 ns; pywasm-cpython is slowest at 59.4 µs, a span of 39400x. The table below carries every number." src="figs/c-wordcount.svg">
 </picture>
 
 <details>
@@ -632,28 +663,28 @@ Iteration counts are calibrated per runner, so compare the per-iteration figures
 
 | Runner | Iterations | ns/op (min) | ns/op (median) | Cold start `t(0)` | Total `t(N)` | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 179 975 764 | 1.46 | 1.50 | 5.4 ms | 267.4 ms | 1.00x | — |
-| `wasmer` | 177 418 041 | 1.62 | 1.62 | 9.2 ms | 296.2 ms | 1.11x | — |
-| `wasmedge` | 1 486 638 | 197.2 | 197.3 | 16.5 ms | 309.7 ms | 135x | — |
-| `wazero` | 99 868 591 | 3.01 | 3.01 | 5.6 ms | 305.8 ms | 2.06x | — |
-| `wasm3` | 11 986 465 | 20.2 | 20.3 | 4.5 ms | 247.2 ms | 14x | — |
-| `dewasm-ruby` | 748 536 | 410.2 | 411.1 | 41.0 ms | 348.1 ms | 282x | — |
-| `dewasm-ruby-yjit` | 958 325 | 273.3 | 273.1 | 41.1 ms | 303.0 ms | 188x | — |
-| `dewasm-ruby-zjit` | 619 243 | 297.4 | 296.2 | 40.7 ms | 224.8 ms | 204x | — |
-| `dewasm-python` | 323 946 | 897.8 | 899.3 | 33.2 ms | 324.0 ms | 617x | — |
-| `dewasm-pypy` | 4 919 747 | 56.8 | 57.0 | 45.5 ms | 324.9 ms | 39x | — |
-| `dewasm-perl` | 200 141 | 1480 | 1482 | 18.7 ms | 314.8 ms | 1016x | — |
-| `dewasm-go` | 92 941 984 | 2.72 | 2.72 | 4.0 ms | 256.6 ms | 1.87x | — |
-| `dewasm-java` | 63 054 338 | 3.49 | 3.52 | 68.7 ms | 288.7 ms | 2.40x | — |
-| `dewasm-bash` | 6 852 | 42404 | 42502 | 125.3 ms | 415.9 ms | 29129x | — |
-| `wasm3-ruby` | 26 095 | 11505 | 11634 | 194.5 ms | 494.7 ms | 7903x | — |
-| `wasm3-ruby-yjit` | 63 553 | 4324 | 4374 | 278.4 ms | 553.2 ms | 2970x | — |
-| `wasm3-python` | 12 444 | 32805 | 33022 | 460.4 ms | 868.6 ms | 22535x | — |
-| `wasm3-pypy` | 20 186 | 10821 | 10850 | 487.4 ms | 705.8 ms | 7434x | — |
-| `pywasm-cpython` | 5 017 | 59457 | 59693 | 281.9 ms | 580.2 ms | 40844x | 1.3 ms |
-| `pywasm-pypy` | 13 376 | 16107 | 16021 | 196.9 ms | 412.3 ms | 11065x | 8.2 ms |
-| `wardite` | 11 545 | 20831 | 20830 | 121.6 ms | 362.0 ms | 14310x | 3.9 ms |
-| `wardite-yjit` | 31 453 | 9728 | 9854 | 144.9 ms | 450.9 ms | 6683x | 10.6 ms |
+| `wasmtime` | 194 548 513 | 1.47 | 1.51 | 5.1 ms | 290.9 ms | 1.00x | — |
+| `wasmer` | 181 965 736 | 1.61 | 1.62 | 8.2 ms | 301.8 ms | 1.10x | — |
+| `wasmedge` | 1 574 328 | 195.9 | 195.9 | 14.9 ms | 323.3 ms | 133x | — |
+| `wazero` | 101 770 561 | 2.98 | 2.99 | 4.9 ms | 308.1 ms | 2.03x | — |
+| `wasm3` | 14 845 801 | 19.8 | 19.9 | 4.0 ms | 297.9 ms | 13x | — |
+| `dewasm-ruby` | 763 679 | 401.1 | 404.0 | 36.5 ms | 342.9 ms | 273x | — |
+| `dewasm-ruby-yjit` | 1 088 816 | 267.1 | 268.4 | 36.8 ms | 327.6 ms | 182x | — |
+| `dewasm-ruby-zjit` | 1 017 402 | 290.6 | 291.0 | 37.6 ms | 333.2 ms | 198x | — |
+| `dewasm-python` | 335 071 | 887.2 | 887.4 | 29.7 ms | 327.0 ms | 604x | — |
+| `dewasm-pypy` | 5 086 382 | 55.9 | 55.9 | 41.2 ms | 325.4 ms | 38x | — |
+| `dewasm-perl` | 206 406 | 1444 | 1447 | 17.2 ms | 315.1 ms | 982x | — |
+| `dewasm-go` | 109 934 030 | 2.67 | 2.71 | 2.6 ms | 296.2 ms | 1.82x | — |
+| `dewasm-java` | 65 208 823 | 3.38 | 3.39 | 61.0 ms | 281.6 ms | 2.30x | — |
+| `dewasm-bash` | 7 261 | 41335 | 41318 | 118.9 ms | 419.0 ms | 28132x | — |
+| `wasm3-ruby` | 18 633 | 13380 | 13425 | 166.9 ms | 416.2 ms | 9106x | — |
+| `wasm3-ruby-yjit` | 58 242 | 4599 | 4628 | 305.1 ms | 572.9 ms | 3130x | — |
+| `wasm3-python` | 7 176 | 34317 | 34923 | 439.3 ms | 685.6 ms | 23356x | — |
+| `wasm3-pypy` | 11 815 | 15178 | 15256 | 592.0 ms | 771.3 ms | 10330x | — |
+| `pywasm-cpython` | 4 794 | 58426 | 59361 | 269.6 ms | 549.7 ms | 39765x | 1.2 ms |
+| `pywasm-pypy` | 12 468 | 15370 | 15267 | 176.3 ms | 368.0 ms | 10461x | 7.6 ms |
+| `wardite` | 17 382 | 20178 | 20392 | 113.7 ms | 464.5 ms | 13733x | 3.7 ms |
+| `wardite-yjit` | 32 149 | 9399 | 9657 | 130.5 ms | 432.6 ms | 6397x | 9.1 ms |
 
 </details>
 
@@ -666,7 +697,7 @@ Every runner executes the same work, so wall times compare directly.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/app-cowsay-dark.svg">
-  <img alt="app/cowsay: seconds per run for 22 runners on a log scale, fastest first. dewasm-go is fastest at 5.75 ms, then wasm3 at 8.16 ms; wasm3-python is slowest at 3.84 s, a span of 668x. The table below carries every number." src="figs/app-cowsay.svg">
+  <img alt="app/cowsay: seconds per run for 22 runners on a log scale, fastest first. dewasm-go is fastest at 3.94 ms, then wasm3 at 7.37 ms; wasm3-python is slowest at 2.33 s, a span of 590x. The table below carries every number." src="figs/app-cowsay.svg">
 </picture>
 
 <details>
@@ -674,28 +705,28 @@ Every runner executes the same work, so wall times compare directly.
 
 | Runner | Runs/sample | Wall time (min) | Wall time (median) | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 25 | 10.3 ms | 10.3 ms | 1.00x | — |
-| `wasmer` | 16 | 14.2 ms | 14.3 ms | 1.39x | — |
-| `wasmedge` | 12 | 26.6 ms | 26.7 ms | 2.59x | — |
-| `wazero` | 3 | 106.6 ms | 107.2 ms | 10x | — |
-| `wasm3` | 39 | 8.1 ms | 8.2 ms | 0.79x | — |
-| `dewasm-ruby` | 3 | 144.5 ms | 146.1 ms | 14x | — |
-| `dewasm-ruby-yjit` | 2 | 198.0 ms | 199.1 ms | 19x | — |
-| `dewasm-ruby-zjit` | 2 | 256.9 ms | 258.2 ms | 25x | — |
-| `dewasm-python` | 1 | 427.8 ms | 428.0 ms | 42x | — |
-| `dewasm-pypy` | 1 | 629.1 ms | 631.1 ms | 61x | — |
-| `dewasm-perl` | 3 | 111.4 ms | 111.8 ms | 11x | — |
-| `dewasm-go` | 1 | 5.1 ms | 5.8 ms | 0.50x | — |
-| `dewasm-java` | 3 | 132.9 ms | 133.8 ms | 13x | — |
-| `dewasm-bash` | 1 | 1.34 s | 1.34 s | 130x | — |
-| `wasm3-ruby` | 1 | 1.56 s | 1.56 s | 152x | — |
-| `wasm3-ruby-yjit` | 1 | 1.25 s | 1.25 s | 122x | — |
-| `wasm3-python` | 1 | 3.84 s | 3.84 s | 374x | — |
-| `wasm3-pypy` | 1 | 1.71 s | 1.72 s | 167x | — |
-| `pywasm-cpython` | 1 | 502.6 ms | 504.2 ms | 49x | 279.0 ms |
-| `pywasm-pypy` | 1 | 891.7 ms | 892.3 ms | 87x | 481.7 ms |
-| `wardite` | 2 | 240.3 ms | 241.1 ms | 23x | 105.8 ms |
-| `wardite-yjit` | 2 | 273.5 ms | 276.2 ms | 27x | 85.4 ms |
+| `wasmtime` | 32 | 9.2 ms | 9.2 ms | 1.00x | — |
+| `wasmer` | 25 | 12.4 ms | 12.5 ms | 1.35x | — |
+| `wasmedge` | 13 | 23.7 ms | 23.7 ms | 2.58x | — |
+| `wazero` | 3 | 100.3 ms | 100.7 ms | 11x | — |
+| `wasm3` | 42 | 7.3 ms | 7.4 ms | 0.80x | — |
+| `dewasm-ruby` | 3 | 132.5 ms | 133.0 ms | 14x | — |
+| `dewasm-ruby-yjit` | 2 | 180.2 ms | 180.8 ms | 20x | — |
+| `dewasm-ruby-zjit` | 2 | 235.8 ms | 236.4 ms | 26x | — |
+| `dewasm-python` | 1 | 393.9 ms | 394.3 ms | 43x | — |
+| `dewasm-pypy` | 1 | 596.5 ms | 597.5 ms | 65x | — |
+| `dewasm-perl` | 3 | 102.1 ms | 102.4 ms | 11x | — |
+| `dewasm-go` | 64 | 3.9 ms | 3.9 ms | 0.43x | — |
+| `dewasm-java` | 3 | 120.6 ms | 121.5 ms | 13x | — |
+| `dewasm-bash` | 1 | 1.25 s | 1.26 s | 137x | — |
+| `wasm3-ruby` | 1 | 815.8 ms | 819.0 ms | 89x | — |
+| `wasm3-ruby-yjit` | 1 | 1.11 s | 1.11 s | 121x | — |
+| `wasm3-python` | 1 | 2.32 s | 2.33 s | 252x | — |
+| `wasm3-pypy` | 1 | 1.75 s | 1.75 s | 190x | — |
+| `pywasm-cpython` | 1 | 470.0 ms | 473.8 ms | 51x | 262.9 ms |
+| `pywasm-pypy` | 1 | 813.6 ms | 829.0 ms | 89x | 432.9 ms |
+| `wardite` | 2 | 217.6 ms | 219.4 ms | 24x | 103.9 ms |
+| `wardite-yjit` | 2 | 243.5 ms | 244.9 ms | 26x | 77.6 ms |
 
 </details>
 
@@ -703,7 +734,7 @@ Every runner executes the same work, so wall times compare directly.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/app-sqlite3-query-dark.svg">
-  <img alt="app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 79.4 ms, then wasmer at 87.5 ms; dewasm-ruby is slowest at 19.3 s, a span of 243x. The table below carries every number." src="figs/app-sqlite3-query.svg">
+  <img alt="app/sqlite3_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 75.2 ms, then wasmer at 83.1 ms; dewasm-ruby is slowest at 18.7 s, a span of 249x. The table below carries every number." src="figs/app-sqlite3-query.svg">
 </picture>
 
 <details>
@@ -711,17 +742,17 @@ Every runner executes the same work, so wall times compare directly.
 
 | Runner | Runs/sample | Wall time (min) | Wall time (median) | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 4 | 79.1 ms | 79.4 ms | 1.00x | — |
-| `wasmer` | 4 | 87.2 ms | 87.5 ms | 1.10x | — |
-| `wasmedge` | 1 | 9.61 s | 9.61 s | 121x | — |
-| `wazero` | 1 | 647.9 ms | 648.5 ms | 8.19x | — |
-| `wasm3` | 1 | 1.13 s | 1.13 s | 14x | — |
-| `dewasm-ruby` | 1 | 19.29 s | 19.31 s | 244x | — |
-| `dewasm-ruby-yjit` | 1 | 9.27 s | 9.32 s | 117x | — |
-| `dewasm-ruby-zjit` | 1 | 14.04 s | 14.04 s | 177x | — |
-| `dewasm-pypy` | 1 | 11.98 s | 12.01 s | 151x | — |
-| `dewasm-go` | 1 | 169.8 ms | 170.4 ms | 2.15x | — |
-| `dewasm-java` | 1 | 2.35 s | 2.37 s | 30x | — |
+| `wasmtime` | 4 | 74.8 ms | 75.2 ms | 1.00x | — |
+| `wasmer` | 4 | 83.1 ms | 83.1 ms | 1.11x | — |
+| `wasmedge` | 1 | 9.42 s | 9.45 s | 126x | — |
+| `wazero` | 1 | 605.4 ms | 612.3 ms | 8.09x | — |
+| `wasm3` | 1 | 1.09 s | 1.10 s | 15x | — |
+| `dewasm-ruby` | 1 | 18.64 s | 18.75 s | 249x | — |
+| `dewasm-ruby-yjit` | 1 | 8.81 s | 8.84 s | 118x | — |
+| `dewasm-ruby-zjit` | 1 | 13.41 s | 13.41 s | 179x | — |
+| `dewasm-pypy` | 1 | 11.36 s | 11.36 s | 152x | — |
+| `dewasm-go` | 2 | 168.3 ms | 168.4 ms | 2.25x | — |
+| `dewasm-java` | 1 | 2.29 s | 2.30 s | 31x | — |
 
 </details>
 
@@ -729,7 +760,7 @@ Every runner executes the same work, so wall times compare directly.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/app-sqlite3-mod-query-dark.svg">
-  <img alt="app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 85.8 ms, then wasmer at 90.0 ms; dewasm-ruby is slowest at 20.3 s, a span of 236x. The table below carries every number." src="figs/app-sqlite3-mod-query.svg">
+  <img alt="app/sqlite3_mod_query: seconds per run for 11 runners on a log scale, fastest first. wasmtime is fastest at 82.6 ms, then wasmer at 85.9 ms; dewasm-ruby is slowest at 19.8 s, a span of 240x. The table below carries every number." src="figs/app-sqlite3-mod-query.svg">
 </picture>
 
 <details>
@@ -737,17 +768,17 @@ Every runner executes the same work, so wall times compare directly.
 
 | Runner | Runs/sample | Wall time (min) | Wall time (median) | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 3 | 85.7 ms | 85.8 ms | 1.00x | — |
-| `wasmer` | 3 | 89.9 ms | 90.0 ms | 1.05x | — |
-| `wasmedge` | 1 | 9.94 s | 9.97 s | 116x | — |
-| `wazero` | 1 | 631.4 ms | 633.9 ms | 7.37x | — |
-| `wasm3` | 1 | 1.19 s | 1.20 s | 14x | — |
-| `dewasm-ruby` | 1 | 20.24 s | 20.27 s | 236x | — |
-| `dewasm-ruby-yjit` | 1 | 8.28 s | 8.31 s | 97x | — |
-| `dewasm-ruby-zjit` | 1 | 14.54 s | 14.55 s | 170x | — |
-| `dewasm-pypy` | 1 | 12.91 s | 13.07 s | 151x | — |
-| `dewasm-go` | 1 | 126.8 ms | 127.0 ms | 1.48x | — |
-| `dewasm-java` | 1 | 5.50 s | 5.55 s | 64x | — |
+| `wasmtime` | 4 | 82.6 ms | 82.6 ms | 1.00x | — |
+| `wasmer` | 4 | 85.6 ms | 85.9 ms | 1.04x | — |
+| `wasmedge` | 1 | 9.76 s | 9.80 s | 118x | — |
+| `wazero` | 1 | 600.5 ms | 605.5 ms | 7.27x | — |
+| `wasm3` | 1 | 1.16 s | 1.17 s | 14x | — |
+| `dewasm-ruby` | 1 | 19.75 s | 19.82 s | 239x | — |
+| `dewasm-ruby-yjit` | 1 | 8.03 s | 8.07 s | 97x | — |
+| `dewasm-ruby-zjit` | 1 | 13.79 s | 13.83 s | 167x | — |
+| `dewasm-pypy` | 1 | 12.16 s | 12.23 s | 147x | — |
+| `dewasm-go` | 3 | 122.1 ms | 122.6 ms | 1.48x | — |
+| `dewasm-java` | 1 | 5.35 s | 5.36 s | 65x | — |
 
 </details>
 
@@ -755,7 +786,7 @@ Every runner executes the same work, so wall times compare directly.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="figs/app-minigzip-dark.svg">
-  <img alt="app/minigzip: seconds per run for 15 runners on a log scale, fastest first. wasmtime is fastest at 45.0 ms, then wasmer at 53.0 ms; pywasm-pypy is slowest at 81.3 s, a span of 1810x. The table below carries every number." src="figs/app-minigzip.svg">
+  <img alt="app/minigzip: seconds per run for 15 runners on a log scale, fastest first. wasmtime is fastest at 42.7 ms, then wasmer at 49.0 ms; pywasm-pypy is slowest at 78.0 s, a span of 1830x. The table below carries every number." src="figs/app-minigzip.svg">
 </picture>
 
 <details>
@@ -763,21 +794,21 @@ Every runner executes the same work, so wall times compare directly.
 
 | Runner | Runs/sample | Wall time (min) | Wall time (median) | vs wasmtime | Load |
 | --- | --- | --- | --- | --- | --- |
-| `wasmtime` | 7 | 45.0 ms | 45.0 ms | 1.00x | — |
-| `wasmer` | 6 | 52.9 ms | 53.0 ms | 1.18x | — |
-| `wasmedge` | 1 | 2.19 s | 2.20 s | 49x | — |
-| `wazero` | 4 | 88.6 ms | 88.6 ms | 1.97x | — |
-| `wasm3` | 2 | 256.0 ms | 256.6 ms | 5.69x | — |
-| `dewasm-ruby` | 1 | 5.28 s | 5.29 s | 117x | — |
-| `dewasm-ruby-yjit` | 1 | 1.63 s | 1.63 s | 36x | — |
-| `dewasm-ruby-zjit` | 1 | 3.31 s | 3.31 s | 73x | — |
-| `dewasm-python` | 1 | 15.32 s | 15.33 s | 341x | — |
-| `dewasm-pypy` | 1 | 2.76 s | 2.76 s | 61x | — |
-| `dewasm-perl` | 1 | 24.25 s | 24.42 s | 539x | — |
-| `dewasm-go` | 1 | 58.1 ms | 58.2 ms | 1.29x | — |
-| `dewasm-java` | 1 | 523.4 ms | 524.1 ms | 12x | — |
-| `wasm3-ruby-yjit` | 1 | 51.57 s | 51.67 s | 1146x | — |
-| `pywasm-pypy` | 1 | 80.55 s | 81.32 s | 1791x | 332.6 ms |
+| `wasmtime` | 7 | 42.6 ms | 42.7 ms | 1.00x | — |
+| `wasmer` | 7 | 49.0 ms | 49.0 ms | 1.15x | — |
+| `wasmedge` | 1 | 2.15 s | 2.15 s | 50x | — |
+| `wazero` | 4 | 84.1 ms | 84.3 ms | 1.97x | — |
+| `wasm3` | 2 | 248.1 ms | 248.8 ms | 5.82x | — |
+| `dewasm-ruby` | 1 | 5.12 s | 5.16 s | 120x | — |
+| `dewasm-ruby-yjit` | 1 | 1.56 s | 1.56 s | 37x | — |
+| `dewasm-ruby-zjit` | 1 | 3.19 s | 3.20 s | 75x | — |
+| `dewasm-python` | 1 | 14.94 s | 15.00 s | 351x | — |
+| `dewasm-pypy` | 1 | 2.58 s | 2.58 s | 60x | — |
+| `dewasm-perl` | 1 | 23.49 s | 23.67 s | 551x | — |
+| `dewasm-go` | 6 | 55.6 ms | 55.9 ms | 1.31x | — |
+| `dewasm-java` | 1 | 506.4 ms | 525.7 ms | 12x | — |
+| `wasm3-ruby-yjit` | 1 | 52.92 s | 53.02 s | 1242x | — |
+| `pywasm-pypy` | 1 | 77.85 s | 78.05 s | 1827x | 305.1 ms |
 
 </details>
 
@@ -815,6 +846,12 @@ Kind classifies the gap: *cost* (runs correctly, but too slowly to keep in the s
 | `wat/f32_alu` | `wardite-yjit` | capability | wardite 0.9.0 does not re-round f32 arithmetic to single precision, so a dependent operation chain diverges from wasmtime (1232349357 vs 1232349355 at 10000 iterations) and the byte-for-byte verification would fail the whole run |
 | `wat/i64_div` | `wardite` | capability | wardite 0.9.0 computes i64.div_s at f64 precision, wrong for operands beyond 2^53: i64.div_s(0x8000000000000000, 3) gives -3074457345618258432 where -3074457345618258602 is correct |
 | `wat/i64_div` | `wardite-yjit` | capability | wardite 0.9.0 computes i64.div_s at f64 precision, wrong for operands beyond 2^53: i64.div_s(0x8000000000000000, 3) gives -3074457345618258432 where -3074457345618258602 is correct |
+| `wat/tail_call` | `wasmer` | capability | wasmer rejects the module: compile error Validate("tail calls support is not enabled") |
+| `wat/tail_call` | `wazero` | capability | wazero 1.12.0 rejects the module: "return_call invalid as feature \"tail-call\" is disabled" |
+| `wat/tail_call` | `pywasm-cpython` | capability | pywasm 2.2.3 has no tail-call opcodes; decoding dies with AssertionError on 0x12, the return_call opcode (pywasm/core.py) |
+| `wat/tail_call` | `pywasm-pypy` | capability | pywasm 2.2.3 has no tail-call opcodes; decoding dies with AssertionError on 0x12, the return_call opcode (pywasm/core.py) |
+| `wat/tail_call` | `wardite` | capability | wardite 0.9.0 decodes return_call but has no implementation: RuntimeError "TODO! unsupported [:default, :return_call, [], nil, nil]" (wardite.rb, eval_insn) |
+| `wat/tail_call` | `wardite-yjit` | capability | wardite 0.9.0 decodes return_call but has no implementation: RuntimeError "TODO! unsupported [:default, :return_call, [], nil, nil]" (wardite.rb, eval_insn) |
 | `app/sqlite3_query` | `dewasm-python` | cost | dewasm-python runs this program correctly but at 56 s and 57 s per run (median, sqlite3_query and sqlite3_mod_query), costing roughly 9 minutes of the roughly 65 minute full suite; dewasm-python stays measured on the other app cases and the microbenchmarks |
 | `app/sqlite3_query` | `dewasm-perl` | cost | dewasm-perl runs this program correctly but at 113 s and 115 s per run (median, sqlite3_query and sqlite3_mod_query), so one warmup plus the timed repetitions across both cases alone cost roughly 19 minutes of the roughly 65 minute full suite; dewasm-perl stays measured on the other app cases and the microbenchmarks |
 | `app/sqlite3_query` | `dewasm-bash` | cost | bash runs ~10000x slower than wasmtime on compute, so 100k SQL inserts do not finish in a practical time |

--- a/records/2026-08-31T09-49-13Z-speed.json
+++ b/records/2026-08-31T09-49-13Z-speed.json
@@ -1,0 +1,13220 @@
+{
+  "schema": 2,
+  "generated_at": "2026-08-31T09:49:13Z",
+  "host": {
+    "os": "macOS 26.6.2",
+    "arch": "aarch64",
+    "kernel": "Darwin 25.6.0",
+    "cpu": "Apple M1 Pro"
+  },
+  "settings": {
+    "reps": 3,
+    "target_ms": 300,
+    "timeout_s": 900,
+    "filter": null
+  },
+  "runtimes": [
+    {
+      "runner": "wasmtime",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "wasmtime 48.0.1 (7bac2c277 2026-08-24)"
+    },
+    {
+      "runner": "wasmer",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "wasmer 7.3.0"
+    },
+    {
+      "runner": "wasmedge",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "wasmedge version 0.17.1"
+    },
+    {
+      "runner": "wazero",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "1.12.0"
+    },
+    {
+      "runner": "wasm3",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "Wasm3 v0.9.0 on arm64-v8a"
+    },
+    {
+      "runner": "dewasm-ruby",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "ruby 4.0.4 (2026-05-12 revision b89eb1bcbf) +PRISM [arm64-darwin25]"
+    },
+    {
+      "runner": "dewasm-ruby-yjit",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "ruby 4.0.4 (2026-05-12 revision b89eb1bcbf) +PRISM [arm64-darwin25]"
+    },
+    {
+      "runner": "dewasm-ruby-zjit",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "ruby 4.0.4 (2026-05-12 revision b89eb1bcbf) +PRISM [arm64-darwin25]"
+    },
+    {
+      "runner": "dewasm-python",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "Python 3.14.7 (main, Aug  5 2026, 10:29:49) [Clang 21.0.0 (clang-2100.1.1.101)]"
+    },
+    {
+      "runner": "dewasm-pypy",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "Python 3.11.15 (194f9f44b505, Aug 22 2026, 08:59:40)"
+    },
+    {
+      "runner": "dewasm-perl",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "v5.44.0"
+    },
+    {
+      "runner": "dewasm-go",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "go version go1.26.2 darwin/arm64"
+    },
+    {
+      "runner": "dewasm-java",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "java version \"25.0.4.1\" 2026-08-18 LTS"
+    },
+    {
+      "runner": "dewasm-bash",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "5.3.15(1)-release"
+    },
+    {
+      "runner": "wasm3-ruby",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "Wasm3 v0.9.0 on wasm"
+    },
+    {
+      "runner": "wasm3-ruby-yjit",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "Wasm3 v0.9.0 on wasm"
+    },
+    {
+      "runner": "wasm3-python",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "Wasm3 v0.9.0 on wasm"
+    },
+    {
+      "runner": "wasm3-pypy",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "Wasm3 v0.9.0 on wasm"
+    },
+    {
+      "runner": "pywasm-cpython",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "pywasm 2.2.3"
+    },
+    {
+      "runner": "pywasm-pypy",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "pywasm 2.2.3"
+    },
+    {
+      "runner": "wardite",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "wardite 0.9.0"
+    },
+    {
+      "runner": "wardite-yjit",
+      "available": true,
+      "unavailable_reason": null,
+      "version": "wardite 0.9.0"
+    }
+  ],
+  "results": [
+    {
+      "workload": "wat/br_table",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 35580703,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005146042,
+        "median_s": 0.005300084,
+        "samples_s": [
+          0.005146042,
+          0.005696209,
+          0.005300084
+        ]
+      },
+      "total": {
+        "min_s": 0.303806959,
+        "median_s": 0.304954791,
+        "samples_s": [
+          0.304954791,
+          0.305360292,
+          0.303806959
+        ]
+      },
+      "compute_s": 0.29866091699999997,
+      "ns_per_op_min": 8.393901520158272,
+      "ns_per_op_median": 8.421832109388058,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 35566665,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.00809575,
+        "median_s": 0.008163292,
+        "samples_s": [
+          0.00809575,
+          0.008163292,
+          0.008505542
+        ]
+      },
+      "total": {
+        "min_s": 0.307265709,
+        "median_s": 0.307417709,
+        "samples_s": [
+          0.307418625,
+          0.307265709,
+          0.307417709
+        ]
+      },
+      "compute_s": 0.299169959,
+      "ns_per_op_min": 8.411526889012507,
+      "ns_per_op_median": 8.413901528299041,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1427536,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.014423708,
+        "median_s": 0.014668042,
+        "samples_s": [
+          0.014423708,
+          0.014668042,
+          0.015321625
+        ]
+      },
+      "total": {
+        "min_s": 0.322805459,
+        "median_s": 0.325175041,
+        "samples_s": [
+          0.322805459,
+          0.337432292,
+          0.325175041
+        ]
+      },
+      "compute_s": 0.30838175100000004,
+      "ns_per_op_min": 216.02379975005888,
+      "ns_per_op_median": 217.51255239797806,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 34445047,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004621833,
+        "median_s": 0.004639042,
+        "samples_s": [
+          0.004639042,
+          0.004693083,
+          0.004621833
+        ]
+      },
+      "total": {
+        "min_s": 0.304798083,
+        "median_s": 0.305103959,
+        "samples_s": [
+          0.305103959,
+          0.304798083,
+          0.30676575
+        ]
+      },
+      "compute_s": 0.30017625,
+      "ns_per_op_min": 8.714641904828872,
+      "ns_per_op_median": 8.723022413062754,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 8285355,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.003921334,
+        "median_s": 0.003939625,
+        "samples_s": [
+          0.003939625,
+          0.003921334,
+          0.003990208
+        ]
+      },
+      "total": {
+        "min_s": 0.222149083,
+        "median_s": 0.22266825,
+        "samples_s": [
+          0.223216916,
+          0.22266825,
+          0.222149083
+        ]
+      },
+      "compute_s": 0.218227749,
+      "ns_per_op_min": 26.33897388826429,
+      "ns_per_op_median": 26.39942706136309,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 1185366,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035070542,
+        "median_s": 0.035759042,
+        "samples_s": [
+          0.038141458,
+          0.035759042,
+          0.035070542
+        ]
+      },
+      "total": {
+        "min_s": 0.287666375,
+        "median_s": 0.289330584,
+        "samples_s": [
+          0.287666375,
+          0.290770375,
+          0.289330584
+        ]
+      },
+      "compute_s": 0.252595833,
+      "ns_per_op_min": 213.09522375367607,
+      "ns_per_op_median": 213.91835264382476,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 1231670,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035962375,
+        "median_s": 0.036308833,
+        "samples_s": [
+          0.035962375,
+          0.036308833,
+          0.037380125
+        ]
+      },
+      "total": {
+        "min_s": 0.297930875,
+        "median_s": 0.29825425,
+        "samples_s": [
+          0.297930875,
+          0.29825425,
+          0.300443416
+        ]
+      },
+      "compute_s": 0.2619685,
+      "ns_per_op_min": 212.69374101829223,
+      "ns_per_op_median": 212.67499979702356,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 1286196,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035281584,
+        "median_s": 0.035451458,
+        "samples_s": [
+          0.035451458,
+          0.03548825,
+          0.035281584
+        ]
+      },
+      "total": {
+        "min_s": 0.308777542,
+        "median_s": 0.308986083,
+        "samples_s": [
+          0.308986083,
+          0.308777542,
+          0.313311709
+        ]
+      },
+      "compute_s": 0.27349595800000004,
+      "ns_per_op_min": 212.63940954566806,
+      "ns_per_op_median": 212.66947261537126,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 769013,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.026349583,
+        "median_s": 0.026546917,
+        "samples_s": [
+          0.026566375,
+          0.026546917,
+          0.026349583
+        ]
+      },
+      "total": {
+        "min_s": 0.326772292,
+        "median_s": 0.328444625,
+        "samples_s": [
+          0.326772292,
+          0.328444625,
+          0.340013875
+        ]
+      },
+      "compute_s": 0.300422709,
+      "ns_per_op_min": 390.6601175792867,
+      "ns_per_op_median": 392.5781592768913,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 4270974,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035963125,
+        "median_s": 0.037310917,
+        "samples_s": [
+          0.035963125,
+          0.037310917,
+          0.039111125
+        ]
+      },
+      "total": {
+        "min_s": 0.298006834,
+        "median_s": 0.29856425,
+        "samples_s": [
+          0.29856425,
+          0.298006834,
+          0.301109375
+        ]
+      },
+      "compute_s": 0.262043709,
+      "ns_per_op_min": 61.354554956316754,
+      "ns_per_op_median": 61.16949740270017,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 352630,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009966208,
+        "median_s": 0.010002208,
+        "samples_s": [
+          0.010089542,
+          0.009966208,
+          0.010002208
+        ]
+      },
+      "total": {
+        "min_s": 0.312598625,
+        "median_s": 0.314759459,
+        "samples_s": [
+          0.314759459,
+          0.312598625,
+          0.315137959
+        ]
+      },
+      "compute_s": 0.30263241700000004,
+      "ns_per_op_min": 858.2151745455578,
+      "ns_per_op_median": 864.2408501829112,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 39624796,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002574125,
+        "median_s": 0.002584083,
+        "samples_s": [
+          0.002584083,
+          0.002574125,
+          0.002603667
+        ]
+      },
+      "total": {
+        "min_s": 0.303498458,
+        "median_s": 0.305822541,
+        "samples_s": [
+          0.303498458,
+          0.305822541,
+          0.308275875
+        ]
+      },
+      "compute_s": 0.30092433300000004,
+      "ns_per_op_min": 7.5943440314494,
+      "ns_per_op_median": 7.652744963027696,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 27398136,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.060365291,
+        "median_s": 0.06297975,
+        "samples_s": [
+          0.06324025,
+          0.060365291,
+          0.06297975
+        ]
+      },
+      "total": {
+        "min_s": 0.325472167,
+        "median_s": 0.32639525,
+        "samples_s": [
+          0.32639525,
+          0.325472167,
+          0.330739958
+        ]
+      },
+      "compute_s": 0.265106876,
+      "ns_per_op_min": 9.676091687405304,
+      "ns_per_op_median": 9.614358436646931,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 8019,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.011547834,
+        "median_s": 0.011688416,
+        "samples_s": [
+          0.011547834,
+          0.011830875,
+          0.011688416
+        ]
+      },
+      "total": {
+        "min_s": 0.298888875,
+        "median_s": 0.299014667,
+        "samples_s": [
+          0.298888875,
+          0.299014667,
+          0.301446125
+        ]
+      },
+      "compute_s": 0.287341041,
+      "ns_per_op_min": 35832.52787130565,
+      "ns_per_op_median": 35830.68350168351,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": 38466,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.116842083,
+        "median_s": 0.116979625,
+        "samples_s": [
+          0.117263375,
+          0.116979625,
+          0.116842083
+        ]
+      },
+      "total": {
+        "min_s": 0.486722042,
+        "median_s": 0.486979792,
+        "samples_s": [
+          0.486979792,
+          0.487332083,
+          0.486722042
+        ]
+      },
+      "compute_s": 0.36987995900000004,
+      "ns_per_op_min": 9615.763505433371,
+      "ns_per_op_median": 9618.888550928094,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": 58577,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.286766667,
+        "median_s": 0.287810292,
+        "samples_s": [
+          0.287810292,
+          0.286766667,
+          0.291756125
+        ]
+      },
+      "total": {
+        "min_s": 0.481129375,
+        "median_s": 0.483853792,
+        "samples_s": [
+          0.481129375,
+          0.48402675,
+          0.483853792
+        ]
+      },
+      "compute_s": 0.19436270800000005,
+      "ns_per_op_min": 3318.0720760708136,
+      "ns_per_op_median": 3346.765795448725,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": 10201,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.313543375,
+        "median_s": 0.316544208,
+        "samples_s": [
+          0.319323334,
+          0.316544208,
+          0.313543375
+        ]
+      },
+      "total": {
+        "min_s": 0.551467708,
+        "median_s": 0.551498375,
+        "samples_s": [
+          0.551467708,
+          0.558631416,
+          0.551498375
+        ]
+      },
+      "compute_s": 0.237924333,
+      "ns_per_op_min": 23323.62836976767,
+      "ns_per_op_median": 23032.464170179395,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": 33152,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.483056791,
+        "median_s": 0.484580209,
+        "samples_s": [
+          0.485127375,
+          0.483056791,
+          0.484580209
+        ]
+      },
+      "total": {
+        "min_s": 0.69152225,
+        "median_s": 0.691826083,
+        "samples_s": [
+          0.691826083,
+          0.694511167,
+          0.69152225
+        ]
+      },
+      "compute_s": 0.20846545900000002,
+      "ns_per_op_min": 6288.171422538611,
+      "ns_per_op_median": 6251.383747586874,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 5949,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.038906666,
+        "median_s": 0.03895475,
+        "samples_s": [
+          0.04177775,
+          0.03895475,
+          0.038906666
+        ]
+      },
+      "total": {
+        "min_s": 0.332779125,
+        "median_s": 0.332967041,
+        "samples_s": [
+          0.332779125,
+          0.334179083,
+          0.332967041
+        ]
+      },
+      "compute_s": 0.29387245900000003,
+      "ns_per_op_min": 49398.63153471173,
+      "ns_per_op_median": 49422.136661623816,
+      "load_ms": 0.894,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 8600,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.070632334,
+        "median_s": 0.070821375,
+        "samples_s": [
+          0.071304458,
+          0.070632334,
+          0.070821375
+        ]
+      },
+      "total": {
+        "min_s": 0.270490709,
+        "median_s": 0.271926459,
+        "samples_s": [
+          0.290019583,
+          0.270490709,
+          0.271926459
+        ]
+      },
+      "compute_s": 0.19985837499999998,
+      "ns_per_op_min": 23239.345930232554,
+      "ns_per_op_median": 23384.312093023254,
+      "load_ms": 5.124,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 15366,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.046431125,
+        "median_s": 0.04664175,
+        "samples_s": [
+          0.047351583,
+          0.04664175,
+          0.046431125
+        ]
+      },
+      "total": {
+        "min_s": 0.356283875,
+        "median_s": 0.356831292,
+        "samples_s": [
+          0.356831292,
+          0.360807166,
+          0.356283875
+        ]
+      },
+      "compute_s": 0.30985275,
+      "ns_per_op_min": 20164.828192112454,
+      "ns_per_op_median": 20186.746192893406,
+      "load_ms": 3.579,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/br_table",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 30532,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.091415708,
+        "median_s": 0.092043,
+        "samples_s": [
+          0.091415708,
+          0.092043,
+          0.092553459
+        ]
+      },
+      "total": {
+        "min_s": 0.347525791,
+        "median_s": 0.348327083,
+        "samples_s": [
+          0.347525791,
+          0.352022334,
+          0.348327083
+        ]
+      },
+      "compute_s": 0.256110083,
+      "ns_per_op_min": 8388.251113585746,
+      "ns_per_op_median": 8393.950052404036,
+      "load_ms": 8.687,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 84753866,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005046584,
+        "median_s": 0.005206709,
+        "samples_s": [
+          0.005046584,
+          0.005206709,
+          0.00527275
+        ]
+      },
+      "total": {
+        "min_s": 0.29478225,
+        "median_s": 0.296048917,
+        "samples_s": [
+          0.296048917,
+          0.29478225,
+          0.296991166
+        ]
+      },
+      "compute_s": 0.289735666,
+      "ns_per_op_min": 3.4185539807706236,
+      "ns_per_op_median": 3.4316099279766195,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 87391953,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.007927167,
+        "median_s": 0.007958625,
+        "samples_s": [
+          0.008019583,
+          0.007927167,
+          0.007958625
+        ]
+      },
+      "total": {
+        "min_s": 0.308203958,
+        "median_s": 0.3087005,
+        "samples_s": [
+          0.3087005,
+          0.308203958,
+          0.309846833
+        ]
+      },
+      "compute_s": 0.300276791,
+      "ns_per_op_min": 3.4359775779355797,
+      "ns_per_op_median": 3.441299395151405,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1486788,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.014087209,
+        "median_s": 0.014174417,
+        "samples_s": [
+          0.014087209,
+          0.014212333,
+          0.014174417
+        ]
+      },
+      "total": {
+        "min_s": 0.308542625,
+        "median_s": 0.313056625,
+        "samples_s": [
+          0.313056625,
+          0.31547425,
+          0.308542625
+        ]
+      },
+      "compute_s": 0.294455416,
+      "ns_per_op_min": 198.048017605738,
+      "ns_per_op_median": 201.0254373858277,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 50901297,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004403084,
+        "median_s": 0.004441333,
+        "samples_s": [
+          0.004441333,
+          0.004403084,
+          0.004476167
+        ]
+      },
+      "total": {
+        "min_s": 0.3046825,
+        "median_s": 0.305185417,
+        "samples_s": [
+          0.306172208,
+          0.3046825,
+          0.305185417
+        ]
+      },
+      "compute_s": 0.300279416,
+      "ns_per_op_min": 5.899248814819002,
+      "ns_per_op_median": 5.908377619532956,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 6978720,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.003980583,
+        "median_s": 0.004023292,
+        "samples_s": [
+          0.004036042,
+          0.003980583,
+          0.004023292
+        ]
+      },
+      "total": {
+        "min_s": 0.308362667,
+        "median_s": 0.309322459,
+        "samples_s": [
+          0.308362667,
+          0.309322459,
+          0.30978075
+        ]
+      },
+      "compute_s": 0.304382084,
+      "ns_per_op_min": 43.615746727193525,
+      "ns_per_op_median": 43.74715807483321,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 1364086,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.034441333,
+        "median_s": 0.034592041,
+        "samples_s": [
+          0.034592041,
+          0.034624541,
+          0.034441333
+        ]
+      },
+      "total": {
+        "min_s": 0.30823175,
+        "median_s": 0.30856875,
+        "samples_s": [
+          0.312117542,
+          0.30856875,
+          0.30823175
+        ]
+      },
+      "compute_s": 0.273790417,
+      "ns_per_op_min": 200.71345721604064,
+      "ns_per_op_median": 200.85002631798875,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 2304123,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.034853,
+        "median_s": 0.034897042,
+        "samples_s": [
+          0.034897042,
+          0.034853,
+          0.035007875
+        ]
+      },
+      "total": {
+        "min_s": 0.277694416,
+        "median_s": 0.278880542,
+        "samples_s": [
+          0.279808708,
+          0.278880542,
+          0.277694416
+        ]
+      },
+      "compute_s": 0.242841416,
+      "ns_per_op_min": 105.39429362060966,
+      "ns_per_op_median": 105.88996333963075,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 1925696,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.034954208,
+        "median_s": 0.035041083,
+        "samples_s": [
+          0.0352535,
+          0.035041083,
+          0.034954208
+        ]
+      },
+      "total": {
+        "min_s": 0.270190458,
+        "median_s": 0.270287792,
+        "samples_s": [
+          0.270287792,
+          0.270190458,
+          0.270486
+        ]
+      },
+      "compute_s": 0.23523625000000004,
+      "ns_per_op_min": 122.15648264315864,
+      "ns_per_op_median": 122.16191392618566,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 738481,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.025576667,
+        "median_s": 0.025768292,
+        "samples_s": [
+          0.025789542,
+          0.025576667,
+          0.025768292
+        ]
+      },
+      "total": {
+        "min_s": 0.327207292,
+        "median_s": 0.328295958,
+        "samples_s": [
+          0.327207292,
+          0.328617333,
+          0.328295958
+        ]
+      },
+      "compute_s": 0.301630625,
+      "ns_per_op_min": 408.4473737306715,
+      "ns_per_op_median": 409.66208473880846,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 2663117,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.03612375,
+        "median_s": 0.036142459,
+        "samples_s": [
+          0.037846042,
+          0.03612375,
+          0.036142459
+        ]
+      },
+      "total": {
+        "min_s": 0.267249,
+        "median_s": 0.270627084,
+        "samples_s": [
+          0.267249,
+          0.270627084,
+          0.271266125
+        ]
+      },
+      "compute_s": 0.23112525,
+      "ns_per_op_min": 86.78749375262146,
+      "ns_per_op_median": 88.04893851828515,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 273922,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009931917,
+        "median_s": 0.009971541,
+        "samples_s": [
+          0.009971541,
+          0.010035916,
+          0.009931917
+        ]
+      },
+      "total": {
+        "min_s": 0.3045145,
+        "median_s": 0.304849333,
+        "samples_s": [
+          0.304849333,
+          0.3045145,
+          0.306566375
+        ]
+      },
+      "compute_s": 0.294582583,
+      "ns_per_op_min": 1075.4250589583896,
+      "ns_per_op_median": 1076.5027708617781,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 74343248,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002434709,
+        "median_s": 0.002443167,
+        "samples_s": [
+          0.002552208,
+          0.002434709,
+          0.002443167
+        ]
+      },
+      "total": {
+        "min_s": 0.303049167,
+        "median_s": 0.303810875,
+        "samples_s": [
+          0.305991333,
+          0.303049167,
+          0.303810875
+        ]
+      },
+      "compute_s": 0.30061445800000003,
+      "ns_per_op_min": 4.043601350320341,
+      "ns_per_op_median": 4.05373340696656,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 71772145,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0601055,
+        "median_s": 0.060521708,
+        "samples_s": [
+          0.060711792,
+          0.060521708,
+          0.0601055
+        ]
+      },
+      "total": {
+        "min_s": 0.312836042,
+        "median_s": 0.313443875,
+        "samples_s": [
+          0.313443875,
+          0.313688542,
+          0.312836042
+        ]
+      },
+      "compute_s": 0.252730542,
+      "ns_per_op_min": 3.5212900770904922,
+      "ns_per_op_median": 3.523959984754531,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 5383,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.011449458,
+        "median_s": 0.011518875,
+        "samples_s": [
+          0.011573583,
+          0.011518875,
+          0.011449458
+        ]
+      },
+      "total": {
+        "min_s": 0.302704375,
+        "median_s": 0.302764458,
+        "samples_s": [
+          0.302704375,
+          0.3031265,
+          0.302764458
+        ]
+      },
+      "compute_s": 0.291254917,
+      "ns_per_op_min": 54106.43080066877,
+      "ns_per_op_median": 54104.69682333273,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": 9852,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.11336825,
+        "median_s": 0.115405916,
+        "samples_s": [
+          0.116253792,
+          0.115405916,
+          0.11336825
+        ]
+      },
+      "total": {
+        "min_s": 0.327222167,
+        "median_s": 0.327784625,
+        "samples_s": [
+          0.327784625,
+          0.327801417,
+          0.327222167
+        ]
+      },
+      "compute_s": 0.213853917,
+      "ns_per_op_min": 21706.65012180268,
+      "ns_per_op_median": 21556.913215590743,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": 23446,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.198204833,
+        "median_s": 0.198386,
+        "samples_s": [
+          0.198386,
+          0.198204833,
+          0.198475417
+        ]
+      },
+      "total": {
+        "min_s": 0.401012208,
+        "median_s": 0.403454167,
+        "samples_s": [
+          0.403454167,
+          0.401012208,
+          0.407579083
+        ]
+      },
+      "compute_s": 0.20280737499999998,
+      "ns_per_op_min": 8649.977608120787,
+      "ns_per_op_median": 8746.40309647701,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": 4546,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.308701542,
+        "median_s": 0.309066916,
+        "samples_s": [
+          0.308701542,
+          0.309066916,
+          0.310437708
+        ]
+      },
+      "total": {
+        "min_s": 0.562674,
+        "median_s": 0.564420375,
+        "samples_s": [
+          0.564607708,
+          0.564420375,
+          0.562674
+        ]
+      },
+      "compute_s": 0.253972458,
+      "ns_per_op_min": 55867.236691597005,
+      "ns_per_op_median": 56171.020457545084,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": 12500,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.471953625,
+        "median_s": 0.473046792,
+        "samples_s": [
+          0.471953625,
+          0.476095542,
+          0.473046792
+        ]
+      },
+      "total": {
+        "min_s": 0.70204525,
+        "median_s": 0.70357375,
+        "samples_s": [
+          0.70204525,
+          0.70357375,
+          0.704413167
+        ]
+      },
+      "compute_s": 0.23009162499999997,
+      "ns_per_op_min": 18407.329999999998,
+      "ns_per_op_median": 18442.15664,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 6188,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.03844975,
+        "median_s": 0.038529459,
+        "samples_s": [
+          0.03844975,
+          0.038529459,
+          0.038732875
+        ]
+      },
+      "total": {
+        "min_s": 0.334674875,
+        "median_s": 0.3363695,
+        "samples_s": [
+          0.334674875,
+          0.336712541,
+          0.3363695
+        ]
+      },
+      "compute_s": 0.296225125,
+      "ns_per_op_min": 47870.89932126697,
+      "ns_per_op_median": 48131.874757595346,
+      "load_ms": 0.602,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 30422,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.068908,
+        "median_s": 0.068951083,
+        "samples_s": [
+          0.068908,
+          0.069307125,
+          0.068951083
+        ]
+      },
+      "total": {
+        "min_s": 0.322504541,
+        "median_s": 0.322770084,
+        "samples_s": [
+          0.322770084,
+          0.322504541,
+          0.325257375
+        ]
+      },
+      "compute_s": 0.25359654099999995,
+      "ns_per_op_min": 8335.95887844323,
+      "ns_per_op_median": 8343.271349681152,
+      "load_ms": 3.457,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 14381,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.04616275,
+        "median_s": 0.046229959,
+        "samples_s": [
+          0.046717125,
+          0.046229959,
+          0.04616275
+        ]
+      },
+      "total": {
+        "min_s": 0.293490708,
+        "median_s": 0.294785917,
+        "samples_s": [
+          0.298154917,
+          0.293490708,
+          0.294785917
+        ]
+      },
+      "compute_s": 0.247327958,
+      "ns_per_op_min": 17198.244767401433,
+      "ns_per_op_median": 17283.635213128437,
+      "load_ms": 3.398,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_direct",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 37699,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.090842291,
+        "median_s": 0.091401375,
+        "samples_s": [
+          0.091549,
+          0.091401375,
+          0.090842291
+        ]
+      },
+      "total": {
+        "min_s": 0.392086209,
+        "median_s": 0.392132041,
+        "samples_s": [
+          0.392132041,
+          0.392086209,
+          0.394380875
+        ]
+      },
+      "compute_s": 0.301243918,
+      "ns_per_op_min": 7990.7668107907375,
+      "ns_per_op_median": 7977.152338258309,
+      "load_ms": 8.428,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 33554432,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005179709,
+        "median_s": 0.005180708,
+        "samples_s": [
+          0.005180708,
+          0.005249958,
+          0.005179709
+        ]
+      },
+      "total": {
+        "min_s": 0.348769375,
+        "median_s": 0.351173709,
+        "samples_s": [
+          0.348769375,
+          0.356535417,
+          0.351173709
+        ]
+      },
+      "compute_s": 0.343589666,
+      "ns_per_op_min": 10.239769995212555,
+      "ns_per_op_median": 10.311394959688187,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 33554432,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.008085125,
+        "median_s": 0.008500833,
+        "samples_s": [
+          0.008528042,
+          0.008500833,
+          0.008085125
+        ]
+      },
+      "total": {
+        "min_s": 0.353967958,
+        "median_s": 0.354566625,
+        "samples_s": [
+          0.3548205,
+          0.353967958,
+          0.354566625
+        ]
+      },
+      "compute_s": 0.345882833,
+      "ns_per_op_min": 10.308111697435379,
+      "ns_per_op_median": 10.313564300537111,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 761262,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.014124792,
+        "median_s": 0.0141445,
+        "samples_s": [
+          0.014247959,
+          0.014124792,
+          0.0141445
+        ]
+      },
+      "total": {
+        "min_s": 0.317188834,
+        "median_s": 0.317375459,
+        "samples_s": [
+          0.317188834,
+          0.317375459,
+          0.321355333
+        ]
+      },
+      "compute_s": 0.303064042,
+      "ns_per_op_min": 398.10740848748526,
+      "ns_per_op_median": 398.3266720261881,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 16777216,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004505583,
+        "median_s": 0.004570833,
+        "samples_s": [
+          0.004570833,
+          0.004629542,
+          0.004505583
+        ]
+      },
+      "total": {
+        "min_s": 0.198415125,
+        "median_s": 0.198767083,
+        "samples_s": [
+          0.198767083,
+          0.19899575,
+          0.198415125
+        ]
+      },
+      "compute_s": 0.193909542,
+      "ns_per_op_min": 11.557909369468689,
+      "ns_per_op_median": 11.574998497962952,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 4680818,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.003959542,
+        "median_s": 0.003993459,
+        "samples_s": [
+          0.004033625,
+          0.003959542,
+          0.003993459
+        ]
+      },
+      "total": {
+        "min_s": 0.305234541,
+        "median_s": 0.306884292,
+        "samples_s": [
+          0.305234541,
+          0.306976416,
+          0.306884292
+        ]
+      },
+      "compute_s": 0.30127499900000004,
+      "ns_per_op_min": 64.36374988303328,
+      "ns_per_op_median": 64.70895322142412,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 420916,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.034701167,
+        "median_s": 0.03476875,
+        "samples_s": [
+          0.034843709,
+          0.034701167,
+          0.03476875
+        ]
+      },
+      "total": {
+        "min_s": 0.309181417,
+        "median_s": 0.310745417,
+        "samples_s": [
+          0.31116625,
+          0.310745417,
+          0.309181417
+        ]
+      },
+      "compute_s": 0.27448025000000004,
+      "ns_per_op_min": 652.1022009141968,
+      "ns_per_op_median": 655.6573449334309,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 708117,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035052084,
+        "median_s": 0.035127041,
+        "samples_s": [
+          0.035324959,
+          0.035127041,
+          0.035052084
+        ]
+      },
+      "total": {
+        "min_s": 0.317745792,
+        "median_s": 0.318103458,
+        "samples_s": [
+          0.318103458,
+          0.317745792,
+          0.319795791
+        ]
+      },
+      "compute_s": 0.28269370800000004,
+      "ns_per_op_min": 399.2189256860096,
+      "ns_per_op_median": 399.6181662069969,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 614939,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.03520475,
+        "median_s": 0.035480875,
+        "samples_s": [
+          0.03520475,
+          0.035480875,
+          0.039658667
+        ]
+      },
+      "total": {
+        "min_s": 0.318067458,
+        "median_s": 0.320719042,
+        "samples_s": [
+          0.320719042,
+          0.318067458,
+          0.320848792
+        ]
+      },
+      "compute_s": 0.282862708,
+      "ns_per_op_min": 459.9849871288046,
+      "ns_per_op_median": 463.8479052393815,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 392868,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.025767958,
+        "median_s": 0.025987458,
+        "samples_s": [
+          0.025767958,
+          0.02603025,
+          0.025987458
+        ]
+      },
+      "total": {
+        "min_s": 0.3259915,
+        "median_s": 0.328437833,
+        "samples_s": [
+          0.3259915,
+          0.328437833,
+          0.333177
+        ]
+      },
+      "compute_s": 0.300223542,
+      "ns_per_op_min": 764.1842603622591,
+      "ns_per_op_median": 769.8524058971461,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 1978238,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035916667,
+        "median_s": 0.035999042,
+        "samples_s": [
+          0.035916667,
+          0.035999042,
+          0.03637
+        ]
+      },
+      "total": {
+        "min_s": 0.309783333,
+        "median_s": 0.310298291,
+        "samples_s": [
+          0.310298291,
+          0.31152,
+          0.309783333
+        ]
+      },
+      "compute_s": 0.273866666,
+      "ns_per_op_min": 138.43969532482947,
+      "ns_per_op_median": 138.65836618243102,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 131072,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010650625,
+        "median_s": 0.010812667,
+        "samples_s": [
+          0.011172916,
+          0.010812667,
+          0.010650625
+        ]
+      },
+      "total": {
+        "min_s": 0.322401042,
+        "median_s": 0.324661625,
+        "samples_s": [
+          0.324661625,
+          0.32650275,
+          0.322401042
+        ]
+      },
+      "compute_s": 0.311750417,
+      "ns_per_op_min": 2378.466926574707,
+      "ns_per_op_median": 2394.477523803711,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 33554432,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002574792,
+        "median_s": 0.00263725,
+        "samples_s": [
+          0.002729875,
+          0.00263725,
+          0.002574792
+        ]
+      },
+      "total": {
+        "min_s": 0.35786,
+        "median_s": 0.357971042,
+        "samples_s": [
+          0.35786,
+          0.359677042,
+          0.357971042
+        ]
+      },
+      "compute_s": 0.355285208,
+      "ns_per_op_min": 10.588324308395386,
+      "ns_per_op_median": 10.589772224426271,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 3944469,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.058934917,
+        "median_s": 0.05929425,
+        "samples_s": [
+          0.059583625,
+          0.05929425,
+          0.058934917
+        ]
+      },
+      "total": {
+        "min_s": 0.270165708,
+        "median_s": 0.270279666,
+        "samples_s": [
+          0.270279666,
+          0.271140834,
+          0.270165708
+        ]
+      },
+      "compute_s": 0.211230791,
+      "ns_per_op_min": 53.55113476617512,
+      "ns_per_op_median": 53.48892740695895,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 4038,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.011592667,
+        "median_s": 0.011642083,
+        "samples_s": [
+          0.011642083,
+          0.011761833,
+          0.011592667
+        ]
+      },
+      "total": {
+        "min_s": 0.306108375,
+        "median_s": 0.306560708,
+        "samples_s": [
+          0.306859334,
+          0.306560708,
+          0.306108375
+        ]
+      },
+      "compute_s": 0.294515708,
+      "ns_per_op_min": 72936.03467062903,
+      "ns_per_op_median": 73035.81599801882,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": 8645,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.114385208,
+        "median_s": 0.114388791,
+        "samples_s": [
+          0.114385208,
+          0.114673459,
+          0.114388791
+        ]
+      },
+      "total": {
+        "min_s": 0.384309125,
+        "median_s": 0.385461875,
+        "samples_s": [
+          0.387259417,
+          0.384309125,
+          0.385461875
+        ]
+      },
+      "compute_s": 0.26992391699999996,
+      "ns_per_op_min": 31223.12515905147,
+      "ns_per_op_median": 31356.053672643146,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": 20390,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.23502075,
+        "median_s": 0.235391541,
+        "samples_s": [
+          0.235391541,
+          0.23502075,
+          0.235692791
+        ]
+      },
+      "total": {
+        "min_s": 0.4750465,
+        "median_s": 0.475283125,
+        "samples_s": [
+          0.476406208,
+          0.475283125,
+          0.4750465
+        ]
+      },
+      "compute_s": 0.24002574999999998,
+      "ns_per_op_min": 11771.738597351641,
+      "ns_per_op_median": 11765.15860716037,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": 3429,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.307911666,
+        "median_s": 0.308057292,
+        "samples_s": [
+          0.309172917,
+          0.308057292,
+          0.307911666
+        ]
+      },
+      "total": {
+        "min_s": 0.603826167,
+        "median_s": 0.605979292,
+        "samples_s": [
+          0.605979292,
+          0.603826167,
+          0.605980375
+        ]
+      },
+      "compute_s": 0.29591450100000005,
+      "ns_per_op_min": 86297.60892388453,
+      "ns_per_op_median": 86883.0562846311,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": 4760,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.474257375,
+        "median_s": 0.474375125,
+        "samples_s": [
+          0.474257375,
+          0.474375125,
+          0.476732458
+        ]
+      },
+      "total": {
+        "min_s": 0.666444959,
+        "median_s": 0.6694375,
+        "samples_s": [
+          0.666444959,
+          0.6694375,
+          0.669981958
+        ]
+      },
+      "compute_s": 0.19218758400000002,
+      "ns_per_op_min": 40375.542857142864,
+      "ns_per_op_median": 40979.49054621849,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 3695,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.038354625,
+        "median_s": 0.038443042,
+        "samples_s": [
+          0.038354625,
+          0.038443042,
+          0.038940791
+        ]
+      },
+      "total": {
+        "min_s": 0.331798584,
+        "median_s": 0.332151292,
+        "samples_s": [
+          0.333280167,
+          0.331798584,
+          0.332151292
+        ]
+      },
+      "compute_s": 0.293443959,
+      "ns_per_op_min": 79416.49769959405,
+      "ns_per_op_median": 79488.02435723951,
+      "load_ms": 0.707,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 7448,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.069567875,
+        "median_s": 0.06989325,
+        "samples_s": [
+          0.06989325,
+          0.069567875,
+          0.069982458
+        ]
+      },
+      "total": {
+        "min_s": 0.267475375,
+        "median_s": 0.267521625,
+        "samples_s": [
+          0.267475375,
+          0.267521625,
+          0.270552375
+        ]
+      },
+      "compute_s": 0.19790750000000001,
+      "ns_per_op_min": 26571.898496240603,
+      "ns_per_op_median": 26534.4219924812,
+      "load_ms": 4.06,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 10110,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.046390292,
+        "median_s": 0.046398583,
+        "samples_s": [
+          0.046398583,
+          0.046560416,
+          0.046390292
+        ]
+      },
+      "total": {
+        "min_s": 0.319610625,
+        "median_s": 0.323085667,
+        "samples_s": [
+          0.319610625,
+          0.323931333,
+          0.323085667
+        ]
+      },
+      "compute_s": 0.273220333,
+      "ns_per_op_min": 27024.760929772503,
+      "ns_per_op_median": 27367.66409495549,
+      "load_ms": 3.535,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/call_indirect",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 21391,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.091608292,
+        "median_s": 0.092146625,
+        "samples_s": [
+          0.092146625,
+          0.096806,
+          0.091608292
+        ]
+      },
+      "total": {
+        "min_s": 0.3799005,
+        "median_s": 0.379963042,
+        "samples_s": [
+          0.379963042,
+          0.381073,
+          0.3799005
+        ]
+      },
+      "compute_s": 0.288292208,
+      "ns_per_op_min": 13477.266513954466,
+      "ns_per_op_median": 13455.023935299892,
+      "load_ms": 8.341,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 40042826,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005101875,
+        "median_s": 0.005110666,
+        "samples_s": [
+          0.005101875,
+          0.005131459,
+          0.005110666
+        ]
+      },
+      "total": {
+        "min_s": 0.305803958,
+        "median_s": 0.305842917,
+        "samples_s": [
+          0.305842917,
+          0.307014334,
+          0.305803958
+        ]
+      },
+      "compute_s": 0.300702083,
+      "ns_per_op_min": 7.509512015960112,
+      "ns_per_op_median": 7.510265409339491,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 39934989,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.008010375,
+        "median_s": 0.008073167,
+        "samples_s": [
+          0.008126708,
+          0.008073167,
+          0.008010375
+        ]
+      },
+      "total": {
+        "min_s": 0.308772583,
+        "median_s": 0.309089333,
+        "samples_s": [
+          0.308772583,
+          0.309089333,
+          0.310960292
+        ]
+      },
+      "compute_s": 0.300762208,
+      "ns_per_op_min": 7.531295626499359,
+      "ns_per_op_median": 7.537654912087243,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1359832,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.014171333,
+        "median_s": 0.014350375,
+        "samples_s": [
+          0.014350375,
+          0.014171333,
+          0.014691125
+        ]
+      },
+      "total": {
+        "min_s": 0.315046375,
+        "median_s": 0.315432458,
+        "samples_s": [
+          0.315432458,
+          0.319793,
+          0.315046375
+        ]
+      },
+      "compute_s": 0.300875042,
+      "ns_per_op_min": 221.2589805211232,
+      "ns_per_op_median": 221.41123535848547,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 5217891,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004485125,
+        "median_s": 0.004542208,
+        "samples_s": [
+          0.004542208,
+          0.004564625,
+          0.004485125
+        ]
+      },
+      "total": {
+        "min_s": 0.296698667,
+        "median_s": 0.298129042,
+        "samples_s": [
+          0.296698667,
+          0.300948416,
+          0.298129042
+        ]
+      },
+      "compute_s": 0.29221354200000005,
+      "ns_per_op_min": 56.00223193623632,
+      "ns_per_op_median": 56.26542102930092,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 13394056,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.003889875,
+        "median_s": 0.003949958,
+        "samples_s": [
+          0.003955959,
+          0.003889875,
+          0.003949958
+        ]
+      },
+      "total": {
+        "min_s": 0.2881675,
+        "median_s": 0.288289334,
+        "samples_s": [
+          0.28860225,
+          0.2881675,
+          0.288289334
+        ]
+      },
+      "compute_s": 0.28427762500000003,
+      "ns_per_op_min": 21.224162792808993,
+      "ns_per_op_median": 21.228773121450295,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 225461,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.034841417,
+        "median_s": 0.034898334,
+        "samples_s": [
+          0.034898334,
+          0.03526775,
+          0.034841417
+        ]
+      },
+      "total": {
+        "min_s": 0.3304875,
+        "median_s": 0.33084175,
+        "samples_s": [
+          0.335078958,
+          0.3304875,
+          0.33084175
+        ]
+      },
+      "compute_s": 0.295646083,
+      "ns_per_op_min": 1311.2958915289119,
+      "ns_per_op_median": 1312.614669499381,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 327852,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.034943208,
+        "median_s": 0.035086917,
+        "samples_s": [
+          0.035152917,
+          0.034943208,
+          0.035086917
+        ]
+      },
+      "total": {
+        "min_s": 0.308182042,
+        "median_s": 0.30859875,
+        "samples_s": [
+          0.309404,
+          0.30859875,
+          0.308182042
+        ]
+      },
+      "compute_s": 0.273238834,
+      "ns_per_op_min": 833.4212815538718,
+      "ns_per_op_median": 834.253971304125,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 287444,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035096584,
+        "median_s": 0.035145709,
+        "samples_s": [
+          0.035145709,
+          0.035206958,
+          0.035096584
+        ]
+      },
+      "total": {
+        "min_s": 0.308891,
+        "median_s": 0.309060667,
+        "samples_s": [
+          0.310463375,
+          0.308891,
+          0.309060667
+        ]
+      },
+      "compute_s": 0.27379441600000004,
+      "ns_per_op_min": 952.5139366276563,
+      "ns_per_op_median": 952.9332948330805,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 217112,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.025830417,
+        "median_s": 0.025871875,
+        "samples_s": [
+          0.025871875,
+          0.025954833,
+          0.025830417
+        ]
+      },
+      "total": {
+        "min_s": 0.325207458,
+        "median_s": 0.325669125,
+        "samples_s": [
+          0.325207458,
+          0.325669125,
+          0.326166459
+        ]
+      },
+      "compute_s": 0.299377041,
+      "ns_per_op_min": 1378.9060070378423,
+      "ns_per_op_median": 1380.8414551015144,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 723178,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035876958,
+        "median_s": 0.036146542,
+        "samples_s": [
+          0.035876958,
+          0.036146542,
+          0.036201583
+        ]
+      },
+      "total": {
+        "min_s": 0.21857475,
+        "median_s": 0.218966167,
+        "samples_s": [
+          0.21857475,
+          0.220836,
+          0.218966167
+        ]
+      },
+      "compute_s": 0.18269779200000003,
+      "ns_per_op_min": 252.63184444217057,
+      "ns_per_op_median": 252.8003133391779,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 138082,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.013554833,
+        "median_s": 0.013629125,
+        "samples_s": [
+          0.013554833,
+          0.013629125,
+          0.013740833
+        ]
+      },
+      "total": {
+        "min_s": 0.316346875,
+        "median_s": 0.3192915,
+        "samples_s": [
+          0.316346875,
+          0.320763333,
+          0.3192915
+        ]
+      },
+      "compute_s": 0.30279204200000004,
+      "ns_per_op_min": 2192.842238669776,
+      "ns_per_op_median": 2213.6294013702004,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 33554432,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002456,
+        "median_s": 0.002585125,
+        "samples_s": [
+          0.002641333,
+          0.002585125,
+          0.002456
+        ]
+      },
+      "total": {
+        "min_s": 0.349505417,
+        "median_s": 0.34957725,
+        "samples_s": [
+          0.349505417,
+          0.34957725,
+          0.349859541
+        ]
+      },
+      "compute_s": 0.34704941699999997,
+      "ns_per_op_min": 10.342878609895706,
+      "ns_per_op_median": 10.34117117524147,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 11105278,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.06019725,
+        "median_s": 0.060553542,
+        "samples_s": [
+          0.06019725,
+          0.060553542,
+          0.062151375
+        ]
+      },
+      "total": {
+        "min_s": 0.261138041,
+        "median_s": 0.261294125,
+        "samples_s": [
+          0.261138041,
+          0.261294125,
+          0.262059166
+        ]
+      },
+      "compute_s": 0.20094079099999998,
+      "ns_per_op_min": 18.09417026750703,
+      "ns_per_op_median": 18.076142083070767,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 603,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.012794125,
+        "median_s": 0.012881083,
+        "samples_s": [
+          0.012794125,
+          0.012881083,
+          0.012994042
+        ]
+      },
+      "total": {
+        "min_s": 0.314109625,
+        "median_s": 0.316651334,
+        "samples_s": [
+          0.318868208,
+          0.316651334,
+          0.314109625
+        ]
+      },
+      "compute_s": 0.3013155,
+      "ns_per_op_min": 499694.0298507463,
+      "ns_per_op_median": 503764.9270315091,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": 21330,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.114225209,
+        "median_s": 0.114537875,
+        "samples_s": [
+          0.114225209,
+          0.114729875,
+          0.114537875
+        ]
+      },
+      "total": {
+        "min_s": 0.5027275,
+        "median_s": 0.507337708,
+        "samples_s": [
+          0.507337708,
+          0.5027275,
+          0.509151625
+        ]
+      },
+      "compute_s": 0.388502291,
+      "ns_per_op_min": 18213.89081106423,
+      "ns_per_op_median": 18415.36957337084,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": 32416,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.238532459,
+        "median_s": 0.23877075,
+        "samples_s": [
+          0.238532459,
+          0.239050208,
+          0.23877075
+        ]
+      },
+      "total": {
+        "min_s": 0.49177875,
+        "median_s": 0.4952585,
+        "samples_s": [
+          0.4952585,
+          0.49177875,
+          0.49603275
+        ]
+      },
+      "compute_s": 0.25324629099999996,
+      "ns_per_op_min": 7812.385581194471,
+      "ns_per_op_median": 7912.381231490622,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": 7562,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.311048084,
+        "median_s": 0.31134675,
+        "samples_s": [
+          0.314434417,
+          0.31134675,
+          0.311048084
+        ]
+      },
+      "total": {
+        "min_s": 0.617148458,
+        "median_s": 0.618684042,
+        "samples_s": [
+          0.618684042,
+          0.621251958,
+          0.617148458
+        ]
+      },
+      "compute_s": 0.30610037399999995,
+      "ns_per_op_min": 40478.75879396984,
+      "ns_per_op_median": 40642.3290134885,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": 5536,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.471566625,
+        "median_s": 0.473820917,
+        "samples_s": [
+          0.474633084,
+          0.471566625,
+          0.473820917
+        ]
+      },
+      "total": {
+        "min_s": 0.666811375,
+        "median_s": 0.667015042,
+        "samples_s": [
+          0.669423542,
+          0.666811375,
+          0.667015042
+        ]
+      },
+      "compute_s": 0.19524474999999997,
+      "ns_per_op_min": 35268.19906069364,
+      "ns_per_op_median": 34897.782695086695,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 2976,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.03845975,
+        "median_s": 0.038481833,
+        "samples_s": [
+          0.0389795,
+          0.038481833,
+          0.03845975
+        ]
+      },
+      "total": {
+        "min_s": 0.331660542,
+        "median_s": 0.33229675,
+        "samples_s": [
+          0.335458292,
+          0.331660542,
+          0.33229675
+        ]
+      },
+      "compute_s": 0.293200792,
+      "ns_per_op_min": 98521.77150537634,
+      "ns_per_op_median": 98728.13071236557,
+      "load_ms": 0.625,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 351,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.069031333,
+        "median_s": 0.069432417,
+        "samples_s": [
+          0.069432417,
+          0.069525916,
+          0.069031333
+        ]
+      },
+      "total": {
+        "min_s": 0.318383,
+        "median_s": 0.324277167,
+        "samples_s": [
+          0.32551525,
+          0.324277167,
+          0.318383
+        ]
+      },
+      "compute_s": 0.24935166700000003,
+      "ns_per_op_min": 710403.6096866098,
+      "ns_per_op_median": 726053.4188034186,
+      "load_ms": 3.601,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 10969,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.046672834,
+        "median_s": 0.046817459,
+        "samples_s": [
+          0.048853292,
+          0.046817459,
+          0.046672834
+        ]
+      },
+      "total": {
+        "min_s": 0.323895209,
+        "median_s": 0.323945375,
+        "samples_s": [
+          0.323945375,
+          0.324835375,
+          0.323895209
+        ]
+      },
+      "compute_s": 0.277222375,
+      "ns_per_op_min": 25273.258729145775,
+      "ns_per_op_median": 25264.6472786945,
+      "load_ms": 3.498,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/conv",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 15601,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.09003375,
+        "median_s": 0.090116084,
+        "samples_s": [
+          0.090116084,
+          0.09003375,
+          0.0904435
+        ]
+      },
+      "total": {
+        "min_s": 0.319364666,
+        "median_s": 0.319800334,
+        "samples_s": [
+          0.319977167,
+          0.319364666,
+          0.319800334
+        ]
+      },
+      "compute_s": 0.22933091600000002,
+      "ns_per_op_min": 14699.757451445423,
+      "ns_per_op_median": 14722.40561502468,
+      "load_ms": 8.587,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 1376525,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005073542,
+        "median_s": 0.005167666,
+        "samples_s": [
+          0.005319875,
+          0.005073542,
+          0.005167666
+        ]
+      },
+      "total": {
+        "min_s": 0.29990175,
+        "median_s": 0.303868541,
+        "samples_s": [
+          0.29990175,
+          0.305669,
+          0.303868541
+        ]
+      },
+      "compute_s": 0.29482820800000004,
+      "ns_per_op_min": 214.18296652803258,
+      "ns_per_op_median": 216.99633134160294,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 28628,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.007958958,
+        "median_s": 0.007959375,
+        "samples_s": [
+          0.008108125,
+          0.007958958,
+          0.007959375
+        ]
+      },
+      "total": {
+        "min_s": 0.292831584,
+        "median_s": 0.292985959,
+        "samples_s": [
+          0.292985959,
+          0.293033,
+          0.292831584
+        ]
+      },
+      "compute_s": 0.28487262599999996,
+      "ns_per_op_min": 9950.839248288386,
+      "ns_per_op_median": 9956.217130082438,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 2710245,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.014097458,
+        "median_s": 0.014153291,
+        "samples_s": [
+          0.014153291,
+          0.014157625,
+          0.014097458
+        ]
+      },
+      "total": {
+        "min_s": 0.315247875,
+        "median_s": 0.31759725,
+        "samples_s": [
+          0.31759725,
+          0.319981917,
+          0.315247875
+        ]
+      },
+      "compute_s": 0.301150417,
+      "ns_per_op_min": 111.11556962562425,
+      "ns_per_op_median": 111.961818580977,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wazero",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "wazero 1.12.0 rejects the module: \"tag section not supported as feature \\\"exception-handling\\\" is disabled\""
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wasm3",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "wasm3 0.9.0 fails to load it: \"out of order Wasm section\" (the tag section is unknown to it)"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 474641,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.034636042,
+        "median_s": 0.034884125,
+        "samples_s": [
+          0.034884125,
+          0.034636042,
+          0.034990583
+        ]
+      },
+      "total": {
+        "min_s": 0.323947917,
+        "median_s": 0.328510792,
+        "samples_s": [
+          0.328510792,
+          0.329645208,
+          0.323947917
+        ]
+      },
+      "compute_s": 0.289311875,
+      "ns_per_op_min": 609.5383142206425,
+      "ns_per_op_median": 618.6289574646944,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 490564,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.03504775,
+        "median_s": 0.035171417,
+        "samples_s": [
+          0.03504775,
+          0.035182,
+          0.035171417
+        ]
+      },
+      "total": {
+        "min_s": 0.255574292,
+        "median_s": 0.261394792,
+        "samples_s": [
+          0.261728291,
+          0.261394792,
+          0.255574292
+        ]
+      },
+      "compute_s": 0.220526542,
+      "ns_per_op_min": 449.53674138338727,
+      "ns_per_op_median": 461.14956458280665,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 496372,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035071166,
+        "median_s": 0.035156583,
+        "samples_s": [
+          0.035387375,
+          0.035071166,
+          0.035156583
+        ]
+      },
+      "total": {
+        "min_s": 0.32680275,
+        "median_s": 0.330102209,
+        "samples_s": [
+          0.32680275,
+          0.330102209,
+          0.331600042
+        ]
+      },
+      "compute_s": 0.291731584,
+      "ns_per_op_min": 587.7277203387782,
+      "ns_per_op_median": 594.2027874255598,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 460195,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.025809667,
+        "median_s": 0.026037459,
+        "samples_s": [
+          0.026085125,
+          0.025809667,
+          0.026037459
+        ]
+      },
+      "total": {
+        "min_s": 0.327510583,
+        "median_s": 0.328362375,
+        "samples_s": [
+          0.327510583,
+          0.328362375,
+          0.331559
+        ]
+      },
+      "compute_s": 0.30170091600000004,
+      "ns_per_op_min": 655.5936418257479,
+      "ns_per_op_median": 656.949588761286,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 4000000,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035530416,
+        "median_s": 0.035754292,
+        "samples_s": [
+          0.035754292,
+          0.035530416,
+          0.035816666
+        ]
+      },
+      "total": {
+        "min_s": 0.052714416,
+        "median_s": 0.052786459,
+        "samples_s": [
+          0.052786459,
+          0.052714416,
+          0.052830167
+        ]
+      },
+      "compute_s": 0.017183999999999998,
+      "ns_per_op_min": 4.295999999999999,
+      "ns_per_op_median": 4.25804175,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 261333,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010740917,
+        "median_s": 0.010806625,
+        "samples_s": [
+          0.010900167,
+          0.010740917,
+          0.010806625
+        ]
+      },
+      "total": {
+        "min_s": 0.312306958,
+        "median_s": 0.31542025,
+        "samples_s": [
+          0.31542025,
+          0.315761583,
+          0.312306958
+        ]
+      },
+      "compute_s": 0.301566041,
+      "ns_per_op_min": 1153.9531593790298,
+      "ns_per_op_median": 1165.6148477230201,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 1504226,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.00242925,
+        "median_s": 0.0025235,
+        "samples_s": [
+          0.00242925,
+          0.0025235,
+          0.002698417
+        ]
+      },
+      "total": {
+        "min_s": 0.293239,
+        "median_s": 0.293808583,
+        "samples_s": [
+          0.297775917,
+          0.293239,
+          0.293808583
+        ]
+      },
+      "compute_s": 0.29080975000000003,
+      "ns_per_op_min": 193.32849585102244,
+      "ns_per_op_median": 193.64449424488075,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 423986,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.059899208,
+        "median_s": 0.060249291,
+        "samples_s": [
+          0.060249291,
+          0.060334084,
+          0.059899208
+        ]
+      },
+      "total": {
+        "min_s": 0.275058916,
+        "median_s": 0.276003458,
+        "samples_s": [
+          0.275058916,
+          0.276003458,
+          0.277933625
+        ]
+      },
+      "compute_s": 0.21515970799999998,
+      "ns_per_op_min": 507.4688975579382,
+      "ns_per_op_median": 508.87096979617246,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "dewasm-bash",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "the bash backend has no exception-handling lowering and rejects the module at conversion time with \"unsupported (exception-handling): tag, exnref value, or try_table/throw/throw_ref instruction\" (see docs/support.md)"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wasm3-ruby",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "the converted wasm3 0.9.0 fails to load it like the native one, \"out of order Wasm section\" (the tag section is unknown to it), measured through the converted interpreter"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wasm3-ruby-yjit",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "the converted wasm3 0.9.0 fails to load it like the native one, \"out of order Wasm section\" (the tag section is unknown to it), measured through the converted interpreter"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wasm3-python",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "the converted wasm3 0.9.0 fails to load it like the native one, \"out of order Wasm section\" (the tag section is unknown to it), measured through the converted interpreter"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wasm3-pypy",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "the converted wasm3 0.9.0 fails to load it like the native one, \"out of order Wasm section\" (the tag section is unknown to it), measured through the converted interpreter"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "pywasm-cpython",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "pywasm 2.2.3 has no exception-handling opcodes; decoding dies with AssertionError on the throw/try_table opcode (pywasm/core.py, from_reader)"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "pywasm-pypy",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "pywasm 2.2.3 has no exception-handling opcodes; decoding dies with AssertionError on the throw/try_table opcode (pywasm/core.py, from_reader)"
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wardite",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "wardite 0.9.0 fails to load the tag section: Wardite::LoadError \"unknown code: 13\""
+    },
+    {
+      "workload": "wat/eh_throw",
+      "runner": "wardite-yjit",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "wardite 0.9.0 fails to load the tag section: Wardite::LoadError \"unknown code: 13\""
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 110122947,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005124083,
+        "median_s": 0.005261458,
+        "samples_s": [
+          0.005581125,
+          0.005261458,
+          0.005124083
+        ]
+      },
+      "total": {
+        "min_s": 0.30523525,
+        "median_s": 0.30525225,
+        "samples_s": [
+          0.308374083,
+          0.30523525,
+          0.30525225
+        ]
+      },
+      "compute_s": 0.300111167,
+      "ns_per_op_min": 2.725237338590294,
+      "ns_per_op_median": 2.724144242162353,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 236489418,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.007828917,
+        "median_s": 0.008333583,
+        "samples_s": [
+          0.007828917,
+          0.008333583,
+          0.008665167
+        ]
+      },
+      "total": {
+        "min_s": 0.302588917,
+        "median_s": 0.303052166,
+        "samples_s": [
+          0.304336875,
+          0.303052166,
+          0.302588917
+        ]
+      },
+      "compute_s": 0.29476,
+      "ns_per_op_min": 1.2463982637903908,
+      "ns_per_op_median": 1.2462231312184973,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 2622853,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.014049958,
+        "median_s": 0.014137167,
+        "samples_s": [
+          0.014272,
+          0.014049958,
+          0.014137167
+        ]
+      },
+      "total": {
+        "min_s": 0.308577458,
+        "median_s": 0.309062334,
+        "samples_s": [
+          0.309062334,
+          0.308577458,
+          0.311376209
+        ]
+      },
+      "compute_s": 0.29452750000000005,
+      "ns_per_op_min": 112.2927971945054,
+      "ns_per_op_median": 112.44441339259195,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wazero",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "wazero 1.12.0 rejects the module: \"tag section not supported as feature \\\"exception-handling\\\" is disabled\""
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wasm3",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "wasm3 0.9.0 fails to load it: \"out of order Wasm section\" (the tag section is unknown to it)"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 2451420,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.034644,
+        "median_s": 0.034654792,
+        "samples_s": [
+          0.034986417,
+          0.034654792,
+          0.034644
+        ]
+      },
+      "total": {
+        "min_s": 0.326486667,
+        "median_s": 0.327015833,
+        "samples_s": [
+          0.326486667,
+          0.329809125,
+          0.327015833
+        ]
+      },
+      "compute_s": 0.291842667,
+      "ns_per_op_min": 119.05045524634701,
+      "ns_per_op_median": 119.2619139111209,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 2515871,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.034878541,
+        "median_s": 0.034915125,
+        "samples_s": [
+          0.034878541,
+          0.034935792,
+          0.034915125
+        ]
+      },
+      "total": {
+        "min_s": 0.33766975,
+        "median_s": 0.338318333,
+        "samples_s": [
+          0.339387458,
+          0.33766975,
+          0.338318333
+        ]
+      },
+      "compute_s": 0.302791209,
+      "ns_per_op_min": 120.35243818144889,
+      "ns_per_op_median": 120.5956934993885,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 2547973,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035187917,
+        "median_s": 0.036647458,
+        "samples_s": [
+          0.035187917,
+          0.036647458,
+          0.037197625
+        ]
+      },
+      "total": {
+        "min_s": 0.340633625,
+        "median_s": 0.34139375,
+        "samples_s": [
+          0.340633625,
+          0.34139375,
+          0.34314675
+        ]
+      },
+      "compute_s": 0.305445708,
+      "ns_per_op_min": 119.8779217833156,
+      "ns_per_op_median": 119.60342279922118,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 1527977,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.025673625,
+        "median_s": 0.025675167,
+        "samples_s": [
+          0.025675167,
+          0.025673625,
+          0.025959375
+        ]
+      },
+      "total": {
+        "min_s": 0.323542042,
+        "median_s": 0.328162,
+        "samples_s": [
+          0.323542042,
+          0.328162,
+          0.328912166
+        ]
+      },
+      "compute_s": 0.297868417,
+      "ns_per_op_min": 194.94299783308256,
+      "ns_per_op_median": 197.96556689007753,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 114891453,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035628625,
+        "median_s": 0.03575975,
+        "samples_s": [
+          0.03584275,
+          0.035628625,
+          0.03575975
+        ]
+      },
+      "total": {
+        "min_s": 0.328330583,
+        "median_s": 0.328418083,
+        "samples_s": [
+          0.328965791,
+          0.328418083,
+          0.328330583
+        ]
+      },
+      "compute_s": 0.292701958,
+      "ns_per_op_min": 2.5476391007083876,
+      "ns_per_op_median": 2.5472593944825475,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 595735,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.00986825,
+        "median_s": 0.0100335,
+        "samples_s": [
+          0.010104708,
+          0.00986825,
+          0.0100335
+        ]
+      },
+      "total": {
+        "min_s": 0.309213541,
+        "median_s": 0.311198792,
+        "samples_s": [
+          0.309213541,
+          0.311198792,
+          0.312916042
+        ]
+      },
+      "compute_s": 0.29934529099999996,
+      "ns_per_op_min": 502.48061806004335,
+      "ns_per_op_median": 505.5356693831989,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 73850197,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002587417,
+        "median_s": 0.002683833,
+        "samples_s": [
+          0.002683833,
+          0.002813125,
+          0.002587417
+        ]
+      },
+      "total": {
+        "min_s": 0.307394209,
+        "median_s": 0.314358333,
+        "samples_s": [
+          0.315427958,
+          0.307394209,
+          0.314358333
+        ]
+      },
+      "compute_s": 0.304806792,
+      "ns_per_op_min": 4.127365997412302,
+      "ns_per_op_median": 4.220361118332561,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 208221136,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.059330333,
+        "median_s": 0.0595255,
+        "samples_s": [
+          0.060416458,
+          0.059330333,
+          0.0595255
+        ]
+      },
+      "total": {
+        "min_s": 0.352808292,
+        "median_s": 0.353414542,
+        "samples_s": [
+          0.354169792,
+          0.353414542,
+          0.352808292
+        ]
+      },
+      "compute_s": 0.293477959,
+      "ns_per_op_min": 1.4094532603068692,
+      "ns_per_op_median": 1.4114275219399437,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "dewasm-bash",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "the bash backend has no exception-handling lowering and rejects the module at conversion time with \"unsupported (exception-handling): tag, exnref value, or try_table/throw/throw_ref instruction\" (see docs/support.md)"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wasm3-ruby",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "the converted wasm3 0.9.0 fails to load it like the native one, \"out of order Wasm section\" (the tag section is unknown to it), measured through the converted interpreter"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wasm3-ruby-yjit",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "the converted wasm3 0.9.0 fails to load it like the native one, \"out of order Wasm section\" (the tag section is unknown to it), measured through the converted interpreter"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wasm3-python",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "the converted wasm3 0.9.0 fails to load it like the native one, \"out of order Wasm section\" (the tag section is unknown to it), measured through the converted interpreter"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wasm3-pypy",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "the converted wasm3 0.9.0 fails to load it like the native one, \"out of order Wasm section\" (the tag section is unknown to it), measured through the converted interpreter"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "pywasm-cpython",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "pywasm 2.2.3 has no exception-handling opcodes; decoding dies with AssertionError on the throw/try_table opcode (pywasm/core.py, from_reader)"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "pywasm-pypy",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "pywasm 2.2.3 has no exception-handling opcodes; decoding dies with AssertionError on the throw/try_table opcode (pywasm/core.py, from_reader)"
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wardite",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "wardite 0.9.0 fails to load the tag section: Wardite::LoadError \"unknown code: 13\""
+    },
+    {
+      "workload": "wat/eh_try",
+      "runner": "wardite-yjit",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "wardite 0.9.0 fails to load the tag section: Wardite::LoadError \"unknown code: 13\""
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 303074129,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0049365,
+        "median_s": 0.005184166,
+        "samples_s": [
+          0.005208584,
+          0.0049365,
+          0.005184166
+        ]
+      },
+      "total": {
+        "min_s": 0.303023334,
+        "median_s": 0.303775416,
+        "samples_s": [
+          0.305224166,
+          0.303775416,
+          0.303023334
+        ]
+      },
+      "compute_s": 0.29808683399999997,
+      "ns_per_op_min": 0.9835443064162034,
+      "ns_per_op_median": 0.9852086385110095,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 303555463,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.007968875,
+        "median_s": 0.007972208,
+        "samples_s": [
+          0.008052334,
+          0.007972208,
+          0.007968875
+        ]
+      },
+      "total": {
+        "min_s": 0.306610375,
+        "median_s": 0.307582083,
+        "samples_s": [
+          0.306610375,
+          0.308601917,
+          0.307582083
+        ]
+      },
+      "compute_s": 0.2986415,
+      "ns_per_op_min": 0.9838119763965506,
+      "ns_per_op_median": 0.9870020853487325,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 3458870,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.014101583,
+        "median_s": 0.014236375,
+        "samples_s": [
+          0.014101583,
+          0.014236375,
+          0.014323541
+        ]
+      },
+      "total": {
+        "min_s": 0.2841325,
+        "median_s": 0.284541125,
+        "samples_s": [
+          0.284541125,
+          0.2841325,
+          0.289029791
+        ]
+      },
+      "compute_s": 0.27003091700000004,
+      "ns_per_op_min": 78.06911419047263,
+      "ns_per_op_median": 78.14828253157823,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 319029219,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004580708,
+        "median_s": 0.004612916,
+        "samples_s": [
+          0.004612916,
+          0.004823209,
+          0.004580708
+        ]
+      },
+      "total": {
+        "min_s": 0.30413375,
+        "median_s": 0.304495625,
+        "samples_s": [
+          0.30413375,
+          0.305763875,
+          0.304495625
+        ]
+      },
+      "compute_s": 0.299553042,
+      "ns_per_op_min": 0.9389517453572176,
+      "ns_per_op_median": 0.939985089578895,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 43912660,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004014084,
+        "median_s": 0.00410925,
+        "samples_s": [
+          0.00410925,
+          0.004014084,
+          0.004205417
+        ]
+      },
+      "total": {
+        "min_s": 0.305824792,
+        "median_s": 0.305867083,
+        "samples_s": [
+          0.305824792,
+          0.305996292,
+          0.305867083
+        ]
+      },
+      "compute_s": 0.30181070800000004,
+      "ns_per_op_min": 6.872977132334959,
+      "ns_per_op_median": 6.871773037661576,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 839681,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.03481075,
+        "median_s": 0.035053375,
+        "samples_s": [
+          0.035486708,
+          0.035053375,
+          0.03481075
+        ]
+      },
+      "total": {
+        "min_s": 0.335245375,
+        "median_s": 0.335436041,
+        "samples_s": [
+          0.337102958,
+          0.335436041,
+          0.335245375
+        ]
+      },
+      "compute_s": 0.300434625,
+      "ns_per_op_min": 357.7961452027615,
+      "ns_per_op_median": 357.7342657509221,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 1279059,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035212958,
+        "median_s": 0.035602916,
+        "samples_s": [
+          0.035212958,
+          0.036050917,
+          0.035602916
+        ]
+      },
+      "total": {
+        "min_s": 0.320271709,
+        "median_s": 0.320360833,
+        "samples_s": [
+          0.320360833,
+          0.320271709,
+          0.322553708
+        ]
+      },
+      "compute_s": 0.285058751,
+      "ns_per_op_min": 222.86599054461132,
+      "ns_per_op_median": 222.63079107375032,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 1017492,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035064166,
+        "median_s": 0.035167833,
+        "samples_s": [
+          0.035064166,
+          0.035442041,
+          0.035167833
+        ]
+      },
+      "total": {
+        "min_s": 0.314338708,
+        "median_s": 0.314926916,
+        "samples_s": [
+          0.316179,
+          0.314926916,
+          0.314338708
+        ]
+      },
+      "compute_s": 0.279274542,
+      "ns_per_op_min": 274.47345237112427,
+      "ns_per_op_median": 274.9496634862977,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 560975,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.025973875,
+        "median_s": 0.026099417,
+        "samples_s": [
+          0.026337417,
+          0.026099417,
+          0.025973875
+        ]
+      },
+      "total": {
+        "min_s": 0.327585,
+        "median_s": 0.32793425,
+        "samples_s": [
+          0.328968417,
+          0.32793425,
+          0.327585
+        ]
+      },
+      "compute_s": 0.30161112500000004,
+      "ns_per_op_min": 537.6551985382594,
+      "ns_per_op_median": 538.0539827978073,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 51030231,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035832084,
+        "median_s": 0.035923167,
+        "samples_s": [
+          0.035957125,
+          0.035923167,
+          0.035832084
+        ]
+      },
+      "total": {
+        "min_s": 0.312370625,
+        "median_s": 0.312713417,
+        "samples_s": [
+          0.312846458,
+          0.312713417,
+          0.312370625
+        ]
+      },
+      "compute_s": 0.276538541,
+      "ns_per_op_min": 5.419112074958077,
+      "ns_per_op_median": 5.42404462170669,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 199606,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009919666,
+        "median_s": 0.009985042,
+        "samples_s": [
+          0.009919666,
+          0.009985042,
+          0.010116459
+        ]
+      },
+      "total": {
+        "min_s": 0.31092825,
+        "median_s": 0.314700417,
+        "samples_s": [
+          0.31092825,
+          0.314700417,
+          0.315275375
+        ]
+      },
+      "compute_s": 0.301008584,
+      "ns_per_op_min": 1508.0137070027954,
+      "ns_per_op_median": 1526.58424596455,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 87970797,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002704875,
+        "median_s": 0.002760084,
+        "samples_s": [
+          0.002760084,
+          0.002704875,
+          0.002973875
+        ]
+      },
+      "total": {
+        "min_s": 0.303812833,
+        "median_s": 0.303915458,
+        "samples_s": [
+          0.304029959,
+          0.303812833,
+          0.303915458
+        ]
+      },
+      "compute_s": 0.301107958,
+      "ns_per_op_min": 3.422817210579552,
+      "ns_per_op_median": 3.4233562076287662,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 178975442,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.060000875,
+        "median_s": 0.060041125,
+        "samples_s": [
+          0.061266,
+          0.060000875,
+          0.060041125
+        ]
+      },
+      "total": {
+        "min_s": 0.349249833,
+        "median_s": 0.35052825,
+        "samples_s": [
+          0.350851334,
+          0.35052825,
+          0.349249833
+        ]
+      },
+      "compute_s": 0.289248958,
+      "ns_per_op_min": 1.6161376933490126,
+      "ns_per_op_median": 1.623055776557322,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 162,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0116615,
+        "median_s": 0.01189625,
+        "samples_s": [
+          0.012019542,
+          0.01189625,
+          0.0116615
+        ]
+      },
+      "total": {
+        "min_s": 0.200219375,
+        "median_s": 0.200286042,
+        "samples_s": [
+          0.203046125,
+          0.200286042,
+          0.200219375
+        ]
+      },
+      "compute_s": 0.188557875,
+      "ns_per_op_min": 1163937.5,
+      "ns_per_op_median": 1162899.950617284,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": 47000,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.112477208,
+        "median_s": 0.113231125,
+        "samples_s": [
+          0.112477208,
+          0.113231125,
+          0.113308584
+        ]
+      },
+      "total": {
+        "min_s": 0.406381667,
+        "median_s": 0.406496291,
+        "samples_s": [
+          0.406381667,
+          0.407588083,
+          0.406496291
+        ]
+      },
+      "compute_s": 0.293904459,
+      "ns_per_op_min": 6253.286361702128,
+      "ns_per_op_median": 6239.684382978723,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": 125035,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.217673209,
+        "median_s": 0.219262458,
+        "samples_s": [
+          0.217673209,
+          0.219262458,
+          0.222880459
+        ]
+      },
+      "total": {
+        "min_s": 0.476357875,
+        "median_s": 0.476784792,
+        "samples_s": [
+          0.477187208,
+          0.476784792,
+          0.476357875
+        ]
+      },
+      "compute_s": 0.25868466599999995,
+      "ns_per_op_min": 2068.8980365497655,
+      "ns_per_op_median": 2059.6019834446356,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": 19886,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.307135708,
+        "median_s": 0.307418417,
+        "samples_s": [
+          0.310810458,
+          0.307135708,
+          0.307418417
+        ]
+      },
+      "total": {
+        "min_s": 0.594084625,
+        "median_s": 0.595372875,
+        "samples_s": [
+          0.595372875,
+          0.594084625,
+          0.600616417
+        ]
+      },
+      "compute_s": 0.286948917,
+      "ns_per_op_min": 14429.695112139194,
+      "ns_per_op_median": 14480.260384189882,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": 121778,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.468809292,
+        "median_s": 0.468890375,
+        "samples_s": [
+          0.468809292,
+          0.471134416,
+          0.468890375
+        ]
+      },
+      "total": {
+        "min_s": 0.76814475,
+        "median_s": 0.768703917,
+        "samples_s": [
+          0.768703917,
+          0.770518542,
+          0.76814475
+        ]
+      },
+      "compute_s": 0.29933545800000005,
+      "ns_per_op_min": 2458.0421586821926,
+      "ns_per_op_median": 2461.968023780978,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 10049,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.038254291,
+        "median_s": 0.038510042,
+        "samples_s": [
+          0.038510042,
+          0.038646583,
+          0.038254291
+        ]
+      },
+      "total": {
+        "min_s": 0.322317083,
+        "median_s": 0.322712875,
+        "samples_s": [
+          0.322712875,
+          0.322317083,
+          0.323125791
+        ]
+      },
+      "compute_s": 0.284062792,
+      "ns_per_op_min": 28267.767141009055,
+      "ns_per_op_median": 28281.70295551796,
+      "load_ms": 0.572,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 33756,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.068997375,
+        "median_s": 0.069109166,
+        "samples_s": [
+          0.068997375,
+          0.069115125,
+          0.069109166
+        ]
+      },
+      "total": {
+        "min_s": 0.276406666,
+        "median_s": 0.276826667,
+        "samples_s": [
+          0.28300375,
+          0.276406666,
+          0.276826667
+        ]
+      },
+      "compute_s": 0.20740929100000002,
+      "ns_per_op_min": 6144.368141959949,
+      "ns_per_op_median": 6153.4986669036625,
+      "load_ms": 3.102,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wardite",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "wardite 0.9.0 does not re-round f32 arithmetic to single precision, so a dependent operation chain diverges from wasmtime (1232349357 vs 1232349355 at 10000 iterations) and the byte-for-byte verification would fail the whole run"
+    },
+    {
+      "workload": "wat/f32_alu",
+      "runner": "wardite-yjit",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "wardite 0.9.0 does not re-round f32 arithmetic to single precision, so a dependent operation chain diverges from wasmtime (1232349357 vs 1232349355 at 10000 iterations) and the byte-for-byte verification would fail the whole run"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 309722106,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004820875,
+        "median_s": 0.004939625,
+        "samples_s": [
+          0.005061791,
+          0.004939625,
+          0.004820875
+        ]
+      },
+      "total": {
+        "min_s": 0.302177375,
+        "median_s": 0.302838958,
+        "samples_s": [
+          0.302838958,
+          0.30303725,
+          0.302177375
+        ]
+      },
+      "compute_s": 0.2973565,
+      "ns_per_op_min": 0.9600751584712522,
+      "ns_per_op_median": 0.9618278037926037,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 310531849,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.007878667,
+        "median_s": 0.008073416,
+        "samples_s": [
+          0.008073416,
+          0.007878667,
+          0.008146667
+        ]
+      },
+      "total": {
+        "min_s": 0.307087042,
+        "median_s": 0.308617542,
+        "samples_s": [
+          0.309455459,
+          0.308617542,
+          0.307087042
+        ]
+      },
+      "compute_s": 0.29920837499999997,
+      "ns_per_op_min": 0.9635352250132643,
+      "ns_per_op_median": 0.9678367193826872,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 3762387,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.014102667,
+        "median_s": 0.015325042,
+        "samples_s": [
+          0.014102667,
+          0.015325042,
+          0.015983625
+        ]
+      },
+      "total": {
+        "min_s": 0.304173917,
+        "median_s": 0.304801333,
+        "samples_s": [
+          0.304173917,
+          0.309965541,
+          0.304801333
+        ]
+      },
+      "compute_s": 0.29007125,
+      "ns_per_op_min": 77.09766432852335,
+      "ns_per_op_median": 76.93953094139438,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 312611669,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004337334,
+        "median_s": 0.004370834,
+        "samples_s": [
+          0.004370834,
+          0.004446375,
+          0.004337334
+        ]
+      },
+      "total": {
+        "min_s": 0.301762083,
+        "median_s": 0.302519459,
+        "samples_s": [
+          0.303052125,
+          0.302519459,
+          0.301762083
+        ]
+      },
+      "compute_s": 0.297424749,
+      "ns_per_op_min": 0.9514192158962562,
+      "ns_per_op_median": 0.9537347916465652,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 57022852,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004035542,
+        "median_s": 0.0040665,
+        "samples_s": [
+          0.0040665,
+          0.004195375,
+          0.004035542
+        ]
+      },
+      "total": {
+        "min_s": 0.306009959,
+        "median_s": 0.307193167,
+        "samples_s": [
+          0.306009959,
+          0.307193167,
+          0.311258792
+        ]
+      },
+      "compute_s": 0.301974417,
+      "ns_per_op_min": 5.295673688857232,
+      "ns_per_op_median": 5.315880499979201,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 3083361,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.034573958,
+        "median_s": 0.034684,
+        "samples_s": [
+          0.03470425,
+          0.034684,
+          0.034573958
+        ]
+      },
+      "total": {
+        "min_s": 0.344671083,
+        "median_s": 0.345668584,
+        "samples_s": [
+          0.349134,
+          0.344671083,
+          0.345668584
+        ]
+      },
+      "compute_s": 0.310097125,
+      "ns_per_op_min": 100.57113811843634,
+      "ns_per_op_median": 100.85896007635823,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 4179925,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035366708,
+        "median_s": 0.037333792,
+        "samples_s": [
+          0.038312125,
+          0.037333792,
+          0.035366708
+        ]
+      },
+      "total": {
+        "min_s": 0.344660958,
+        "median_s": 0.34717175,
+        "samples_s": [
+          0.35125,
+          0.34717175,
+          0.344660958
+        ]
+      },
+      "compute_s": 0.30929425,
+      "ns_per_op_min": 73.9951673774051,
+      "ns_per_op_median": 74.12524339551547,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 3621106,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.03522725,
+        "median_s": 0.035252583,
+        "samples_s": [
+          0.03522725,
+          0.035273417,
+          0.035252583
+        ]
+      },
+      "total": {
+        "min_s": 0.329336375,
+        "median_s": 0.332185458,
+        "samples_s": [
+          0.33283275,
+          0.329336375,
+          0.332185458
+        ]
+      },
+      "compute_s": 0.294109125,
+      "ns_per_op_min": 81.22079966728397,
+      "ns_per_op_median": 82.000602854487,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 1602770,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.025806584,
+        "median_s": 0.02604425,
+        "samples_s": [
+          0.026345125,
+          0.025806584,
+          0.02604425
+        ]
+      },
+      "total": {
+        "min_s": 0.266315958,
+        "median_s": 0.266430084,
+        "samples_s": [
+          0.267111541,
+          0.266430084,
+          0.266315958
+        ]
+      },
+      "compute_s": 0.24050937400000003,
+      "ns_per_op_min": 150.05856985094556,
+      "ns_per_op_median": 149.9814907940628,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 138501581,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.03591925,
+        "median_s": 0.035979208,
+        "samples_s": [
+          0.03591925,
+          0.035979208,
+          0.036038917
+        ]
+      },
+      "total": {
+        "min_s": 0.32834525,
+        "median_s": 0.329580375,
+        "samples_s": [
+          0.329580375,
+          0.32834525,
+          0.332022167
+        ]
+      },
+      "compute_s": 0.29242599999999996,
+      "ns_per_op_min": 2.1113549599119734,
+      "ns_per_op_median": 2.1198398233446882,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 369755,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.013561667,
+        "median_s": 0.013567042,
+        "samples_s": [
+          0.013678875,
+          0.013567042,
+          0.013561667
+        ]
+      },
+      "total": {
+        "min_s": 0.313268417,
+        "median_s": 0.317152166,
+        "samples_s": [
+          0.313268417,
+          0.317152166,
+          0.31993825
+        ]
+      },
+      "compute_s": 0.29970675,
+      "ns_per_op_min": 810.5549620694784,
+      "ns_per_op_median": 821.0439994050116,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 87154116,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002508792,
+        "median_s": 0.002587958,
+        "samples_s": [
+          0.002676291,
+          0.002587958,
+          0.002508792
+        ]
+      },
+      "total": {
+        "min_s": 0.302840583,
+        "median_s": 0.30286775,
+        "samples_s": [
+          0.30286775,
+          0.305374209,
+          0.302840583
+        ]
+      },
+      "compute_s": 0.300331791,
+      "ns_per_op_min": 3.4459851672409827,
+      "ns_per_op_median": 3.4453885344898687,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 182196682,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.060195041,
+        "median_s": 0.060467083,
+        "samples_s": [
+          0.060599792,
+          0.060467083,
+          0.060195041
+        ]
+      },
+      "total": {
+        "min_s": 0.352938083,
+        "median_s": 0.353354917,
+        "samples_s": [
+          0.352938083,
+          0.353354917,
+          0.353889167
+        ]
+      },
+      "compute_s": 0.292743042,
+      "ns_per_op_min": 1.6067418944544776,
+      "ns_per_op_median": 1.6075365960835664,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 535,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.011773084,
+        "median_s": 0.011776041,
+        "samples_s": [
+          0.011891292,
+          0.011776041,
+          0.011773084
+        ]
+      },
+      "total": {
+        "min_s": 0.311992583,
+        "median_s": 0.3120535,
+        "samples_s": [
+          0.31221875,
+          0.3120535,
+          0.311992583
+        ]
+      },
+      "compute_s": 0.300219499,
+      "ns_per_op_min": 561157.9420560747,
+      "ns_per_op_median": 561266.2785046728,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": 58497,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.113787667,
+        "median_s": 0.113795042,
+        "samples_s": [
+          0.113795042,
+          0.113937833,
+          0.113787667
+        ]
+      },
+      "total": {
+        "min_s": 0.433070417,
+        "median_s": 0.437259417,
+        "samples_s": [
+          0.438077708,
+          0.437259417,
+          0.433070417
+        ]
+      },
+      "compute_s": 0.31928275,
+      "ns_per_op_min": 5458.104689129357,
+      "ns_per_op_median": 5529.5891242285925,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": 165520,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.218408041,
+        "median_s": 0.219575583,
+        "samples_s": [
+          0.220202875,
+          0.218408041,
+          0.219575583
+        ]
+      },
+      "total": {
+        "min_s": 0.498355166,
+        "median_s": 0.499455166,
+        "samples_s": [
+          0.500001417,
+          0.498355166,
+          0.499455166
+        ]
+      },
+      "compute_s": 0.279947125,
+      "ns_per_op_min": 1691.3190248912517,
+      "ns_per_op_median": 1690.910965442243,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": 54626,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.310007209,
+        "median_s": 0.3101315,
+        "samples_s": [
+          0.310007209,
+          0.310417542,
+          0.3101315
+        ]
+      },
+      "total": {
+        "min_s": 1.030458083,
+        "median_s": 1.030890291,
+        "samples_s": [
+          1.030458083,
+          1.030890291,
+          1.0310345
+        ]
+      },
+      "compute_s": 0.7204508740000001,
+      "ns_per_op_min": 13188.790575916233,
+      "ns_per_op_median": 13194.42739721012,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": 111750,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.469519,
+        "median_s": 0.470933875,
+        "samples_s": [
+          0.472075834,
+          0.470933875,
+          0.469519
+        ]
+      },
+      "total": {
+        "min_s": 0.69606525,
+        "median_s": 0.696405458,
+        "samples_s": [
+          0.696405458,
+          0.69606525,
+          0.698429583
+        ]
+      },
+      "compute_s": 0.22654624999999995,
+      "ns_per_op_min": 2027.259507829977,
+      "ns_per_op_median": 2017.6428008948544,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 10362,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.03848525,
+        "median_s": 0.038556042,
+        "samples_s": [
+          0.03848525,
+          0.0388605,
+          0.038556042
+        ]
+      },
+      "total": {
+        "min_s": 0.333926417,
+        "median_s": 0.334306208,
+        "samples_s": [
+          0.334306208,
+          0.333926417,
+          0.334797708
+        ]
+      },
+      "compute_s": 0.295441167,
+      "ns_per_op_min": 28511.98291835553,
+      "ns_per_op_median": 28541.80331982243,
+      "load_ms": 0.568,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 44700,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.069045167,
+        "median_s": 0.069046917,
+        "samples_s": [
+          0.069046917,
+          0.06960825,
+          0.069045167
+        ]
+      },
+      "total": {
+        "min_s": 0.30039075,
+        "median_s": 0.30174075,
+        "samples_s": [
+          0.303861041,
+          0.30039075,
+          0.30174075
+        ]
+      },
+      "compute_s": 0.23134558299999997,
+      "ns_per_op_min": 5175.51639821029,
+      "ns_per_op_median": 5205.678590604028,
+      "load_ms": 3.158,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 37254,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.046606416,
+        "median_s": 0.046961875,
+        "samples_s": [
+          0.046961875,
+          0.046606416,
+          0.0501065
+        ]
+      },
+      "total": {
+        "min_s": 0.321083709,
+        "median_s": 0.321494667,
+        "samples_s": [
+          0.321699292,
+          0.321083709,
+          0.321494667
+        ]
+      },
+      "compute_s": 0.274477293,
+      "ns_per_op_min": 7367.726767595426,
+      "ns_per_op_median": 7369.216513662962,
+      "load_ms": 3.484,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/f64_alu",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 83370,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.094468625,
+        "median_s": 0.094893708,
+        "samples_s": [
+          0.094468625,
+          0.094893708,
+          0.098536917
+        ]
+      },
+      "total": {
+        "min_s": 0.380545,
+        "median_s": 0.380637041,
+        "samples_s": [
+          0.381323,
+          0.380545,
+          0.380637041
+        ]
+      },
+      "compute_s": 0.28607637500000005,
+      "ns_per_op_min": 3431.406681060334,
+      "ns_per_op_median": 3427.411934748711,
+      "load_ms": 8.225,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 131671637,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004882917,
+        "median_s": 0.005129959,
+        "samples_s": [
+          0.005303792,
+          0.005129959,
+          0.004882917
+        ]
+      },
+      "total": {
+        "min_s": 0.305508959,
+        "median_s": 0.305941417,
+        "samples_s": [
+          0.307464833,
+          0.305508959,
+          0.305941417
+        ]
+      },
+      "compute_s": 0.30062604200000004,
+      "ns_per_op_min": 2.2831495745739083,
+      "ns_per_op_median": 2.2845577442012055,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 131513515,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0079825,
+        "median_s": 0.0080585,
+        "samples_s": [
+          0.0079825,
+          0.00948125,
+          0.0080585
+        ]
+      },
+      "total": {
+        "min_s": 0.308258709,
+        "median_s": 0.3087905,
+        "samples_s": [
+          0.309827,
+          0.308258709,
+          0.3087905
+        ]
+      },
+      "compute_s": 0.300276209,
+      "ns_per_op_min": 2.283234609005774,
+      "ns_per_op_median": 2.2867003440672997,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 2056604,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.014104375,
+        "median_s": 0.014127083,
+        "samples_s": [
+          0.014127083,
+          0.014104375,
+          0.014159708
+        ]
+      },
+      "total": {
+        "min_s": 0.3172595,
+        "median_s": 0.317997125,
+        "samples_s": [
+          0.319761083,
+          0.3172595,
+          0.317997125
+        ]
+      },
+      "compute_s": 0.303155125,
+      "ns_per_op_min": 147.40568675350238,
+      "ns_per_op_median": 147.7533069078928,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 115104499,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004403709,
+        "median_s": 0.004543917,
+        "samples_s": [
+          0.004639625,
+          0.004543917,
+          0.004403709
+        ]
+      },
+      "total": {
+        "min_s": 0.305801584,
+        "median_s": 0.306005416,
+        "samples_s": [
+          0.306005416,
+          0.305801584,
+          0.306682125
+        ]
+      },
+      "compute_s": 0.30139787500000004,
+      "ns_per_op_min": 2.618471715862297,
+      "ns_per_op_median": 2.6190244657595874,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 16777216,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.003913917,
+        "median_s": 0.003996,
+        "samples_s": [
+          0.004112542,
+          0.003996,
+          0.003913917
+        ]
+      },
+      "total": {
+        "min_s": 0.217856917,
+        "median_s": 0.21821,
+        "samples_s": [
+          0.217856917,
+          0.218249833,
+          0.21821
+        ]
+      },
+      "compute_s": 0.21394300000000002,
+      "ns_per_op_min": 12.751996517181398,
+      "ns_per_op_median": 12.768149375915527,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 1675249,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.03472725,
+        "median_s": 0.034839958,
+        "samples_s": [
+          0.034839958,
+          0.03489125,
+          0.03472725
+        ]
+      },
+      "total": {
+        "min_s": 0.336590084,
+        "median_s": 0.339197958,
+        "samples_s": [
+          0.336590084,
+          0.340212708,
+          0.339197958
+        ]
+      },
+      "compute_s": 0.301862834,
+      "ns_per_op_min": 180.1898308848416,
+      "ns_per_op_median": 181.67926081436252,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 2190852,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035191042,
+        "median_s": 0.035205416,
+        "samples_s": [
+          0.035205416,
+          0.035207416,
+          0.035191042
+        ]
+      },
+      "total": {
+        "min_s": 0.333871375,
+        "median_s": 0.335276167,
+        "samples_s": [
+          0.333871375,
+          0.3364145,
+          0.335276167
+        ]
+      },
+      "compute_s": 0.298680333,
+      "ns_per_op_min": 136.33067546324443,
+      "ns_per_op_median": 136.96532262334472,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 1912475,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.03494175,
+        "median_s": 0.035068916,
+        "samples_s": [
+          0.035132333,
+          0.03494175,
+          0.035068916
+        ]
+      },
+      "total": {
+        "min_s": 0.31828925,
+        "median_s": 0.319680291,
+        "samples_s": [
+          0.319680291,
+          0.31977575,
+          0.31828925
+        ]
+      },
+      "compute_s": 0.28334750000000003,
+      "ns_per_op_min": 148.15749225480076,
+      "ns_per_op_median": 148.81835056667407,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 548200,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.025705666,
+        "median_s": 0.0257315,
+        "samples_s": [
+          0.025705666,
+          0.0257315,
+          0.025839167
+        ]
+      },
+      "total": {
+        "min_s": 0.327475291,
+        "median_s": 0.329874,
+        "samples_s": [
+          0.331646334,
+          0.327475291,
+          0.329874
+        ]
+      },
+      "compute_s": 0.301769625,
+      "ns_per_op_min": 550.4735954031376,
+      "ns_per_op_median": 554.8020795330171,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 30309930,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035692041,
+        "median_s": 0.035844209,
+        "samples_s": [
+          0.035692041,
+          0.036173542,
+          0.035844209
+        ]
+      },
+      "total": {
+        "min_s": 0.320901541,
+        "median_s": 0.321399791,
+        "samples_s": [
+          0.321428375,
+          0.320901541,
+          0.321399791
+        ]
+      },
+      "compute_s": 0.2852095,
+      "ns_per_op_min": 9.409770989243459,
+      "ns_per_op_median": 9.421189095454856,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 444661,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.00994225,
+        "median_s": 0.010015166,
+        "samples_s": [
+          0.010154833,
+          0.010015166,
+          0.00994225
+        ]
+      },
+      "total": {
+        "min_s": 0.310090875,
+        "median_s": 0.31328775,
+        "samples_s": [
+          0.310090875,
+          0.314292125,
+          0.31328775
+        ]
+      },
+      "compute_s": 0.300148625,
+      "ns_per_op_min": 675.0055098153425,
+      "ns_per_op_median": 682.0309943979795,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 99371466,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002474083,
+        "median_s": 0.002475125,
+        "samples_s": [
+          0.002604958,
+          0.002475125,
+          0.002474083
+        ]
+      },
+      "total": {
+        "min_s": 0.301982333,
+        "median_s": 0.302068,
+        "samples_s": [
+          0.302068,
+          0.301982333,
+          0.302162542
+        ]
+      },
+      "compute_s": 0.29950825,
+      "ns_per_op_min": 3.0140266824683857,
+      "ns_per_op_median": 3.014878285080347,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 133502140,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.060120084,
+        "median_s": 0.060443333,
+        "samples_s": [
+          0.060120084,
+          0.061709333,
+          0.060443333
+        ]
+      },
+      "total": {
+        "min_s": 0.365717292,
+        "median_s": 0.366007375,
+        "samples_s": [
+          0.365717292,
+          0.366007375,
+          0.367630833
+        ]
+      },
+      "compute_s": 0.305597208,
+      "ns_per_op_min": 2.289080969039148,
+      "ns_per_op_median": 2.288832538564551,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 12121,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.011900333,
+        "median_s": 0.01195975,
+        "samples_s": [
+          0.011995958,
+          0.01195975,
+          0.011900333
+        ]
+      },
+      "total": {
+        "min_s": 0.309496042,
+        "median_s": 0.310114291,
+        "samples_s": [
+          0.309496042,
+          0.310114291,
+          0.3116735
+        ]
+      },
+      "compute_s": 0.29759570900000004,
+      "ns_per_op_min": 24552.075653823948,
+      "ns_per_op_median": 24598.18010065176,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": 26526,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.112780083,
+        "median_s": 0.113874375,
+        "samples_s": [
+          0.113874375,
+          0.112780083,
+          0.113883708
+        ]
+      },
+      "total": {
+        "min_s": 0.40253225,
+        "median_s": 0.403436125,
+        "samples_s": [
+          0.403436125,
+          0.40253225,
+          0.404185625
+        ]
+      },
+      "compute_s": 0.28975216699999995,
+      "ns_per_op_min": 10923.326811430292,
+      "ns_per_op_median": 10916.148307321117,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": 73092,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.233641,
+        "median_s": 0.234792666,
+        "samples_s": [
+          0.234792666,
+          0.236719458,
+          0.233641
+        ]
+      },
+      "total": {
+        "min_s": 0.511338917,
+        "median_s": 0.511420209,
+        "samples_s": [
+          0.513845417,
+          0.511338917,
+          0.511420209
+        ]
+      },
+      "compute_s": 0.277697917,
+      "ns_per_op_min": 3799.2929048322662,
+      "ns_per_op_median": 3784.648703004432,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": 20313,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.309159291,
+        "median_s": 0.30949875,
+        "samples_s": [
+          0.3099915,
+          0.30949875,
+          0.309159291
+        ]
+      },
+      "total": {
+        "min_s": 0.842687917,
+        "median_s": 0.849460084,
+        "samples_s": [
+          0.849460084,
+          0.856621209,
+          0.842687917
+        ]
+      },
+      "compute_s": 0.5335286260000001,
+      "ns_per_op_min": 26265.378132230595,
+      "ns_per_op_median": 26582.057500123075,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": 26535,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.471820584,
+        "median_s": 0.472679417,
+        "samples_s": [
+          0.472874084,
+          0.472679417,
+          0.471820584
+        ]
+      },
+      "total": {
+        "min_s": 0.65741825,
+        "median_s": 0.662341,
+        "samples_s": [
+          0.65741825,
+          0.662341,
+          0.667040125
+        ]
+      },
+      "compute_s": 0.185597666,
+      "ns_per_op_min": 6994.4475598266445,
+      "ns_per_op_median": 7147.600640663274,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 5519,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.038510375,
+        "median_s": 0.038924083,
+        "samples_s": [
+          0.039102666,
+          0.038924083,
+          0.038510375
+        ]
+      },
+      "total": {
+        "min_s": 0.32902025,
+        "median_s": 0.329603209,
+        "samples_s": [
+          0.32902025,
+          0.332016667,
+          0.329603209
+        ]
+      },
+      "compute_s": 0.29050987500000003,
+      "ns_per_op_min": 52638.13643776046,
+      "ns_per_op_median": 52668.803406414205,
+      "load_ms": 0.601,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 14028,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.071227708,
+        "median_s": 0.0712675,
+        "samples_s": [
+          0.071227708,
+          0.0712675,
+          0.07160225
+        ]
+      },
+      "total": {
+        "min_s": 0.293723375,
+        "median_s": 0.293766333,
+        "samples_s": [
+          0.293766333,
+          0.293723375,
+          0.298120375
+        ]
+      },
+      "compute_s": 0.222495667,
+      "ns_per_op_min": 15860.825990875392,
+      "ns_per_op_median": 15861.051682349587,
+      "load_ms": 3.416,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 17510,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.047025125,
+        "median_s": 0.047056083,
+        "samples_s": [
+          0.047056083,
+          0.047201833,
+          0.047025125
+        ]
+      },
+      "total": {
+        "min_s": 0.307535834,
+        "median_s": 0.309390084,
+        "samples_s": [
+          0.310105167,
+          0.309390084,
+          0.307535834
+        ]
+      },
+      "compute_s": 0.260510709,
+      "ns_per_op_min": 14877.824614505997,
+      "ns_per_op_median": 14981.953226727586,
+      "load_ms": 3.46,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_alu",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 31422,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.090758834,
+        "median_s": 0.091009458,
+        "samples_s": [
+          0.090758834,
+          0.091300083,
+          0.091009458
+        ]
+      },
+      "total": {
+        "min_s": 0.304952125,
+        "median_s": 0.3057325,
+        "samples_s": [
+          0.3057325,
+          0.306100125,
+          0.304952125
+        ]
+      },
+      "compute_s": 0.214193291,
+      "ns_per_op_min": 6816.666380243142,
+      "ns_per_op_median": 6833.525618993063,
+      "load_ms": 8.008,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 40050301,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004857833,
+        "median_s": 0.004901542,
+        "samples_s": [
+          0.004901542,
+          0.005087,
+          0.004857833
+        ]
+      },
+      "total": {
+        "min_s": 0.306369708,
+        "median_s": 0.307383417,
+        "samples_s": [
+          0.308270458,
+          0.307383417,
+          0.306369708
+        ]
+      },
+      "compute_s": 0.30151187500000004,
+      "ns_per_op_min": 7.5283298120531,
+      "ns_per_op_median": 7.552549355371886,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 40159084,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0082155,
+        "median_s": 0.008456958,
+        "samples_s": [
+          0.008596834,
+          0.008456958,
+          0.0082155
+        ]
+      },
+      "total": {
+        "min_s": 0.3106275,
+        "median_s": 0.312584542,
+        "samples_s": [
+          0.3106275,
+          0.312584542,
+          0.322914166
+        ]
+      },
+      "compute_s": 0.302412,
+      "ns_per_op_min": 7.530351040875335,
+      "ns_per_op_median": 7.57307074035852,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1714168,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.014291875,
+        "median_s": 0.014352291,
+        "samples_s": [
+          0.014597916,
+          0.014291875,
+          0.014352291
+        ]
+      },
+      "total": {
+        "min_s": 0.319387458,
+        "median_s": 0.32139175,
+        "samples_s": [
+          0.32139175,
+          0.319387458,
+          0.322158208
+        ]
+      },
+      "compute_s": 0.305095583,
+      "ns_per_op_min": 177.98464502895865,
+      "ns_per_op_median": 179.11865056400535,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 39514012,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004372792,
+        "median_s": 0.0045065,
+        "samples_s": [
+          0.004701125,
+          0.004372792,
+          0.0045065
+        ]
+      },
+      "total": {
+        "min_s": 0.302023041,
+        "median_s": 0.302216,
+        "samples_s": [
+          0.304055333,
+          0.302023041,
+          0.302216
+        ]
+      },
+      "compute_s": 0.297650249,
+      "ns_per_op_min": 7.5327772082470394,
+      "ns_per_op_median": 7.534276701641938,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 16777216,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.00387175,
+        "median_s": 0.004011125,
+        "samples_s": [
+          0.0041425,
+          0.004011125,
+          0.00387175
+        ]
+      },
+      "total": {
+        "min_s": 0.264250042,
+        "median_s": 0.2652745,
+        "samples_s": [
+          0.265525167,
+          0.2652745,
+          0.264250042
+        ]
+      },
+      "compute_s": 0.260378292,
+      "ns_per_op_min": 15.519755601882935,
+      "ns_per_op_median": 15.572510659694673,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 806591,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.034987708,
+        "median_s": 0.03524075,
+        "samples_s": [
+          0.035390167,
+          0.03524075,
+          0.034987708
+        ]
+      },
+      "total": {
+        "min_s": 0.327640834,
+        "median_s": 0.332689958,
+        "samples_s": [
+          0.333889833,
+          0.332689958,
+          0.327640834
+        ]
+      },
+      "compute_s": 0.292653126,
+      "ns_per_op_min": 362.82716519276806,
+      "ns_per_op_median": 368.77327914643234,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 1304573,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035644583,
+        "median_s": 0.036159375,
+        "samples_s": [
+          0.036159375,
+          0.035644583,
+          0.036960458
+        ]
+      },
+      "total": {
+        "min_s": 0.287459625,
+        "median_s": 0.289479542,
+        "samples_s": [
+          0.289589208,
+          0.289479542,
+          0.287459625
+        ]
+      },
+      "compute_s": 0.251815042,
+      "ns_per_op_min": 193.02487633884803,
+      "ns_per_op_median": 194.17860633325998,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 822294,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035438125,
+        "median_s": 0.03614475,
+        "samples_s": [
+          0.036937,
+          0.03614475,
+          0.035438125
+        ]
+      },
+      "total": {
+        "min_s": 0.231667125,
+        "median_s": 0.232810167,
+        "samples_s": [
+          0.232810167,
+          0.233760167,
+          0.231667125
+        ]
+      },
+      "compute_s": 0.196229,
+      "ns_per_op_min": 238.63605960885036,
+      "ns_per_op_median": 239.16679070989207,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 286040,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.026067458,
+        "median_s": 0.026210834,
+        "samples_s": [
+          0.026210834,
+          0.026067458,
+          0.026681458
+        ]
+      },
+      "total": {
+        "min_s": 0.30139825,
+        "median_s": 0.304688083,
+        "samples_s": [
+          0.30139825,
+          0.304688083,
+          0.310063083
+        ]
+      },
+      "compute_s": 0.275330792,
+      "ns_per_op_min": 962.5604530834848,
+      "ns_per_op_median": 973.5605125157321,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 13730730,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035910917,
+        "median_s": 0.03637575,
+        "samples_s": [
+          0.03637575,
+          0.036624,
+          0.035910917
+        ]
+      },
+      "total": {
+        "min_s": 0.226895667,
+        "median_s": 0.227852375,
+        "samples_s": [
+          0.228803,
+          0.227852375,
+          0.226895667
+        ]
+      },
+      "compute_s": 0.19098474999999998,
+      "ns_per_op_min": 13.909293242238393,
+      "ns_per_op_median": 13.945116173721281,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 248573,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010058167,
+        "median_s": 0.010086916,
+        "samples_s": [
+          0.010286583,
+          0.010086916,
+          0.010058167
+        ]
+      },
+      "total": {
+        "min_s": 0.307407583,
+        "median_s": 0.309411125,
+        "samples_s": [
+          0.307407583,
+          0.3128625,
+          0.309411125
+        ]
+      },
+      "compute_s": 0.297349416,
+      "ns_per_op_min": 1196.2257204121124,
+      "ns_per_op_median": 1204.1702397283696,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 39698098,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002533958,
+        "median_s": 0.002567208,
+        "samples_s": [
+          0.002756083,
+          0.002567208,
+          0.002533958
+        ]
+      },
+      "total": {
+        "min_s": 0.303451167,
+        "median_s": 0.30372625,
+        "samples_s": [
+          0.304021875,
+          0.30372625,
+          0.303451167
+        ]
+      },
+      "compute_s": 0.300917209,
+      "ns_per_op_min": 7.5801417236664586,
+      "ns_per_op_median": 7.586233526855619,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 23905571,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.060466792,
+        "median_s": 0.0605515,
+        "samples_s": [
+          0.0605515,
+          0.062252584,
+          0.060466792
+        ]
+      },
+      "total": {
+        "min_s": 0.249661041,
+        "median_s": 0.250086167,
+        "samples_s": [
+          0.249661041,
+          0.250086167,
+          0.252083042
+        ]
+      },
+      "compute_s": 0.189194249,
+      "ns_per_op_min": 7.9142325862034415,
+      "ns_per_op_median": 7.928472697849386,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 4357,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.011476167,
+        "median_s": 0.011547542,
+        "samples_s": [
+          0.011679958,
+          0.011547542,
+          0.011476167
+        ]
+      },
+      "total": {
+        "min_s": 0.303505708,
+        "median_s": 0.304037,
+        "samples_s": [
+          0.304037,
+          0.304569417,
+          0.303505708
+        ]
+      },
+      "compute_s": 0.292029541,
+      "ns_per_op_min": 67025.37089740648,
+      "ns_per_op_median": 67130.92907964195,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": 16332,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.113233542,
+        "median_s": 0.115483459,
+        "samples_s": [
+          0.119965833,
+          0.115483459,
+          0.113233542
+        ]
+      },
+      "total": {
+        "min_s": 0.335196708,
+        "median_s": 0.336012292,
+        "samples_s": [
+          0.340769709,
+          0.335196708,
+          0.336012292
+        ]
+      },
+      "compute_s": 0.221963166,
+      "ns_per_op_min": 13590.69103600294,
+      "ns_per_op_median": 13502.867560617191,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": 44309,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.227383042,
+        "median_s": 0.22975225,
+        "samples_s": [
+          0.22975225,
+          0.244998125,
+          0.227383042
+        ]
+      },
+      "total": {
+        "min_s": 0.455546667,
+        "median_s": 0.459608167,
+        "samples_s": [
+          0.459608167,
+          0.455546667,
+          0.463848916
+        ]
+      },
+      "compute_s": 0.228163625,
+      "ns_per_op_min": 5149.37428062019,
+      "ns_per_op_median": 5187.5672436751,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": 9220,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.30840375,
+        "median_s": 0.310133083,
+        "samples_s": [
+          0.311448208,
+          0.30840375,
+          0.310133083
+        ]
+      },
+      "total": {
+        "min_s": 0.605908083,
+        "median_s": 0.609860958,
+        "samples_s": [
+          0.610923125,
+          0.605908083,
+          0.609860958
+        ]
+      },
+      "compute_s": 0.297504333,
+      "ns_per_op_min": 32267.281236442515,
+      "ns_per_op_median": 32508.446312364424,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": 27298,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.470482042,
+        "median_s": 0.471645708,
+        "samples_s": [
+          0.473961292,
+          0.470482042,
+          0.471645708
+        ]
+      },
+      "total": {
+        "min_s": 0.685609333,
+        "median_s": 0.686800791,
+        "samples_s": [
+          0.702014084,
+          0.685609333,
+          0.686800791
+        ]
+      },
+      "compute_s": 0.21512729100000005,
+      "ns_per_op_min": 7880.6978899553105,
+      "ns_per_op_median": 7881.71598651916,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 4855,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.038314958,
+        "median_s": 0.038616875,
+        "samples_s": [
+          0.038646542,
+          0.038616875,
+          0.038314958
+        ]
+      },
+      "total": {
+        "min_s": 0.331069708,
+        "median_s": 0.332733208,
+        "samples_s": [
+          0.331069708,
+          0.332733208,
+          0.334540625
+        ]
+      },
+      "compute_s": 0.29275475,
+      "ns_per_op_min": 60299.63954685891,
+      "ns_per_op_median": 60580.08918640577,
+      "load_ms": 0.597,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 9760,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.069655583,
+        "median_s": 0.069818542,
+        "samples_s": [
+          0.069818542,
+          0.069655583,
+          0.07216625
+        ]
+      },
+      "total": {
+        "min_s": 0.27850825,
+        "median_s": 0.278998459,
+        "samples_s": [
+          0.278998459,
+          0.27850825,
+          0.279332
+        ]
+      },
+      "compute_s": 0.20885266700000002,
+      "ns_per_op_min": 21398.838831967216,
+      "ns_per_op_median": 21432.36854508197,
+      "load_ms": 3.414,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 14812,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.046565542,
+        "median_s": 0.046781958,
+        "samples_s": [
+          0.049255083,
+          0.046781958,
+          0.046565542
+        ]
+      },
+      "total": {
+        "min_s": 0.310191542,
+        "median_s": 0.311044917,
+        "samples_s": [
+          0.311077167,
+          0.311044917,
+          0.310191542
+        ]
+      },
+      "compute_s": 0.26362599999999997,
+      "ns_per_op_min": 17798.13664596273,
+      "ns_per_op_median": 17841.13954901431,
+      "load_ms": 3.438,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i32_div",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 27205,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.090968042,
+        "median_s": 0.091100084,
+        "samples_s": [
+          0.090968042,
+          0.091100084,
+          0.091191833
+        ]
+      },
+      "total": {
+        "min_s": 0.319045708,
+        "median_s": 0.321839625,
+        "samples_s": [
+          0.321839625,
+          0.329240292,
+          0.319045708
+        ]
+      },
+      "compute_s": 0.22807766599999998,
+      "ns_per_op_min": 8383.6671935306,
+      "ns_per_op_median": 8481.512258775962,
+      "load_ms": 7.984,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 131932944,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005067459,
+        "median_s": 0.005074458,
+        "samples_s": [
+          0.005067459,
+          0.005074458,
+          0.005145334
+        ]
+      },
+      "total": {
+        "min_s": 0.307334958,
+        "median_s": 0.30740125,
+        "samples_s": [
+          0.307334958,
+          0.307679208,
+          0.30740125
+        ]
+      },
+      "compute_s": 0.302267499,
+      "ns_per_op_min": 2.2910691585871077,
+      "ns_per_op_median": 2.2915185762852377,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 131695323,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.00829225,
+        "median_s": 0.008371333,
+        "samples_s": [
+          0.008372958,
+          0.008371333,
+          0.00829225
+        ]
+      },
+      "total": {
+        "min_s": 0.309634083,
+        "median_s": 0.311361125,
+        "samples_s": [
+          0.311361125,
+          0.312390166,
+          0.309634083
+        ]
+      },
+      "compute_s": 0.301341833,
+      "ns_per_op_min": 2.288174144194931,
+      "ns_per_op_median": 2.3006875650398007,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 2037678,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.014079875,
+        "median_s": 0.014091959,
+        "samples_s": [
+          0.014091959,
+          0.014167791,
+          0.014079875
+        ]
+      },
+      "total": {
+        "min_s": 0.317826542,
+        "median_s": 0.319083667,
+        "samples_s": [
+          0.319083667,
+          0.317826542,
+          0.320305458
+        ]
+      },
+      "compute_s": 0.30374666699999997,
+      "ns_per_op_min": 149.06509615356302,
+      "ns_per_op_median": 149.67610584204178,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 112301993,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004869708,
+        "median_s": 0.004905042,
+        "samples_s": [
+          0.005125208,
+          0.004905042,
+          0.004869708
+        ]
+      },
+      "total": {
+        "min_s": 0.2972525,
+        "median_s": 0.298285875,
+        "samples_s": [
+          0.2972525,
+          0.298787292,
+          0.298285875
+        ]
+      },
+      "compute_s": 0.29238279199999995,
+      "ns_per_op_min": 2.6035405444674518,
+      "ns_per_op_median": 2.6124276619026694,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 16777216,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.003899292,
+        "median_s": 0.004137459,
+        "samples_s": [
+          0.004137459,
+          0.00414475,
+          0.003899292
+        ]
+      },
+      "total": {
+        "min_s": 0.202144709,
+        "median_s": 0.2024765,
+        "samples_s": [
+          0.204147458,
+          0.202144709,
+          0.2024765
+        ]
+      },
+      "compute_s": 0.198245417,
+      "ns_per_op_min": 11.816347658634186,
+      "ns_per_op_median": 11.821928083896637,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 242355,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035087417,
+        "median_s": 0.036693875,
+        "samples_s": [
+          0.035087417,
+          0.036693875,
+          0.036935375
+        ]
+      },
+      "total": {
+        "min_s": 0.332635667,
+        "median_s": 0.332779292,
+        "samples_s": [
+          0.332635667,
+          0.332779292,
+          0.333255333
+        ]
+      },
+      "compute_s": 0.29754825,
+      "ns_per_op_min": 1227.7372036888037,
+      "ns_per_op_median": 1221.7012935569721,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 309953,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.034959458,
+        "median_s": 0.035065583,
+        "samples_s": [
+          0.035065583,
+          0.034959458,
+          0.035137291
+        ]
+      },
+      "total": {
+        "min_s": 0.326043833,
+        "median_s": 0.326477167,
+        "samples_s": [
+          0.326933792,
+          0.326043833,
+          0.326477167
+        ]
+      },
+      "compute_s": 0.291084375,
+      "ns_per_op_min": 939.1242381909516,
+      "ns_per_op_median": 940.1799111478192,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 251132,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.03509225,
+        "median_s": 0.03512425,
+        "samples_s": [
+          0.035150333,
+          0.03512425,
+          0.03509225
+        ]
+      },
+      "total": {
+        "min_s": 0.285723916,
+        "median_s": 0.2873185,
+        "samples_s": [
+          0.290511125,
+          0.285723916,
+          0.2873185
+        ]
+      },
+      "compute_s": 0.25063166600000003,
+      "ns_per_op_min": 998.0076852014081,
+      "ns_per_op_median": 1004.2298472516443,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 479435,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.025552875,
+        "median_s": 0.02572575,
+        "samples_s": [
+          0.025768084,
+          0.02572575,
+          0.025552875
+        ]
+      },
+      "total": {
+        "min_s": 0.320856583,
+        "median_s": 0.326234541,
+        "samples_s": [
+          0.326234541,
+          0.320856583,
+          0.332904667
+        ]
+      },
+      "compute_s": 0.295303708,
+      "ns_per_op_min": 615.9410723038577,
+      "ns_per_op_median": 626.7977744636917,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 1107302,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035571333,
+        "median_s": 0.035680167,
+        "samples_s": [
+          0.035680167,
+          0.03595225,
+          0.035571333
+        ]
+      },
+      "total": {
+        "min_s": 0.275789042,
+        "median_s": 0.27983825,
+        "samples_s": [
+          0.279998792,
+          0.27983825,
+          0.275789042
+        ]
+      },
+      "compute_s": 0.240217709,
+      "ns_per_op_min": 216.93965061022197,
+      "ns_per_op_median": 220.49818658324472,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 302703,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009897542,
+        "median_s": 0.010018334,
+        "samples_s": [
+          0.010032542,
+          0.010018334,
+          0.009897542
+        ]
+      },
+      "total": {
+        "min_s": 0.305104,
+        "median_s": 0.306772666,
+        "samples_s": [
+          0.306772666,
+          0.308920417,
+          0.305104
+        ]
+      },
+      "compute_s": 0.295206458,
+      "ns_per_op_min": 975.2346623588138,
+      "ns_per_op_median": 980.3481696580477,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 115816204,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002475166,
+        "median_s": 0.002716292,
+        "samples_s": [
+          0.002943583,
+          0.002716292,
+          0.002475166
+        ]
+      },
+      "total": {
+        "min_s": 0.301987375,
+        "median_s": 0.303203416,
+        "samples_s": [
+          0.303203416,
+          0.301987375,
+          0.30446475
+        ]
+      },
+      "compute_s": 0.29951220900000003,
+      "ns_per_op_min": 2.5860993423683616,
+      "ns_per_op_median": 2.5945171195560857,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 79902297,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.060065375,
+        "median_s": 0.060467125,
+        "samples_s": [
+          0.060472375,
+          0.060065375,
+          0.060467125
+        ]
+      },
+      "total": {
+        "min_s": 0.24691925,
+        "median_s": 0.24700675,
+        "samples_s": [
+          0.24700675,
+          0.24691925,
+          0.248395208
+        ]
+      },
+      "compute_s": 0.186853875,
+      "ns_per_op_min": 2.3385294542909074,
+      "ns_per_op_median": 2.3345965260548143,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 8274,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.01224475,
+        "median_s": 0.012308875,
+        "samples_s": [
+          0.012308875,
+          0.01224475,
+          0.012690375
+        ]
+      },
+      "total": {
+        "min_s": 0.23552675,
+        "median_s": 0.236259792,
+        "samples_s": [
+          0.236259792,
+          0.239007667,
+          0.23552675
+        ]
+      },
+      "compute_s": 0.223282,
+      "ns_per_op_min": 26985.98017887358,
+      "ns_per_op_median": 27066.825839980662,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": 27258,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.114296458,
+        "median_s": 0.114467917,
+        "samples_s": [
+          0.114296458,
+          0.114467917,
+          0.122324625
+        ]
+      },
+      "total": {
+        "min_s": 0.437702583,
+        "median_s": 0.440969959,
+        "samples_s": [
+          0.437702583,
+          0.440969959,
+          0.441761417
+        ]
+      },
+      "compute_s": 0.323406125,
+      "ns_per_op_min": 11864.631484334874,
+      "ns_per_op_median": 11978.20977327757,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": 53063,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.233840208,
+        "median_s": 0.234722916,
+        "samples_s": [
+          0.234722916,
+          0.233840208,
+          0.23826175
+        ]
+      },
+      "total": {
+        "min_s": 0.500453917,
+        "median_s": 0.502984041,
+        "samples_s": [
+          0.503508917,
+          0.500453917,
+          0.502984041
+        ]
+      },
+      "compute_s": 0.266613709,
+      "ns_per_op_min": 5024.474850649228,
+      "ns_per_op_median": 5055.521267172983,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": 9648,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.309929459,
+        "median_s": 0.310927125,
+        "samples_s": [
+          0.313119,
+          0.310927125,
+          0.309929459
+        ]
+      },
+      "total": {
+        "min_s": 0.556807375,
+        "median_s": 0.560549583,
+        "samples_s": [
+          0.560549583,
+          0.556807375,
+          0.56582075
+        ]
+      },
+      "compute_s": 0.24687791599999998,
+      "ns_per_op_min": 25588.507048092866,
+      "ns_per_op_median": 25872.974502487563,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": 22842,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.470556125,
+        "median_s": 0.471308042,
+        "samples_s": [
+          0.470556125,
+          0.471308042,
+          0.473759041
+        ]
+      },
+      "total": {
+        "min_s": 0.68525325,
+        "median_s": 0.691117,
+        "samples_s": [
+          0.691685625,
+          0.691117,
+          0.68525325
+        ]
+      },
+      "compute_s": 0.21469712500000004,
+      "ns_per_op_min": 9399.22620611155,
+      "ns_per_op_median": 9623.017161369407,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 5374,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.038804458,
+        "median_s": 0.038974541,
+        "samples_s": [
+          0.038804458,
+          0.039314125,
+          0.038974541
+        ]
+      },
+      "total": {
+        "min_s": 0.340753125,
+        "median_s": 0.341345083,
+        "samples_s": [
+          0.344031125,
+          0.341345083,
+          0.340753125
+        ]
+      },
+      "compute_s": 0.301948667,
+      "ns_per_op_min": 56186.9495720134,
+      "ns_per_op_median": 56265.4525493115,
+      "load_ms": 0.592,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 649,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.072591458,
+        "median_s": 0.073143542,
+        "samples_s": [
+          0.073143542,
+          0.073604041,
+          0.072591458
+        ]
+      },
+      "total": {
+        "min_s": 0.256196,
+        "median_s": 0.258627875,
+        "samples_s": [
+          0.258627875,
+          0.256196,
+          0.259255416
+        ]
+      },
+      "compute_s": 0.18360454199999998,
+      "ns_per_op_min": 282903.7627118644,
+      "ns_per_op_median": 285800.2049306626,
+      "load_ms": 3.399,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 11634,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.046301875,
+        "median_s": 0.046318542,
+        "samples_s": [
+          0.046667333,
+          0.046301875,
+          0.046318542
+        ]
+      },
+      "total": {
+        "min_s": 0.232922834,
+        "median_s": 0.235305166,
+        "samples_s": [
+          0.235305166,
+          0.237055625,
+          0.232922834
+        ]
+      },
+      "compute_s": 0.186620959,
+      "ns_per_op_min": 16040.996991576414,
+      "ns_per_op_median": 16244.337631081316,
+      "load_ms": 3.626,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_alu",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 36512,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.089218541,
+        "median_s": 0.090945833,
+        "samples_s": [
+          0.090945833,
+          0.091116458,
+          0.089218541
+        ]
+      },
+      "total": {
+        "min_s": 0.411837834,
+        "median_s": 0.415613792,
+        "samples_s": [
+          0.428218333,
+          0.411837834,
+          0.415613792
+        ]
+      },
+      "compute_s": 0.32261929300000003,
+      "ns_per_op_min": 8835.979760078879,
+      "ns_per_op_median": 8892.089148773006,
+      "load_ms": 8.57,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 36833376,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005036041,
+        "median_s": 0.005053958,
+        "samples_s": [
+          0.005036041,
+          0.005053958,
+          0.005253458
+        ]
+      },
+      "total": {
+        "min_s": 0.305134166,
+        "median_s": 0.3053575,
+        "samples_s": [
+          0.30536525,
+          0.3053575,
+          0.305134166
+        ]
+      },
+      "compute_s": 0.300098125,
+      "ns_per_op_min": 8.14745096946856,
+      "ns_per_op_median": 8.153027895135107,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 36430157,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.008072334,
+        "median_s": 0.008162041,
+        "samples_s": [
+          0.008162041,
+          0.008574416,
+          0.008072334
+        ]
+      },
+      "total": {
+        "min_s": 0.304214208,
+        "median_s": 0.304441209,
+        "samples_s": [
+          0.306131292,
+          0.304214208,
+          0.304441209
+        ]
+      },
+      "compute_s": 0.29614187399999997,
+      "ns_per_op_min": 8.129030956413391,
+      "ns_per_op_median": 8.132799647281235,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1748598,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.014253209,
+        "median_s": 0.014446,
+        "samples_s": [
+          0.014253209,
+          0.014921125,
+          0.014446
+        ]
+      },
+      "total": {
+        "min_s": 0.32830625,
+        "median_s": 0.328316375,
+        "samples_s": [
+          0.328505458,
+          0.32830625,
+          0.328316375
+        ]
+      },
+      "compute_s": 0.31405304100000003,
+      "ns_per_op_min": 179.6027680461719,
+      "ns_per_op_median": 179.49830378394577,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 36531881,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004429042,
+        "median_s": 0.00448875,
+        "samples_s": [
+          0.00448875,
+          0.004508375,
+          0.004429042
+        ]
+      },
+      "total": {
+        "min_s": 0.301703167,
+        "median_s": 0.3024745,
+        "samples_s": [
+          0.302891292,
+          0.3024745,
+          0.301703167
+        ]
+      },
+      "compute_s": 0.297274125,
+      "ns_per_op_min": 8.137388956237977,
+      "ns_per_op_median": 8.156868517117966,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 16739719,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.003854208,
+        "median_s": 0.003861125,
+        "samples_s": [
+          0.003949583,
+          0.003854208,
+          0.003861125
+        ]
+      },
+      "total": {
+        "min_s": 0.2692265,
+        "median_s": 0.269460417,
+        "samples_s": [
+          0.2698925,
+          0.2692265,
+          0.269460417
+        ]
+      },
+      "compute_s": 0.26537229199999995,
+      "ns_per_op_min": 15.852852249192471,
+      "ns_per_op_median": 15.86641281135006,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 170863,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.034730875,
+        "median_s": 0.034852542,
+        "samples_s": [
+          0.034852542,
+          0.035427292,
+          0.034730875
+        ]
+      },
+      "total": {
+        "min_s": 0.313648167,
+        "median_s": 0.314218042,
+        "samples_s": [
+          0.313648167,
+          0.314218042,
+          0.323367459
+        ]
+      },
+      "compute_s": 0.278917292,
+      "ns_per_op_min": 1632.4031065824668,
+      "ns_per_op_median": 1635.026307626578,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 232551,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035011917,
+        "median_s": 0.035159,
+        "samples_s": [
+          0.035011917,
+          0.035297792,
+          0.035159
+        ]
+      },
+      "total": {
+        "min_s": 0.287252291,
+        "median_s": 0.293350208,
+        "samples_s": [
+          0.293416042,
+          0.287252291,
+          0.293350208
+        ]
+      },
+      "compute_s": 0.252240374,
+      "ns_per_op_min": 1084.6669074740594,
+      "ns_per_op_median": 1110.2562792677736,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 200310,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035154041,
+        "median_s": 0.035376584,
+        "samples_s": [
+          0.035376584,
+          0.035648334,
+          0.035154041
+        ]
+      },
+      "total": {
+        "min_s": 0.309812834,
+        "median_s": 0.3102285,
+        "samples_s": [
+          0.3102285,
+          0.311044125,
+          0.309812834
+        ]
+      },
+      "compute_s": 0.27465879299999996,
+      "ns_per_op_min": 1371.1686535869399,
+      "ns_per_op_median": 1372.13277419999,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 292937,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.025578542,
+        "median_s": 0.0256905,
+        "samples_s": [
+          0.02585675,
+          0.025578542,
+          0.0256905
+        ]
+      },
+      "total": {
+        "min_s": 0.3293165,
+        "median_s": 0.329891208,
+        "samples_s": [
+          0.3293165,
+          0.333770292,
+          0.329891208
+        ]
+      },
+      "compute_s": 0.30373795800000003,
+      "ns_per_op_min": 1036.8712658353163,
+      "ns_per_op_median": 1038.4509570317168,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 766931,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035667625,
+        "median_s": 0.035749708,
+        "samples_s": [
+          0.035749708,
+          0.036022125,
+          0.035667625
+        ]
+      },
+      "total": {
+        "min_s": 0.239404791,
+        "median_s": 0.239828291,
+        "samples_s": [
+          0.239828291,
+          0.239404791,
+          0.240867083
+        ]
+      },
+      "compute_s": 0.203737166,
+      "ns_per_op_min": 265.65253719043824,
+      "ns_per_op_median": 266.09771022425747,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 202182,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.00982375,
+        "median_s": 0.009903417,
+        "samples_s": [
+          0.009903417,
+          0.00982375,
+          0.009954833
+        ]
+      },
+      "total": {
+        "min_s": 0.30987175,
+        "median_s": 0.310271041,
+        "samples_s": [
+          0.310606917,
+          0.30987175,
+          0.310271041
+        ]
+      },
+      "compute_s": 0.300048,
+      "ns_per_op_min": 1484.0490251357687,
+      "ns_per_op_median": 1485.6298978148402,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 36463918,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002485083,
+        "median_s": 0.002572125,
+        "samples_s": [
+          0.002683042,
+          0.002572125,
+          0.002485083
+        ]
+      },
+      "total": {
+        "min_s": 0.299543417,
+        "median_s": 0.300056375,
+        "samples_s": [
+          0.299543417,
+          0.300056375,
+          0.300343833
+        ]
+      },
+      "compute_s": 0.297058334,
+      "ns_per_op_min": 8.146637835243048,
+      "ns_per_op_median": 8.15831831346264,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 26114761,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.060589667,
+        "median_s": 0.060893167,
+        "samples_s": [
+          0.060589667,
+          0.061317167,
+          0.060893167
+        ]
+      },
+      "total": {
+        "min_s": 0.280790375,
+        "median_s": 0.281911667,
+        "samples_s": [
+          0.284107292,
+          0.280790375,
+          0.281911667
+        ]
+      },
+      "compute_s": 0.22020070799999997,
+      "ns_per_op_min": 8.43203994859459,
+      "ns_per_op_median": 8.463355264863422,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 3923,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.011547042,
+        "median_s": 0.01163675,
+        "samples_s": [
+          0.011692958,
+          0.01163675,
+          0.011547042
+        ]
+      },
+      "total": {
+        "min_s": 0.304361709,
+        "median_s": 0.305539834,
+        "samples_s": [
+          0.305725667,
+          0.304361709,
+          0.305539834
+        ]
+      },
+      "compute_s": 0.292814667,
+      "ns_per_op_min": 74640.4963038491,
+      "ns_per_op_median": 74917.94137139946,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": 21603,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.113847125,
+        "median_s": 0.113972125,
+        "samples_s": [
+          0.113847125,
+          0.113972125,
+          0.118502875
+        ]
+      },
+      "total": {
+        "min_s": 0.429185333,
+        "median_s": 0.429535084,
+        "samples_s": [
+          0.429185333,
+          0.429535084,
+          0.429804208
+        ]
+      },
+      "compute_s": 0.315338208,
+      "ns_per_op_min": 14596.963755034023,
+      "ns_per_op_median": 14607.367448965424,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": 35811,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.227448334,
+        "median_s": 0.235354916,
+        "samples_s": [
+          0.227448334,
+          0.243750791,
+          0.235354916
+        ]
+      },
+      "total": {
+        "min_s": 0.46234225,
+        "median_s": 0.465398875,
+        "samples_s": [
+          0.465398875,
+          0.46679425,
+          0.46234225
+        ]
+      },
+      "compute_s": 0.234893916,
+      "ns_per_op_min": 6559.267152550892,
+      "ns_per_op_median": 6423.835106531513,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": 10756,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.30854175,
+        "median_s": 0.310474667,
+        "samples_s": [
+          0.30854175,
+          0.314865792,
+          0.310474667
+        ]
+      },
+      "total": {
+        "min_s": 0.643705417,
+        "median_s": 0.648156833,
+        "samples_s": [
+          0.643705417,
+          0.657421167,
+          0.648156833
+        ]
+      },
+      "compute_s": 0.33516366699999994,
+      "ns_per_op_min": 31160.62355894384,
+      "ns_per_op_median": 31394.77184827074,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": 10036,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.471256541,
+        "median_s": 0.472928792,
+        "samples_s": [
+          0.472928792,
+          0.473487125,
+          0.471256541
+        ]
+      },
+      "total": {
+        "min_s": 0.66953925,
+        "median_s": 0.673769125,
+        "samples_s": [
+          0.674246917,
+          0.673769125,
+          0.66953925
+        ]
+      },
+      "compute_s": 0.19828270900000006,
+      "ns_per_op_min": 19757.145177361504,
+      "ns_per_op_median": 20011.990135512155,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 4638,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.038648041,
+        "median_s": 0.038886167,
+        "samples_s": [
+          0.038886167,
+          0.038648041,
+          0.038945333
+        ]
+      },
+      "total": {
+        "min_s": 0.339474333,
+        "median_s": 0.340346084,
+        "samples_s": [
+          0.340346084,
+          0.339474333,
+          0.341494416
+        ]
+      },
+      "compute_s": 0.300826292,
+      "ns_per_op_min": 64861.210004312205,
+      "ns_per_op_median": 64997.82600258731,
+      "load_ms": 0.604,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 460,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.069235042,
+        "median_s": 0.06957525,
+        "samples_s": [
+          0.069235042,
+          0.06988625,
+          0.06957525
+        ]
+      },
+      "total": {
+        "min_s": 0.247900375,
+        "median_s": 0.24869675,
+        "samples_s": [
+          0.24869675,
+          0.247900375,
+          0.251621708
+        ]
+      },
+      "compute_s": 0.178665333,
+      "ns_per_op_min": 388402.89782608696,
+      "ns_per_op_median": 389394.5652173913,
+      "load_ms": 3.436,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wardite",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "wardite 0.9.0 computes i64.div_s at f64 precision, wrong for operands beyond 2^53: i64.div_s(0x8000000000000000, 3) gives -3074457345618258432 where -3074457345618258602 is correct"
+    },
+    {
+      "workload": "wat/i64_div",
+      "runner": "wardite-yjit",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "wardite 0.9.0 computes i64.div_s at f64 precision, wrong for operands beyond 2^53: i64.div_s(0x8000000000000000, 3) gives -3074457345618258432 where -3074457345618258602 is correct"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 204340275,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004967459,
+        "median_s": 0.005192708,
+        "samples_s": [
+          0.005192708,
+          0.004967459,
+          0.005254416
+        ]
+      },
+      "total": {
+        "min_s": 0.304617959,
+        "median_s": 0.305145458,
+        "samples_s": [
+          0.307221083,
+          0.305145458,
+          0.304617959
+        ]
+      },
+      "compute_s": 0.2996505,
+      "ns_per_op_min": 1.466428974904727,
+      "ns_per_op_median": 1.4679081253071622,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 192003237,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.007901667,
+        "median_s": 0.008046542,
+        "samples_s": [
+          0.00832625,
+          0.007901667,
+          0.008046542
+        ]
+      },
+      "total": {
+        "min_s": 0.30575375,
+        "median_s": 0.307201292,
+        "samples_s": [
+          0.308707209,
+          0.30575375,
+          0.307201292
+        ]
+      },
+      "compute_s": 0.297852083,
+      "ns_per_op_min": 1.5512867785661342,
+      "ns_per_op_median": 1.5580713881401906,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1215436,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.013994375,
+        "median_s": 0.014100792,
+        "samples_s": [
+          0.014103041,
+          0.013994375,
+          0.014100792
+        ]
+      },
+      "total": {
+        "min_s": 0.316242083,
+        "median_s": 0.316668459,
+        "samples_s": [
+          0.318378875,
+          0.316668459,
+          0.316242083
+        ]
+      },
+      "compute_s": 0.302247708,
+      "ns_per_op_min": 248.6743094659036,
+      "ns_per_op_median": 248.93755574131427,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 122401742,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004463083,
+        "median_s": 0.004471292,
+        "samples_s": [
+          0.004546791,
+          0.004471292,
+          0.004463083
+        ]
+      },
+      "total": {
+        "min_s": 0.307256833,
+        "median_s": 0.309764791,
+        "samples_s": [
+          0.309764791,
+          0.307256833,
+          0.310402875
+        ]
+      },
+      "compute_s": 0.30279375000000003,
+      "ns_per_op_min": 2.4737699403003592,
+      "ns_per_op_median": 2.4941924355945844,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 15076340,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.003995042,
+        "median_s": 0.004045333,
+        "samples_s": [
+          0.004056125,
+          0.003995042,
+          0.004045333
+        ]
+      },
+      "total": {
+        "min_s": 0.298788917,
+        "median_s": 0.302821834,
+        "samples_s": [
+          0.303509583,
+          0.298788917,
+          0.302821834
+        ]
+      },
+      "compute_s": 0.294793875,
+      "ns_per_op_min": 19.553411172738212,
+      "ns_per_op_median": 19.817575154181984,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 712448,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.034555083,
+        "median_s": 0.034658375,
+        "samples_s": [
+          0.034863708,
+          0.034658375,
+          0.034555083
+        ]
+      },
+      "total": {
+        "min_s": 0.337448542,
+        "median_s": 0.338493542,
+        "samples_s": [
+          0.342386125,
+          0.337448542,
+          0.338493542
+        ]
+      },
+      "compute_s": 0.30289345900000003,
+      "ns_per_op_min": 425.1446547677866,
+      "ns_per_op_median": 426.4664466740028,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 904085,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.03466625,
+        "median_s": 0.034792125,
+        "samples_s": [
+          0.034885375,
+          0.03466625,
+          0.034792125
+        ]
+      },
+      "total": {
+        "min_s": 0.307353208,
+        "median_s": 0.307616375,
+        "samples_s": [
+          0.307616375,
+          0.307353208,
+          0.307655875
+        ]
+      },
+      "compute_s": 0.272686958,
+      "ns_per_op_min": 301.61650508525196,
+      "ns_per_op_median": 301.7683624880404,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 842104,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035244375,
+        "median_s": 0.035735125,
+        "samples_s": [
+          0.035735125,
+          0.035738209,
+          0.035244375
+        ]
+      },
+      "total": {
+        "min_s": 0.307294417,
+        "median_s": 0.311058542,
+        "samples_s": [
+          0.307294417,
+          0.312058167,
+          0.311058542
+        ]
+      },
+      "compute_s": 0.272050042,
+      "ns_per_op_min": 323.0599094648642,
+      "ns_per_op_median": 326.9470481080722,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 164381,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.025835375,
+        "median_s": 0.025869125,
+        "samples_s": [
+          0.02599325,
+          0.025869125,
+          0.025835375
+        ]
+      },
+      "total": {
+        "min_s": 0.327349417,
+        "median_s": 0.328370667,
+        "samples_s": [
+          0.327349417,
+          0.328370667,
+          0.331201459
+        ]
+      },
+      "compute_s": 0.301514042,
+      "ns_per_op_min": 1834.239005724506,
+      "ns_per_op_median": 1840.24639100626,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 4012239,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.036642584,
+        "median_s": 0.036746208,
+        "samples_s": [
+          0.036642584,
+          0.036918042,
+          0.036746208
+        ]
+      },
+      "total": {
+        "min_s": 0.314709084,
+        "median_s": 0.3200785,
+        "samples_s": [
+          0.3200785,
+          0.314709084,
+          0.320186792
+        ]
+      },
+      "compute_s": 0.2780665,
+      "ns_per_op_min": 69.30457034089943,
+      "ns_per_op_median": 70.61700262621444,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 65536,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009842917,
+        "median_s": 0.009859584,
+        "samples_s": [
+          0.00986225,
+          0.009859584,
+          0.009842917
+        ]
+      },
+      "total": {
+        "min_s": 0.202386083,
+        "median_s": 0.206045167,
+        "samples_s": [
+          0.202386083,
+          0.206887209,
+          0.206045167
+        ]
+      },
+      "compute_s": 0.192543166,
+      "ns_per_op_min": 2937.975555419922,
+      "ns_per_op_median": 2993.554428100586,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 122957926,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.00241475,
+        "median_s": 0.002596667,
+        "samples_s": [
+          0.002596667,
+          0.002600917,
+          0.00241475
+        ]
+      },
+      "total": {
+        "min_s": 0.303269333,
+        "median_s": 0.304019541,
+        "samples_s": [
+          0.305013458,
+          0.304019541,
+          0.303269333
+        ]
+      },
+      "compute_s": 0.30085458299999995,
+      "ns_per_op_min": 2.446809187396345,
+      "ns_per_op_median": 2.451431020396359,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 52135954,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.059814666,
+        "median_s": 0.060156958,
+        "samples_s": [
+          0.059814666,
+          0.06019025,
+          0.060156958
+        ]
+      },
+      "total": {
+        "min_s": 0.280065292,
+        "median_s": 0.282853,
+        "samples_s": [
+          0.286498,
+          0.282853,
+          0.280065292
+        ]
+      },
+      "compute_s": 0.220250626,
+      "ns_per_op_min": 4.224543891534045,
+      "ns_per_op_median": 4.271448490229986,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 6337,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0115345,
+        "median_s": 0.011574042,
+        "samples_s": [
+          0.01174525,
+          0.011574042,
+          0.0115345
+        ]
+      },
+      "total": {
+        "min_s": 0.318405042,
+        "median_s": 0.318792542,
+        "samples_s": [
+          0.318792542,
+          0.318405042,
+          0.323312209
+        ]
+      },
+      "compute_s": 0.306870542,
+      "ns_per_op_min": 48425.207827047496,
+      "ns_per_op_median": 48480.11677449897,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": 14546,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.11446775,
+        "median_s": 0.114899958,
+        "samples_s": [
+          0.114899958,
+          0.116275042,
+          0.11446775
+        ]
+      },
+      "total": {
+        "min_s": 0.383558875,
+        "median_s": 0.383947875,
+        "samples_s": [
+          0.386187125,
+          0.383947875,
+          0.383558875
+        ]
+      },
+      "compute_s": 0.26909112500000004,
+      "ns_per_op_min": 18499.321119208034,
+      "ns_per_op_median": 18496.350680599473,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": 38711,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.2403965,
+        "median_s": 0.240480083,
+        "samples_s": [
+          0.242064542,
+          0.240480083,
+          0.2403965
+        ]
+      },
+      "total": {
+        "min_s": 0.504360833,
+        "median_s": 0.515540417,
+        "samples_s": [
+          0.504360833,
+          0.515540417,
+          0.517324833
+        ]
+      },
+      "compute_s": 0.263964333,
+      "ns_per_op_min": 6818.84562527447,
+      "ns_per_op_median": 7105.482524347083,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": 5584,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.308351583,
+        "median_s": 0.312887334,
+        "samples_s": [
+          0.312887334,
+          0.308351583,
+          0.314524708
+        ]
+      },
+      "total": {
+        "min_s": 0.576111625,
+        "median_s": 0.578435959,
+        "samples_s": [
+          0.578435959,
+          0.585346708,
+          0.576111625
+        ]
+      },
+      "compute_s": 0.26776004200000003,
+      "ns_per_op_min": 47951.29691977078,
+      "ns_per_op_median": 47555.2695200573,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": 10604,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.471973834,
+        "median_s": 0.475248542,
+        "samples_s": [
+          0.471973834,
+          0.475248542,
+          0.475655958
+        ]
+      },
+      "total": {
+        "min_s": 0.674755917,
+        "median_s": 0.677432416,
+        "samples_s": [
+          0.680739208,
+          0.674755917,
+          0.677432416
+        ]
+      },
+      "compute_s": 0.20278208300000006,
+      "ns_per_op_min": 19123.168898528864,
+      "ns_per_op_median": 19066.755375330067,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 3506,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.038639542,
+        "median_s": 0.038695917,
+        "samples_s": [
+          0.038695917,
+          0.038700333,
+          0.038639542
+        ]
+      },
+      "total": {
+        "min_s": 0.335263542,
+        "median_s": 0.335863625,
+        "samples_s": [
+          0.340266542,
+          0.335863625,
+          0.335263542
+        ]
+      },
+      "compute_s": 0.296624,
+      "ns_per_op_min": 84604.67769537935,
+      "ns_per_op_median": 84759.75698802054,
+      "load_ms": 0.722,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 4528,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.070819667,
+        "median_s": 0.0710295,
+        "samples_s": [
+          0.071177292,
+          0.070819667,
+          0.0710295
+        ]
+      },
+      "total": {
+        "min_s": 0.254136292,
+        "median_s": 0.255331125,
+        "samples_s": [
+          0.254136292,
+          0.255331125,
+          0.25675875
+        ]
+      },
+      "compute_s": 0.18331662499999998,
+      "ns_per_op_min": 40485.120362190806,
+      "ns_per_op_median": 40702.65569787986,
+      "load_ms": 4.773,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 11204,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.046748708,
+        "median_s": 0.046803833,
+        "samples_s": [
+          0.047922792,
+          0.046803833,
+          0.046748708
+        ]
+      },
+      "total": {
+        "min_s": 0.346082458,
+        "median_s": 0.34746875,
+        "samples_s": [
+          0.349523542,
+          0.34746875,
+          0.346082458
+        ]
+      },
+      "compute_s": 0.29933374999999995,
+      "ns_per_op_min": 26716.68600499821,
+      "ns_per_op_median": 26835.49776865405,
+      "load_ms": 3.556,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_narrow",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 25328,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.091174458,
+        "median_s": 0.091718291,
+        "samples_s": [
+          0.092923375,
+          0.091718291,
+          0.091174458
+        ]
+      },
+      "total": {
+        "min_s": 0.435957791,
+        "median_s": 0.438290291,
+        "samples_s": [
+          0.435957791,
+          0.440117292,
+          0.438290291
+        ]
+      },
+      "compute_s": 0.34478333299999997,
+      "ns_per_op_min": 13612.73424668351,
+      "ns_per_op_median": 13683.354390397979,
+      "load_ms": 8.054,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 300255922,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004959042,
+        "median_s": 0.004987041,
+        "samples_s": [
+          0.005086958,
+          0.004987041,
+          0.004959042
+        ]
+      },
+      "total": {
+        "min_s": 0.300641541,
+        "median_s": 0.300663584,
+        "samples_s": [
+          0.300641541,
+          0.300997458,
+          0.300663584
+        ]
+      },
+      "compute_s": 0.295682499,
+      "ns_per_op_min": 0.9847682504660141,
+      "ns_per_op_median": 0.9847484140545942,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 307213294,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.00790275,
+        "median_s": 0.008149625,
+        "samples_s": [
+          0.008153041,
+          0.008149625,
+          0.00790275
+        ]
+      },
+      "total": {
+        "min_s": 0.309838916,
+        "median_s": 0.310643667,
+        "samples_s": [
+          0.309838916,
+          0.313882166,
+          0.310643667
+        ]
+      },
+      "compute_s": 0.301936166,
+      "ns_per_op_min": 0.982822592306178,
+      "ns_per_op_median": 0.9846385163267056,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 2694983,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.014674417,
+        "median_s": 0.015332084,
+        "samples_s": [
+          0.014674417,
+          0.015332084,
+          0.015590292
+        ]
+      },
+      "total": {
+        "min_s": 0.341240583,
+        "median_s": 0.341336542,
+        "samples_s": [
+          0.341240583,
+          0.341696084,
+          0.341336542
+        ]
+      },
+      "compute_s": 0.326566166,
+      "ns_per_op_min": 121.17559405755064,
+      "ns_per_op_median": 120.96716676876997,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 197883085,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004371291,
+        "median_s": 0.004604584,
+        "samples_s": [
+          0.004906625,
+          0.004371291,
+          0.004604584
+        ]
+      },
+      "total": {
+        "min_s": 0.303385334,
+        "median_s": 0.304917709,
+        "samples_s": [
+          0.303385334,
+          0.308397792,
+          0.304917709
+        ]
+      },
+      "compute_s": 0.299014043,
+      "ns_per_op_min": 1.5110641872194381,
+      "ns_per_op_median": 1.5176290838603004,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 33554432,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004049625,
+        "median_s": 0.004123667,
+        "samples_s": [
+          0.004123667,
+          0.004208625,
+          0.004049625
+        ]
+      },
+      "total": {
+        "min_s": 0.331783542,
+        "median_s": 0.332528625,
+        "samples_s": [
+          0.332528625,
+          0.331783542,
+          0.3336245
+        ]
+      },
+      "compute_s": 0.327733917,
+      "ns_per_op_min": 9.767231851816177,
+      "ns_per_op_median": 9.787230432033539,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 1722736,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.034548042,
+        "median_s": 0.03460675,
+        "samples_s": [
+          0.03460675,
+          0.034548042,
+          0.034732958
+        ]
+      },
+      "total": {
+        "min_s": 0.336241125,
+        "median_s": 0.33856475,
+        "samples_s": [
+          0.338599875,
+          0.33856475,
+          0.336241125
+        ]
+      },
+      "compute_s": 0.301693083,
+      "ns_per_op_min": 175.124385280159,
+      "ns_per_op_median": 176.4391061660057,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 2126756,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.034734834,
+        "median_s": 0.034768542,
+        "samples_s": [
+          0.035204166,
+          0.034734834,
+          0.034768542
+        ]
+      },
+      "total": {
+        "min_s": 0.311079709,
+        "median_s": 0.315003125,
+        "samples_s": [
+          0.318183875,
+          0.315003125,
+          0.311079709
+        ]
+      },
+      "compute_s": 0.276344875,
+      "ns_per_op_min": 129.93727301110235,
+      "ns_per_op_median": 131.7662124851182,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 1923394,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035208917,
+        "median_s": 0.035246625,
+        "samples_s": [
+          0.035208917,
+          0.035246625,
+          0.035446334
+        ]
+      },
+      "total": {
+        "min_s": 0.299937041,
+        "median_s": 0.300718542,
+        "samples_s": [
+          0.302359875,
+          0.299937041,
+          0.300718542
+        ]
+      },
+      "compute_s": 0.264728124,
+      "ns_per_op_min": 137.63593106768556,
+      "ns_per_op_median": 138.0226396671717,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 391714,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.025397166,
+        "median_s": 0.025667583,
+        "samples_s": [
+          0.025667583,
+          0.025397166,
+          0.025680208
+        ]
+      },
+      "total": {
+        "min_s": 0.310267375,
+        "median_s": 0.313120708,
+        "samples_s": [
+          0.310267375,
+          0.313120708,
+          0.316323667
+        ]
+      },
+      "compute_s": 0.28487020900000004,
+      "ns_per_op_min": 727.2403054269188,
+      "ns_per_op_median": 733.8341876981677,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 5812182,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.036579833,
+        "median_s": 0.036783208,
+        "samples_s": [
+          0.036783208,
+          0.036876791,
+          0.036579833
+        ]
+      },
+      "total": {
+        "min_s": 0.33981525,
+        "median_s": 0.341541458,
+        "samples_s": [
+          0.33981525,
+          0.34582675,
+          0.341541458
+        ]
+      },
+      "compute_s": 0.303235417,
+      "ns_per_op_min": 52.172388442068744,
+      "ns_per_op_median": 52.43439555058668,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 308837,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009747416,
+        "median_s": 0.009987916,
+        "samples_s": [
+          0.010618,
+          0.009987916,
+          0.009747416
+        ]
+      },
+      "total": {
+        "min_s": 0.300969375,
+        "median_s": 0.30560125,
+        "samples_s": [
+          0.310898542,
+          0.300969375,
+          0.30560125
+        ]
+      },
+      "compute_s": 0.291221959,
+      "ns_per_op_min": 942.9633075052536,
+      "ns_per_op_median": 957.1823777591416,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 202985666,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.00250025,
+        "median_s": 0.002587625,
+        "samples_s": [
+          0.002587625,
+          0.00250025,
+          0.002588125
+        ]
+      },
+      "total": {
+        "min_s": 0.302233875,
+        "median_s": 0.3022995,
+        "samples_s": [
+          0.3022995,
+          0.304485958,
+          0.302233875
+        ]
+      },
+      "compute_s": 0.299733625,
+      "ns_per_op_min": 1.4766245858956366,
+      "ns_per_op_median": 1.4765174354725126,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 166020287,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.06032125,
+        "median_s": 0.060517959,
+        "samples_s": [
+          0.060517959,
+          0.06054025,
+          0.06032125
+        ]
+      },
+      "total": {
+        "min_s": 0.34514675,
+        "median_s": 0.345344125,
+        "samples_s": [
+          0.34514675,
+          0.345344125,
+          0.34561925
+        ]
+      },
+      "compute_s": 0.2848255,
+      "ns_per_op_min": 1.7156065993308396,
+      "ns_per_op_median": 1.7156106108887765,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 10077,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.011507583,
+        "median_s": 0.011532542,
+        "samples_s": [
+          0.011532542,
+          0.011594958,
+          0.011507583
+        ]
+      },
+      "total": {
+        "min_s": 0.312655333,
+        "median_s": 0.314316625,
+        "samples_s": [
+          0.314386959,
+          0.314316625,
+          0.312655333
+        ]
+      },
+      "compute_s": 0.30114775,
+      "ns_per_op_min": 29884.663094174855,
+      "ns_per_op_median": 30047.04604545004,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": 39498,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.112353625,
+        "median_s": 0.113305542,
+        "samples_s": [
+          0.112353625,
+          0.113514292,
+          0.113305542
+        ]
+      },
+      "total": {
+        "min_s": 0.463291208,
+        "median_s": 0.464240208,
+        "samples_s": [
+          0.464240208,
+          0.463291208,
+          0.466626791
+        ]
+      },
+      "compute_s": 0.350937583,
+      "ns_per_op_min": 8884.945642817358,
+      "ns_per_op_median": 8884.871790976758,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": 94331,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.223910375,
+        "median_s": 0.224217,
+        "samples_s": [
+          0.2249595,
+          0.223910375,
+          0.224217
+        ]
+      },
+      "total": {
+        "min_s": 0.507506917,
+        "median_s": 0.507554708,
+        "samples_s": [
+          0.507506917,
+          0.507554708,
+          0.513569584
+        ]
+      },
+      "compute_s": 0.28359654199999995,
+      "ns_per_op_min": 3006.39812998908,
+      "ns_per_op_median": 3003.654238797426,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": 8753,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.308640375,
+        "median_s": 0.310564834,
+        "samples_s": [
+          0.310655209,
+          0.308640375,
+          0.310564834
+        ]
+      },
+      "total": {
+        "min_s": 0.50748175,
+        "median_s": 0.510735041,
+        "samples_s": [
+          0.511221791,
+          0.50748175,
+          0.510735041
+        ]
+      },
+      "compute_s": 0.19884137499999993,
+      "ns_per_op_min": 22716.939906317828,
+      "ns_per_op_median": 22868.75436993031,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": 55812,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.471143833,
+        "median_s": 0.47263975,
+        "samples_s": [
+          0.47263975,
+          0.471143833,
+          0.475226667
+        ]
+      },
+      "total": {
+        "min_s": 0.721099584,
+        "median_s": 0.721595166,
+        "samples_s": [
+          0.721099584,
+          0.721595166,
+          0.724417
+        ]
+      },
+      "compute_s": 0.24995575099999995,
+      "ns_per_op_min": 4478.530620655055,
+      "ns_per_op_median": 4460.607324589693,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 7025,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.038271792,
+        "median_s": 0.038543667,
+        "samples_s": [
+          0.038641542,
+          0.038543667,
+          0.038271792
+        ]
+      },
+      "total": {
+        "min_s": 0.307987,
+        "median_s": 0.310058459,
+        "samples_s": [
+          0.310058459,
+          0.307987,
+          0.312812
+        ]
+      },
+      "compute_s": 0.26971520800000004,
+      "ns_per_op_min": 38393.62391459075,
+      "ns_per_op_median": 38649.79245551601,
+      "load_ms": 0.65,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 35016,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.070362291,
+        "median_s": 0.070541667,
+        "samples_s": [
+          0.070541667,
+          0.070362291,
+          0.070701084
+        ]
+      },
+      "total": {
+        "min_s": 0.322009291,
+        "median_s": 0.322989583,
+        "samples_s": [
+          0.322009291,
+          0.322989583,
+          0.324717167
+        ]
+      },
+      "compute_s": 0.25164699999999995,
+      "ns_per_op_min": 7186.628969613889,
+      "ns_per_op_median": 7209.501827735894,
+      "load_ms": 4.528,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 14722,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.046379041,
+        "median_s": 0.046814875,
+        "samples_s": [
+          0.046814875,
+          0.04684025,
+          0.046379041
+        ]
+      },
+      "total": {
+        "min_s": 0.2331465,
+        "median_s": 0.234331417,
+        "samples_s": [
+          0.234331417,
+          0.2356495,
+          0.2331465
+        ]
+      },
+      "compute_s": 0.186767459,
+      "ns_per_op_min": 12686.283045781824,
+      "ns_per_op_median": 12737.164923244123,
+      "load_ms": 3.564,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/mem_rw",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 39520,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.08967175,
+        "median_s": 0.090312167,
+        "samples_s": [
+          0.090680792,
+          0.090312167,
+          0.08967175
+        ]
+      },
+      "total": {
+        "min_s": 0.323169917,
+        "median_s": 0.32576725,
+        "samples_s": [
+          0.32636325,
+          0.323169917,
+          0.32576725
+        ]
+      },
+      "compute_s": 0.23349816699999998,
+      "ns_per_op_min": 5908.354428137651,
+      "ns_per_op_median": 5957.871533400809,
+      "load_ms": 8.166,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/tail_call",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 87823627,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004988875,
+        "median_s": 0.005019875,
+        "samples_s": [
+          0.004988875,
+          0.005930666,
+          0.005019875
+        ]
+      },
+      "total": {
+        "min_s": 0.306224792,
+        "median_s": 0.3063445,
+        "samples_s": [
+          0.306531375,
+          0.3063445,
+          0.306224792
+        ]
+      },
+      "compute_s": 0.301235917,
+      "ns_per_op_min": 3.430009978977525,
+      "ns_per_op_median": 3.431020048853141,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "wat/tail_call",
+      "runner": "wasmer",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "wasmer rejects the module: compile error Validate(\"tail calls support is not enabled\")"
+    },
+    {
+      "workload": "wat/tail_call",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1622373,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.013999333,
+        "median_s": 0.014011167,
+        "samples_s": [
+          0.014235083,
+          0.014011167,
+          0.013999333
+        ]
+      },
+      "total": {
+        "min_s": 0.314512833,
+        "median_s": 0.319093208,
+        "samples_s": [
+          0.319093208,
+          0.320369792,
+          0.314512833
+        ]
+      },
+      "compute_s": 0.3005135,
+      "ns_per_op_min": 185.23083162749873,
+      "ns_per_op_median": 188.04679380142545,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/tail_call",
+      "runner": "wazero",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "wazero 1.12.0 rejects the module: \"return_call invalid as feature \\\"tail-call\\\" is disabled\""
+    },
+    {
+      "workload": "wat/tail_call",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 5743174,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.003924292,
+        "median_s": 0.003948875,
+        "samples_s": [
+          0.003948875,
+          0.003924292,
+          0.004005208
+        ]
+      },
+      "total": {
+        "min_s": 0.298347417,
+        "median_s": 0.304347042,
+        "samples_s": [
+          0.304347042,
+          0.298347417,
+          0.306256709
+        ]
+      },
+      "compute_s": 0.294423125,
+      "ns_per_op_min": 51.26487983822186,
+      "ns_per_op_median": 52.30525263556354,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/tail_call",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 483388,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.03462525,
+        "median_s": 0.034683875,
+        "samples_s": [
+          0.03473075,
+          0.03462525,
+          0.034683875
+        ]
+      },
+      "total": {
+        "min_s": 0.332187416,
+        "median_s": 0.334485708,
+        "samples_s": [
+          0.334485708,
+          0.332187416,
+          0.334596875
+        ]
+      },
+      "compute_s": 0.297562166,
+      "ns_per_op_min": 615.5762368945857,
+      "ns_per_op_median": 620.209506648903,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/tail_call",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 978383,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.034761417,
+        "median_s": 0.034791334,
+        "samples_s": [
+          0.034791334,
+          0.034761417,
+          0.034809709
+        ]
+      },
+      "total": {
+        "min_s": 0.296452875,
+        "median_s": 0.299098458,
+        "samples_s": [
+          0.299834458,
+          0.296452875,
+          0.299098458
+        ]
+      },
+      "compute_s": 0.261691458,
+      "ns_per_op_min": 267.47343116141633,
+      "ns_per_op_median": 270.1468893061306,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/tail_call",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 630900,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035091708,
+        "median_s": 0.035269542,
+        "samples_s": [
+          0.0358105,
+          0.035269542,
+          0.035091708
+        ]
+      },
+      "total": {
+        "min_s": 0.270410167,
+        "median_s": 0.271308916,
+        "samples_s": [
+          0.270410167,
+          0.271782958,
+          0.271308916
+        ]
+      },
+      "compute_s": 0.23531845899999998,
+      "ns_per_op_min": 372.98852274528446,
+      "ns_per_op_median": 374.1311998731971,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/tail_call",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 444673,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.02583325,
+        "median_s": 0.025896792,
+        "samples_s": [
+          0.026130667,
+          0.02583325,
+          0.025896792
+        ]
+      },
+      "total": {
+        "min_s": 0.323342,
+        "median_s": 0.329350375,
+        "samples_s": [
+          0.323342,
+          0.329350375,
+          0.331366334
+        ]
+      },
+      "compute_s": 0.29750875000000004,
+      "ns_per_op_min": 669.0506282144408,
+      "ns_per_op_median": 682.4196274565804,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/tail_call",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 1491521,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035498,
+        "median_s": 0.035630541,
+        "samples_s": [
+          0.035498,
+          0.035630541,
+          0.035787459
+        ]
+      },
+      "total": {
+        "min_s": 0.242703791,
+        "median_s": 0.242813792,
+        "samples_s": [
+          0.243841,
+          0.242813792,
+          0.242703791
+        ]
+      },
+      "compute_s": 0.207205791,
+      "ns_per_op_min": 138.9224764518904,
+      "ns_per_op_median": 138.90736436161475,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/tail_call",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 118652,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010016041,
+        "median_s": 0.0100345,
+        "samples_s": [
+          0.0100345,
+          0.010016041,
+          0.01012575
+        ]
+      },
+      "total": {
+        "min_s": 0.30137075,
+        "median_s": 0.302653833,
+        "samples_s": [
+          0.30444575,
+          0.30137075,
+          0.302653833
+        ]
+      },
+      "compute_s": 0.29135470900000005,
+      "ns_per_op_min": 2455.539805481577,
+      "ns_per_op_median": 2466.198066614975,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/tail_call",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 34414360,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002475791,
+        "median_s": 0.002477125,
+        "samples_s": [
+          0.002552542,
+          0.002477125,
+          0.002475791
+        ]
+      },
+      "total": {
+        "min_s": 0.30852475,
+        "median_s": 0.314932458,
+        "samples_s": [
+          0.30852475,
+          0.327301917,
+          0.314932458
+        ]
+      },
+      "compute_s": 0.306048959,
+      "ns_per_op_min": 8.893059728555173,
+      "ns_per_op_median": 9.0792138223695,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/tail_call",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 13927883,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.058760625,
+        "median_s": 0.059168625,
+        "samples_s": [
+          0.059168625,
+          0.058760625,
+          0.059701208
+        ]
+      },
+      "total": {
+        "min_s": 0.303930125,
+        "median_s": 0.304146709,
+        "samples_s": [
+          0.305256667,
+          0.303930125,
+          0.304146709
+        ]
+      },
+      "compute_s": 0.24516949999999998,
+      "ns_per_op_min": 17.602782849338983,
+      "ns_per_op_median": 17.5890394828848,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/tail_call",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 3871,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.011914541,
+        "median_s": 0.012193042,
+        "samples_s": [
+          0.012193042,
+          0.012230042,
+          0.011914541
+        ]
+      },
+      "total": {
+        "min_s": 0.310147333,
+        "median_s": 0.310695958,
+        "samples_s": [
+          0.310695958,
+          0.310147333,
+          0.311539958
+        ]
+      },
+      "compute_s": 0.298232792,
+      "ns_per_op_min": 77042.82924308964,
+      "ns_per_op_median": 77112.61069491088,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/tail_call",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": 15860,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.111996625,
+        "median_s": 0.113112792,
+        "samples_s": [
+          0.113112792,
+          0.111996625,
+          0.116257917
+        ]
+      },
+      "total": {
+        "min_s": 0.406238459,
+        "median_s": 0.408625666,
+        "samples_s": [
+          0.408625666,
+          0.406238459,
+          0.410044291
+        ]
+      },
+      "compute_s": 0.294241834,
+      "ns_per_op_min": 18552.448549810844,
+      "ns_per_op_median": 18632.58978562421,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/tail_call",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": 30103,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.198300583,
+        "median_s": 0.19869025,
+        "samples_s": [
+          0.19869025,
+          0.201167709,
+          0.198300583
+        ]
+      },
+      "total": {
+        "min_s": 0.4243575,
+        "median_s": 0.424478291,
+        "samples_s": [
+          0.424478291,
+          0.426686083,
+          0.4243575
+        ]
+      },
+      "compute_s": 0.226056917,
+      "ns_per_op_min": 7509.448128093545,
+      "ns_per_op_median": 7500.5162608377905,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/tail_call",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": 7028,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.309395,
+        "median_s": 0.30970025,
+        "samples_s": [
+          0.30970025,
+          0.313665708,
+          0.309395
+        ]
+      },
+      "total": {
+        "min_s": 0.647658041,
+        "median_s": 0.652897458,
+        "samples_s": [
+          0.658148209,
+          0.647658041,
+          0.652897458
+        ]
+      },
+      "compute_s": 0.33826304100000004,
+      "ns_per_op_min": 48130.768497438825,
+      "ns_per_op_median": 48832.84120660216,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/tail_call",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": 12320,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.470548792,
+        "median_s": 0.47254075,
+        "samples_s": [
+          0.473033916,
+          0.470548792,
+          0.47254075
+        ]
+      },
+      "total": {
+        "min_s": 0.702948333,
+        "median_s": 0.704655625,
+        "samples_s": [
+          0.7061375,
+          0.704655625,
+          0.702948333
+        ]
+      },
+      "compute_s": 0.23239954100000004,
+      "ns_per_op_min": 18863.599107142858,
+      "ns_per_op_median": 18840.49310064935,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "wat/tail_call",
+      "runner": "pywasm-cpython",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "pywasm 2.2.3 has no tail-call opcodes; decoding dies with AssertionError on 0x12, the return_call opcode (pywasm/core.py)"
+    },
+    {
+      "workload": "wat/tail_call",
+      "runner": "pywasm-pypy",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "pywasm 2.2.3 has no tail-call opcodes; decoding dies with AssertionError on 0x12, the return_call opcode (pywasm/core.py)"
+    },
+    {
+      "workload": "wat/tail_call",
+      "runner": "wardite",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "wardite 0.9.0 decodes return_call but has no implementation: RuntimeError \"TODO! unsupported [:default, :return_call, [], nil, nil]\" (wardite.rb, eval_insn)"
+    },
+    {
+      "workload": "wat/tail_call",
+      "runner": "wardite-yjit",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "wardite 0.9.0 decodes return_call but has no implementation: RuntimeError \"TODO! unsupported [:default, :return_call, [], nil, nil]\" (wardite.rb, eval_insn)"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 3073840,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004941375,
+        "median_s": 0.005077625,
+        "samples_s": [
+          0.004941375,
+          0.005119708,
+          0.005077625
+        ]
+      },
+      "total": {
+        "min_s": 0.294903791,
+        "median_s": 0.29578325,
+        "samples_s": [
+          0.294903791,
+          0.295907958,
+          0.29578325
+        ]
+      },
+      "compute_s": 0.289962416,
+      "ns_per_op_min": 94.33230617078313,
+      "ns_per_op_median": 94.57409136454727,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 2911399,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.008334083,
+        "median_s": 0.0084565,
+        "samples_s": [
+          0.008334083,
+          0.009137166,
+          0.0084565
+        ]
+      },
+      "total": {
+        "min_s": 0.2831075,
+        "median_s": 0.283665375,
+        "samples_s": [
+          0.284629334,
+          0.283665375,
+          0.2831075
+        ]
+      },
+      "compute_s": 0.274773417,
+      "ns_per_op_min": 94.3784816165699,
+      "ns_per_op_median": 94.52805163428303,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 65536,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.01409575,
+        "median_s": 0.014116666,
+        "samples_s": [
+          0.01417075,
+          0.014116666,
+          0.01409575
+        ]
+      },
+      "total": {
+        "min_s": 0.255775875,
+        "median_s": 0.258352125,
+        "samples_s": [
+          0.255775875,
+          0.261752083,
+          0.258352125
+        ]
+      },
+      "compute_s": 0.241680125,
+      "ns_per_op_min": 3687.746047973633,
+      "ns_per_op_median": 3726.737350463867,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 2833631,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004829583,
+        "median_s": 0.005009125,
+        "samples_s": [
+          0.005016542,
+          0.005009125,
+          0.004829583
+        ]
+      },
+      "total": {
+        "min_s": 0.304951958,
+        "median_s": 0.306261417,
+        "samples_s": [
+          0.306568167,
+          0.306261417,
+          0.304951958
+        ]
+      },
+      "compute_s": 0.300122375,
+      "ns_per_op_min": 105.91441687361551,
+      "ns_per_op_median": 106.31316921645761,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 673524,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.003971959,
+        "median_s": 0.003983417,
+        "samples_s": [
+          0.003971959,
+          0.00403225,
+          0.003983417
+        ]
+      },
+      "total": {
+        "min_s": 0.302729333,
+        "median_s": 0.305879,
+        "samples_s": [
+          0.3108295,
+          0.305879,
+          0.302729333
+        ]
+      },
+      "compute_s": 0.29875737399999996,
+      "ns_per_op_min": 443.57346434573964,
+      "ns_per_op_median": 448.23285139059635,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 42173,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035169291,
+        "median_s": 0.035396042,
+        "samples_s": [
+          0.035396042,
+          0.035169291,
+          0.036448542
+        ]
+      },
+      "total": {
+        "min_s": 0.227803083,
+        "median_s": 0.230860458,
+        "samples_s": [
+          0.231308083,
+          0.230860458,
+          0.227803083
+        ]
+      },
+      "compute_s": 0.192633792,
+      "ns_per_op_min": 4567.704265762454,
+      "ns_per_op_median": 4634.823607521399,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 135395,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035307334,
+        "median_s": 0.037598125,
+        "samples_s": [
+          0.03791,
+          0.037598125,
+          0.035307334
+        ]
+      },
+      "total": {
+        "min_s": 0.244474167,
+        "median_s": 0.244733125,
+        "samples_s": [
+          0.244752416,
+          0.244474167,
+          0.244733125
+        ]
+      },
+      "compute_s": 0.209166833,
+      "ns_per_op_min": 1544.8637911296576,
+      "ns_per_op_median": 1529.8570848258798,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 81804,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0353565,
+        "median_s": 0.035356833,
+        "samples_s": [
+          0.035864833,
+          0.0353565,
+          0.035356833
+        ]
+      },
+      "total": {
+        "min_s": 0.321027417,
+        "median_s": 0.321942083,
+        "samples_s": [
+          0.321942083,
+          0.322476708,
+          0.321027417
+        ]
+      },
+      "compute_s": 0.28567091699999997,
+      "ns_per_op_min": 3492.1387340472343,
+      "ns_per_op_median": 3503.315852525549,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 65536,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0263805,
+        "median_s": 0.02653,
+        "samples_s": [
+          0.02653,
+          0.026626458,
+          0.0263805
+        ]
+      },
+      "total": {
+        "min_s": 0.258543,
+        "median_s": 0.259506584,
+        "samples_s": [
+          0.259506584,
+          0.26162575,
+          0.258543
+        ]
+      },
+      "compute_s": 0.23216250000000002,
+      "ns_per_op_min": 3542.5186157226567,
+      "ns_per_op_median": 3554.9405517578125,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 2288272,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.036155042,
+        "median_s": 0.0362415,
+        "samples_s": [
+          0.036155042,
+          0.036589291,
+          0.0362415
+        ]
+      },
+      "total": {
+        "min_s": 0.352469791,
+        "median_s": 0.352535916,
+        "samples_s": [
+          0.352535916,
+          0.353726958,
+          0.352469791
+        ]
+      },
+      "compute_s": 0.316314749,
+      "ns_per_op_min": 138.23301993818916,
+      "ns_per_op_median": 138.2241341938371,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 5403,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.009962834,
+        "median_s": 0.009995875,
+        "samples_s": [
+          0.010178291,
+          0.009995875,
+          0.009962834
+        ]
+      },
+      "total": {
+        "min_s": 0.303409291,
+        "median_s": 0.303876208,
+        "samples_s": [
+          0.303409291,
+          0.31013275,
+          0.303876208
+        ]
+      },
+      "compute_s": 0.29344645700000005,
+      "ns_per_op_min": 54311.76327965946,
+      "ns_per_op_median": 54392.06607440311,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 1299150,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002468208,
+        "median_s": 0.002494042,
+        "samples_s": [
+          0.002494042,
+          0.002636917,
+          0.002468208
+        ]
+      },
+      "total": {
+        "min_s": 0.302523709,
+        "median_s": 0.302765292,
+        "samples_s": [
+          0.302765292,
+          0.303127167,
+          0.302523709
+        ]
+      },
+      "compute_s": 0.30005550099999995,
+      "ns_per_op_min": 230.96293807489508,
+      "ns_per_op_median": 231.1290074279337,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 2611945,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.059948708,
+        "median_s": 0.061616,
+        "samples_s": [
+          0.061681292,
+          0.061616,
+          0.059948708
+        ]
+      },
+      "total": {
+        "min_s": 0.309849375,
+        "median_s": 0.310835791,
+        "samples_s": [
+          0.309849375,
+          0.310835791,
+          0.313717042
+        ]
+      },
+      "compute_s": 0.24990066699999997,
+      "ns_per_op_min": 95.6760831487646,
+      "ns_per_op_median": 95.4154053779846,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 180,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.01218675,
+        "median_s": 0.012283375,
+        "samples_s": [
+          0.01218675,
+          0.012368375,
+          0.012283375
+        ]
+      },
+      "total": {
+        "min_s": 3.488825,
+        "median_s": 3.498706375,
+        "samples_s": [
+          3.498706375,
+          3.488825,
+          3.558510416
+        ]
+      },
+      "compute_s": 3.4766382499999997,
+      "ns_per_op_min": 19314656.94444444,
+      "ns_per_op_median": 19369016.666666668,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": 1086,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.115254875,
+        "median_s": 0.11574875,
+        "samples_s": [
+          0.115254875,
+          0.11584375,
+          0.11574875
+        ]
+      },
+      "total": {
+        "min_s": 0.412014542,
+        "median_s": 0.415449625,
+        "samples_s": [
+          0.420291625,
+          0.412014542,
+          0.415449625
+        ]
+      },
+      "compute_s": 0.296759667,
+      "ns_per_op_min": 273259.36187845306,
+      "ns_per_op_median": 275967.65653775324,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": 2964,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.259982917,
+        "median_s": 0.260716,
+        "samples_s": [
+          0.260716,
+          0.259982917,
+          0.261419667
+        ]
+      },
+      "total": {
+        "min_s": 0.539090542,
+        "median_s": 0.539243708,
+        "samples_s": [
+          0.543659667,
+          0.539090542,
+          0.539243708
+        ]
+      },
+      "compute_s": 0.27910762499999997,
+      "ns_per_op_min": 94165.86538461539,
+      "ns_per_op_median": 93970.21187584345,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": 512,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.312500708,
+        "median_s": 0.313620375,
+        "samples_s": [
+          0.313620375,
+          0.312500708,
+          0.314623958
+        ]
+      },
+      "total": {
+        "min_s": 0.648727959,
+        "median_s": 0.6491055,
+        "samples_s": [
+          0.6523895,
+          0.6491055,
+          0.648727959
+        ]
+      },
+      "compute_s": 0.336227251,
+      "ns_per_op_min": 656693.849609375,
+      "ns_per_op_median": 655244.384765625,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": 932,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.478888667,
+        "median_s": 0.48080525,
+        "samples_s": [
+          0.478888667,
+          0.484532291,
+          0.48080525
+        ]
+      },
+      "total": {
+        "min_s": 0.6979685,
+        "median_s": 0.699836042,
+        "samples_s": [
+          0.6979685,
+          0.703231458,
+          0.699836042
+        ]
+      },
+      "compute_s": 0.219079833,
+      "ns_per_op_min": 235064.1984978541,
+      "ns_per_op_median": 235011.57939914166,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 256,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.038434083,
+        "median_s": 0.038766625,
+        "samples_s": [
+          0.038774083,
+          0.038766625,
+          0.038434083
+        ]
+      },
+      "total": {
+        "min_s": 0.408905542,
+        "median_s": 0.410082084,
+        "samples_s": [
+          0.410082084,
+          0.408905542,
+          0.410853792
+        ]
+      },
+      "compute_s": 0.370471459,
+      "ns_per_op_min": 1447154.13671875,
+      "ns_per_op_median": 1450451.01171875,
+      "load_ms": 0.828,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 196,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.070850791,
+        "median_s": 0.07111,
+        "samples_s": [
+          0.070850791,
+          0.071222583,
+          0.07111
+        ]
+      },
+      "total": {
+        "min_s": 0.290377334,
+        "median_s": 0.290487,
+        "samples_s": [
+          0.290487,
+          0.290377334,
+          0.291391875
+        ]
+      },
+      "compute_s": 0.219526543,
+      "ns_per_op_min": 1120033.3826530613,
+      "ns_per_op_median": 1119270.4081632653,
+      "load_ms": 5.078,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 792,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.046397208,
+        "median_s": 0.046429709,
+        "samples_s": [
+          0.046853417,
+          0.046397208,
+          0.046429709
+        ]
+      },
+      "total": {
+        "min_s": 0.340546542,
+        "median_s": 0.34109275,
+        "samples_s": [
+          0.340546542,
+          0.34109275,
+          0.341290042
+        ]
+      },
+      "compute_s": 0.294149334,
+      "ns_per_op_min": 371400.67424242425,
+      "ns_per_op_median": 372049.2941919192,
+      "load_ms": 3.535,
+      "verification": "match"
+    },
+    {
+      "workload": "c/mandelbrot",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 1448,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0921665,
+        "median_s": 0.093168833,
+        "samples_s": [
+          0.096498709,
+          0.093168833,
+          0.0921665
+        ]
+      },
+      "total": {
+        "min_s": 0.346132375,
+        "median_s": 0.346661208,
+        "samples_s": [
+          0.352231833,
+          0.346132375,
+          0.346661208
+        ]
+      },
+      "compute_s": 0.253965875,
+      "ns_per_op_min": 175390.7976519337,
+      "ns_per_op_median": 175063.79488950275,
+      "load_ms": 8.898,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 1041374,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004937333,
+        "median_s": 0.004965125,
+        "samples_s": [
+          0.00498075,
+          0.004937333,
+          0.004965125
+        ]
+      },
+      "total": {
+        "min_s": 0.304669334,
+        "median_s": 0.305328583,
+        "samples_s": [
+          0.307653875,
+          0.305328583,
+          0.304669334
+        ]
+      },
+      "compute_s": 0.299732001,
+      "ns_per_op_min": 287.8235878752494,
+      "ns_per_op_median": 288.42995696070767,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 999866,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.008278708,
+        "median_s": 0.008376,
+        "samples_s": [
+          0.008278708,
+          0.008376,
+          0.008401042
+        ]
+      },
+      "total": {
+        "min_s": 0.296000625,
+        "median_s": 0.296852417,
+        "samples_s": [
+          0.296000625,
+          0.296852417,
+          0.304916333
+        ]
+      },
+      "compute_s": 0.287721917,
+      "ns_per_op_min": 287.7604769039051,
+      "ns_per_op_median": 288.5150780204547,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 7623,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.014273417,
+        "median_s": 0.014422958,
+        "samples_s": [
+          0.016158583,
+          0.014422958,
+          0.014273417
+        ]
+      },
+      "total": {
+        "min_s": 0.315791875,
+        "median_s": 0.318532875,
+        "samples_s": [
+          0.318532875,
+          0.315791875,
+          0.325750292
+        ]
+      },
+      "compute_s": 0.301518458,
+      "ns_per_op_min": 39553.77908959727,
+      "ns_per_op_median": 39893.73173291355,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 802548,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004609459,
+        "median_s": 0.004640666,
+        "samples_s": [
+          0.004609459,
+          0.00473775,
+          0.004640666
+        ]
+      },
+      "total": {
+        "min_s": 0.302269541,
+        "median_s": 0.302971958,
+        "samples_s": [
+          0.302269541,
+          0.302971958,
+          0.303245958
+        ]
+      },
+      "compute_s": 0.297660082,
+      "ns_per_op_min": 370.89380572875393,
+      "ns_per_op_median": 371.73015445805106,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 53700,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.003985,
+        "median_s": 0.00407925,
+        "samples_s": [
+          0.004167916,
+          0.00407925,
+          0.003985
+        ]
+      },
+      "total": {
+        "min_s": 0.263237666,
+        "median_s": 0.263361875,
+        "samples_s": [
+          0.263457708,
+          0.263361875,
+          0.263237666
+        ]
+      },
+      "compute_s": 0.25925266599999996,
+      "ns_per_op_min": 4827.796387337057,
+      "ns_per_op_median": 4828.354283054005,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 3383,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.034815208,
+        "median_s": 0.03491625,
+        "samples_s": [
+          0.03491625,
+          0.034815208,
+          0.034992167
+        ]
+      },
+      "total": {
+        "min_s": 0.300235958,
+        "median_s": 0.300594917,
+        "samples_s": [
+          0.300235958,
+          0.301925542,
+          0.300594917
+        ]
+      },
+      "compute_s": 0.26542075000000004,
+      "ns_per_op_min": 78457.21253325451,
+      "ns_per_op_median": 78533.45167011529,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 5624,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.036123375,
+        "median_s": 0.036476916,
+        "samples_s": [
+          0.036476916,
+          0.03755525,
+          0.036123375
+        ]
+      },
+      "total": {
+        "min_s": 0.22709375,
+        "median_s": 0.227250542,
+        "samples_s": [
+          0.22709375,
+          0.227250542,
+          0.227536959
+        ]
+      },
+      "compute_s": 0.19097037500000003,
+      "ns_per_op_min": 33956.32556899005,
+      "ns_per_op_median": 33921.34174964438,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 5740,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.035612917,
+        "median_s": 0.035708,
+        "samples_s": [
+          0.035708,
+          0.035612917,
+          0.037337667
+        ]
+      },
+      "total": {
+        "min_s": 0.339410208,
+        "median_s": 0.340187375,
+        "samples_s": [
+          0.340187375,
+          0.341481833,
+          0.339410208
+        ]
+      },
+      "compute_s": 0.30379729099999997,
+      "ns_per_op_min": 52926.35731707316,
+      "ns_per_op_median": 53045.18728222996,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 1083,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.026734833,
+        "median_s": 0.026750458,
+        "samples_s": [
+          0.0272855,
+          0.026734833,
+          0.026750458
+        ]
+      },
+      "total": {
+        "min_s": 0.313392541,
+        "median_s": 0.31407825,
+        "samples_s": [
+          0.314763125,
+          0.313392541,
+          0.31407825
+        ]
+      },
+      "compute_s": 0.286657708,
+      "ns_per_op_min": 264688.55771006463,
+      "ns_per_op_median": 265307.28716528165,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 13308,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.037132291,
+        "median_s": 0.037236875,
+        "samples_s": [
+          0.037236875,
+          0.037314666,
+          0.037132291
+        ]
+      },
+      "total": {
+        "min_s": 0.224434,
+        "median_s": 0.226792583,
+        "samples_s": [
+          0.229262958,
+          0.224434,
+          0.226792583
+        ]
+      },
+      "compute_s": 0.18730170899999998,
+      "ns_per_op_min": 14074.36947700631,
+      "ns_per_op_median": 14243.741208295762,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 954,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.010058875,
+        "median_s": 0.010141208,
+        "samples_s": [
+          0.010141208,
+          0.010058875,
+          0.010157708
+        ]
+      },
+      "total": {
+        "min_s": 0.307270084,
+        "median_s": 0.31069575,
+        "samples_s": [
+          0.315193875,
+          0.307270084,
+          0.31069575
+        ]
+      },
+      "compute_s": 0.297211209,
+      "ns_per_op_min": 311542.1477987421,
+      "ns_per_op_median": 315046.6897274633,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 871481,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002505334,
+        "median_s": 0.002548334,
+        "samples_s": [
+          0.002777792,
+          0.002548334,
+          0.002505334
+        ]
+      },
+      "total": {
+        "min_s": 0.301953958,
+        "median_s": 0.302208791,
+        "samples_s": [
+          0.303123709,
+          0.301953958,
+          0.302208791
+        ]
+      },
+      "compute_s": 0.299448624,
+      "ns_per_op_min": 343.6088956615233,
+      "ns_per_op_median": 343.8519680865102,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 512038,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.059799916,
+        "median_s": 0.060238708,
+        "samples_s": [
+          0.060238708,
+          0.059799916,
+          0.060555708
+        ]
+      },
+      "total": {
+        "min_s": 0.340906458,
+        "median_s": 0.343997333,
+        "samples_s": [
+          0.340906458,
+          0.364119416,
+          0.343997333
+        ]
+      },
+      "compute_s": 0.281106542,
+      "ns_per_op_min": 548.9954690862787,
+      "ns_per_op_median": 554.1749342822213,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 19,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.013812541,
+        "median_s": 0.01389925,
+        "samples_s": [
+          0.01396675,
+          0.013812541,
+          0.01389925
+        ]
+      },
+      "total": {
+        "min_s": 0.303776917,
+        "median_s": 0.304071792,
+        "samples_s": [
+          0.303776917,
+          0.304071792,
+          0.306418
+        ]
+      },
+      "compute_s": 0.28996437599999997,
+      "ns_per_op_min": 15261282.947368419,
+      "ns_per_op_median": 15272239.052631581,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": 75,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.117237125,
+        "median_s": 0.117857583,
+        "samples_s": [
+          0.117237125,
+          0.117892042,
+          0.117857583
+        ]
+      },
+      "total": {
+        "min_s": 0.38374025,
+        "median_s": 0.387734708,
+        "samples_s": [
+          0.387734708,
+          0.390285583,
+          0.38374025
+        ]
+      },
+      "compute_s": 0.266503125,
+      "ns_per_op_min": 3553375.0,
+      "ns_per_op_median": 3598361.6666666665,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": 192,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.2767005,
+        "median_s": 0.277039792,
+        "samples_s": [
+          0.277039792,
+          0.2767005,
+          0.290604209
+        ]
+      },
+      "total": {
+        "min_s": 0.522994083,
+        "median_s": 0.524212417,
+        "samples_s": [
+          0.53992475,
+          0.522994083,
+          0.524212417
+        ]
+      },
+      "compute_s": 0.24629358300000004,
+      "ns_per_op_min": 1282779.0781250002,
+      "ns_per_op_median": 1287357.4218749998,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": 27,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.320059208,
+        "median_s": 0.320832542,
+        "samples_s": [
+          0.320832542,
+          0.3257265,
+          0.320059208
+        ]
+      },
+      "total": {
+        "min_s": 0.566575375,
+        "median_s": 0.567526583,
+        "samples_s": [
+          0.566575375,
+          0.567526583,
+          0.569184792
+        ]
+      },
+      "compute_s": 0.246516167,
+      "ns_per_op_min": 9130228.407407407,
+      "ns_per_op_median": 9136816.333333334,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": 36,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.506414875,
+        "median_s": 0.508583667,
+        "samples_s": [
+          0.508583667,
+          0.514456584,
+          0.506414875
+        ]
+      },
+      "total": {
+        "min_s": 0.725240417,
+        "median_s": 0.7305785,
+        "samples_s": [
+          0.7305785,
+          0.725240417,
+          0.736206375
+        ]
+      },
+      "compute_s": 0.21882554199999993,
+      "ns_per_op_min": 6078487.277777776,
+      "ns_per_op_median": 6166523.138888889,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 20,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.039694334,
+        "median_s": 0.039788375,
+        "samples_s": [
+          0.039694334,
+          0.039788375,
+          0.039950333
+        ]
+      },
+      "total": {
+        "min_s": 0.325335833,
+        "median_s": 0.32579625,
+        "samples_s": [
+          0.325335833,
+          0.32579625,
+          0.328920292
+        ]
+      },
+      "compute_s": 0.285641499,
+      "ns_per_op_min": 14282074.95,
+      "ns_per_op_median": 14300393.75,
+      "load_ms": 1.17,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 32,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.080151959,
+        "median_s": 0.081559,
+        "samples_s": [
+          0.081559,
+          0.085763708,
+          0.080151959
+        ]
+      },
+      "total": {
+        "min_s": 0.280661125,
+        "median_s": 0.280739583,
+        "samples_s": [
+          0.282551958,
+          0.280661125,
+          0.280739583
+        ]
+      },
+      "compute_s": 0.20050916600000002,
+      "ns_per_op_min": 6265911.437500001,
+      "ns_per_op_median": 6224393.218750001,
+      "load_ms": 7.625,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 74,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.047563792,
+        "median_s": 0.05106875,
+        "samples_s": [
+          0.047563792,
+          0.05106875,
+          0.051646833
+        ]
+      },
+      "total": {
+        "min_s": 0.346074584,
+        "median_s": 0.349996166,
+        "samples_s": [
+          0.353334709,
+          0.349996166,
+          0.346074584
+        ]
+      },
+      "compute_s": 0.298510792,
+      "ns_per_op_min": 4033929.621621622,
+      "ns_per_op_median": 4039559.6756756757,
+      "load_ms": 3.654,
+      "verification": "match"
+    },
+    {
+      "workload": "c/sha256",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 133,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.092721584,
+        "median_s": 0.094217833,
+        "samples_s": [
+          0.094462084,
+          0.094217833,
+          0.092721584
+        ]
+      },
+      "total": {
+        "min_s": 0.341097584,
+        "median_s": 0.3427365,
+        "samples_s": [
+          0.341097584,
+          0.346869375,
+          0.3427365
+        ]
+      },
+      "compute_s": 0.248376,
+      "ns_per_op_min": 1867488.7218045113,
+      "ns_per_op_median": 1868561.4060150376,
+      "load_ms": 8.977,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": 194548513,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.005088333,
+        "median_s": 0.005132583,
+        "samples_s": [
+          0.005132583,
+          0.005088333,
+          0.005196542
+        ]
+      },
+      "total": {
+        "min_s": 0.290940167,
+        "median_s": 0.297945792,
+        "samples_s": [
+          0.290940167,
+          0.306368417,
+          0.297945792
+        ]
+      },
+      "compute_s": 0.285851834,
+      "ns_per_op_min": 1.4693087579651662,
+      "ns_per_op_median": 1.5050909641236885,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": 181965736,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.008179125,
+        "median_s": 0.008362625,
+        "samples_s": [
+          0.008179125,
+          0.008362625,
+          0.008528084
+        ]
+      },
+      "total": {
+        "min_s": 0.301830166,
+        "median_s": 0.302889041,
+        "samples_s": [
+          0.303538958,
+          0.302889041,
+          0.301830166
+        ]
+      },
+      "compute_s": 0.293651041,
+      "ns_per_op_min": 1.6137710728134005,
+      "ns_per_op_median": 1.6185817312331812,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": 1574328,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.014870292,
+        "median_s": 0.014904625,
+        "samples_s": [
+          0.01491925,
+          0.014904625,
+          0.014870292
+        ]
+      },
+      "total": {
+        "min_s": 0.323307209,
+        "median_s": 0.323338833,
+        "samples_s": [
+          0.323338833,
+          0.323307209,
+          0.324310334
+        ]
+      },
+      "compute_s": 0.308436917,
+      "ns_per_op_min": 195.9165542377446,
+      "ns_per_op_median": 195.9148335035647,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": 101770561,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.004904459,
+        "median_s": 0.005058416,
+        "samples_s": [
+          0.005175792,
+          0.004904459,
+          0.005058416
+        ]
+      },
+      "total": {
+        "min_s": 0.308143292,
+        "median_s": 0.30931675,
+        "samples_s": [
+          0.312697917,
+          0.30931675,
+          0.308143292
+        ]
+      },
+      "compute_s": 0.303238833,
+      "ns_per_op_min": 2.9796321256399483,
+      "ns_per_op_median": 2.98964976718562,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": 14845801,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0039965,
+        "median_s": 0.004136334,
+        "samples_s": [
+          0.004136334,
+          0.0039965,
+          0.004186292
+        ]
+      },
+      "total": {
+        "min_s": 0.297892416,
+        "median_s": 0.300275708,
+        "samples_s": [
+          0.300467417,
+          0.300275708,
+          0.297892416
+        ]
+      },
+      "compute_s": 0.293895916,
+      "ns_per_op_min": 19.796568470775004,
+      "ns_per_op_median": 19.94768581365195,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": 763679,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0365375,
+        "median_s": 0.03680575,
+        "samples_s": [
+          0.0365375,
+          0.037044791,
+          0.03680575
+        ]
+      },
+      "total": {
+        "min_s": 0.342880292,
+        "median_s": 0.345358917,
+        "samples_s": [
+          0.342880292,
+          0.345358917,
+          0.349278958
+        ]
+      },
+      "compute_s": 0.306342792,
+      "ns_per_op_min": 401.14078297295066,
+      "ns_per_op_median": 404.0351600607061,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": 1088816,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.036793625,
+        "median_s": 0.036958,
+        "samples_s": [
+          0.036793625,
+          0.036958,
+          0.0369735
+        ]
+      },
+      "total": {
+        "min_s": 0.327603334,
+        "median_s": 0.329207709,
+        "samples_s": [
+          0.329891417,
+          0.329207709,
+          0.327603334
+        ]
+      },
+      "compute_s": 0.290809709,
+      "ns_per_op_min": 267.08801946334364,
+      "ns_per_op_median": 268.4105569719769,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": 1017402,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.0375825,
+        "median_s": 0.037687,
+        "samples_s": [
+          0.039617041,
+          0.0375825,
+          0.037687
+        ]
+      },
+      "total": {
+        "min_s": 0.333248,
+        "median_s": 0.333710375,
+        "samples_s": [
+          0.335852584,
+          0.333710375,
+          0.333248
+        ]
+      },
+      "compute_s": 0.29566549999999997,
+      "ns_per_op_min": 290.6083337756363,
+      "ns_per_op_median": 290.9600875563445,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": 335071,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.029711,
+        "median_s": 0.029823625,
+        "samples_s": [
+          0.029823625,
+          0.029711,
+          0.030033166
+        ]
+      },
+      "total": {
+        "min_s": 0.327000917,
+        "median_s": 0.327158375,
+        "samples_s": [
+          0.327000917,
+          0.328765667,
+          0.327158375
+        ]
+      },
+      "compute_s": 0.297289917,
+      "ns_per_op_min": 887.2445451859456,
+      "ns_per_op_median": 887.3783466787636,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": 5086382,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.041201375,
+        "median_s": 0.041231291,
+        "samples_s": [
+          0.041231291,
+          0.041283542,
+          0.041201375
+        ]
+      },
+      "total": {
+        "min_s": 0.325417917,
+        "median_s": 0.325433208,
+        "samples_s": [
+          0.325544875,
+          0.325417917,
+          0.325433208
+        ]
+      },
+      "compute_s": 0.284216542,
+      "ns_per_op_min": 55.87793877848734,
+      "ns_per_op_median": 55.87506345374767,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": 206406,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.017166916,
+        "median_s": 0.017229583,
+        "samples_s": [
+          0.017256833,
+          0.017229583,
+          0.017166916
+        ]
+      },
+      "total": {
+        "min_s": 0.315133667,
+        "median_s": 0.315967833,
+        "samples_s": [
+          0.315967833,
+          0.315133667,
+          0.322225667
+        ]
+      },
+      "compute_s": 0.29796675100000003,
+      "ns_per_op_min": 1443.5953945137253,
+      "ns_per_op_median": 1447.3331686094396,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": 109934030,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.002568041,
+        "median_s": 0.002708875,
+        "samples_s": [
+          0.002764083,
+          0.002568041,
+          0.002708875
+        ]
+      },
+      "total": {
+        "min_s": 0.296181167,
+        "median_s": 0.300636917,
+        "samples_s": [
+          0.296181167,
+          0.305048375,
+          0.300636917
+        ]
+      },
+      "compute_s": 0.293613126,
+      "ns_per_op_min": 2.6708119951574596,
+      "ns_per_op_median": 2.7100620435728593,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": 65208823,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.061027833,
+        "median_s": 0.061057375,
+        "samples_s": [
+          0.061057375,
+          0.061027833,
+          0.061555208
+        ]
+      },
+      "total": {
+        "min_s": 0.281602458,
+        "median_s": 0.282403916,
+        "samples_s": [
+          0.281602458,
+          0.282403916,
+          0.292274042
+        ]
+      },
+      "compute_s": 0.220574625,
+      "ns_per_op_min": 3.3825886567527834,
+      "ns_per_op_median": 3.39442625731797,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": 7261,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.118905625,
+        "median_s": 0.119332666,
+        "samples_s": [
+          0.118905625,
+          0.119501875,
+          0.119332666
+        ]
+      },
+      "total": {
+        "min_s": 0.419038125,
+        "median_s": 0.419339709,
+        "samples_s": [
+          0.419038125,
+          0.420786,
+          0.419339709
+        ]
+      },
+      "compute_s": 0.30013249999999997,
+      "ns_per_op_min": 41334.87122985814,
+      "ns_per_op_median": 41317.59303126291,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": 18633,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.166881958,
+        "median_s": 0.167776542,
+        "samples_s": [
+          0.167776542,
+          0.166881958,
+          0.167842458
+        ]
+      },
+      "total": {
+        "min_s": 0.416183417,
+        "median_s": 0.417915334,
+        "samples_s": [
+          0.426385084,
+          0.416183417,
+          0.417915334
+        ]
+      },
+      "compute_s": 0.249301459,
+      "ns_per_op_min": 13379.566307089572,
+      "ns_per_op_median": 13424.504481296624,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": 58242,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.305106208,
+        "median_s": 0.305579292,
+        "samples_s": [
+          0.305579292,
+          0.305106208,
+          0.306985
+        ]
+      },
+      "total": {
+        "min_s": 0.572937542,
+        "median_s": 0.5751035,
+        "samples_s": [
+          0.5751035,
+          0.572937542,
+          0.585953875
+        ]
+      },
+      "compute_s": 0.26783133400000003,
+      "ns_per_op_min": 4598.594382061056,
+      "ns_per_op_median": 4627.6605885786885,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": 7176,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.439343834,
+        "median_s": 0.442398542,
+        "samples_s": [
+          0.439343834,
+          0.444616417,
+          0.442398542
+        ]
+      },
+      "total": {
+        "min_s": 0.685599792,
+        "median_s": 0.693006916,
+        "samples_s": [
+          0.694458292,
+          0.685599792,
+          0.693006916
+        ]
+      },
+      "compute_s": 0.246255958,
+      "ns_per_op_min": 34316.60507246377,
+      "ns_per_op_median": 34923.129041248605,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": 11815,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.59199225,
+        "median_s": 0.595005417,
+        "samples_s": [
+          0.595005417,
+          0.598584333,
+          0.59199225
+        ]
+      },
+      "total": {
+        "min_s": 0.771320167,
+        "median_s": 0.775257959,
+        "samples_s": [
+          0.771320167,
+          0.775257959,
+          0.783774209
+        ]
+      },
+      "compute_s": 0.17932791699999995,
+      "ns_per_op_min": 15177.987050359707,
+      "ns_per_op_median": 15256.245619974614,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": 4794,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.269557833,
+        "median_s": 0.270416166,
+        "samples_s": [
+          0.269557833,
+          0.274274875,
+          0.270416166
+        ]
+      },
+      "total": {
+        "min_s": 0.549654458,
+        "median_s": 0.554994333,
+        "samples_s": [
+          0.549654458,
+          0.555808125,
+          0.554994333
+        ]
+      },
+      "compute_s": 0.280096625,
+      "ns_per_op_min": 58426.496662494785,
+      "ns_per_op_median": 59361.319774718395,
+      "load_ms": 1.246,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": 12468,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.176349792,
+        "median_s": 0.178985375,
+        "samples_s": [
+          0.180302667,
+          0.178985375,
+          0.176349792
+        ]
+      },
+      "total": {
+        "min_s": 0.367983083,
+        "median_s": 0.369330333,
+        "samples_s": [
+          0.367983083,
+          0.370628125,
+          0.369330333
+        ]
+      },
+      "compute_s": 0.19163329099999998,
+      "ns_per_op_min": 15370.010506897655,
+      "ns_per_op_median": 15266.679339108117,
+      "load_ms": 7.589,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": 17382,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.113716875,
+        "median_s": 0.114176833,
+        "samples_s": [
+          0.113716875,
+          0.114472292,
+          0.114176833
+        ]
+      },
+      "total": {
+        "min_s": 0.464455375,
+        "median_s": 0.468634875,
+        "samples_s": [
+          0.464455375,
+          0.469199958,
+          0.468634875
+        ]
+      },
+      "compute_s": 0.3507385,
+      "ns_per_op_min": 20178.259118628466,
+      "ns_per_op_median": 20392.247267288,
+      "load_ms": 3.657,
+      "verification": "match"
+    },
+    {
+      "workload": "c/wordcount",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": 32149,
+      "runs_per_sample": null,
+      "reps": 3,
+      "cold_start": {
+        "min_s": 0.13046875,
+        "median_s": 0.131033792,
+        "samples_s": [
+          0.131033792,
+          0.135265625,
+          0.13046875
+        ]
+      },
+      "total": {
+        "min_s": 0.432637041,
+        "median_s": 0.441510125,
+        "samples_s": [
+          0.432637041,
+          0.441510125,
+          0.457922083
+        ]
+      },
+      "compute_s": 0.302168291,
+      "ns_per_op_min": 9398.99502317335,
+      "ns_per_op_median": 9657.418053438676,
+      "load_ms": 9.121,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 32,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.009192829375000001,
+        "median_s": 0.00921969528125,
+        "samples_s": [
+          0.00929109778125,
+          0.00921969528125,
+          0.009192829375000001
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 25,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.012445765079999999,
+        "median_s": 0.012524423359999998,
+        "samples_s": [
+          0.012524423359999998,
+          0.012563238319999996,
+          0.012445765079999999
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 13,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.023693108923076925,
+        "median_s": 0.02370662830769231,
+        "samples_s": [
+          0.02376357069230769,
+          0.02370662830769231,
+          0.023693108923076925
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 3,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.10033799966666668,
+        "median_s": 0.10074462466666667,
+        "samples_s": [
+          0.10074462466666667,
+          0.101552139,
+          0.10033799966666668
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 42,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.007334581285714287,
+        "median_s": 0.007368127023809524,
+        "samples_s": [
+          0.007375640738095238,
+          0.007368127023809524,
+          0.007334581285714287
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 3,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.13245455566666667,
+        "median_s": 0.13302262499999998,
+        "samples_s": [
+          0.13245455566666667,
+          0.13302262499999998,
+          0.134690167
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 2,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.1802211455,
+        "median_s": 0.180834917,
+        "samples_s": [
+          0.180834917,
+          0.1802211455,
+          0.1834939375
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 2,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.23581722900000002,
+        "median_s": 0.23641547899999998,
+        "samples_s": [
+          0.23581722900000002,
+          0.23641547899999998,
+          0.2381181455
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.393946458,
+        "median_s": 0.394345083,
+        "samples_s": [
+          0.393946458,
+          0.394345083,
+          0.395177417
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.59649375,
+        "median_s": 0.597494167,
+        "samples_s": [
+          0.59649375,
+          0.599422916,
+          0.597494167
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 3,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.10214973633333334,
+        "median_s": 0.10244583299999999,
+        "samples_s": [
+          0.10302716633333335,
+          0.10244583299999999,
+          0.10214973633333334
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 64,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.0039409902031250004,
+        "median_s": 0.0039423131875,
+        "samples_s": [
+          0.003950772796875001,
+          0.0039409902031250004,
+          0.0039423131875
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 3,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.12061819466666666,
+        "median_s": 0.12152361133333334,
+        "samples_s": [
+          0.12061819466666666,
+          0.12353605599999999,
+          0.12152361133333334
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "dewasm-bash",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 1.254822083,
+        "median_s": 1.255031625,
+        "samples_s": [
+          1.255031625,
+          1.254822083,
+          1.291139125
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wasm3-ruby",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.81582375,
+        "median_s": 0.819047,
+        "samples_s": [
+          0.820048542,
+          0.819047,
+          0.81582375
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 1.110047,
+        "median_s": 1.110938209,
+        "samples_s": [
+          1.110938209,
+          1.110047,
+          1.118505625
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wasm3-python",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 2.320685334,
+        "median_s": 2.326334542,
+        "samples_s": [
+          2.326334542,
+          2.351722333,
+          2.320685334
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wasm3-pypy",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 1.746228875,
+        "median_s": 1.749678166,
+        "samples_s": [
+          1.749678166,
+          1.764068459,
+          1.746228875
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "pywasm-cpython",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.470007042,
+        "median_s": 0.473801792,
+        "samples_s": [
+          0.470007042,
+          0.473801792,
+          0.477787791
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": 262.932,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.81363425,
+        "median_s": 0.829045541,
+        "samples_s": [
+          0.81363425,
+          0.836816292,
+          0.829045541
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": 432.904,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wardite",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 2,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.2176018545,
+        "median_s": 0.219370208,
+        "samples_s": [
+          0.2176018545,
+          0.219370208,
+          0.22122029199999999
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": 103.905,
+      "verification": "match"
+    },
+    {
+      "workload": "app/cowsay",
+      "runner": "wardite-yjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 2,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.2435116875,
+        "median_s": 0.2449439995,
+        "samples_s": [
+          0.2449439995,
+          0.2435116875,
+          0.24604695799999998
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": 77.605,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 4,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.07484680199999999,
+        "median_s": 0.07520613525,
+        "samples_s": [
+          0.07484680199999999,
+          0.0754371145,
+          0.07520613525
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 4,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.0831128025,
+        "median_s": 0.0831140315,
+        "samples_s": [
+          0.0831140315,
+          0.0831128025,
+          0.08314461425
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 9.419818042,
+        "median_s": 9.447263292,
+        "samples_s": [
+          9.478827333,
+          9.419818042,
+          9.447263292
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.605366334,
+        "median_s": 0.612347292,
+        "samples_s": [
+          0.605366334,
+          0.616586,
+          0.612347292
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 1.094578417,
+        "median_s": 1.097053292,
+        "samples_s": [
+          1.094578417,
+          1.099863167,
+          1.097053292
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 18.641816208,
+        "median_s": 18.746726958,
+        "samples_s": [
+          18.818688,
+          18.641816208,
+          18.746726958
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 8.809084334,
+        "median_s": 8.843876999999999,
+        "samples_s": [
+          8.952254583,
+          8.809084334,
+          8.843876999999999
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 13.407954334,
+        "median_s": 13.413182583,
+        "samples_s": [
+          13.407954334,
+          13.4484845,
+          13.413182583
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-python",
+      "status": "skipped",
+      "kind": "cost",
+      "reason": "dewasm-python runs this program correctly but at 56 s and 57 s per run (median, sqlite3_query and sqlite3_mod_query), costing roughly 9 minutes of the roughly 65 minute full suite; dewasm-python stays measured on the other app cases and the microbenchmarks"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 11.361551209,
+        "median_s": 11.36354175,
+        "samples_s": [
+          11.361551209,
+          11.376659708,
+          11.36354175
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-perl",
+      "status": "skipped",
+      "kind": "cost",
+      "reason": "dewasm-perl runs this program correctly but at 113 s and 115 s per run (median, sqlite3_query and sqlite3_mod_query), so one warmup plus the timed repetitions across both cases alone cost roughly 19 minutes of the roughly 65 minute full suite; dewasm-perl stays measured on the other app cases and the microbenchmarks"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 2,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.16829943749999998,
+        "median_s": 0.168363458,
+        "samples_s": [
+          0.1701779795,
+          0.16829943749999998,
+          0.168363458
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 2.287429042,
+        "median_s": 2.3033345,
+        "samples_s": [
+          2.3033345,
+          2.287429042,
+          2.317536834
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "dewasm-bash",
+      "status": "skipped",
+      "kind": "cost",
+      "reason": "bash runs ~10000x slower than wasmtime on compute, so 100k SQL inserts do not finish in a practical time"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wasm3-ruby",
+      "status": "skipped",
+      "kind": "cost",
+      "reason": "the converted wasm3 runs this program correctly (stdout matching the oracle) at 160 s per run on wasm3-ruby-yjit, the fastest of the four wasm3-* runners, so one warmup plus the timed repetitions across both query cases and all four runners would add hours to the suite"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wasm3-ruby-yjit",
+      "status": "skipped",
+      "kind": "cost",
+      "reason": "the converted wasm3 runs this program correctly (stdout matching the oracle) at 160 s per run on wasm3-ruby-yjit, the fastest of the four wasm3-* runners, so one warmup plus the timed repetitions across both query cases and all four runners would add hours to the suite"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wasm3-python",
+      "status": "skipped",
+      "kind": "cost",
+      "reason": "the converted wasm3 runs this program correctly (stdout matching the oracle) at 160 s per run on wasm3-ruby-yjit, the fastest of the four wasm3-* runners, so one warmup plus the timed repetitions across both query cases and all four runners would add hours to the suite"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wasm3-pypy",
+      "status": "skipped",
+      "kind": "cost",
+      "reason": "the converted wasm3 runs this program correctly (stdout matching the oracle) at 160 s per run on wasm3-ruby-yjit, the fastest of the four wasm3-* runners, so one warmup plus the timed repetitions across both query cases and all four runners would add hours to the suite"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "pywasm-cpython",
+      "status": "skipped",
+      "kind": "cost",
+      "reason": "pywasm runs this program correctly (byte-identical to wasmtime under -batch) at ~17.9 ms/row: measured 358 s at 20k rows, so the 100k-row script needs roughly half an hour per sample"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "pywasm-pypy",
+      "status": "skipped",
+      "kind": "cost",
+      "reason": "pywasm runs this program correctly (byte-identical to wasmtime under -batch) at ~17.9 ms/row: measured 358 s at 20k rows, so the 100k-row script needs roughly half an hour per sample"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wardite",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "wardite loads the sqlite3 shell but cannot execute a query, raising Wardite::EvalError (\"maybe empty or invalid stack\", convert.generated.rb:200) as soon as any SQL runs"
+    },
+    {
+      "workload": "app/sqlite3_query",
+      "runner": "wardite-yjit",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "wardite loads the sqlite3 shell but cannot execute a query, raising Wardite::EvalError (\"maybe empty or invalid stack\", convert.generated.rb:200) as soon as any SQL runs"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 4,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.08256603125,
+        "median_s": 0.08259972975,
+        "samples_s": [
+          0.08256603125,
+          0.08329303125,
+          0.08259972975
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 4,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.08563277075,
+        "median_s": 0.0858954165,
+        "samples_s": [
+          0.0858954165,
+          0.08597216675,
+          0.08563277075
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 9.758208458,
+        "median_s": 9.800593833,
+        "samples_s": [
+          9.800593833,
+          9.807328209,
+          9.758208458
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.600514125,
+        "median_s": 0.605496666,
+        "samples_s": [
+          0.600514125,
+          0.60593675,
+          0.605496666
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 1.159696708,
+        "median_s": 1.168914042,
+        "samples_s": [
+          1.182049459,
+          1.159696708,
+          1.168914042
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 19.748105083,
+        "median_s": 19.8157545,
+        "samples_s": [
+          19.8157545,
+          19.870035416,
+          19.748105083
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 8.031215583,
+        "median_s": 8.071031916999999,
+        "samples_s": [
+          8.088100583,
+          8.071031916999999,
+          8.031215583
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 13.794727708,
+        "median_s": 13.831111332999999,
+        "samples_s": [
+          13.794727708,
+          13.831893417,
+          13.831111332999999
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-python",
+      "status": "skipped",
+      "kind": "cost",
+      "reason": "dewasm-python runs this program correctly but at 56 s and 57 s per run (median, sqlite3_query and sqlite3_mod_query), costing roughly 9 minutes of the roughly 65 minute full suite; dewasm-python stays measured on the other app cases and the microbenchmarks"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 12.155915125,
+        "median_s": 12.233741,
+        "samples_s": [
+          12.329639209,
+          12.233741,
+          12.155915125
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-perl",
+      "status": "skipped",
+      "kind": "cost",
+      "reason": "dewasm-perl runs this program correctly but at 113 s and 115 s per run (median, sqlite3_query and sqlite3_mod_query), so one warmup plus the timed repetitions across both cases alone cost roughly 19 minutes of the roughly 65 minute full suite; dewasm-perl stays measured on the other app cases and the microbenchmarks"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 3,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.12213086133333333,
+        "median_s": 0.12257494433333334,
+        "samples_s": [
+          0.12213086133333333,
+          0.12257494433333334,
+          0.12313333366666668
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 5.354698917,
+        "median_s": 5.36443075,
+        "samples_s": [
+          5.354698917,
+          5.36443075,
+          5.400654542
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "dewasm-bash",
+      "status": "skipped",
+      "kind": "cost",
+      "reason": "bash runs ~10000x slower than wasmtime on compute, so 100k SQL inserts do not finish in a practical time"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wasm3-ruby",
+      "status": "skipped",
+      "kind": "cost",
+      "reason": "the converted wasm3 runs this program correctly (stdout matching the oracle) at 160 s per run on wasm3-ruby-yjit, the fastest of the four wasm3-* runners, so one warmup plus the timed repetitions across both query cases and all four runners would add hours to the suite"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wasm3-ruby-yjit",
+      "status": "skipped",
+      "kind": "cost",
+      "reason": "the converted wasm3 runs this program correctly (stdout matching the oracle) at 160 s per run on wasm3-ruby-yjit, the fastest of the four wasm3-* runners, so one warmup plus the timed repetitions across both query cases and all four runners would add hours to the suite"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wasm3-python",
+      "status": "skipped",
+      "kind": "cost",
+      "reason": "the converted wasm3 runs this program correctly (stdout matching the oracle) at 160 s per run on wasm3-ruby-yjit, the fastest of the four wasm3-* runners, so one warmup plus the timed repetitions across both query cases and all four runners would add hours to the suite"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wasm3-pypy",
+      "status": "skipped",
+      "kind": "cost",
+      "reason": "the converted wasm3 runs this program correctly (stdout matching the oracle) at 160 s per run on wasm3-ruby-yjit, the fastest of the four wasm3-* runners, so one warmup plus the timed repetitions across both query cases and all four runners would add hours to the suite"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "pywasm-cpython",
+      "status": "skipped",
+      "kind": "cost",
+      "reason": "pywasm runs this program correctly (byte-identical to wasmtime under -batch) at ~17.9 ms/row: measured 358 s at 20k rows, so the 100k-row script needs roughly half an hour per sample"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "pywasm-pypy",
+      "status": "skipped",
+      "kind": "cost",
+      "reason": "pywasm runs this program correctly (byte-identical to wasmtime under -batch) at ~17.9 ms/row: measured 358 s at 20k rows, so the 100k-row script needs roughly half an hour per sample"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wardite",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "wardite loads the sqlite3 shell but cannot execute a query, raising Wardite::EvalError (\"maybe empty or invalid stack\", convert.generated.rb:200) as soon as any SQL runs"
+    },
+    {
+      "workload": "app/sqlite3_mod_query",
+      "runner": "wardite-yjit",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "wardite loads the sqlite3 shell but cannot execute a query, raising Wardite::EvalError (\"maybe empty or invalid stack\", convert.generated.rb:200) as soon as any SQL runs"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wasmtime",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 7,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.042618630857142854,
+        "median_s": 0.04268783328571428,
+        "samples_s": [
+          0.04268783328571428,
+          0.04274595257142857,
+          0.042618630857142854
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "reference"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wasmer",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 7,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.04895432128571429,
+        "median_s": 0.049044136999999995,
+        "samples_s": [
+          0.04922447028571429,
+          0.04895432128571429,
+          0.049044136999999995
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wasmedge",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 2.150155833,
+        "median_s": 2.151613833,
+        "samples_s": [
+          2.150155833,
+          2.151613833,
+          2.152583
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wazero",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 4,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.08413883324999999,
+        "median_s": 0.084283552,
+        "samples_s": [
+          0.084283552,
+          0.08436959375,
+          0.08413883324999999
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wasm3",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 2,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.2480990415,
+        "median_s": 0.2487612495,
+        "samples_s": [
+          0.2491364165,
+          0.2487612495,
+          0.2480990415
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-ruby",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 5.123536375,
+        "median_s": 5.159128875,
+        "samples_s": [
+          5.159128875,
+          5.123536375,
+          5.1606305
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-ruby-yjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 1.5574419160000001,
+        "median_s": 1.5620116670000002,
+        "samples_s": [
+          1.5620116670000002,
+          1.5574419160000001,
+          1.575677792
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-ruby-zjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 3.185113875,
+        "median_s": 3.198661875,
+        "samples_s": [
+          3.206382084,
+          3.198661875,
+          3.185113875
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-python",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 14.937986709,
+        "median_s": 15.000706791,
+        "samples_s": [
+          15.000706791,
+          15.011192459,
+          14.937986709
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-pypy",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 2.578206458,
+        "median_s": 2.578337958,
+        "samples_s": [
+          2.578337958,
+          2.605286208,
+          2.578206458
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-perl",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 23.493213417,
+        "median_s": 23.672274,
+        "samples_s": [
+          23.68116225,
+          23.493213417,
+          23.672274
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-go",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 6,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.055625972333333336,
+        "median_s": 0.05587825683333334,
+        "samples_s": [
+          0.0561445905,
+          0.05587825683333334,
+          0.055625972333333336
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-java",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 0.506439458,
+        "median_s": 0.525723,
+        "samples_s": [
+          0.525723,
+          0.5500605,
+          0.506439458
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "dewasm-bash",
+      "status": "skipped",
+      "kind": "cost",
+      "reason": "bash compresses this workload's generated text at ~0.61 ms/byte (measured 30.6 s on a 50000-byte prefix), so the full 1.2 MB input needs roughly 12 minutes per run"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wasm3-ruby",
+      "status": "skipped",
+      "kind": "cost",
+      "reason": "the converted wasm3 compresses the full 1.2 MB input correctly (byte-identical to wasmtime) but at 149 s per run on plain ruby and 301 s on pypy, both measured, and roughly 7 minutes on cpython (measured 107 s on a 300000-byte prefix); wasm3-ruby-yjit runs it at 54 s and stays measured"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wasm3-ruby-yjit",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 52.923096833,
+        "median_s": 53.019280917,
+        "samples_s": [
+          53.023182084,
+          52.923096833,
+          53.019280917
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": null,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wasm3-python",
+      "status": "skipped",
+      "kind": "cost",
+      "reason": "the converted wasm3 compresses the full 1.2 MB input correctly (byte-identical to wasmtime) but at 149 s per run on plain ruby and 301 s on pypy, both measured, and roughly 7 minutes on cpython (measured 107 s on a 300000-byte prefix); wasm3-ruby-yjit runs it at 54 s and stays measured"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wasm3-pypy",
+      "status": "skipped",
+      "kind": "cost",
+      "reason": "the converted wasm3 compresses the full 1.2 MB input correctly (byte-identical to wasmtime) but at 149 s per run on plain ruby and 301 s on pypy, both measured, and roughly 7 minutes on cpython (measured 107 s on a 300000-byte prefix); wasm3-ruby-yjit runs it at 54 s and stays measured"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "pywasm-cpython",
+      "status": "skipped",
+      "kind": "cost",
+      "reason": "pywasm under CPython compresses this workload's generated text at ~0.46 ms/byte (measured 9.2 s on a 20000-byte prefix), so the full 1.2 MB input needs roughly 9 minutes per run"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "pywasm-pypy",
+      "status": "ok",
+      "iterations": null,
+      "runs_per_sample": 1,
+      "reps": 3,
+      "cold_start": null,
+      "total": {
+        "min_s": 77.849643083,
+        "median_s": 78.047819292,
+        "samples_s": [
+          78.047819292,
+          77.849643083,
+          78.137579791
+        ]
+      },
+      "compute_s": null,
+      "ns_per_op_min": null,
+      "ns_per_op_median": null,
+      "load_ms": 305.133,
+      "verification": "match"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wardite",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "wardite computes the correct compressed output but its driver crashes on exit (IOError: closed stream at wardite.rb:40) because minigzip closes stdout itself and wardite's fd_close closes the real fd under it, so the driver's own trailing flush fails and the process exits 1"
+    },
+    {
+      "workload": "app/minigzip",
+      "runner": "wardite-yjit",
+      "status": "skipped",
+      "kind": "capability",
+      "reason": "wardite computes the correct compressed output but its driver crashes on exit (IOError: closed stream at wardite.rb:40) because minigzip closes stdout itself and wardite's fd_close closes the real fd under it, so the driver's own trailing flush fails and the process exits 1"
+    }
+  ]
+}

--- a/records/README.md
+++ b/records/README.md
@@ -22,6 +22,7 @@ A run appends its line with a `TODO`; fill it in when committing the record.
 - `2026-08-24T22-56-29Z-speed.json`: TODO: describe the occasion.
 - `2026-08-24T23-27-21Z-speed.json`: TODO: describe the occasion.
 - `2026-08-30T05-11-20Z-speed.json`: the first record with the converted-wasm3 runners (#279) on the wasm3 v0.9.0 pin (#278).
+- `2026-08-31T09-49-13Z-speed.json`: the first record on the official wasm3 asset (#291), with tail calls lowered in every backend (#288, #296) and a pending tail call parked rather than allocated (#297); adds `wat/tail_call` (#294).
 
 ## Size records
 


### PR DESCRIPTION
The first full run since the tail-call work. None of the recorded numbers were comparable across it, so the suite was re-measured rather than patched:

- the converted-interpreter runners now convert upstream's own `wasm3-wasi.wasm` rather than a build with its dispatch turned off (#291),
- every backend lowers the proposal, bash included (#288, #296),
- a pending tail call is parked rather than allocated (#297),
- and `wat/tail_call` is a new workload (#294).

**No cell failed**, and every app was re-fetched through `setup.sh` first so each one matches its pin.

## `wat/tail_call`, paired with `call_direct`

The pairing is the point of the case: same four functions, same arithmetic, same printed result, so the ratio is the cost of a frame-replacing call against a nesting one.

| runner | ns/iter | vs `call_direct` |
| --- | ---: | ---: |
| wasmtime | 3.4 | 1.00x |
| dewasm-go | 9.1 | 2.24x |
| dewasm-java | 17.6 | 4.99x |
| wasm3 | 52.3 | 1.20x |
| wasmedge | 188.0 | 0.94x |
| dewasm-pypy | 138.9 | 1.58x |
| dewasm-ruby-yjit | 270.1 | 2.55x |
| dewasm-ruby-zjit | 374.1 | 3.06x |
| dewasm-ruby | 620.2 | 3.09x |
| dewasm-python | 682.4 | 1.67x |
| dewasm-perl | 2466.2 | 2.29x |
| wasm3-ruby-yjit | 7500.5 | 0.86x |
| dewasm-bash | 77112.6 | 1.43x |

A native compiler makes a tail call free. The trampolines cost between 1.4x and 5x an ordinary call, which is where #297 left them, down from 9.93x on Go and 8.52x on Java before it. Through the converted interpreter the ratio sits just under 1, since wasm3's own interpretation dominates either way.

## `app/cowsay` through the converted wasm3

The pin change shows up here, since the asset is a different build of the same interpreter:

| runner | old build | official asset |
| --- | ---: | ---: |
| wasm3-ruby | 1556 ms | 819 ms |
| wasm3-python | 3842 ms | 2326 ms |
| wasm3-ruby-yjit | 1252 ms | 1111 ms |
| wasm3-pypy | 1720 ms | 1750 ms |

## A note on how this run was got right

The first attempt produced a record that had to be thrown away: the app cache in the worktree still held the *previous* wasm3 pin, so it measured the old build, and `app/cowsay` failed on the ruby hosts because that build needs the stack raise #291 removed. The cache was stale, not the code.

The harness reads `cache/<app>.wasm` without checking it against the pin, so a stale cache is measured silently. Worth fixing separately by recording the sha256 of each module actually measured, which would make a record say what it measured rather than depend on the cache having been right; that is a schema change and wants its own migration (decision 87).