### PR TITLE
Refuse to run against an app cache that does not match its pins

### DIFF
--- a/.github/actions/apps-cache-tools/action.yml
+++ b/.github/actions/apps-cache-tools/action.yml
@@ -1,0 +1,20 @@
+name: Install the tools the apps cache is keyed on
+description: >
+  Installs wasm-opt and the wasi-vfs CLI, the two tools whose versions appear in
+  examples/apps/scripts stamps. A job that reads the restored apps cache needs them
+  to verify it against its pins (examples/apps/setup.sh --check), even though it
+  does not build anything.
+runs:
+  using: composite
+  steps:
+    # Binaryen comes from the pinned upstream release, not apt, for the same reason the apps-cache job takes it from there.
+    - shell: bash
+      run: |
+        curl -sSfL -o /tmp/binaryen.tar.gz https://github.com/WebAssembly/binaryen/releases/download/version_132/binaryen-version_132-x86_64-linux.tar.gz
+        tar -xzf /tmp/binaryen.tar.gz -C /tmp
+        sudo cp /tmp/binaryen-version_132/bin/wasm-opt /usr/local/bin/
+        curl -fsSL --retry 5 -o /tmp/wasi-vfs-cli.zip \
+          https://github.com/kateinoigakukun/wasi-vfs/releases/download/v0.6.3/wasi-vfs-cli-x86_64-unknown-linux-gnu.zip
+        echo "c9ee8179f6f0882abc37024fbe0cd678311aa8a29083fa364915ed4d29a69485  /tmp/wasi-vfs-cli.zip" | shasum -a 256 -c -
+        sudo unzip -o /tmp/wasi-vfs-cli.zip -d /usr/local/bin
+        sudo chmod +x /usr/local/bin/wasi-vfs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,8 @@ jobs:
           path: examples/apps/cache
           key: ${{ needs.apps-cache.outputs.key }}
           fail-on-cache-miss: true
+      # The cache-matches-its-pins test reproduces the stamps, which name these two tools' versions.
+      - uses: ./.github/actions/apps-cache-tools
       - name: Test
         if: github.event_name == 'pull_request'
         run: cargo test -p dewasm-backend-${{ matrix.backend }} --no-fail-fast
@@ -161,6 +163,8 @@ jobs:
           path: examples/apps/cache
           key: ${{ needs.apps-cache.outputs.key }}
           fail-on-cache-miss: true
+      # The cache-matches-its-pins test reproduces the stamps, which name these two tools' versions.
+      - uses: ./.github/actions/apps-cache-tools
       # Speed categories: the `slow_test` feature covers the slow cases.
       # `dewasm-test-helper/wasmtime_test` runs the apps_wasmtime snapshot-freshness suite, which execs the xtask binary (it embeds the pinned wasmtime crate, so nothing is installed for it) and never builds it, hence the explicit build step below; `dewasm/slow_test` runs the slow cross-backend `--data-file` real-app cases.
       - name: Build the snapshot runner

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Everything else the test suite needs (interpreters, submodules, the apps cache) 
 | `cargo run -p dewasm -- input.wasm --target ruby --mode standalone -o out.rb` | Convert; `.wat` input works too, `-o -` for stdout. |
 | `cargo xtask record-speed [filter]` | Measure the cross-runtime benchmark suite into a record under `records/`; see [`docs/benchmarks/README.md`](docs/benchmarks/README.md). |
 | `cargo xtask record-size` | Measure the distribution sizes into a record under `records/`; see [`docs/sizes/README.md`](docs/sizes/README.md). |
-| `examples/apps/setup.sh` | Fetch/build the pinned real-world apps into the gitignored cache; tool requirements are in docs/testing.md. |
+| `examples/apps/setup.sh` | Fetch/build the pinned real-world apps into the gitignored cache; `--check` verifies without fetching and names anything stale. Tool requirements are in docs/testing.md. |
 
 After any non-trivial change, run `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test`.
 The slower test categories are opt-in cargo features: `--features slow_test` (CI's main run) adds each backend's slow app cases and the full spec-testsuite run; `--features ultra_slow_test` adds the cases CI cannot afford, run in local pre-release verification.

--- a/crates/dewasm-test-helper/tests/apps_cache_pins.rs
+++ b/crates/dewasm-test-helper/tests/apps_cache_pins.rs
@@ -1,0 +1,25 @@
+//! The app cache matches the pins the fetch scripts hold.
+//!
+//! Every suite that runs a real app reads `examples/apps/cache/<app>.wasm` through [`dewasm_test_helper::apps_cache_dir`], which says nothing about *which* build is there.
+//! A copy left over from an earlier pin is a different program: it may fail in ways that look like a code regression, or pass and prove nothing about what is pinned now.
+//!
+//! Checking on every `apps_cache_dir()` call would cost a subprocess per case, so the check is one test instead: `cargo test` runs it once, and a stale cache is named here rather than diagnosed from whatever the app did afterwards.
+//!
+//! The pins live in the fetch scripts and `setup.sh --check` asks them, so nothing is duplicated here; it needs no network.
+
+use std::process::Command;
+
+#[test]
+fn the_app_cache_matches_its_pins() {
+    let script =
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../examples/apps/setup.sh");
+    let out = Command::new(&script)
+        .arg("--check")
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run {}: {e}", script.display()));
+    assert!(
+        out.status.success(),
+        "the app cache does not match its pins, so the suites below would run the wrong programs:\n{}\nrun examples/apps/setup.sh",
+        String::from_utf8_lossy(&out.stderr).trim_end()
+    );
+}

--- a/crates/xtask/src/bench/mod.rs
+++ b/crates/xtask/src/bench/mod.rs
@@ -127,7 +127,31 @@ pub fn record(args: impl Iterator<Item = String>) -> Result<()> {
     if opts.list {
         return list(&opts, &runners, &workloads);
     }
+    verify_app_pins()?;
     run(&opts, &runners, &workloads)
+}
+
+/// Refuse to measure an app cache that does not match its pin.
+///
+/// The harness reads `cache/<app>.wasm` directly, so a copy left over from an earlier pin would be measured as the current one and its numbers committed as a record.
+/// The pins live in the fetch scripts, which already compare them against the cached stamp, so this asks them rather than keeping a second copy that could drift.
+/// `--check` needs no network: it reports and fails instead of fetching.
+fn verify_app_pins() -> Result<()> {
+    let script = repo_root().join("examples/apps/setup.sh");
+    if !script.exists() {
+        return Ok(());
+    }
+    let out = std::process::Command::new(&script)
+        .arg("--check")
+        .output()
+        .with_context(|| format!("failed to run {}", display_path(&script)))?;
+    if out.status.success() {
+        return Ok(());
+    }
+    bail!(
+        "the app cache does not match its pins, so the run would measure the wrong modules:\n{}\nrun examples/apps/setup.sh",
+        String::from_utf8_lossy(&out.stderr).trim_end()
+    );
 }
 
 /// Whether `workload` has at least one runner selected by `filter`.

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -14,6 +14,9 @@ $ cargo xtask render-speed           # results.md and its charts, from that reco
 
 Measuring and rendering are two commands: a run writes a dated `<timestamp>Z-speed.json` to [`records/`](../../records/README.md) and nothing else, and rendering turns a record into `docs/benchmarks/results.md` with its charts.
 That way a wording fix in the document costs a second, not a re-measurement of the whole suite.
+
+`record-speed` verifies the app cache against its pins before it measures anything, and refuses to start if a cached copy came from an earlier pin.
+A stale copy is a different program, and its numbers would be committed as a record of the current one.
 Useful options:
 
 | Command | Effect |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -16,6 +16,7 @@ The following tools and setup steps are required to run all tests correctly:
   * These environment variables override the lookup: `$DEWASM_RUBY`, `$DEWASM_PYTHON`, `$DEWASM_PERL`, `$DEWASM_BASH`, `$DEWASM_GO`, `$DEWASM_JAVA`, `$DEWASM_JAVAC`.
 - **Testsuite submodules**: initialize them once with `git submodule update --init`.
 - **The `.wasm` apps cache**: initialize it once with `examples/apps/setup.sh`.
+  Re-run it after pulling a change that re-pins an app: a cached copy from the previous pin is a different program, and `examples/apps/setup.sh --check` names any that are stale without fetching.
   * Cached `.wasm` files are located in `examples/apps/cache`.
   * Building some apps from source needs more: `zig` (sqlite3 and others), a host Ruby with `rake` (mruby); each `scripts/*.sh` fails loudly naming what it is missing.
 

--- a/examples/apps/scripts/common.sh
+++ b/examples/apps/scripts/common.sh
@@ -43,14 +43,22 @@ new_tmpdir() {
 
 # is_cached <stamp> <key> <output...>: true when every output exists and the stamp matches key.
 # The stamp records which pinned inputs the cached copy came from; a re-pin refetches/rebuilds instead of silently keeping a stale copy (which would fail the snapshot comparison inscrutably).
+#
+# Under DEWASM_APPS_CHECK a mismatch is reported and the script exits 2 rather than fetching, which is what `setup.sh --check` runs and what a consumer calls before reading the cache.
+# Hooking it here rather than in each script is deliberate: every path that decides whether to rebuild goes through this one call, `fetch_app`'s included.
 is_cached() {
   local stamp="$1" key="$2"
   shift 2
-  local f
+  local f fresh=0
   for f in "$@"; do
-    [ -e "$f" ] || return 1
+    [ -e "$f" ] || fresh=1
   done
-  [ "$(cat "$stamp" 2>/dev/null || true)" = "$key" ]
+  [ "$(cat "$stamp" 2>/dev/null || true)" = "$key" ] || fresh=1
+  if [ -n "${DEWASM_APPS_CHECK-}" ] && [ "$fresh" = 1 ]; then
+    echo "${APP_NAME:-$(basename "$0" .sh)}: cache does not match the pin (run examples/apps/setup.sh)" >&2
+    exit 2
+  fi
+  [ "$fresh" = 0 ]
 }
 
 # write_stamp <stamp> <key>: record the pin the fresh artifacts came from.

--- a/examples/apps/setup.sh
+++ b/examples/apps/setup.sh
@@ -7,7 +7,20 @@
 # `scripts/sqlite3.sh` to (re)build just sqlite3 after bumping its pin); this driver simply runs them all.
 # Shared boilerplate lives in scripts/common.sh.
 
+# `--check` verifies instead of fetching: every app whose cached copy does not match its pin is named, and the exit status is nonzero.
+# It needs no network, so a consumer can call it before reading the cache and refuse to proceed on a stale one rather than measure or test the wrong artifact.
+
 set -euo pipefail
+
+check=
+if [ "${1-}" = --check ]; then
+  check=1
+  shift
+fi
+if [ $# -gt 0 ]; then
+  echo "usage: setup.sh [--check]" >&2
+  exit 2
+fi
 
 cd "$(dirname "$0")/scripts"
 
@@ -16,6 +29,17 @@ for s in *.sh; do
   [ "$s" = common.sh ] || apps+=("$s")
 done
 IFS=$'\n' read -r -d '' -a apps < <(printf '%s\n' "${apps[@]}" | sort && printf '\0')
+
+if [ -n "$check" ]; then
+  # Every app is reported, not just the first, so one run names everything to re-fetch.
+  stale=0
+  for app in "${apps[@]}"; do
+    DEWASM_APPS_CHECK=1 APP_NAME="${app%.sh}" ./"$app" >/dev/null || stale=1
+  done
+  [ "$stale" = 0 ] || exit 1
+  echo "apps: every cached copy matches its pin"
+  exit 0
+fi
 
 for app in "${apps[@]}"; do
   ./"$app"


### PR DESCRIPTION
Fixes #300.

## Why

The harness reads `examples/apps/cache/<app>.wasm` directly, so a copy left over from an earlier pin is measured as if it were the current one.

That happened while recording #299: the cache still held the previous wasm3 pin, so the run measured the build whose dispatch had been turned off rather than the official asset. It was caught only because that build *also* fails without the stack raise #291 removed. A stale artifact that merely ran slower would have passed every cell and been committed as a record of the current program.

CI never hits this because it runs `setup.sh` first. A local run had no such step.

## The fix

Verification was not missing. The pins live in the fetch scripts, and `common.sh`'s `is_cached <stamp> <key>` already compares them against the cached stamp, refetching on a mismatch. It was simply never invoked before measuring.

Under `DEWASM_APPS_CHECK`, `is_cached` reports and exits instead of fetching. Hooking that one function covers all fourteen call sites and `fetch_app`'s internal one, so no per-app script changed.

```console
$ examples/apps/setup.sh --check
cowsay: cache does not match the pin (run examples/apps/setup.sh)
wasm3: cache does not match the pin (run examples/apps/setup.sh)
$ echo $?
1
```

It names everything stale rather than stopping at the first, so one run tells you all of what to re-fetch, and it needs no network.

`record-speed` calls it before measuring and refuses to start:

```console
$ cargo xtask record-speed cowsay
Error: the app cache does not match its pins, so the run would measure the wrong modules:
wasm3: cache does not match the pin (run examples/apps/setup.sh)
run examples/apps/setup.sh
```

Not one cell runs. This is decision 15's rule ("fail loud on a bad environment, never proceed") applied to the benchmark, where the output is a committed claim rather than a test result someone reads.

`--list` deliberately skips the check, so it still works as an environment probe.

The pins stay in the scripts and are not copied into the Rust side: a second copy would drift, and the thing that knows the pin is the thing that fetched it.

## Verification

- A stale stamp and a missing file are both caught, and both apps are named in one run.
- `record-speed` refuses on a mismatch and proceeds once the cache matches.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `shellcheck` on both touched scripts, and `cargo test` all pass.

## Considered and rejected

Recording the sha256 of each measured module in the record. It says what was measured after the fact, which does not stop the wrong thing from being measured.

## The test suite too

Second commit. Every suite that runs a real app reads the same cache and says nothing about which build is there, and both failure modes showed up while recording #299: the stale wasm3 made `wasm3_cowsay` fail in a way that looked like a code regression, and it would equally have passed while proving nothing about the current pin.

Checking inside `apps_cache_dir` would cost a subprocess per case, so this is one test instead. It runs once per `cargo test`, takes 0.75 s, and names what is stale:

```console
$ cargo test -p dewasm-test-helper --test apps_cache_pins
the app cache does not match its pins, so the suites below would run the wrong programs:
wasm3: cache does not match the pin (run examples/apps/setup.sh)
```

A strict check has to reproduce the stamps, and two of them name a tool's version: `nes` and `sqlite3` fold in `wasm-opt --version`, `ruby-packed` folds in `wasi-vfs --version`. The other twelve are keyed on their pin alone. The jobs that restore the apps cache install neither tool, so they get a composite action that does.

An earlier draft instead reported a key the host could not reproduce as *unverifiable* and passed it over. That was dropped: it weakens the check everywhere to accommodate one environment, when installing two tools in two jobs keeps it strict.
