### PR TITLE
Amortize Ruby and Java memory.grow with geometric buffer capacity

### DIFF
--- a/crates/dewasm-backend-java/units/memory/_class.java
+++ b/crates/dewasm-backend-java/units/memory/_class.java
@@ -4,6 +4,8 @@
 // The ByteBuffer is re-wrapped on grow.
 byte[] d;
 java.nio.ByteBuffer bb;
+// Visible memory size in bytes; d.length is capacity and may exceed it (grow reallocates geometrically).
+int size;
 int maxPages;
 
 Memory(int minPages, int maxPages) {
@@ -14,6 +16,7 @@ Memory(int minPages, int maxPages) {
         Rt.trap("cannot allocate " + minPages + " pages of linear memory (exceeds Java's byte[] limit)");
     }
     this.d = new byte[(int) bytes];
+    this.size = (int) bytes;
     this.maxPages = maxPages;
     rewrap();
 }
@@ -23,8 +26,9 @@ private void rewrap() {
 }
 
 // Bounds-check [addr, addr+length) and return the int index into the buffer.
+// The check is against size, not d.length: the tail past size is unreachable and, being never written, stays zero-filled (Java zero-initializes arrays) until grow makes it visible.
 private int at(long addr, long length) {
-    if (addr < 0 || addr + length > d.length) {
+    if (addr < 0 || addr + length > size) {
         Rt.trap("out of bounds memory access");
     }
     return (int) addr;

--- a/crates/dewasm-backend-java/units/memory/grow.java
+++ b/crates/dewasm-backend-java/units/memory/grow.java
@@ -2,19 +2,25 @@
 // Byte size checked in long against the byte[] cap (32768 pages > max array);
 // allocation failure is also -1: wasm lets grow fail, never crash.
 int grow(int delta) {
-    int old = d.length / 65536;
+    int old = size / 65536;
     long want = (long) old + (delta & 0xFFFFFFFFL);
     if (want > maxPages || want * 65536 > Integer.MAX_VALUE) {
         return -1;
     }
-    byte[] nd;
-    try {
-        nd = new byte[(int) (want * 65536)];
-    } catch (OutOfMemoryError e) {
-        return -1;
+    int newSize = (int) (want * 65536);
+    if (newSize > d.length) {
+        // Geometric capacity amortizes one-page grow loops; the new array is zero-initialized, so the pages becoming visible are zero (see at).
+        long cap = Math.min((long) maxPages * 65536, Integer.MAX_VALUE);
+        byte[] nd;
+        try {
+            nd = new byte[(int) Math.max(newSize, Math.min((long) d.length * 2, cap))];
+        } catch (OutOfMemoryError e) {
+            return -1;
+        }
+        System.arraycopy(d, 0, nd, 0, size);
+        d = nd;
+        rewrap();
     }
-    System.arraycopy(d, 0, nd, 0, d.length);
-    d = nd;
-    rewrap();
+    size = newSize;
     return old;
 }

--- a/crates/dewasm-backend-java/units/memory/size.java
+++ b/crates/dewasm-backend-java/units/memory/size.java
@@ -1,1 +1,1 @@
-int size() { return d.length / 65536; }
+int size() { return size / 65536; }

--- a/crates/dewasm-backend-ruby/units/memory/_class.rb
+++ b/crates/dewasm-backend-ruby/units/memory/_class.rb
@@ -17,6 +17,8 @@ def initialize(min_pages, max_pages)
   @max_pages = max_pages && max_pages < 65536 ? max_pages : 65536
 end
 
+# @buffer's capacity may exceed @size (grow resizes it geometrically).
+# Every access bounds-checks against @size, so the tail past @size is unreachable and stays zero-filled until grow makes it visible.
 def check(addr, len)
   Rt.trap("out of bounds memory access") if addr + len > @size
 end

--- a/crates/dewasm-backend-ruby/units/memory/grow.rb
+++ b/crates/dewasm-backend-ruby/units/memory/grow.rb
@@ -3,6 +3,9 @@ def grow(delta)
   old = size
   return M32 if old + delta > @max_pages
   @size += delta * PAGE_SIZE
-  @buffer.resize(@size) # zero-fills the new tail
+  if @size > @buffer.size
+    # Geometric capacity amortizes one-page grow loops; resize zero-fills, so the pages becoming visible are zero (see check).
+    @buffer.resize([@size, [@buffer.size * 2, @max_pages * PAGE_SIZE].min].max)
+  end
   old
 end


### PR DESCRIPTION
## Why

A guest allocator that grows the linear memory one page at a time paid a full-memory copy per page: the Ruby backend resized its IO::Buffer to the exact visible size on every memory.grow, and the Java backend reallocated and copied its byte[] the same way.
Measured on the prism parser module (zig wasi-libc, 257-page initial memory), its 13 one-page grows per parse cost about a quarter of the total runtime on the Ruby backend, and even more on Java.

## How

Both backends now track the visible size separately and grow the underlying buffer geometrically (double, clamped to the page maximum) only when the visible size exceeds the capacity.
This is safe because every access already bounds-checks against the visible size: the tail past it is unreachable, and it is never written, so it stays zero-filled until grow makes it visible.
The grow return value, memory.size, the page-maximum refusal, and Java's OutOfMemoryError handling are unchanged; the invariant is documented next to the bounds check in each backend.

Python and Go do not need this: bytearray.extend and append are already amortized by their runtimes.

## Measurements

Ruby, converted prism module, fresh instance per parse: a 30 kB parse drops from 112 ms to 91 ms, a small parse from 9.7 ms to 4.3 ms, and 12 of the 13 per-parse resizes disappear.
Java, same module, 30 fresh-instance iterations: warm minimum drops from 13.4 ms to 7.3 ms.
Serialized output is byte-identical before and after on both backends.

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and the full `cargo test` pass.