### PR TITLE
Add a windowed Ruby DOOM frontend on gosu

### DIFF
--- a/agents/decisions/50-doom-example-shape.md
+++ b/agents/decisions/50-doom-example-shape.md
@@ -3,6 +3,7 @@
 Status: **Accepted, 2026-07-30.**
 `examples/doom` runs the unmodified [jacobenget/doom.wasm](https://github.com/jacobenget/doom.wasm) v0.1.0 release binary through `--mode library`, with an ebiten frontend for the Go backend and a Swing frontend for the Java backend; both pass a headless smoke that renders a real frame well above DOOM's native 35Hz tic rate.
 Extended the same day with Ruby and Python frontends that render into the terminal (ANSI truecolor half-blocks, stdlib only), the same criterion applied at slower tick rates, where a pixel window would be pointless but a diffed terminal frame costs under 1ms.
+Extended again with `ruby-gosu/`, a windowed Ruby frontend on gosu, and with it the first second frontend for a backend that already had one.
 
 ## Context
 
@@ -34,4 +35,8 @@ The example is documentation-level: fetched and built by its own scripts, outsid
   No sound: the module exposes no audio interface.
   [Decision 53](53-doom-frame-snapshot.md) later closes part of this gap with a deterministic framebuffer snapshot (ultra-slow execution, a CI-side conversion smoke).
 - Carry-over: the Ruby (~15 ticks/sec under YJIT) and Python (~1.3) frontends confirmed the criterion: each was a new host layer only, with the guest untouched.
+  So did `ruby-gosu/`, which additionally shows the criterion does not cap a backend at one frontend: the title's "per-language" describes how the demo grew, not a limit on it, and two frontends for one backend cost nothing beyond their own host code.
+  It also revises the reading that a slow backend implies a terminal.
+  What made a window look unaffordable for Ruby was per-pixel cost against a ~15 ticks/sec budget, and the module's 640x400 framebuffer is an exact 2x upscale of DOOM's native 320x200 (`I_InitGraphics: Auto-scaling factor: 2`), so halving it back is lossless and leaves a quarter of the pixels to convert; the frame is then uploaded once as a 320x200 texture and scaled by the GPU, making the render cost independent of window size.
+  The window also restores real key releases, which no terminal can deliver, so Ctrl (fire) and Shift (run) work as in DOOM instead of being synthesized or dropped.
   The terminal renderer doubles as the frontend shape for any backend too slow for a window, including Bash, which after [decision 51](51-bash-assoc-memory.md)/[decision 52](52-bash-inline-memops.md) boots in ~2 minutes and renders a frame every ~34 seconds in `bash/`.

--- a/examples/doom/README.md
+++ b/examples/doom/README.md
@@ -1,10 +1,11 @@
 # DOOM on dewasm
 
-One DOOM, six languages: the unmodified [jacobenget/doom.wasm](https://github.com/jacobenget/doom.wasm) v0.1.0 binary (DOOM compiled to a single wasm module with a ten-function host interface and the shareware WAD embedded), converted by `dewasm --mode library` and played through a native frontend per language:
+One DOOM, six languages: the unmodified [jacobenget/doom.wasm](https://github.com/jacobenget/doom.wasm) v0.1.0 binary (DOOM compiled to a single wasm module with a ten-function host interface and the shareware WAD embedded), converted by `dewasm --mode library` and played through seven native frontends across six languages:
 
 - [`go/`](go/): Go, rendering with [ebiten](https://github.com/hajimehoshi/ebiten)
 - [`java/`](java/): Java, rendering with Swing (plain JDK, zero dependencies)
 - [`ruby/`](ruby/): Ruby, rendering *into the terminal* as 24-bit-color ANSI half-blocks (stdlib only, run with `--yjit`)
+- [`ruby-gosu/`](ruby-gosu/): the same Ruby library in a window, with [gosu](https://www.libgosu.org/); the 640x400 framebuffer is an exact 2x upscale of DOOM's native 320x200, so the texture it uploads is a quarter of the pixels and the render cost does not grow with the window
 - [`python/`](python/): Python, the same terminal renderer (stdlib only; ~45 ticks/sec under PyPy, ~1.2-1.8 under CPython)
 - [`perl/`](perl/): Perl, the same terminal renderer (core modules only; ~0.7 ticks/sec, no JIT and per-call depth accounting)
 - [`bash/`](bash/): pure Bash, same terminal renderer; ~2 minutes to boot and ~34 seconds per frame, an existence proof and likely a first (also available as a [single-file `doom.bash` Gist](https://gist.github.com/makenowjust/b1e9c2a585183f41a5f8f61b4bc9924c), separate from this MIT repo because the built artifact embeds the GPL-2.0 engine)
@@ -20,7 +21,7 @@ The compared oracle is `doom_frame.ppm`; this PNG is the same frame for human ey
 ## Run
 
 ```sh
-go/run.sh    # or: java/run.sh
+go/run.sh    # or: java/run.sh, ruby-gosu/run.sh
 ```
 
 `build.sh` fetches the wasm binary (checksum-pinned, via `../apps/scripts/doom.sh`) into the gitignored apps cache; no other assets are needed.
@@ -28,6 +29,7 @@ Each frontend also has a headless `-smoke`/`--smoke` mode that ticks the game wi
 
 Measured on an Apple Silicon laptop, headless: Go ~70 ticks/sec, Java ~55, both comfortably above DOOM's native 35Hz tic rate.
 Ruby reaches ~15 ticks/sec with YJIT, Python ~45 under PyPy but ~1.2-1.8 under CPython, and Perl ~0.7, which is why those three render into the terminal instead of a window: the ANSI diff renderer costs a few ms/frame at most, so the wasm tick stays the only bottleneck.
+A window is not actually ruled out at those rates, as `ruby-gosu/` shows: what the terminal avoids is per-pixel cost, and halving the framebuffer back to 320x200 (lossless, since DOOM upscales it by exactly 2) avoids it just as well while restoring the key releases a terminal cannot report.
 Bash, after the associative-memory and inlined-load/store work, boots in ~2 minutes and draws a frame every ~34 seconds, not playable but genuinely running.
 Terminals report key presses but not releases, so the terminal frontends synthesize key-up events after a short hold window, and fire is on `f` (Ctrl never reaches a terminal app as a plain key).
 

--- a/examples/doom/ruby-gosu/.gitignore
+++ b/examples/doom/ruby-gosu/.gitignore
@@ -1,0 +1,3 @@
+/doom_gen.rb
+/screenshot.png
+/.savegame/

--- a/examples/doom/ruby-gosu/README.md
+++ b/examples/doom/ruby-gosu/README.md
@@ -1,0 +1,99 @@
+# DOOM (Ruby, gosu window)
+
+An interactive DOOM frontend that renders into a window with [gosu](https://www.libgosu.org/), the SDL2-backed 2D game library for Ruby.
+The sibling [`../ruby`](../ruby) frontend draws the same game into a terminal; this one takes a real window.
+
+`build.sh` fetches jacobenget/doom.wasm (checksum-pinned into the shared apps cache) and converts it to Ruby with dewasm (`doom_gen.rb`, ~10MB, gitignored, regenerated on every build).
+`main.rb` implements the module's ten host imports (console logging, save-game I/O, the game clock, and frame delivery) plus the gosu window, its renderer and its keyboard input.
+
+## Requirements
+
+The gosu gem, which builds a native extension against SDL2:
+
+```sh
+gem install gosu          # Debian/Ubuntu: sudo apt install libsdl2-dev
+```
+
+`build.sh` checks for it and prints the per-platform header package if it is missing.
+
+## Why a window is affordable here
+
+The terminal frontend exists because the Ruby backend only manages ~15 ticks/sec under YJIT, far below what a GUI usually needs, while a terminal has orders of magnitude fewer cells to redraw than a window has pixels.
+A window costs no more than a terminal here because the per-frame work does not scale with the window: the frame is uploaded once as a 320x200 texture and the GPU does the scaling, so `--scale 6` costs exactly what `--scale 1` costs.
+
+The framebuffer the module hands over is 640x400, but DOOM renders at 320x200 and upscales by exactly 2 (its own startup log reads `I_InitGraphics: Auto-scaling factor: 2`).
+Halving it back is therefore lossless, and leaves 64000 pixels per frame to convert instead of 256000.
+`FrameConverter` verifies that on the first frame rather than trusting it, and falls back to full resolution if a future build of the module ever stops holding it.
+
+What the window buys over the terminal is real key releases.
+Terminals report presses only, so the terminal frontend has to synthesize a release after a hold window, and cannot deliver Ctrl as a plain key at all.
+Here Ctrl (fire) and Shift (run) work as they do in DOOM.
+
+## Run
+
+```sh
+./run.sh
+```
+
+builds and opens a window.
+The window is resizable: the frame keeps its 8:5 aspect ratio and is centered, with black bars on whichever axis runs out first.
+
+| Option | Effect |
+| --- | --- |
+| `--scale N` | Window size as a multiple of 320x200, 1 to 8 (default 3, so 960x600). |
+| `--fullscreen` | Start fullscreen. |
+| `--smooth` | Scale the frame with interpolation instead of nearest-neighbor, saving ~10ms per frame. |
+| `--smoke` | Headless self-check, described below. |
+
+`./run.sh --smoke` needs no display: it inits the game, ticks it 60 times with no window, reports the tick rate and the per-frame conversion cost, sanity-checks the last frame, writes it to `screenshot.png`, and exits non-zero on failure.
+gosu encodes PNGs without a graphics context, so unlike the terminal frontend (which falls back to binary PPM for want of a stdlib PNG writer) this writes a real PNG.
+
+## Rendering
+
+Handing a frame to gosu takes two per-pixel transformations, and they are the only part of this frontend where a straightforward Ruby loop would cost more than the wasm tick itself.
+The module stores pixels as B,G,R,A while gosu wants R,G,B,A, and the module's alpha byte is always 0 where gosu needs 0xff.
+
+Two facts about DOOM's renderer keep that down to a few hundred Ruby-level operations per frame rather than 64000.
+It is paletted (VGA Mode 13h, at most 256 colors per palette and a handful of palettes over a session), so each distinct 32-bit source word is swizzled once and memoized; a real frame holds around 175 of them.
+Its 640x400 output is an exact 2x upscale, so each row is read with a single `unpack("Vx4" * 320)`, where `V` takes a 32-bit pixel and `x4` skips the duplicated neighbor.
+That leaves one `unpack`, one memoized `map!` and one `pack` per row, all at C level except the hash lookups.
+
+Uploading the result is one `Gosu::Image.from_blob` per frame.
+gosu interpolates an image scaled past its native size unless its texture was created with `retro: true`, which `Image.from_blob` has no parameter for, so the default path blits the frame into a persistent nearest-neighbor render target instead.
+That is what `--smooth` turns off, trading DOOM's crisp pixels for the ~10ms.
+
+Measured on an x86-64 Linux container under Ruby 3.3.6 **without** YJIT (that build of Ruby has no YJIT support), at the default `--scale 3`:
+
+| Step | Cost per frame |
+| --- | --- |
+| Framebuffer conversion (640x400 BGRA to 320x200 RGBA) | 9.9ms |
+| `Gosu::Image.from_blob` | 2.0ms |
+| Nearest-neighbor blit (skipped by `--smooth`) | 10.0ms |
+| One `tickGame` | 226ms |
+
+The wasm tick dominates by an order of magnitude, which is the point: rendering is not what makes this frontend slow, and YJIT (which `run.sh` always passes, and which `main.rb` warns about on stderr if it ends up missing) is what moves the tick figure.
+The sibling terminal frontend measures the same Ruby backend at 15.9 ticks/sec with YJIT on an Apple Silicon laptop.
+
+## Controls
+
+| Key | Action |
+| --- | --- |
+| Arrow keys | Move / turn |
+| Ctrl | Fire |
+| Space | Use (open doors, flip switches) |
+| Shift | Run |
+| , / . | Strafe left / right |
+| Tab | Automap |
+| Enter | Menu confirm |
+| Escape | Menu / pause |
+| Backspace | Menu back |
+| 0-9 | Weapon select / text entry |
+| Letters | Text entry, `y` / `n` prompts |
+| F1 | Show or hide the on-screen status bar |
+| F10 | Quit |
+
+gosu closes a window on Escape unless the frontend overrides its `button_down`, which this one does: Escape belongs to DOOM's menu, and quitting is F10 or the window's close button.
+
+Save games are written to `.savegame/` (gitignored) relative to wherever the script runs.
+
+No sound: the module exposes no audio interface.

--- a/examples/doom/ruby-gosu/audio.rb
+++ b/examples/doom/ruby-gosu/audio.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "tmpdir"
+
+# Implements the wasm module's thirteen `audio` imports on gosu.
+#
+# Doom hands over sample data once per sound (`registerSound`) and then names
+# it by id, so nothing here needs to know how a WAD is laid out. Music arrives
+# as standard MIDI: the module converts Doom's own MUS encoding before calling
+# `registerSong`.
+#
+# gosu loads samples and songs from files rather than from memory, so each
+# registration is written to a temporary file first, which is also what Doom's
+# own SDL backend does with music.
+class DoomAudio
+  # Doom's `sep` runs 0 (hard left) to 254 (hard right); 127 is centred.
+  # Its volumes run 0 to 127.
+  SEPARATION_CENTRE = 127.0
+  MAX_VOLUME = 127.0
+
+  # A DMX sound lump is an 8-byte header followed by unsigned 8-bit mono
+  # samples, of which DMX ignores 16 at each end.
+  DMX_FORMAT = 3
+  DMX_HEADER_BYTES = 8
+  DMX_PAD_SAMPLES = 16
+
+  def initialize(memory)
+    @memory = memory
+    @samples = {}
+    @channels = {}
+    @songs = {}
+    @playing = nil
+    @music_volume = 1.0
+    @dir = Dir.mktmpdir("dewasm-doom-audio")
+    at_exit { FileUtils.remove_entry(@dir) if File.directory?(@dir) }
+  end
+
+  # The import table to hand to the generated module.
+  def imports
+    {
+      "registerSound" => method(:register_sound),
+      "startSound" => method(:start_sound),
+      "stopSound" => method(:stop_sound),
+      "updateSoundParams" => method(:update_sound_params),
+      "soundIsPlaying" => method(:sound_is_playing),
+      "registerSong" => method(:register_song),
+      "unregisterSong" => method(:unregister_song),
+      "playSong" => method(:play_song),
+      "stopSong" => method(:stop_song),
+      "pauseSong" => method(:pause_song),
+      "resumeSong" => method(:resume_song),
+      "setMusicVolume" => method(:set_music_volume),
+      "songIsPlaying" => method(:song_is_playing),
+    }
+  end
+
+  private
+
+  def register_sound(sfx_id, ptr, length)
+    wav = wav_from_dmx(@memory.get_string(ptr, length))
+    return if wav.nil?
+
+    path = File.join(@dir, "sfx#{sfx_id}.wav")
+    File.binwrite(path, wav)
+    @samples[sfx_id] = Gosu::Sample.new(path)
+  rescue StandardError => e
+    # A sound that will not load is not worth ending the game over; Doom
+    # carries on silently for it and keeps asking for the others.
+    warn "audio: sfx #{sfx_id} not registered (#{e.class}: #{e.message})"
+  end
+
+  # Wrap a DMX lump's samples in a WAV container, dropping the pad DMX skips.
+  # Returns nil for anything that is not a valid DMX sound, matching the
+  # checks in Doom's own `CacheSFX`.
+  def wav_from_dmx(lump)
+    return nil if lump.bytesize < DMX_HEADER_BYTES
+
+    format, rate, count = lump.unpack("vvV")
+    return nil unless format == DMX_FORMAT
+    return nil if count > lump.bytesize - DMX_HEADER_BYTES || count <= 48
+
+    pcm = lump.byteslice(DMX_HEADER_BYTES + DMX_PAD_SAMPLES, count - 2 * DMX_PAD_SAMPLES)
+    return nil if pcm.nil? || pcm.empty?
+
+    # Canonical 44-byte WAV header: PCM, mono, 8 bits per sample.
+    +"RIFF" << [36 + pcm.bytesize].pack("V") << "WAVEfmt " <<
+      [16, 1, 1, rate, rate, 1, 8].pack("VvvVVvv") <<
+      "data" << [pcm.bytesize].pack("V") << pcm
+  end
+
+  def start_sound(sfx_id, channel, volume, separation)
+    sample = @samples[sfx_id]
+    return if sample.nil?
+
+    stop_sound(channel)
+    @channels[channel] = sample.play_pan(pan_of(separation), volume_of(volume), 1.0, false)
+  end
+
+  def stop_sound(channel)
+    @channels.delete(channel)&.stop
+  end
+
+  def update_sound_params(channel, volume, separation)
+    playing = @channels[channel]
+    return if playing.nil?
+
+    playing.volume = volume_of(volume)
+    playing.pan = pan_of(separation)
+  end
+
+  def sound_is_playing(channel)
+    @channels[channel]&.playing? ? 1 : 0
+  end
+
+  def pan_of(separation) = ((separation - SEPARATION_CENTRE) / SEPARATION_CENTRE).clamp(-1.0, 1.0)
+
+  def volume_of(volume) = (volume / MAX_VOLUME).clamp(0.0, 1.0)
+
+  def register_song(ptr, length)
+    handle = @songs.size + 1
+    path = File.join(@dir, "song#{handle}.mid")
+    File.binwrite(path, @memory.get_string(ptr, length))
+    @songs[handle] = Gosu::Song.new(path)
+    handle
+  rescue StandardError => e
+    warn "audio: music not registered (#{e.class}: #{e.message})"
+    # 0 tells Doom the music could not be registered; it then plays none.
+    0
+  end
+
+  def unregister_song(handle)
+    song = @songs.delete(handle)
+    return if song.nil?
+
+    song.stop if @playing.equal?(song)
+    @playing = nil if @playing.equal?(song)
+  end
+
+  def play_song(handle, looping)
+    song = @songs[handle]
+    return if song.nil?
+
+    song.volume = @music_volume
+    song.play(looping != 0)
+    @playing = song
+  end
+
+  def stop_song
+    @playing&.stop
+    @playing = nil
+  end
+
+  def pause_song = @playing&.pause
+
+  def resume_song
+    # gosu resumes a paused song by playing it again; `Song#play` on the
+    # current song is what un-pauses it.
+    @playing&.play(true)
+  end
+
+  def set_music_volume(volume)
+    @music_volume = volume_of(volume)
+    @playing&.volume = @music_volume
+  end
+
+  def song_is_playing = @playing&.playing? ? 1 : 0
+end

--- a/examples/doom/ruby-gosu/build.sh
+++ b/examples/doom/ruby-gosu/build.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Regenerate the dewasm-generated DOOM library and check the frontend. doom_gen.rb is ~10MB of generated code and is gitignored, so this step has to run before main.rb can require it from a clean checkout.
+# There's no compile step for Ruby; `ruby -c` stands in for one.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+repo_root="$(cd ../../.. && pwd)"
+
+../../apps/scripts/doom.sh
+
+(
+  cd "$repo_root"
+  cargo run -q -p dewasm -- \
+    examples/apps/cache/doom.wasm \
+    --target ruby --mode library --module-name Doom \
+    -o examples/doom/ruby-gosu/doom_gen.rb
+)
+
+ruby -c main.rb
+
+# gosu is the only thing this frontend needs beyond the stdlib, and it builds a native extension against system SDL2.
+# Reporting that here, with the install command, beats a bare LoadError out of main.rb.
+if ! ruby -e 'require "gosu"' >/dev/null 2>&1; then
+  cat >&2 <<'MSG'
+build: the gosu gem is not installed. Install it with:
+
+  gem install gosu
+
+It compiles against SDL2 development headers:
+  Debian/Ubuntu  sudo apt install libsdl2-dev
+  Fedora         sudo dnf install SDL2-devel
+  macOS          brew install sdl2
+MSG
+  exit 1
+fi
+
+echo "build complete: doom_gen.rb regenerated"

--- a/examples/doom/ruby-gosu/main.rb
+++ b/examples/doom/ruby-gosu/main.rb
@@ -1,0 +1,367 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Interactive windowed frontend for the dewasm-generated DOOM library
+# (doom_gen.rb, produced from jacobenget/doom.wasm by build.sh), rendering with gosu.
+#
+# The sibling ../ruby frontend draws into a terminal because the Ruby backend only manages ~15 ticks/sec under YJIT and a terminal has orders of magnitude fewer cells than a window has pixels.
+# This one takes the window anyway, which is affordable because the module's 640x400 framebuffer is an exact 2x upscale of DOOM's native 320x200: halving it back is lossless and leaves 64000 pixels per frame to hand to the GPU, not 256000.
+# What the window buys over the terminal is real key releases, so Ctrl (fire) and Shift (run) work as they do in DOOM.
+#
+# Run with --smoke for a headless self-check (no window, no display needed).
+
+require_relative "doom_gen"
+require "gosu"
+
+SAVE_DIR = ".savegame"
+
+def save_game_path(id)
+  File.join(SAVE_DIR, "doomsav#{id}.dsg")
+end
+
+# Wires the wasm module's ten host imports to Ruby.
+# `doom_holder` exists because these closures have to be built before Doom.new returns the instance they read memory from; it's filled in immediately after construction and only read from within calls the imports themselves receive later (never during Doom.new itself).
+def build_imports(doom_holder, frame_state)
+  {
+    "console" => {
+      "onErrorMessage" => lambda do |off, len|
+        warn doom_holder[0].memory.buffer.get_string(off, len)
+      end,
+      "onInfoMessage" => lambda do |off, len|
+        puts doom_holder[0].memory.buffer.get_string(off, len)
+      end,
+    },
+    "gameSaving" => {
+      "sizeOfSaveGame" => lambda do |id|
+        path = save_game_path(id)
+        File.exist?(path) ? File.size(path) : 0
+      end,
+      "readSaveGame" => lambda do |id, dst_off|
+        path = save_game_path(id)
+        next 0 unless File.exist?(path)
+
+        bytes = File.binread(path)
+        doom_holder[0].memory.buffer.set_string(bytes, dst_off, bytes.bytesize, 0)
+        bytes.bytesize
+      end,
+      "writeSaveGame" => lambda do |id, src_off, length|
+        Dir.mkdir(SAVE_DIR) unless Dir.exist?(SAVE_DIR)
+        bytes = doom_holder[0].memory.buffer.get_string(src_off, length)
+        File.binwrite(save_game_path(id), bytes)
+        length
+      end,
+    },
+    "runtimeControl" => {
+      # Backs DOOM's internal 35Hz pacing, so it has to be a real monotonic clock (not a fake stepped one) or the game's notion of elapsed time would drift from how often we actually call tickGame.
+      "timeInMilliseconds" => lambda do
+        Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
+      end,
+    },
+    "ui" => {
+      # Converted here, inside the tick, rather than copied out for later: the memory buffer this reads can be replaced by a subsequent tick that grows the module's memory.
+      "drawFrame" => lambda do |buf_off|
+        frame_state[:buf_off] = buf_off
+        frame_state[:rgba] = frame_state[:converter].convert(doom_holder[0].memory.buffer, buf_off)
+      end,
+    },
+    "loading" => {
+      "onGameInit" => lambda do |w, h|
+        frame_state[:width] = w
+        frame_state[:height] = h
+        frame_state[:converter] = FrameConverter.new(w, h)
+      end,
+      # Leaving both output slots untouched (they arrive pre-zeroed) selects the wasm-embedded shareware WAD; supplying external WADs is out of scope for this frontend.
+      "wadSizes" => lambda { |_num_off, _bytes_off| },
+      "readWads" => lambda { |_dst_off, _lengths_off| },
+    },
+  }
+end
+
+# Turns the module's framebuffer into the RGBA blob gosu wants.
+#
+# Two transformations, both per pixel and therefore the only part of this frontend where a naive Ruby loop would cost more than the wasm tick itself:
+# the module stores B,G,R,A while gosu wants R,G,B,A, and the module's alpha byte is always 0 where gosu needs 0xff.
+#
+# The work is kept to a few hundred Ruby-level operations per frame rather than 64000 by two facts about DOOM's renderer.
+# It is paletted (VGA Mode 13h, at most 256 colors per palette and a handful of palettes over a session), so every distinct 32-bit source word is swizzled once and memoized.
+# And its 640x400 output is an exact 2x nearest upscale of its native 320x200, so reading every other pixel of every other row is lossless.
+# The first frame checks that rather than trusting it, and falls back to full resolution if a future build of the module ever stops holding it.
+class FrameConverter
+  attr_reader :out_w, :out_h
+
+  # out_w/out_h are not known until the first frame decides whether halving is lossless, so they start at full resolution and #convert narrows them once.
+  def initialize(src_w, src_h)
+    @src_w = src_w
+    @src_h = src_h
+    @src_stride = src_w * 4
+    @step = nil
+    @out_w = src_w
+    @out_h = src_h
+    @swizzled = Hash.new do |memo, word|
+      memo[word] = 0xff000000 | ((word & 0x0000ff) << 16) | (word & 0x00ff00) | ((word >> 16) & 0xff)
+    end
+  end
+
+  def convert(buffer, base_off)
+    choose_step(buffer, base_off) unless @step
+    rgba = String.new(capacity: @out_w * @out_h * 4)
+    @out_h.times do |y|
+      row = buffer.get_string(base_off + y * @step * @src_stride, @src_stride)
+      rgba << row.unpack(@row_template).map! { |word| @swizzled[word] }.pack("V*")
+    end
+    rgba
+  end
+
+  private
+
+  def choose_step(buffer, base_off)
+    @step = upscaled_2x?(buffer, base_off) ? 2 : 1
+    warn "doom: framebuffer is not a 2x upscale; rendering at full #{@src_w}x#{@src_h}" if @step == 1
+    @out_w = @src_w / @step
+    @out_h = @src_h / @step
+    # One C-level unpack per row: "V" reads a 32-bit BGRA word and "x4" skips the duplicated neighbor.
+    @row_template = ((@step == 2 ? "Vx4" : "V") * @out_w).freeze
+  end
+
+  # True when every 2x2 block of the framebuffer is uniform, i.e. the image carries no more detail than its 320x200 half.
+  def upscaled_2x?(buffer, base_off)
+    return false unless @src_w.even? && @src_h.even?
+
+    even_pixels = ("Vx4" * (@src_w / 2)).freeze
+    odd_pixels = ("x4V" * (@src_w / 2)).freeze
+    (@src_h / 2).times do |y|
+      top = buffer.get_string(base_off + y * 2 * @src_stride, @src_stride)
+      return false unless top == buffer.get_string(base_off + (y * 2 + 1) * @src_stride, @src_stride)
+      return false unless top.unpack(even_pixels) == top.unpack(odd_pixels)
+    end
+    true
+  end
+end
+
+# Translates a gosu button id to the code reportKeyDown/reportKeyUp expect: the module's KEY_* constant for special keys, or the ASCII value of the lowercase character for letters and digits (text entry, and weapon-select digits).
+class KeyMap
+  def initialize(doom)
+    @by_button = {
+      Gosu::KB_LEFT => doom.global_get("KEY_LEFTARROW"),
+      Gosu::KB_RIGHT => doom.global_get("KEY_RIGHTARROW"),
+      Gosu::KB_UP => doom.global_get("KEY_UPARROW"),
+      Gosu::KB_DOWN => doom.global_get("KEY_DOWNARROW"),
+      Gosu::KB_LEFT_CONTROL => doom.global_get("KEY_FIRE"),
+      Gosu::KB_RIGHT_CONTROL => doom.global_get("KEY_FIRE"),
+      Gosu::KB_SPACE => doom.global_get("KEY_USE"),
+      Gosu::KB_LEFT_SHIFT => doom.global_get("KEY_SHIFT"),
+      Gosu::KB_RIGHT_SHIFT => doom.global_get("KEY_SHIFT"),
+      Gosu::KB_LEFT_ALT => doom.global_get("KEY_ALT"),
+      Gosu::KB_RIGHT_ALT => doom.global_get("KEY_ALT"),
+      Gosu::KB_TAB => doom.global_get("KEY_TAB"),
+      Gosu::KB_ESCAPE => doom.global_get("KEY_ESCAPE"),
+      Gosu::KB_RETURN => doom.global_get("KEY_ENTER"),
+      Gosu::KB_ENTER => doom.global_get("KEY_ENTER"),
+      Gosu::KB_BACKSPACE => doom.global_get("KEY_BACKSPACE"),
+      Gosu::KB_COMMA => doom.global_get("KEY_STRAFE_L"),
+      Gosu::KB_PERIOD => doom.global_get("KEY_STRAFE_R"),
+    }
+    (Gosu::KB_A..Gosu::KB_Z).each_with_index { |id, i| @by_button[id] = "a".ord + i }
+    # KB_1..KB_9 run 30..38 and KB_0 sits above them at 39, so the digit row is not one contiguous ascending range.
+    (Gosu::KB_1..Gosu::KB_9).each_with_index { |id, i| @by_button[id] = "1".ord + i }
+    @by_button[Gosu::KB_0] = "0".ord
+  end
+
+  def [](button_id) = @by_button[button_id]
+end
+
+CONTROLS_TEXT = "arrows move   ctrl fire   space use   shift run   ,/. strafe   tab automap   " \
+                "esc menu   1-7 weapon   F1 hud   F10 quit"
+
+class DoomWindow < Gosu::Window
+  # DOOM's own internal tic rate.
+  # tickGame paces itself off runtimeControl.timeInMilliseconds no matter how often it is called, so matching 35Hz makes one update advance exactly one tic instead of some updates being no-ops.
+  TICKS_PER_SECOND = 35
+  # The caption only has to be legible, not frame-accurate, and asking the window manager to retitle the window is not free.
+  CAPTION_UPDATE_EVERY = TICKS_PER_SECOND
+  HUD_HEIGHT = 18
+
+  def initialize(doom, frame_state, scale:, fullscreen:, retro:)
+    @converter = frame_state.fetch(:converter)
+    super(@converter.out_w * scale, @converter.out_h * scale, fullscreen: fullscreen, resizable: true)
+    self.caption = "DOOM (dewasm)"
+    self.update_interval = 1000.0 / TICKS_PER_SECOND
+
+    @frame_state = frame_state
+    @keys = KeyMap.new(doom)
+    # Fetched once out of the exports table: invoke() would redo the hash lookup and splat the arguments on every one of these calls.
+    @tick_game = doom.exports.fetch("tickGame")
+    @report_key_down = doom.exports.fetch("reportKeyDown")
+    @report_key_up = doom.exports.fetch("reportKeyUp")
+
+    @retro = retro
+    @canvas = nil
+    @font = Gosu::Font.new(13)
+    @show_hud = true
+    @ticks = 0
+    @rate_ticks = 0
+    @rate_window_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    @rate = 0.0
+  end
+
+  def update
+    @tick_game.call # drives ui.drawFrame internally, refreshing frame_state[:rgba]
+    @ticks += 1
+    @rate_ticks += 1
+    return unless (@ticks % CAPTION_UPDATE_EVERY).zero?
+
+    now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    @rate = @rate_ticks / (now - @rate_window_start)
+    @rate_ticks = 0
+    @rate_window_start = now
+    self.caption = format("DOOM (dewasm) - %.1f ticks/sec", @rate)
+  end
+
+  def draw
+    rgba = @frame_state[:rgba]
+    return unless rgba
+
+    image = frame_image(rgba)
+    # Letterbox: the window is resizable and need not keep the framebuffer's 8:5 ratio, so the frame is scaled by whichever axis runs out first and centred, leaving black bars on the other.
+    scale = [width.to_f / image.width, height.to_f / image.height].min
+    draw_w = image.width * scale
+    draw_h = image.height * scale
+    image.draw((width - draw_w) / 2, (height - draw_h) / 2, 0, scale, scale)
+    draw_hud if @show_hud
+  end
+
+  def button_down(id)
+    # Deliberately no `super`: gosu's default button_down closes the window on Escape, which is DOOM's menu key.
+    case id
+    when Gosu::KB_F10 then close
+    when Gosu::KB_F1 then @show_hud = !@show_hud
+    else
+      code = @keys[id]
+      @report_key_down.call(code) if code
+    end
+  end
+
+  def button_up(id)
+    code = @keys[id]
+    @report_key_up.call(code) if code
+  end
+
+  private
+
+  # Uploads the frame to the GPU.
+  # Gosu interpolates a scaled-up image unless the texture was created with `retro: true`, which Image.from_blob has no way to ask for, so the retro path blits the frame into a persistent nearest-neighbor render target instead.
+  # That costs about 10ms a frame against from_blob's 2, which is why --smooth exists.
+  def frame_image(rgba)
+    image = Gosu::Image.from_blob(@converter.out_w, @converter.out_h, rgba)
+    return image unless @retro
+
+    @canvas ||= Gosu.render(image.width, image.height, retro: true) { }
+    @canvas.insert(image, 0, 0)
+    @canvas
+  end
+
+  # A dark bar along the bottom edge, so the tick rate and the controls stay legible against DOOM's own (highly variable) palette.
+  def draw_hud
+    bar_y = height - HUD_HEIGHT
+    draw_rect(0, bar_y, width, HUD_HEIGHT, Gosu::Color.new(180, 0, 0, 0), 1)
+    @font.draw_text(format("%.1f ticks/sec  |  %s", @rate, CONTROLS_TEXT), 5, bar_y + 3, 2)
+  end
+end
+
+def check_yjit!
+  return if defined?(RubyVM::YJIT) && RubyVM::YJIT.enabled?
+
+  warn "doom: YJIT is not enabled (run with `ruby --yjit`, or set RUBY_YJIT_ENABLE=1) " \
+       "- the Ruby backend is already dewasm's slowest, and needs YJIT to stay playable."
+end
+
+def start_doom
+  frame_state = { width: 0, height: 0, rgba: nil, buf_off: nil, converter: nil }
+  doom_holder = [nil]
+  doom = Doom.new(build_imports(doom_holder, frame_state))
+  doom_holder[0] = doom
+  doom.invoke("initGame")
+  # initGame renders the title screen, so a frame has been through FrameConverter by now and out_w/out_h have settled; the window sizes itself from them, and would pick the unhalved 640x400 if this were ever not true.
+  if frame_state[:converter].nil? || frame_state[:rgba].nil?
+    warn "doom: FAIL: initGame produced no frame (loading.onGameInit or ui.drawFrame was never called)"
+    exit 1
+  end
+  [doom, frame_state]
+end
+
+def run_smoke
+  doom, frame_state = start_doom
+  converter = frame_state.fetch(:converter)
+  tick_game = doom.exports.fetch("tickGame")
+
+  ticks = 60
+  start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  ticks.times { tick_game.call }
+  elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+
+  rgba = frame_state[:rgba]
+  unless rgba
+    warn "smoke: FAIL: no frame was ever captured"
+    exit 1
+  end
+
+  # Timed separately from the loop above because conversion runs inside the tick, as part of ui.drawFrame.
+  convert_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  10.times { converter.convert(doom.memory.buffer, frame_state.fetch(:buf_off)) }
+  convert_ms = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - convert_start) / 10 * 1000
+
+  puts format(
+    "smoke: ran %d ticks in %.3fs - %.1f ticks/sec (%.2fms/frame framebuffer conversion)",
+    ticks, elapsed, ticks / elapsed, convert_ms
+  )
+
+  distinct = rgba.unpack("V*").uniq.size
+  puts "smoke: final frame is #{converter.out_w}x#{converter.out_h} with #{distinct} distinct colors"
+  # DOOM's software renderer is paletted (classic VGA Mode 13h: at most 256 colors), so a healthy frame tops out in the low hundreds, not the thousands a truecolor renderer would produce.
+  # A degenerate frame (blank/solid) instead lands in the single digits.
+  if distinct <= 50
+    warn "smoke: FAIL: frame looks degenerate (too few distinct colors)"
+    exit 1
+  end
+
+  # Gosu decodes and encodes images without a window, so unlike the terminal frontend (which falls back to PPM for want of a stdlib PNG writer) this writes a real PNG with no display attached.
+  Gosu::Image.from_blob(converter.out_w, converter.out_h, rgba).save("screenshot.png")
+  puts "smoke: wrote #{File.expand_path('screenshot.png')}"
+end
+
+def parse_options(argv)
+  options = { scale: 3, fullscreen: false, retro: true }
+  until argv.empty?
+    case (arg = argv.shift)
+    when "--scale" then options[:scale] = Integer(argv.shift, exception: false) || 0
+    when "--fullscreen" then options[:fullscreen] = true
+    when "--smooth" then options[:retro] = false
+    else
+      warn "doom: unknown option #{arg}"
+      warn "usage: main.rb [--smoke] [--scale N] [--fullscreen] [--smooth]"
+      exit 2
+    end
+  end
+  unless (1..8).cover?(options[:scale])
+    warn "doom: --scale must be an integer between 1 and 8"
+    exit 2
+  end
+  options
+end
+
+def run_interactive(options)
+  # Gosu.render, which the nearest-neighbor path needs, arrived in gosu 1.1; degrade to interpolated scaling rather than refusing to run.
+  if options[:retro] && !Gosu.respond_to?(:render)
+    warn "doom: this gosu is too old for nearest-neighbor scaling; falling back to --smooth"
+    options[:retro] = false
+  end
+  doom, frame_state = start_doom
+  DoomWindow.new(doom, frame_state, **options).show
+end
+
+check_yjit!
+if ARGV.delete("--smoke")
+  run_smoke
+else
+  run_interactive(parse_options(ARGV))
+end

--- a/examples/doom/ruby-gosu/main.rb
+++ b/examples/doom/ruby-gosu/main.rb
@@ -209,12 +209,12 @@ class DoomWindow < Gosu::Window
     @ticks += 1
     @rate_ticks += 1
     return unless (@ticks % CAPTION_UPDATE_EVERY).zero?
-
+    
     now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     @rate = @rate_ticks / (now - @rate_window_start)
     @rate_ticks = 0
     @rate_window_start = now
-    self.caption = format("DOOM (dewasm) - %.1f ticks/sec", @rate)
+    self.caption = format("DOOM (dewasm) - %.1f tps #{RUBY_DESCRIPTION} ", @rate)
   end
 
   def draw

--- a/examples/doom/ruby-gosu/run.sh
+++ b/examples/doom/ruby-gosu/run.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Build (if needed) and run the DOOM frontend, forwarding any arguments
+# (e.g. `./run.sh --smoke` for the headless self-check, or `./run.sh --scale 4`).
+# --yjit is required: the Ruby backend is dewasm's slowest, and only YJIT keeps DOOM playable.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+./build.sh
+export RUBY_YJIT_ENABLE=1
+exec ruby --yjit main.rb "$@"


### PR DESCRIPTION
examples/doom/ruby renders into a terminal because the Ruby backend manages only ~15 ticks/sec under YJIT, and a window looked unaffordable at that budget. What actually made it look unaffordable was per-pixel cost, and the module's framebuffer removes most of it: DOOM renders at 320x200 and upscales by exactly 2 (its own log reads "Auto-scaling factor: 2"), so halving the 640x400 buffer back is lossless and leaves a quarter of the pixels to convert. The frame then goes up as one 320x200 texture and the GPU scales it, so the render cost does not grow with the window.

A window also restores real key releases, which no terminal can report, so Ctrl (fire) and Shift (run) work as they do in DOOM instead of being synthesized after a hold window or dropped.

I confirmed this frontend works well on both of x86-64/linux and aarch64/darwin (Apple Silicon Mac).
Apple M1 (8 Core):                       10-12 ticks/sec
Intel Core Ultra 7 155H(3.80GHz) 27-30 ticks/sec (on WSL2)