### PR TITLE
Add windowed Ruby frontends on gosu for the DOOM and NES demos

### DIFF
--- a/agents/decisions/50-doom-example-shape.md
+++ b/agents/decisions/50-doom-example-shape.md
@@ -3,6 +3,7 @@
 Status: **Accepted, 2026-07-30.**
 `examples/doom` runs the unmodified [jacobenget/doom.wasm](https://github.com/jacobenget/doom.wasm) v0.1.0 release binary through `--mode library`, with an ebiten frontend for the Go backend and a Swing frontend for the Java backend; both pass a headless smoke that renders a real frame well above DOOM's native 35Hz tic rate.
 Extended the same day with Ruby and Python frontends that render into the terminal (ANSI truecolor half-blocks, stdlib only), the same criterion applied at slower tick rates, where a pixel window would be pointless but a diffed terminal frame costs under 1ms.
+Extended again with `ruby/gui/`, a windowed Ruby frontend on gosu that shares the terminal frontend's generated library, and with it the first second frontend for a backend that already had one.
 
 ## Context
 
@@ -34,4 +35,9 @@ The example is documentation-level: fetched and built by its own scripts, outsid
   No sound: the module exposes no audio interface.
   [Decision 53](53-doom-frame-snapshot.md) later closes part of this gap with a deterministic framebuffer snapshot (ultra-slow execution, a CI-side conversion smoke).
 - Carry-over: the Ruby (~15 ticks/sec under YJIT) and Python (~1.3) frontends confirmed the criterion: each was a new host layer only, with the guest untouched.
+  So did `ruby/gui/`, which additionally shows the criterion does not cap a backend at one frontend: the title's "per-language" describes how the demo grew, not a limit on it, and a second frontend for one backend costs nothing beyond its own host code because it requires the sibling's generated `doom_gen.rb` instead of regenerating its own.
+  It also revises the reading that a slow backend implies a terminal.
+  What made a window look unaffordable for Ruby was per-pixel cost against a ~15 ticks/sec budget, and the module's 640x400 framebuffer is an exact 2x upscale of DOOM's native 320x200 (`I_InitGraphics: Auto-scaling factor: 2`), so halving it back is lossless and leaves a quarter of the pixels to convert; the frame is then uploaded once as a 320x200 texture and scaled by the GPU, making the render cost independent of window size.
+  The window also restores real key releases, which no terminal can deliver, so Ctrl (fire) and Shift (run) work as in DOOM instead of being synthesized or dropped.
+  Its gosu dependency is scoped to `gui/` with bundler (`Gemfile.lock` checked in, installs into a gitignored `vendor/bundle`), so `ruby/` itself stays stdlib-only and the gem version stays pinned instead of depending on a globally installed gosu.
   The terminal renderer doubles as the frontend shape for any backend too slow for a window, including Bash, which after [decision 51](51-bash-assoc-memory.md)/[decision 52](52-bash-inline-memops.md) boots in ~2 minutes and renders a frame every ~34 seconds in `bash/`.

--- a/agents/decisions/59-nes-example-agnes.md
+++ b/agents/decisions/59-nes-example-agnes.md
@@ -4,6 +4,7 @@ Status: **Accepted, 2026-08-04.**
 `examples/nes` runs a NES emulator converted with `--mode library` on all six backends, in the DOOM demo's shape ([decision 50](50-doom-example-shape.md)): one wasm artifact, per-language native frontends, a deterministic framebuffer snapshot ([decision 53](53-doom-frame-snapshot.md)/[decision 56](56-unified-snapshot-regeneration.md)).
 Unlike DOOM there is no suitable upstream binary, so `examples/apps/scripts/nes.sh` builds `nes.wasm` from a pinned emulation library plus a thin wrapper checked in at `examples/apps/src/nes_demo.c`.
 Amended 2026-08-04: the frame is handed over as agnes's own palette-index buffer plus its palette (`screenOffset`/`paletteOffset`) instead of a BGRA image rendered in-guest, which cost 12-15% of frame time on every backend and told the host nothing it could not compose itself (issue #117); the composed pixels are identical, so the pinned snapshot is unchanged.
+Extended with `ruby/gui/`, a windowed Ruby frontend on gosu sharing the terminal frontend's generated library; the second-frontend rationale and the bundler scoping are recorded with the DOOM example's counterpart in [decision 50](50-doom-example-shape.md).
 
 ## Context
 

--- a/examples/doom/README.md
+++ b/examples/doom/README.md
@@ -1,10 +1,11 @@
 # DOOM on dewasm
 
-One DOOM, six languages: the unmodified [jacobenget/doom.wasm](https://github.com/jacobenget/doom.wasm) v0.1.0 binary (DOOM compiled to a single wasm module with a ten-function host interface and the shareware WAD embedded), converted by `dewasm --mode library` and played through a native frontend per language:
+One DOOM, six languages: the unmodified [jacobenget/doom.wasm](https://github.com/jacobenget/doom.wasm) v0.1.0 binary (DOOM compiled to a single wasm module with a ten-function host interface and the shareware WAD embedded), converted by `dewasm --mode library` and played through seven native frontends across six languages:
 
 - [`go/`](go/): Go, rendering with [ebiten](https://github.com/hajimehoshi/ebiten)
 - [`java/`](java/): Java, rendering with Swing (plain JDK, zero dependencies)
 - [`ruby/`](ruby/): Ruby, rendering *into the terminal* as 24-bit-color ANSI half-blocks (stdlib only, run with `--yjit`)
+- [`ruby/gui/`](ruby/gui/): the same generated Ruby library in a window, with [gosu](https://www.libgosu.org/); the 640x400 framebuffer is an exact 2x upscale of DOOM's native 320x200, so the texture it uploads is a quarter of the pixels and the render cost does not grow with the window
 - [`python/`](python/): Python, the same terminal renderer (stdlib only; ~45 ticks/sec under PyPy, ~1.2-1.8 under CPython)
 - [`perl/`](perl/): Perl, the same terminal renderer (core modules only; ~0.7 ticks/sec, no JIT and per-call depth accounting)
 - [`bash/`](bash/): pure Bash, same terminal renderer; ~2 minutes to boot and ~34 seconds per frame, an existence proof and likely a first (also available as a [single-file `doom.bash` Gist](https://gist.github.com/makenowjust/b1e9c2a585183f41a5f8f61b4bc9924c), separate from this MIT repo because the built artifact embeds the GPL-2.0 engine)
@@ -20,7 +21,7 @@ The compared oracle is `doom_frame.ppm`; this PNG is the same frame for human ey
 ## Run
 
 ```sh
-go/run.sh    # or: java/run.sh
+go/run.sh    # or: java/run.sh, ruby/gui/run.sh
 ```
 
 `build.sh` fetches the wasm binary (checksum-pinned, via `../apps/scripts/doom.sh`) into the gitignored apps cache; no other assets are needed.
@@ -28,6 +29,7 @@ Each frontend also has a headless `-smoke`/`--smoke` mode that ticks the game wi
 
 Measured on an Apple Silicon laptop, headless: Go ~70 ticks/sec, Java ~55, both comfortably above DOOM's native 35Hz tic rate.
 Ruby reaches ~15 ticks/sec with YJIT, Python ~45 under PyPy but ~1.2-1.8 under CPython, and Perl ~0.7, which is why those three render into the terminal instead of a window: the ANSI diff renderer costs a few ms/frame at most, so the wasm tick stays the only bottleneck.
+A window is not actually ruled out at those rates, as `ruby/gui/` shows: what the terminal avoids is per-pixel cost, and halving the framebuffer back to 320x200 (lossless, since DOOM upscales it by exactly 2) avoids it just as well while restoring the key releases a terminal cannot report.
 Bash, after the associative-memory and inlined-load/store work, boots in ~2 minutes and draws a frame every ~34 seconds, not playable but genuinely running.
 Terminals report key presses but not releases, so the terminal frontends synthesize key-up events after a short hold window, and fire is on `f` (Ctrl never reaches a terminal app as a plain key).
 

--- a/examples/doom/ruby/README.md
+++ b/examples/doom/ruby/README.md
@@ -3,6 +3,7 @@
 An interactive DOOM frontend that renders into the terminal instead of a window (see `../go` and `../java` for the pixel-window frontends).
 `build.sh` fetches jacobenget/doom.wasm (checksum-pinned into the shared apps cache) and converts it to Ruby with dewasm (`doom_gen.rb`, ~11MB, gitignored, regenerated on every build) and `main.rb` implements the module's ten host imports (console logging, save-game I/O, the game clock, and frame delivery) plus a terminal renderer and raw-mode keyboard input.
 A terminal is not a downgrade here: the Ruby backend only manages ~15 ticks/sec under YJIT, far below what a GUI needs but plenty for a terminal, which has orders of magnitude fewer cells to redraw than a window has pixels.
+The [`gui/`](gui/) subdirectory runs the same generated library in a real window with gosu, sharing this directory's `doom_gen.rb`; what it buys is real key releases, which no terminal can report.
 
 ## Run
 

--- a/examples/doom/ruby/gui/.gitignore
+++ b/examples/doom/ruby/gui/.gitignore
@@ -1,0 +1,4 @@
+/vendor/
+/.bundle/
+/screenshot.png
+/.savegame/

--- a/examples/doom/ruby/gui/Gemfile
+++ b/examples/doom/ruby/gui/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "gosu", "~> 1.4"

--- a/examples/doom/ruby/gui/Gemfile.lock
+++ b/examples/doom/ruby/gui/Gemfile.lock
@@ -1,0 +1,17 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    gosu (1.4.6)
+
+PLATFORMS
+  arm64-darwin-25
+  ruby
+
+DEPENDENCIES
+  gosu (~> 1.4)
+
+CHECKSUMS
+  gosu (1.4.6) sha256=80c7fa48cf61f4960ef067fdd1c000d98b4adc8e11faeaa486543d00908a5c15
+
+BUNDLED WITH
+  4.0.10

--- a/examples/doom/ruby/gui/README.md
+++ b/examples/doom/ruby/gui/README.md
@@ -1,0 +1,105 @@
+# DOOM (Ruby, gosu window)
+
+An interactive DOOM frontend that renders into a window with [gosu](https://www.libgosu.org/), the SDL2-backed 2D game library for Ruby.
+The parent [`../`](../) frontend draws the same game into a terminal; this one takes a real window.
+
+Both frontends share one generated library: `../build.sh` fetches jacobenget/doom.wasm (checksum-pinned into the shared apps cache) and converts it to Ruby with dewasm (`../doom_gen.rb`, ~11MB, gitignored, regenerated on every build).
+`main.rb` implements the module's ten host imports (console logging, save-game I/O, the game clock, and frame delivery) plus the gosu window, its renderer and its keyboard input.
+
+## Requirements
+
+gosu is installed by `run.sh` with bundler, into the gitignored `vendor/bundle` of this directory, at the version pinned by `Gemfile.lock`.
+Nothing is installed globally, and the parent terminal frontend stays stdlib-only.
+
+The gem builds a native extension against SDL2, so its development headers have to be present:
+
+| Platform | Install |
+| --- | --- |
+| Debian/Ubuntu | `sudo apt install libsdl2-dev` |
+| Fedora | `sudo dnf install SDL2-devel` |
+| macOS | `brew install sdl2` |
+
+On macOS, Homebrew's `sdl2` currently resolves to sdl2-compat, whose `sdl2-config` does not support the `--static-libs` flag gosu's build uses; the extension then builds without its SDL2 and AppKit link line and fails at require time with a missing-symbol error.
+Until gosu handles sdl2-compat, install against a real SDL2 (`brew install sdl2 --formula` with a pre-compat bottle, or MacPorts), or wrap `sdl2-config` so `--static-libs` answers with the `--libs` output.
+
+## Why a window is affordable here
+
+The terminal frontend exists because the Ruby backend only manages ~15 ticks/sec under YJIT, far below what a GUI usually needs, while a terminal has orders of magnitude fewer cells to redraw than a window has pixels.
+A window costs no more than a terminal here because the per-frame work does not scale with the window: the frame is uploaded once as a 320x200 texture and the GPU does the scaling, so `--scale 6` costs exactly what `--scale 1` costs.
+
+The framebuffer the module hands over is 640x400, but DOOM renders at 320x200 and upscales by exactly 2 (its own startup log reads `I_InitGraphics: Auto-scaling factor: 2`).
+Halving it back is therefore lossless, and leaves 64000 pixels per frame to convert instead of 256000.
+`FrameConverter` verifies that on the first frame rather than trusting it, and falls back to full resolution if a future build of the module ever stops holding it.
+
+What the window buys over the terminal is real key releases.
+Terminals report presses only, so the terminal frontend has to synthesize a release after a hold window, and cannot deliver Ctrl as a plain key at all.
+Here Ctrl (fire) and Shift (run) work as they do in DOOM.
+
+## Run
+
+```sh
+./run.sh
+```
+
+builds and opens a window.
+The window is resizable: the frame keeps its 8:5 aspect ratio and is centered, with black bars on whichever axis runs out first.
+
+| Option | Effect |
+| --- | --- |
+| `--scale N` | Window size as a multiple of 320x200, 1 to 8 (default 3, so 960x600). |
+| `--fullscreen` | Start fullscreen. |
+| `--smooth` | Scale the frame with interpolation instead of nearest-neighbor, saving ~10ms per frame. |
+| `--smoke` | Headless self-check, described below. |
+
+`./run.sh --smoke` needs no display: it inits the game, ticks it 60 times with no window, reports the tick rate and the per-frame conversion cost, sanity-checks the last frame, writes it to `screenshot.png`, and exits non-zero on failure.
+gosu encodes PNGs without a graphics context, so unlike the terminal frontend (which falls back to binary PPM for want of a stdlib PNG writer) this writes a real PNG.
+
+## Rendering
+
+Handing a frame to gosu takes two per-pixel transformations, and they are the only part of this frontend where a straightforward Ruby loop would cost more than the wasm tick itself.
+The module stores pixels as B,G,R,A while gosu wants R,G,B,A, and the module's alpha byte is always 0 where gosu needs 0xff.
+
+Two facts about DOOM's renderer keep that down to a few hundred Ruby-level operations per frame rather than 64000.
+It is paletted (VGA Mode 13h, at most 256 colors per palette and a handful of palettes over a session), so each distinct 32-bit source word is swizzled once and memoized; a real frame holds around 175 of them.
+Its 640x400 output is an exact 2x upscale, so each row is read with a single `unpack("Vx4" * 320)`, where `V` takes a 32-bit pixel and `x4` skips the duplicated neighbor.
+That leaves one `unpack`, one memoized `map!` and one `pack` per row, all at C level except the hash lookups.
+
+Uploading the result is one `Gosu::Image.from_blob` per frame.
+gosu interpolates an image scaled past its native size unless its texture was created with `retro: true`, which `Image.from_blob` has no parameter for, so the default path blits the frame into a persistent nearest-neighbor render target instead.
+That is what `--smooth` turns off, trading DOOM's crisp pixels for the ~10ms.
+
+Measured on an x86-64 Linux container under Ruby 3.3.6 **without** YJIT (that build of Ruby has no YJIT support), at the default `--scale 3`:
+
+| Step | Cost per frame |
+| --- | --- |
+| Framebuffer conversion (640x400 BGRA to 320x200 RGBA) | 9.9ms |
+| `Gosu::Image.from_blob` | 2.0ms |
+| Nearest-neighbor blit (skipped by `--smooth`) | 10.0ms |
+| One `tickGame` | 226ms |
+
+The wasm tick dominates by an order of magnitude, which is the point: rendering is not what makes this frontend slow, and YJIT (which `run.sh` always passes, and which `main.rb` warns about on stderr if it ends up missing) is what moves the tick figure.
+The terminal frontend measures the same Ruby backend at 15.9 ticks/sec with YJIT on an Apple Silicon laptop.
+
+## Controls
+
+| Key | Action |
+| --- | --- |
+| Arrow keys | Move / turn |
+| Ctrl | Fire |
+| Space | Use (open doors, flip switches) |
+| Shift | Run |
+| , / . | Strafe left / right |
+| Tab | Automap |
+| Enter | Menu confirm |
+| Escape | Menu / pause |
+| Backspace | Menu back |
+| 0-9 | Weapon select / text entry |
+| Letters | Text entry, `y` / `n` prompts |
+| F1 | Show or hide the on-screen status bar |
+| F10 | Quit |
+
+gosu closes a window on Escape unless the frontend overrides its `button_down`, which this one does: Escape belongs to DOOM's menu, and quitting is F10 or the window's close button.
+
+Save games are written to `.savegame/` (gitignored) relative to wherever the script runs.
+
+No sound: the module exposes no audio interface.

--- a/examples/doom/ruby/gui/main.rb
+++ b/examples/doom/ruby/gui/main.rb
@@ -1,0 +1,366 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Interactive windowed frontend for the dewasm-generated DOOM library (../doom_gen.rb, produced from jacobenget/doom.wasm by ../build.sh and shared with the terminal frontend), rendering with gosu.
+#
+# The parent ../main.rb draws into a terminal because the Ruby backend only manages ~15 ticks/sec under YJIT and a terminal has orders of magnitude fewer cells than a window has pixels.
+# This one takes the window anyway, which is affordable because the module's 640x400 framebuffer is an exact 2x upscale of DOOM's native 320x200: halving it back is lossless and leaves 64000 pixels per frame to hand to the GPU, not 256000.
+# What the window buys over the terminal is real key releases, so Ctrl (fire) and Shift (run) work as they do in DOOM.
+#
+# Run with --smoke for a headless self-check (no window, no display needed).
+
+require_relative "../doom_gen"
+require "gosu"
+
+SAVE_DIR = ".savegame"
+
+def save_game_path(id)
+  File.join(SAVE_DIR, "doomsav#{id}.dsg")
+end
+
+# Wires the wasm module's ten host imports to Ruby.
+# `doom_holder` exists because these closures have to be built before Doom.new returns the instance they read memory from; it's filled in immediately after construction and only read from within calls the imports themselves receive later (never during Doom.new itself).
+def build_imports(doom_holder, frame_state)
+  {
+    "console" => {
+      "onErrorMessage" => lambda do |off, len|
+        warn doom_holder[0].memory.buffer.get_string(off, len)
+      end,
+      "onInfoMessage" => lambda do |off, len|
+        puts doom_holder[0].memory.buffer.get_string(off, len)
+      end,
+    },
+    "gameSaving" => {
+      "sizeOfSaveGame" => lambda do |id|
+        path = save_game_path(id)
+        File.exist?(path) ? File.size(path) : 0
+      end,
+      "readSaveGame" => lambda do |id, dst_off|
+        path = save_game_path(id)
+        next 0 unless File.exist?(path)
+
+        bytes = File.binread(path)
+        doom_holder[0].memory.buffer.set_string(bytes, dst_off, bytes.bytesize, 0)
+        bytes.bytesize
+      end,
+      "writeSaveGame" => lambda do |id, src_off, length|
+        Dir.mkdir(SAVE_DIR) unless Dir.exist?(SAVE_DIR)
+        bytes = doom_holder[0].memory.buffer.get_string(src_off, length)
+        File.binwrite(save_game_path(id), bytes)
+        length
+      end,
+    },
+    "runtimeControl" => {
+      # Backs DOOM's internal 35Hz pacing, so it has to be a real monotonic clock (not a fake stepped one) or the game's notion of elapsed time would drift from how often we actually call tickGame.
+      "timeInMilliseconds" => lambda do
+        Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
+      end,
+    },
+    "ui" => {
+      # Converted here, inside the tick, rather than copied out for later: the memory buffer this reads can be replaced by a subsequent tick that grows the module's memory.
+      "drawFrame" => lambda do |buf_off|
+        frame_state[:buf_off] = buf_off
+        frame_state[:rgba] = frame_state[:converter].convert(doom_holder[0].memory.buffer, buf_off)
+      end,
+    },
+    "loading" => {
+      "onGameInit" => lambda do |w, h|
+        frame_state[:width] = w
+        frame_state[:height] = h
+        frame_state[:converter] = FrameConverter.new(w, h)
+      end,
+      # Leaving both output slots untouched (they arrive pre-zeroed) selects the wasm-embedded shareware WAD; supplying external WADs is out of scope for this frontend.
+      "wadSizes" => lambda { |_num_off, _bytes_off| },
+      "readWads" => lambda { |_dst_off, _lengths_off| },
+    },
+  }
+end
+
+# Turns the module's framebuffer into the RGBA blob gosu wants.
+#
+# Two transformations, both per pixel and therefore the only part of this frontend where a naive Ruby loop would cost more than the wasm tick itself:
+# the module stores B,G,R,A while gosu wants R,G,B,A, and the module's alpha byte is always 0 where gosu needs 0xff.
+#
+# The work is kept to a few hundred Ruby-level operations per frame rather than 64000 by two facts about DOOM's renderer.
+# It is paletted (VGA Mode 13h, at most 256 colors per palette and a handful of palettes over a session), so every distinct 32-bit source word is swizzled once and memoized.
+# And its 640x400 output is an exact 2x nearest upscale of its native 320x200, so reading every other pixel of every other row is lossless.
+# The first frame checks that rather than trusting it, and falls back to full resolution if a future build of the module ever stops holding it.
+class FrameConverter
+  attr_reader :out_w, :out_h
+
+  # out_w/out_h are not known until the first frame decides whether halving is lossless, so they start at full resolution and #convert narrows them once.
+  def initialize(src_w, src_h)
+    @src_w = src_w
+    @src_h = src_h
+    @src_stride = src_w * 4
+    @step = nil
+    @out_w = src_w
+    @out_h = src_h
+    @swizzled = Hash.new do |memo, word|
+      memo[word] = 0xff000000 | ((word & 0x0000ff) << 16) | (word & 0x00ff00) | ((word >> 16) & 0xff)
+    end
+  end
+
+  def convert(buffer, base_off)
+    choose_step(buffer, base_off) unless @step
+    rgba = String.new(capacity: @out_w * @out_h * 4)
+    @out_h.times do |y|
+      row = buffer.get_string(base_off + y * @step * @src_stride, @src_stride)
+      rgba << row.unpack(@row_template).map! { |word| @swizzled[word] }.pack("V*")
+    end
+    rgba
+  end
+
+  private
+
+  def choose_step(buffer, base_off)
+    @step = upscaled_2x?(buffer, base_off) ? 2 : 1
+    warn "doom: framebuffer is not a 2x upscale; rendering at full #{@src_w}x#{@src_h}" if @step == 1
+    @out_w = @src_w / @step
+    @out_h = @src_h / @step
+    # One C-level unpack per row: "V" reads a 32-bit BGRA word and "x4" skips the duplicated neighbor.
+    @row_template = ((@step == 2 ? "Vx4" : "V") * @out_w).freeze
+  end
+
+  # True when every 2x2 block of the framebuffer is uniform, i.e. the image carries no more detail than its 320x200 half.
+  def upscaled_2x?(buffer, base_off)
+    return false unless @src_w.even? && @src_h.even?
+
+    even_pixels = ("Vx4" * (@src_w / 2)).freeze
+    odd_pixels = ("x4V" * (@src_w / 2)).freeze
+    (@src_h / 2).times do |y|
+      top = buffer.get_string(base_off + y * 2 * @src_stride, @src_stride)
+      return false unless top == buffer.get_string(base_off + (y * 2 + 1) * @src_stride, @src_stride)
+      return false unless top.unpack(even_pixels) == top.unpack(odd_pixels)
+    end
+    true
+  end
+end
+
+# Translates a gosu button id to the code reportKeyDown/reportKeyUp expect: the module's KEY_* constant for special keys, or the ASCII value of the lowercase character for letters and digits (text entry, and weapon-select digits).
+class KeyMap
+  def initialize(doom)
+    @by_button = {
+      Gosu::KB_LEFT => doom.global_get("KEY_LEFTARROW"),
+      Gosu::KB_RIGHT => doom.global_get("KEY_RIGHTARROW"),
+      Gosu::KB_UP => doom.global_get("KEY_UPARROW"),
+      Gosu::KB_DOWN => doom.global_get("KEY_DOWNARROW"),
+      Gosu::KB_LEFT_CONTROL => doom.global_get("KEY_FIRE"),
+      Gosu::KB_RIGHT_CONTROL => doom.global_get("KEY_FIRE"),
+      Gosu::KB_SPACE => doom.global_get("KEY_USE"),
+      Gosu::KB_LEFT_SHIFT => doom.global_get("KEY_SHIFT"),
+      Gosu::KB_RIGHT_SHIFT => doom.global_get("KEY_SHIFT"),
+      Gosu::KB_LEFT_ALT => doom.global_get("KEY_ALT"),
+      Gosu::KB_RIGHT_ALT => doom.global_get("KEY_ALT"),
+      Gosu::KB_TAB => doom.global_get("KEY_TAB"),
+      Gosu::KB_ESCAPE => doom.global_get("KEY_ESCAPE"),
+      Gosu::KB_RETURN => doom.global_get("KEY_ENTER"),
+      Gosu::KB_ENTER => doom.global_get("KEY_ENTER"),
+      Gosu::KB_BACKSPACE => doom.global_get("KEY_BACKSPACE"),
+      Gosu::KB_COMMA => doom.global_get("KEY_STRAFE_L"),
+      Gosu::KB_PERIOD => doom.global_get("KEY_STRAFE_R"),
+    }
+    (Gosu::KB_A..Gosu::KB_Z).each_with_index { |id, i| @by_button[id] = "a".ord + i }
+    # KB_1..KB_9 run 30..38 and KB_0 sits above them at 39, so the digit row is not one contiguous ascending range.
+    (Gosu::KB_1..Gosu::KB_9).each_with_index { |id, i| @by_button[id] = "1".ord + i }
+    @by_button[Gosu::KB_0] = "0".ord
+  end
+
+  def [](button_id) = @by_button[button_id]
+end
+
+CONTROLS_TEXT = "arrows move   ctrl fire   space use   shift run   ,/. strafe   tab automap   " \
+                "esc menu   1-7 weapon   F1 hud   F10 quit"
+
+class DoomWindow < Gosu::Window
+  # DOOM's own internal tic rate.
+  # tickGame paces itself off runtimeControl.timeInMilliseconds no matter how often it is called, so matching 35Hz makes one update advance exactly one tic instead of some updates being no-ops.
+  TICKS_PER_SECOND = 35
+  # The caption only has to be legible, not frame-accurate, and asking the window manager to retitle the window is not free.
+  CAPTION_UPDATE_EVERY = TICKS_PER_SECOND
+  HUD_HEIGHT = 18
+
+  def initialize(doom, frame_state, scale:, fullscreen:, retro:)
+    @converter = frame_state.fetch(:converter)
+    super(@converter.out_w * scale, @converter.out_h * scale, fullscreen: fullscreen, resizable: true)
+    self.caption = "DOOM (dewasm)"
+    self.update_interval = 1000.0 / TICKS_PER_SECOND
+
+    @frame_state = frame_state
+    @keys = KeyMap.new(doom)
+    # Fetched once out of the exports table: invoke() would redo the hash lookup and splat the arguments on every one of these calls.
+    @tick_game = doom.exports.fetch("tickGame")
+    @report_key_down = doom.exports.fetch("reportKeyDown")
+    @report_key_up = doom.exports.fetch("reportKeyUp")
+
+    @retro = retro
+    @canvas = nil
+    @font = Gosu::Font.new(13)
+    @show_hud = true
+    @ticks = 0
+    @rate_ticks = 0
+    @rate_window_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    @rate = 0.0
+  end
+
+  def update
+    @tick_game.call # drives ui.drawFrame internally, refreshing frame_state[:rgba]
+    @ticks += 1
+    @rate_ticks += 1
+    return unless (@ticks % CAPTION_UPDATE_EVERY).zero?
+
+    now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    @rate = @rate_ticks / (now - @rate_window_start)
+    @rate_ticks = 0
+    @rate_window_start = now
+    self.caption = format("DOOM (dewasm) - %.1f ticks/sec", @rate)
+  end
+
+  def draw
+    rgba = @frame_state[:rgba]
+    return unless rgba
+
+    image = frame_image(rgba)
+    # Letterbox: the window is resizable and need not keep the framebuffer's 8:5 ratio, so the frame is scaled by whichever axis runs out first and centred, leaving black bars on the other.
+    scale = [width.to_f / image.width, height.to_f / image.height].min
+    draw_w = image.width * scale
+    draw_h = image.height * scale
+    image.draw((width - draw_w) / 2, (height - draw_h) / 2, 0, scale, scale)
+    draw_hud if @show_hud
+  end
+
+  def button_down(id)
+    # Deliberately no `super`: gosu's default button_down closes the window on Escape, which is DOOM's menu key.
+    case id
+    when Gosu::KB_F10 then close
+    when Gosu::KB_F1 then @show_hud = !@show_hud
+    else
+      code = @keys[id]
+      @report_key_down.call(code) if code
+    end
+  end
+
+  def button_up(id)
+    code = @keys[id]
+    @report_key_up.call(code) if code
+  end
+
+  private
+
+  # Uploads the frame to the GPU.
+  # Gosu interpolates a scaled-up image unless the texture was created with `retro: true`, which Image.from_blob has no way to ask for, so the retro path blits the frame into a persistent nearest-neighbor render target instead.
+  # That costs about 10ms a frame against from_blob's 2, which is why --smooth exists.
+  def frame_image(rgba)
+    image = Gosu::Image.from_blob(@converter.out_w, @converter.out_h, rgba)
+    return image unless @retro
+
+    @canvas ||= Gosu.render(image.width, image.height, retro: true) { }
+    @canvas.insert(image, 0, 0)
+    @canvas
+  end
+
+  # A dark bar along the bottom edge, so the tick rate and the controls stay legible against DOOM's own (highly variable) palette.
+  def draw_hud
+    bar_y = height - HUD_HEIGHT
+    draw_rect(0, bar_y, width, HUD_HEIGHT, Gosu::Color.new(180, 0, 0, 0), 1)
+    @font.draw_text(format("%.1f ticks/sec  |  %s", @rate, CONTROLS_TEXT), 5, bar_y + 3, 2)
+  end
+end
+
+def check_yjit!
+  return if defined?(RubyVM::YJIT) && RubyVM::YJIT.enabled?
+
+  warn "doom: YJIT is not enabled (run with `ruby --yjit`, or set RUBY_YJIT_ENABLE=1) " \
+       "- the Ruby backend is already dewasm's slowest, and needs YJIT to stay playable."
+end
+
+def start_doom
+  frame_state = { width: 0, height: 0, rgba: nil, buf_off: nil, converter: nil }
+  doom_holder = [nil]
+  doom = Doom.new(build_imports(doom_holder, frame_state))
+  doom_holder[0] = doom
+  doom.invoke("initGame")
+  # initGame renders the title screen, so a frame has been through FrameConverter by now and out_w/out_h have settled; the window sizes itself from them, and would pick the unhalved 640x400 if this were ever not true.
+  if frame_state[:converter].nil? || frame_state[:rgba].nil?
+    warn "doom: FAIL: initGame produced no frame (loading.onGameInit or ui.drawFrame was never called)"
+    exit 1
+  end
+  [doom, frame_state]
+end
+
+def run_smoke
+  doom, frame_state = start_doom
+  converter = frame_state.fetch(:converter)
+  tick_game = doom.exports.fetch("tickGame")
+
+  ticks = 60
+  start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  ticks.times { tick_game.call }
+  elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+
+  rgba = frame_state[:rgba]
+  unless rgba
+    warn "smoke: FAIL: no frame was ever captured"
+    exit 1
+  end
+
+  # Timed separately from the loop above because conversion runs inside the tick, as part of ui.drawFrame.
+  convert_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  10.times { converter.convert(doom.memory.buffer, frame_state.fetch(:buf_off)) }
+  convert_ms = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - convert_start) / 10 * 1000
+
+  puts format(
+    "smoke: ran %d ticks in %.3fs - %.1f ticks/sec (%.2fms/frame framebuffer conversion)",
+    ticks, elapsed, ticks / elapsed, convert_ms
+  )
+
+  distinct = rgba.unpack("V*").uniq.size
+  puts "smoke: final frame is #{converter.out_w}x#{converter.out_h} with #{distinct} distinct colors"
+  # DOOM's software renderer is paletted (classic VGA Mode 13h: at most 256 colors), so a healthy frame tops out in the low hundreds, not the thousands a truecolor renderer would produce.
+  # A degenerate frame (blank/solid) instead lands in the single digits.
+  if distinct <= 50
+    warn "smoke: FAIL: frame looks degenerate (too few distinct colors)"
+    exit 1
+  end
+
+  # Gosu decodes and encodes images without a window, so unlike the terminal frontend (which falls back to PPM for want of a stdlib PNG writer) this writes a real PNG with no display attached.
+  Gosu::Image.from_blob(converter.out_w, converter.out_h, rgba).save("screenshot.png")
+  puts "smoke: wrote #{File.expand_path('screenshot.png')}"
+end
+
+def parse_options(argv)
+  options = { scale: 3, fullscreen: false, retro: true }
+  until argv.empty?
+    case (arg = argv.shift)
+    when "--scale" then options[:scale] = Integer(argv.shift, exception: false) || 0
+    when "--fullscreen" then options[:fullscreen] = true
+    when "--smooth" then options[:retro] = false
+    else
+      warn "doom: unknown option #{arg}"
+      warn "usage: main.rb [--smoke] [--scale N] [--fullscreen] [--smooth]"
+      exit 2
+    end
+  end
+  unless (1..8).cover?(options[:scale])
+    warn "doom: --scale must be an integer between 1 and 8"
+    exit 2
+  end
+  options
+end
+
+def run_interactive(options)
+  # Gosu.render, which the nearest-neighbor path needs, arrived in gosu 1.1; degrade to interpolated scaling rather than refusing to run.
+  if options[:retro] && !Gosu.respond_to?(:render)
+    warn "doom: this gosu is too old for nearest-neighbor scaling; falling back to --smooth"
+    options[:retro] = false
+  end
+  doom, frame_state = start_doom
+  DoomWindow.new(doom, frame_state, **options).show
+end
+
+check_yjit!
+if ARGV.delete("--smoke")
+  run_smoke
+else
+  run_interactive(parse_options(ARGV))
+end

--- a/examples/doom/ruby/gui/run.sh
+++ b/examples/doom/ruby/gui/run.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Build (if needed) and run the windowed DOOM frontend, forwarding any arguments
+# (e.g. `./run.sh --smoke` for the headless self-check, or `./run.sh --scale 4`).
+# The generated library is shared with the terminal frontend: ../build.sh fetches
+# doom.wasm and regenerates ../doom_gen.rb, which main.rb requires.
+# gosu is installed with bundler into the gitignored vendor/bundle, so the gem and
+# its version stay scoped to this directory. --yjit is required: the Ruby backend
+# is dewasm's slowest, and only YJIT keeps DOOM playable.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+../build.sh
+
+bundle config set --local path vendor/bundle
+bundle install --quiet
+
+ruby -c main.rb > /dev/null
+
+exec bundle exec ruby --yjit main.rb "$@"

--- a/examples/doom/ruby/run.sh
+++ b/examples/doom/ruby/run.sh
@@ -6,5 +6,4 @@ set -euo pipefail
 cd "$(dirname "$0")"
 
 ./build.sh
-export RUBY_YJIT_ENABLE=1
 exec ruby --yjit main.rb "$@"

--- a/examples/nes/README.md
+++ b/examples/nes/README.md
@@ -1,10 +1,11 @@
 # NES on dewasm
 
-One NES, six languages: [agnes](https://github.com/kgabis/agnes) (a dependency-free C NES emulation library, MIT) plus a thin wrapper ([`../apps/src/nes_demo.c`](../apps/src/nes_demo.c)) compiled to a single 19KB wasm module with an **empty import section**, converted by `dewasm --mode library` and played through a native frontend per language:
+One NES, six languages: [agnes](https://github.com/kgabis/agnes) (a dependency-free C NES emulation library, MIT) plus a thin wrapper ([`../apps/src/nes_demo.c`](../apps/src/nes_demo.c)) compiled to a single 19KB wasm module with an **empty import section**, converted by `dewasm --mode library` and played through seven native frontends across six languages:
 
 - [`go/`](go/): Go, rendering with [ebiten](https://github.com/hajimehoshi/ebiten)
 - [`java/`](java/): Java, rendering with Swing (plain JDK, zero dependencies)
 - [`ruby/`](ruby/): Ruby, rendering *into the terminal* as 24-bit-color ANSI half-blocks (stdlib only, run with `--yjit`)
+- [`ruby/gui/`](ruby/gui/): the same generated Ruby library in a window, with [gosu](https://www.libgosu.org/), in the shape of the DOOM demo's [`ruby/gui`](../doom/ruby/gui); real key releases feed `setInput`'s held-button bitmask directly
 - [`python/`](python/): Python, the same terminal renderer (stdlib only, ~11 frames/sec under PyPy, ~2.2 under CPython)
 - [`perl/`](perl/): Perl, the same terminal renderer (core modules only, ~0.9 frames/sec)
 - [`bash/`](bash/): pure Bash, same terminal renderer; ~20-40 seconds per frame, an existence proof in the bash-DOOM tradition
@@ -20,7 +21,7 @@ The compared oracle is `nes_frame.ppm`; this PNG is the same frame for human eye
 ## Run
 
 ```sh
-go/run.sh    # or: java/run.sh, ruby/run.sh, ...
+go/run.sh    # or: java/run.sh, ruby/run.sh, ruby/gui/run.sh, ...
 go/run.sh path/to/other.nes   # any ROM agnes's mappers cover
 ```
 

--- a/examples/nes/ruby/README.md
+++ b/examples/nes/ruby/README.md
@@ -1,6 +1,7 @@
 # NES (Ruby, ANSI terminal)
 
 An interactive NES frontend that renders into the terminal instead of a window (see `../go` for the pixel-window frontend).
+The [`gui/`](gui/) subdirectory runs the same generated library in a real window with gosu, sharing this directory's `nes_gen.rb`; its real key releases feed `setInput`'s bitmask directly instead of the hold-window synthesis below.
 `build.sh` builds `cache/nes.wasm` (an [agnes](https://github.com/kgabis/agnes)-based emulator wrapped by `examples/apps/src/nes_demo.c`) via `examples/apps/scripts/nes.sh` and converts it to Ruby with dewasm (`nes_gen.rb`, gitignored, regenerated on every build).
 Unlike `../../doom`, `nes.wasm` has **zero host imports** (there is nothing to wire up), so `main.rb` only loads a ROM into the module's linear memory and drives the game loop itself: pacing, input polling, and frame presentation are entirely the host's job (the module has no clock import of its own to pace against, unlike DOOM's internal 35Hz timer).
 

--- a/examples/nes/ruby/gui/.gitignore
+++ b/examples/nes/ruby/gui/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+/.bundle/
+/screenshot.png

--- a/examples/nes/ruby/gui/Gemfile
+++ b/examples/nes/ruby/gui/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "gosu", "~> 1.4"

--- a/examples/nes/ruby/gui/Gemfile.lock
+++ b/examples/nes/ruby/gui/Gemfile.lock
@@ -1,0 +1,17 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    gosu (1.4.6)
+
+PLATFORMS
+  arm64-darwin-25
+  ruby
+
+DEPENDENCIES
+  gosu (~> 1.4)
+
+CHECKSUMS
+  gosu (1.4.6) sha256=80c7fa48cf61f4960ef067fdd1c000d98b4adc8e11faeaa486543d00908a5c15
+
+BUNDLED WITH
+  4.0.10

--- a/examples/nes/ruby/gui/README.md
+++ b/examples/nes/ruby/gui/README.md
@@ -1,0 +1,55 @@
+# NES (Ruby, gosu window)
+
+An interactive NES frontend that renders into a window with [gosu](https://www.libgosu.org/), the SDL2-backed 2D game library for Ruby.
+The parent [`../`](../) frontend draws the same emulator into a terminal; this one takes a real window.
+It is the NES counterpart of [`../../../doom/ruby/gui`](../../../doom/ruby/gui), in the same shape: the generated library is shared with the terminal frontend (`../build.sh` regenerates `../nes_gen.rb`, which both require), and gosu is scoped to this directory with bundler.
+
+## Requirements
+
+gosu is installed by `run.sh` with bundler, into the gitignored `vendor/bundle` of this directory, at the version pinned by `Gemfile.lock`.
+Nothing is installed globally, and the parent terminal frontend stays stdlib-only.
+The gem builds a native extension against SDL2; the development-header packages and the current macOS sdl2-compat caveat are in the [DOOM gui frontend's README](../../../doom/ruby/gui/README.md#requirements).
+
+## Run
+
+```sh
+./run.sh
+./run.sh path/to/game.nes   # any ROM agnes's mappers cover
+```
+
+builds and opens a window.
+The window is resizable: the frame keeps its ratio and is centered, with black bars on whichever axis runs out first.
+
+| Option | Effect |
+| --- | --- |
+| `--scale N` | Window size as a multiple of 256x240, 1 to 8 (default 3, so 768x720). |
+| `--fullscreen` | Start fullscreen. |
+| `--smooth` | Scale the frame with interpolation instead of nearest-neighbor. |
+| `--smoke` | Headless self-check, described below. |
+
+`./run.sh --smoke` needs no display: it inits the emulator, ticks it 300 times with no input, reports the tick rate and the per-frame conversion cost, sanity-checks the last frame, writes it to `screenshot.png`, and exits non-zero on failure.
+
+## Rendering
+
+The module hands over agnes's own frame representation: one palette *index* per pixel at `screenOffset()`, against the fixed 64-entry palette at `paletteOffset()`.
+That keeps the per-pixel conversion to one Array lookup: each of the 256 possible index bytes maps to a precomputed 32-bit RGBA word (the module's `& 0x3f` mask folded into the table), so a frame is one `unpack`, one `map!` over the table and one `pack`, all at C level except the lookups.
+The 256x240 result is uploaded once per frame and the GPU does the scaling, so the render cost does not grow with the window; nearest-neighbor versus interpolated scaling works exactly as in the DOOM gui frontend (`retro: true` render target, `--smooth` to opt out).
+
+Pacing is gosu's own 60Hz update interval (the NTSC NES's real rate is ~60.0988Hz: close enough that no calibration is needed).
+When the interpreter cannot sustain 60 ticks/sec, updates simply run late, which is the same fastest-sustainable-rate behavior the terminal frontend implements by hand.
+
+## Controls
+
+Where the terminal frontend has to synthesize key releases after a hold window, gosu reports real `button_down`/`button_up` events, and the held-button bitmask `setInput` wants every tick falls out of them directly.
+
+| Key | Action |
+| --- | --- |
+| Arrow keys | D-pad |
+| x | A |
+| z | B |
+| Enter | Start |
+| Space | Select |
+| F1 | Show or hide the on-screen status bar |
+| q / Escape | Quit |
+
+The bundled ROM is [Alter Ego](https://forums.nesdev.org/viewtopic.php?t=7999) by Shiru, released into the public domain.

--- a/examples/nes/ruby/gui/main.rb
+++ b/examples/nes/ruby/gui/main.rb
@@ -1,0 +1,281 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Interactive windowed frontend for the dewasm-generated NES library (../nes_gen.rb, produced from the agnes-based cache/nes.wasm by ../build.sh and shared with the terminal frontend), rendering with gosu.
+#
+# The parent ../main.rb draws into a terminal; this one takes a real window.
+# Like there, nes.wasm has zero host imports, so the host drives everything itself: pacing (gosu's 60Hz update interval, matching the NTSC NES's ~60.0988Hz closely enough), input polling, and frame presentation.
+# What the window buys over the terminal is real key releases: setInput wants the full held-button bitmask every tick, and gosu's button_down/button_up report exactly that, where a terminal has to synthesize releases after a hold window.
+#
+# Run with --smoke for a headless self-check (no window, no display needed).
+
+require_relative "../nes_gen"
+require "gosu"
+
+DEFAULT_ROM_PATH = File.join(__dir__, "..", "..", "..", "apps", "cache", "alter_ego.nes")
+
+# Button bits accepted by the module's setInput export (examples/apps/src/nes_demo.c).
+BUTTON_BITS = {
+  a: 0x01,
+  b: 0x02,
+  select: 0x04,
+  start: 0x08,
+  up: 0x10,
+  down: 0x20,
+  left: 0x40,
+  right: 0x80,
+}.freeze
+
+# Read the ROM file, copy it into the module's linear memory via allocRom, and initialize the emulator.
+# Raises if the ROM is rejected (unsupported mapper or corrupt file), the module's own way of signalling failure.
+def load_rom(nes, path)
+  rom = File.binread(path)
+  ptr = nes.invoke("allocRom", rom.bytesize)
+  nes.memory.buffer.set_string(rom, ptr, rom.bytesize, 0)
+  ok = nes.invoke("initGame")
+  raise "nes: initGame failed for #{path} (ROM rejected or unsupported mapper)" unless ok == 1
+end
+
+def new_nes
+  nes = Nes.new
+  # Reactor init before any other export (nes.wasm has no WASI surface to run it implicitly).
+  nes.invoke("_initialize")
+  nes
+end
+
+# Turns the module's frame (one palette index per pixel at screenOffset, against the fixed 64-entry palette at paletteOffset) into the RGBA blob gosu wants.
+#
+# The guest hands over indices, not colors, which keeps the per-pixel work to one Array lookup: each of the 256 possible index bytes maps to a precomputed 32-bit RGBA word (the module's `& 0x3f` mask folded into the table), so a frame is one `unpack`, one `map!` over the lookup table and one `pack`, all at C level except the lookups.
+class FrameConverter
+  def initialize(palette)
+    # pack("V*") writes little-endian, so the word R | G<<8 | B<<16 | A<<24 lands in memory as the R,G,B,A bytes gosu reads.
+    @lut = Array.new(256) do |i|
+      r, g, b = palette[i & 0x3f]
+      r | (g << 8) | (b << 16) | (0xff << 24)
+    end
+  end
+
+  def convert(screen)
+    screen.unpack("C*").map! { |ix| @lut[ix] }.pack("V*")
+  end
+end
+
+# The module's fixed 64-entry palette (R,G,B,A per entry; alpha is padding), read once: it never changes, unlike the per-frame index buffer.
+def read_palette(nes)
+  bytes = nes.memory.buffer.get_string(nes.invoke("paletteOffset"), 64 * 4).bytes
+  Array.new(64) { |i| bytes[i * 4, 3] }
+end
+
+CONTROLS_TEXT = "arrows d-pad   x=A z=B   enter start   space select   F1 hud   q/esc quit"
+
+class NesWindow < Gosu::Window
+  # The NTSC NES runs at ~60.0988Hz; 60 exactly is close enough that no separate calibration is needed.
+  # When the interpreter cannot sustain it, gosu's update simply runs late, which is the same fastest-sustainable-rate behavior the terminal frontend implements by hand.
+  TICKS_PER_SECOND = 60
+  # The caption only has to be legible, not frame-accurate, and asking the window manager to retitle the window is not free.
+  CAPTION_UPDATE_EVERY = TICKS_PER_SECOND
+  HUD_HEIGHT = 18
+
+  def initialize(nes, frame_w, frame_h, converter, screen_off, scale:, fullscreen:, retro:)
+    super(frame_w * scale, frame_h * scale, fullscreen: fullscreen, resizable: true)
+    self.caption = "NES (dewasm)"
+    self.update_interval = 1000.0 / TICKS_PER_SECOND
+
+    @frame_w = frame_w
+    @frame_h = frame_h
+    @converter = converter
+    @screen_off = screen_off
+    # Fetched once out of the exports table: invoke() would redo the hash lookup and splat the arguments on every one of these calls.
+    @set_input = nes.exports.fetch("setInput")
+    @tick_game = nes.exports.fetch("tickGame")
+    @buffer = nes.memory.buffer
+    @held = 0
+    @rgba = nil
+
+    @retro = retro
+    @canvas = nil
+    @font = Gosu::Font.new(13)
+    @show_hud = true
+    @ticks = 0
+    @rate_ticks = 0
+    @rate_window_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    @rate = 0.0
+  end
+
+  def update
+    @set_input.call(@held)
+    @tick_game.call
+    @rgba = @converter.convert(@buffer.get_string(@screen_off, @frame_w * @frame_h))
+    @ticks += 1
+    @rate_ticks += 1
+    return unless (@ticks % CAPTION_UPDATE_EVERY).zero?
+
+    now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    @rate = @rate_ticks / (now - @rate_window_start)
+    @rate_ticks = 0
+    @rate_window_start = now
+    self.caption = format("NES (dewasm) - %.1f ticks/sec", @rate)
+  end
+
+  def draw
+    rgba = @rgba
+    return unless rgba
+
+    image = frame_image(rgba)
+    # Letterbox: the window is resizable and need not keep the frame's ratio, so the frame is scaled by whichever axis runs out first and centred, leaving black bars on the other.
+    scale = [width.to_f / image.width, height.to_f / image.height].min
+    draw_w = image.width * scale
+    draw_h = image.height * scale
+    image.draw((width - draw_w) / 2, (height - draw_h) / 2, 0, scale, scale)
+    draw_hud if @show_hud
+  end
+
+  def button_down(id)
+    case id
+    when Gosu::KB_ESCAPE, Gosu::KB_Q, Gosu::KB_F10 then close
+    when Gosu::KB_F1 then @show_hud = !@show_hud
+    else
+      bit = button_bit(id)
+      @held |= bit if bit
+    end
+  end
+
+  def button_up(id)
+    bit = button_bit(id)
+    @held &= ~bit if bit
+  end
+
+  private
+
+  def button_bit(id)
+    case id
+    when Gosu::KB_UP then BUTTON_BITS[:up]
+    when Gosu::KB_DOWN then BUTTON_BITS[:down]
+    when Gosu::KB_LEFT then BUTTON_BITS[:left]
+    when Gosu::KB_RIGHT then BUTTON_BITS[:right]
+    when Gosu::KB_X then BUTTON_BITS[:a]
+    when Gosu::KB_Z then BUTTON_BITS[:b]
+    when Gosu::KB_RETURN, Gosu::KB_ENTER then BUTTON_BITS[:start]
+    when Gosu::KB_SPACE then BUTTON_BITS[:select]
+    end
+  end
+
+  # Uploads the frame to the GPU.
+  # Gosu interpolates a scaled-up image unless the texture was created with `retro: true`, which Image.from_blob has no way to ask for, so the retro path blits the frame into a persistent nearest-neighbor render target instead.
+  # That is what --smooth turns off.
+  def frame_image(rgba)
+    image = Gosu::Image.from_blob(@frame_w, @frame_h, rgba)
+    return image unless @retro
+
+    @canvas ||= Gosu.render(image.width, image.height, retro: true) { }
+    @canvas.insert(image, 0, 0)
+    @canvas
+  end
+
+  # A dark bar along the bottom edge, so the tick rate and the controls stay legible against the game's own palette.
+  def draw_hud
+    bar_y = height - HUD_HEIGHT
+    draw_rect(0, bar_y, width, HUD_HEIGHT, Gosu::Color.new(180, 0, 0, 0), 1)
+    @font.draw_text(format("%.1f ticks/sec  |  %s", @rate, CONTROLS_TEXT), 5, bar_y + 3, 2)
+  end
+end
+
+def check_yjit!
+  return if defined?(RubyVM::YJIT) && RubyVM::YJIT.enabled?
+
+  warn "nes: YJIT is not enabled (run with `ruby --yjit`, or set RUBY_YJIT_ENABLE=1) " \
+       "- the Ruby backend is already dewasm's slowest, and needs YJIT to stay playable."
+end
+
+def start_nes(rom_path)
+  nes = new_nes
+  load_rom(nes, rom_path)
+  frame_w = nes.invoke("frameWidth")
+  frame_h = nes.invoke("frameHeight")
+  screen_off = nes.invoke("screenOffset")
+  converter = FrameConverter.new(read_palette(nes))
+  [nes, frame_w, frame_h, converter, screen_off]
+end
+
+def run_smoke(rom_path)
+  nes, frame_w, frame_h, converter, screen_off = start_nes(rom_path)
+  set_input = nes.exports.fetch("setInput")
+  tick_game = nes.exports.fetch("tickGame")
+
+  ticks = 300
+  start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  ticks.times do
+    set_input.call(0)
+    tick_game.call
+  end
+  elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+
+  # Timed separately from the loop above: the interactive window converts once per tick, but the tick cost is what varies between machines and Rubies.
+  screen = nes.memory.buffer.get_string(screen_off, frame_w * frame_h)
+  convert_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  rgba = nil
+  10.times { rgba = converter.convert(screen) }
+  convert_ms = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - convert_start) / 10 * 1000
+
+  puts format(
+    "smoke: ran %d ticks in %.3fs - %.1f ticks/sec (%.2fms/frame framebuffer conversion)",
+    ticks, elapsed, ticks / elapsed, convert_ms
+  )
+
+  distinct = rgba.unpack("V*").uniq.size
+  puts "smoke: final frame is #{frame_w}x#{frame_h} with #{distinct} distinct colors"
+  # The NES PPU palette tops out at 64 colors total, so a healthy frame lands in the dozens; a degenerate (blank/solid) frame lands in the single digits
+  # (mirroring the >4 threshold the snapshot oracle uses, crates/xtask/src/nes_snapshot.rs).
+  if distinct <= 4
+    warn "smoke: FAIL: frame looks degenerate (too few distinct colors)"
+    exit 1
+  end
+
+  # Gosu decodes and encodes images without a window, so unlike the terminal frontend (which falls back to PPM for want of a stdlib PNG writer) this writes a real PNG with no display attached.
+  Gosu::Image.from_blob(frame_w, frame_h, rgba).save("screenshot.png")
+  puts "smoke: wrote #{File.expand_path('screenshot.png')}"
+end
+
+def parse_options(argv)
+  options = { scale: 3, fullscreen: false, retro: true }
+  rom_path = nil
+  until argv.empty?
+    case (arg = argv.shift)
+    when "--scale" then options[:scale] = Integer(argv.shift, exception: false) || 0
+    when "--fullscreen" then options[:fullscreen] = true
+    when "--smooth" then options[:retro] = false
+    else
+      if arg.start_with?("--") || rom_path
+        warn "nes: unknown option #{arg}"
+        warn "usage: main.rb [--smoke] [--scale N] [--fullscreen] [--smooth] [rom.nes]"
+        exit 2
+      end
+      rom_path = arg
+    end
+  end
+  unless (1..8).cover?(options[:scale])
+    warn "nes: --scale must be an integer between 1 and 8"
+    exit 2
+  end
+  [options, rom_path || DEFAULT_ROM_PATH]
+end
+
+def run_interactive(options, rom_path)
+  # Gosu.render, which the nearest-neighbor path needs, arrived in gosu 1.1; degrade to interpolated scaling rather than refusing to run.
+  if options[:retro] && !Gosu.respond_to?(:render)
+    warn "nes: this gosu is too old for nearest-neighbor scaling; falling back to --smooth"
+    options[:retro] = false
+  end
+  nes, frame_w, frame_h, converter, screen_off = start_nes(rom_path)
+  NesWindow.new(nes, frame_w, frame_h, converter, screen_off, **options).show
+end
+
+check_yjit!
+argv = ARGV.dup
+smoke = argv.delete("--smoke") ? true : false
+options, rom_path = parse_options(argv)
+if smoke
+  run_smoke(rom_path)
+else
+  run_interactive(options, rom_path)
+end

--- a/examples/nes/ruby/gui/run.sh
+++ b/examples/nes/ruby/gui/run.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Build (if needed) and run the windowed NES frontend, forwarding any arguments
+# (e.g. `./run.sh --smoke` for the headless self-check, or `./run.sh path/to/game.nes`).
+# The generated library is shared with the terminal frontend: ../build.sh builds
+# nes.wasm and regenerates ../nes_gen.rb, which main.rb requires.
+# gosu is installed with bundler into the gitignored vendor/bundle, so the gem and
+# its version stay scoped to this directory. --yjit is required: the Ruby backend
+# is dewasm's slowest, and only YJIT keeps the emulator playable.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+../build.sh
+
+bundle config set --local path vendor/bundle
+bundle install --quiet
+
+ruby -c main.rb > /dev/null
+
+exec bundle exec ruby --yjit main.rb "$@"

--- a/examples/nes/ruby/run.sh
+++ b/examples/nes/ruby/run.sh
@@ -6,5 +6,4 @@ set -euo pipefail
 cd "$(dirname "$0")"
 
 ./build.sh
-export RUBY_YJIT_ENABLE=1
 exec ruby --yjit main.rb "$@"


### PR DESCRIPTION
Based on #304 by @sisshiki1969, reshaped as discussed, and extended with the NES counterpart.
Closes #304.

## What changed against #304

- The frontend lives under `examples/doom/ruby/gui/` and requires the terminal frontend's generated `doom_gen.rb` instead of regenerating its own copy: the two hosts differ only in presentation, and #304's `ruby-gosu/build.sh` was the sibling's with only the output path changed.
- gosu is installed by `run.sh` with bundler into a gitignored `vendor/bundle`, at the version `Gemfile.lock` pins.
  Nothing is installed globally, and `ruby/` itself stays stdlib-only.
  The README also documents why `gem install gosu` currently breaks on Homebrew's sdl2-compat (its `sdl2-config` does not support the `--static-libs` flag gosu's build uses, so the extension links without SDL2 and AppKit and fails at require time).
- `audio.rb` is dropped: it was not wired to anything, and the pinned doom.wasm v0.1.0 has no `audio` import (its import section is exactly the ten functions the READMEs describe).
- The window caption keeps the tick rate but not `RUBY_DESCRIPTION`, and the wording is `ticks/sec` throughout.

## Added on top

- `examples/nes/ruby/gui/`: the NES counterpart in the same shape (shared `nes_gen.rb`, bundler-scoped gosu).
  The window pays off more than for DOOM: `setInput` wants the full held-button bitmask every tick, and gosu's `button_down`/`button_up` deliver real key releases where the terminal frontend synthesizes them after a hold window.
- The redundant `export RUBY_YJIT_ENABLE=1` is dropped from the existing Ruby `run.sh` scripts: both exec `ruby --yjit` directly and spawn no child ruby, so the flag alone is sufficient (measured).

## Verification

- `examples/doom/ruby/gui/run.sh --smoke`: 60 ticks, 320x200 halving verified on the first frame, 240 distinct colors, title screen PNG confirmed by eye.
- `examples/nes/ruby/gui/run.sh --smoke`: 300 ticks, 10 distinct colors, Alter Ego title screen PNG confirmed by eye.
- Both terminal frontends' `--smoke` still pass after the `run.sh` cleanup, at their usual YJIT-level rates.
- The NES frame is deterministic over the input-free smoke, and the terminal frontend's `screenshot.ppm` is byte-identical between CRuby and monoruby master, for what that cross-checks of the generated library.
